### PR TITLE
Update CPS and nullability annotations

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -70,8 +70,8 @@
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.7.DesignTime"                   Version="15.7.1" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.8.DesignTime"                   Version="15.8.1" />
     <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="8.0.0-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="16.0.102" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="16.0.102" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="16.3.1-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="16.3.1-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="16.0.28729" />
     <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="15.5.31" />
     <PackageReference Update="Microsoft.VisualStudio.VSHelp"                                          Version="16.0.28321-alpha" />
@@ -105,8 +105,8 @@
     <PackageReference Update="Microsoft.Test.Apex.VisualStudio"                                       Version="16.3.29003.189" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.2.133-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.2.133-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.4.28-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.4.28-pre" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="3.2.0-beta4-19359-03" />
@@ -128,10 +128,10 @@
     <PackageReference Update="NuGet.VisualStudio"                                                     Version="5.1.0-rtm.5921" />
 
     <!-- MSBuild -->
-    <PackageReference Update="Microsoft.Build"                                                        Version="16.0.461"/>
-    <PackageReference Update="Microsoft.Build.Utilities.Core"                                         Version="16.0.461"/>
-    <PackageReference Update="Microsoft.Build.Engine"                                                 Version="16.0.461"/>
-    <PackageReference Update="Microsoft.Build.Tasks.Core"                                             Version="16.0.461"/>
+    <PackageReference Update="Microsoft.Build"                                                        Version="16.1.76"/>
+    <PackageReference Update="Microsoft.Build.Utilities.Core"                                         Version="16.1.76"/>
+    <PackageReference Update="Microsoft.Build.Engine"                                                 Version="16.1.76"/>
+    <PackageReference Update="Microsoft.Build.Tasks.Core"                                             Version="16.1.76"/>
 
     <!-- Libraries -->
     <PackageReference Update="Newtonsoft.Json"                                                        Version="12.0.2"/>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject_VsLangProjectProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject_VsLangProjectProperties.cs
@@ -15,8 +15,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             {
                 ConfigurationGeneralBrowseObject browseObject = await _projectProperties.Value.GetConfigurationGeneralBrowseObjectPropertiesAsync();
                 IEvaluatedProperty evaluatedProperty = func(browseObject);
-                object value = await evaluatedProperty.GetValueAsync();
-                return (T)value;
+                object? value = await evaluatedProperty.GetValueAsync();
+
+                // IEvaluatedProperty.GetValueAsync always returns a non-null value, though
+                // it inherits this method from IProperty which can return null.
+                return (T)value!;
             });
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.ErrorListDetails.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.ErrorListDetails.cs
@@ -30,9 +30,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
                 set;
             }
 
-            public string GetFileFullPath(string projectFile)
+            public string GetFileFullPath(string? projectFile)
             {
-                string baseFilePath = ProjectFile;
+                string? baseFilePath = ProjectFile;
                 if (string.IsNullOrEmpty(baseFilePath))
                 {
                     baseFilePath = projectFile;
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
 
                 if (!string.IsNullOrEmpty(baseFilePath) && !string.IsNullOrEmpty(File))
                 {
-                    return TryMakeRooted(baseFilePath, File);
+                    return TryMakeRooted(baseFilePath!, File);
                 }
 
                 return string.Empty;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             string directoryName = Path.GetDirectoryName(path);
             string fileName = Path.GetFileName(path);
 
-            string templateLanguage = await GetTemplateLanguageAsync();
+            string? templateLanguage = await GetTemplateLanguageAsync();
             if (string.IsNullOrEmpty(templateLanguage))
                 return false;
 
@@ -66,11 +66,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             return false;
         }
 
-        private async Task<string> GetTemplateLanguageAsync()
+        private async Task<string?> GetTemplateLanguageAsync()
         {
             ConfigurationGeneral general = await _properties.GetConfigurationGeneralPropertiesAsync();
 
-            return (string)await general.TemplateLanguage.GetValueAsync();
+            return (string?)await general.TemplateLanguage.GetValueAsync();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileEnumValuesGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileEnumValuesGenerator.cs
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// <summary>
         /// See <see cref="IDynamicEnumValuesGenerator"/>
         /// </summary>
-        public async Task<IEnumValue> TryCreateEnumValueAsync(string userSuppliedValue)
+        public async Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue)
         {
             return (await _listedValues.GetValueAsync())
             .FirstOrDefault(v => LaunchProfile.IsSameProfileName(v.Name, userSuppliedValue));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractAddItemCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractAddItemCommandHandler.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         /// </summary>
         protected abstract ImmutableDictionary<long, ImmutableArray<TemplateDetails>> GetTemplateDetails();
 
-        public Task<CommandStatusResult> GetCommandStatusAsync(IImmutableSet<IProjectTree> nodes, long commandId, bool focused, string commandText, CommandStatus progressiveStatus)
+        public Task<CommandStatusResult> GetCommandStatusAsync(IImmutableSet<IProjectTree> nodes, long commandId, bool focused, string? commandText, CommandStatus progressiveStatus)
         {
             Requires.NotNull(nodes, nameof(nodes));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
@@ -34,7 +34,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             if (CanMove() && !_previousIncludes.IsEmpty && hints.TryGetValue(ProjectChangeFileSystemEntityHint.AddedFile, out IImmutableSet<IProjectChangeHint> addedFileHints))
             {
                 IProjectChangeHint hint = addedFileHints.First();
-                ConfiguredProject configuredProject = hint.UnconfiguredProject.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject;
+                ConfiguredProject? configuredProject = hint.UnconfiguredProject.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject;
+                Assumes.NotNull(configuredProject);
                 await OrderingHelper.Move(configuredProject, _accessor, _previousIncludes, _target!, _action);
             }
 
@@ -49,8 +50,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             // However we check to see if we captured the previous includes for sanity to ensure it only gets set once.
             if (CanMove() && _previousIncludes.IsEmpty)
             {
-                ConfiguredProject configuredProject = hint.UnconfiguredProject.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject;
-
+                ConfiguredProject? configuredProject = hint.UnconfiguredProject.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject;
+                Assumes.NotNull(configuredProject);
                 _previousIncludes = await OrderingHelper.GetAllEvaluatedIncludes(configuredProject, _accessor);
 
                 _isHinting = true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -166,17 +166,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             Requires.NotNull(project, nameof(project));
             Requires.NotNull(target, nameof(target));
 
-            IProjectTree newTarget = target;
+            IProjectTree? newTarget = target;
 
             // This is to handle adding files to empty folders since empty folders do not have a valid display order yet.
             // We need to find a target up the tree that has a valid display order, because it most likely will have our reference element that we want.
-            while (!HasValidDisplayOrder(newTarget) && !newTarget.Flags.Contains(ProjectTreeFlags.ProjectRoot))
+            while (!HasValidDisplayOrder(newTarget) && !newTarget!.Flags.Contains(ProjectTreeFlags.ProjectRoot))
             {
                 newTarget = newTarget.Parent;
             }
 
             var excludeIncludes = elements.Select(x => x.Include).ToImmutableArray();
-            ProjectItemElement? referenceElement = GetChildren(newTarget).Select(x => TryGetReferenceElement(project, x, excludeIncludes, MoveAction.Above)).FirstOrDefault(x => x != null);
+            ProjectItemElement? referenceElement = GetChildren(newTarget!).Select(x => TryGetReferenceElement(project, x, excludeIncludes, MoveAction.Above)).FirstOrDefault(x => x != null);
             if (referenceElement == null)
             {
                 return false;
@@ -246,7 +246,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
                     // Technically it is possible to have more than one of the same item names.
                     // We only want to add one of them.
                     // Sanity check
-                    if (hashSet.Add(tree2.Item.ItemName))
+                    if (tree2.Item.ItemName != null && hashSet.Add(tree2.Item.ItemName))
                     {
                         includes.Add(tree2.DisplayOrder, tree2.Item.ItemName);
                     }
@@ -289,7 +289,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// <returns>a sibling</returns>
         private static IProjectTree2? GetSiblingByDisplayOrder(IProjectTree projectTree, Func<int, ImmutableArray<IProjectTree>, IProjectTree2?> returnSibling)
         {
-            IProjectTree parent = projectTree.Parent;
+            IProjectTree? parent = projectTree.Parent;
             int displayOrder = GetDisplayOrder(projectTree);
             if (!IsValidDisplayOrder(displayOrder) || parent == null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/PasteOrdering.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/PasteOrdering.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return PasteProcessor.CanHandleDataObject(dataObject, dropTarget, currentProvider);
         }
 
-        public Task<IEnumerable<ICopyPasteItem>> ProcessDataObjectAsync(object dataObject, IProjectTree dropTarget, IProjectTreeProvider currentProvider, DropEffects effect)
+        public Task<IEnumerable<ICopyPasteItem>?> ProcessDataObjectAsync(object dataObject, IProjectTree dropTarget, IProjectTreeProvider currentProvider, DropEffects effect)
         {
             _dropTarget = dropTarget;
             return PasteProcessor.ProcessDataObjectAsync(dataObject, dropTarget, currentProvider, effect);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreService.PackageRestoreServiceInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreService.PackageRestoreServiceInstance.cs
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 
             private async Task NominateForRestoreAsync(ProjectRestoreInfo restoreInfo, CancellationToken cancellationToken)
             {
-                RestoreLogger.BeginNominateRestore(_logger, _project.FullPath, restoreInfo);
+                RestoreLogger.BeginNominateRestore(_logger, _project.FullPath!, restoreInfo);
 
                 try
                 {
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
                 {
                     CodeMarkers.Instance.CodeMarker(CodeMarkerTimerId.PerfPackageRestoreEnd);
 
-                    RestoreLogger.EndNominateRestore(_logger, _project.FullPath);
+                    RestoreLogger.EndNominateRestore(_logger, _project.FullPath!);
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
                 return _threadingService.ExecuteSynchronously(async () =>
                 {
                     ConfiguredBrowseObject browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync();
-                    object value = await browseObjectProperties.RunCodeAnalysis.GetValueAsync();
+                    object? value = await browseObjectProperties.RunCodeAnalysis.GetValueAsync();
                     return ((bool?)value).GetValueOrDefault();
                 });
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             public async Task<(bool success, string? property)> TryGetPropertyAsync(IProjectProperties defaultProperties)
             {
                 // check if value already exists
-                string unevaluatedPropertyValue = await defaultProperties.GetUnevaluatedPropertyValueAsync(BuildEvent);
+                string? unevaluatedPropertyValue = await defaultProperties.GetUnevaluatedPropertyValueAsync(BuildEvent);
                 if (unevaluatedPropertyValue != null)
                 {
                     return (true, unevaluatedPropertyValue);
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
 
             public async Task<bool> TrySetPropertyAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties)
             {
-                string currentValue = await defaultProperties.GetUnevaluatedPropertyValueAsync(BuildEvent);
+                string? currentValue = await defaultProperties.GetUnevaluatedPropertyValueAsync(BuildEvent);
                 if (currentValue == null)
                 {
                     return false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikerValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikerValueProvider.cs
@@ -34,8 +34,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
             ConfigurationGeneral configuration = await _properties.GetConfigurationGeneralPropertiesAsync();
-            string currentTargetFramework = (string)await configuration.TargetFramework.GetValueAsync();
-            string currentTargetFrameworks = (string)await configuration.TargetFrameworks.GetValueAsync();
+            string? currentTargetFramework = (string?)await configuration.TargetFramework.GetValueAsync();
+            string? currentTargetFrameworks = (string?)await configuration.TargetFrameworks.GetValueAsync();
             if (!string.IsNullOrEmpty(currentTargetFrameworks))
             {
                 throw new InvalidOperationException(VSResources.MultiTFEditNotSupported);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
@@ -33,8 +33,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             {
                 ProjectProperties projectProperties = configuredProject.Services.ExportProvider.GetExportedValue<ProjectProperties>();
                 ConfigurationGeneral configuration = await projectProperties.GetConfigurationGeneralPropertiesAsync();
-                string currentTargetFrameworkMoniker = (string)await configuration.TargetFrameworkMoniker.GetValueAsync();
-                builder.Add(currentTargetFrameworkMoniker);
+                string? currentTargetFrameworkMoniker = (string?)await configuration.TargetFrameworkMoniker.GetValueAsync();
+                Assumes.NotNull(currentTargetFrameworkMoniker);
+                builder.Add(currentTargetFrameworkMoniker!);
             }
 
             return string.Join(";", builder.ToArrayAndFree());

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
@@ -64,10 +64,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             return entryPointNames.Select(name => (IEnumValue)new PageEnumValue(new EnumValue { Name = name, DisplayName = name })).ToArray();
         }
 
-        public Task<IEnumValue> TryCreateEnumValueAsync(string userSuppliedValue)
+        public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue)
         {
             var value = new PageEnumValue(new EnumValue { Name = userSuppliedValue, DisplayName = userSuppliedValue });
-            return Task.FromResult<IEnumValue>(value);
+            return Task.FromResult<IEnumValue?>(value);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             ProjectSystem.Properties.IProjectProperties commonProperties = _configuredProject.Value.Services.ProjectPropertiesProvider.GetCommonProperties();
             pbstrBuildMacroValue = _threadingService?.ExecuteSynchronously(() => commonProperties.GetEvaluatedPropertyValueAsync(bstrBuildMacroName));
 
-            if (pbstrBuildMacroValue == null)
+            if (string.IsNullOrEmpty(pbstrBuildMacroValue))
             {
                 pbstrBuildMacroValue = string.Empty;
                 return HResult.Fail;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/Renamer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/Renamer.cs
@@ -160,7 +160,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
         {
             foreach (Project proj in _workspace.CurrentSolution.Projects)
             {
-                if (StringComparers.Paths.Equals(proj.FilePath, _projectVsServices.Project.FullPath))
+                if (StringComparers.Paths.Equals(proj.FilePath, _projectVsServices.Project.FullPath!))
                 {
                     return proj;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TargetFrameworkProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TargetFrameworkProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             _nuGetFrameworkParser = nugetFrameworkParser;
         }
 
-        public ITargetFramework? GetTargetFramework(string shortOrFullName)
+        public ITargetFramework? GetTargetFramework(string? shortOrFullName)
         {
             if (string.IsNullOrEmpty(shortOrFullName))
             {
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             }
 
             // Fast path for an exact name match
-            if (_targetFrameworkByName.TryGetValue(shortOrFullName, out ITargetFramework existing))
+            if (_targetFrameworkByName.TryGetValue(shortOrFullName!, out ITargetFramework existing))
             {
                 return existing;
             }
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 if (_targetFrameworkByName.TryGetValue(frameworkName.FullName, out ITargetFramework exitingByFullName))
                 {
                     // The full name was known, so cache by the provided (unknown) name too for next time
-                    ImmutableInterlocked.TryAdd(ref _targetFrameworkByName, shortOrFullName, exitingByFullName);
+                    ImmutableInterlocked.TryAdd(ref _targetFrameworkByName, shortOrFullName!, exitingByFullName);
 
                     return exitingByFullName;
                 }
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 if (shortName != null && _targetFrameworkByName.TryGetValue(shortName, out ITargetFramework exitingByShortName))
                 {
                     // The short name was known, so cache by the provided (unknown) name too for next time
-                    ImmutableInterlocked.TryAdd(ref _targetFrameworkByName, shortOrFullName, exitingByShortName);
+                    ImmutableInterlocked.TryAdd(ref _targetFrameworkByName, shortOrFullName!, exitingByShortName);
 
                     return exitingByShortName;
                 }
@@ -75,20 +75,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 // This is a completely new target framework. Create, cache and return it.
                 var targetFramework = new TargetFramework(frameworkName, shortName);
 
-                ImmutableInterlocked.TryAdd(ref _targetFrameworkByName, shortOrFullName, targetFramework);
+                ImmutableInterlocked.TryAdd(ref _targetFrameworkByName, shortOrFullName!, targetFramework);
 
                 return targetFramework;
             }
             catch
             {
                 // Note: catching all exceptions and return a generic TargetFramework for given shortOrFullName
-                return new TargetFramework(shortOrFullName);
+                return new TargetFramework(shortOrFullName!);
             }
         }
 
         public ITargetFramework? GetNearestFramework(
-            ITargetFramework targetFramework,
-            IEnumerable<ITargetFramework> otherFrameworks)
+            ITargetFramework? targetFramework,
+            IEnumerable<ITargetFramework>? otherFrameworks)
         {
             if (targetFramework?.FrameworkName == null || otherFrameworks == null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetector.cs
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             // is true for both add and a reload of an unloaded project
             if (SolutionOpen && fAdded == 1 && CompatibilityLevelWarnedForCurrentSolution != CompatibilityLevel.NotSupported)
             {
-                UnconfiguredProject project = pHierarchy.AsUnconfiguredProject();
+                UnconfiguredProject? project = pHierarchy.AsUnconfiguredProject();
                 if (project != null)
                 {
                     _threadHandling.Value.RunAndForget(async () =>
@@ -329,7 +329,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             if (project.Capabilities.AppliesTo($"{ProjectCapability.DotNet} & {ProjectCapability.PackageReferences}"))
             {
-                IProjectProperties properties = project.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject.Services.ProjectPropertiesProvider.GetCommonProperties();
+                ConfiguredProject? activeConfiguredProject = project.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject;
+                Assumes.NotNull(activeConfiguredProject);
+                IProjectProperties properties = activeConfiguredProject.Services.ProjectPropertiesProvider.GetCommonProperties();
                 string tfm = await properties.GetEvaluatedPropertyValueAsync("TargetFrameworkMoniker");
                 if (!string.IsNullOrEmpty(tfm))
                 {
@@ -341,7 +343,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     else if (fw.Identifier.Equals(".NETFramework", StringComparison.OrdinalIgnoreCase))
                     {
                         // The interesting case here is Asp.Net Core on full framework
-                        IImmutableSet<IUnresolvedPackageReference> pkgReferences = await project.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject.Services.PackageReferences.GetUnresolvedReferencesAsync();
+                        IImmutableSet<IUnresolvedPackageReference> pkgReferences = await activeConfiguredProject.Services.PackageReferences.GetUnresolvedReferencesAsync();
 
                         // Look through the package references
                         foreach (IUnresolvedPackageReference pkgRef in pkgReferences)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
@@ -117,6 +117,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
             IProjectTreeServiceState result = await _projectTree.Value.TreeService.PublishAnyNonLoadingTreeAsync();
 
             if (result.TreeProvider.FindByPath(result.Tree, documentMoniker) is IProjectItemTree treeItem &&
+                treeItem.Parent != null &&
                 !treeItem.Parent.Flags.Contains(ProjectTreeFlags.SourceFile) &&
                 StringComparers.ItemTypes.Equals(treeItem.Item.ItemType, Compile.SchemaName))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -127,14 +127,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public async Task<ActiveConfiguredObjects<ProjectConfiguration>?> GetActiveProjectConfigurationsAsync()
         {
-            ProjectConfiguration? activeSolutionConfiguration = _services.ActiveConfiguredProjectProvider.ActiveProjectConfiguration;
+            ProjectConfiguration? activeSolutionConfiguration = _services.ActiveConfiguredProjectProvider?.ActiveProjectConfiguration;
 
             if (activeSolutionConfiguration == null)
             {
                 return null;
             }
 
-            IImmutableSet<ProjectConfiguration> configurations = await _services.ProjectConfigurationsService.GetKnownProjectConfigurationsAsync();
+            IImmutableSet<ProjectConfiguration> configurations = await _services.ProjectConfigurationsService!.GetKnownProjectConfigurationsAsync();
 
             var builder = PooledArray<ProjectConfiguration>.GetInstance();
             IImmutableSet<string> dimensionNames = GetDimensionNames();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
@@ -63,7 +63,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 
             async Task<string?> GetPropertyValueAsync(UnconfiguredProject project)
             {
-                ConfiguredProject configuredProject = await project.GetSuggestedConfiguredProjectAsync();
+                ConfiguredProject? configuredProject = await project.GetSuggestedConfiguredProjectAsync();
+
+                Assumes.NotNull(configuredProject);
 
                 return await ProjectAccessor.OpenProjectForReadAsync(configuredProject, evaluatedProject =>
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
@@ -35,14 +35,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // correctly. 
             ConfigurationGeneral props = await _commonProjectServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync();
 
-            string targetFrameworks = (string)await props.TargetFrameworks.GetValueAsync();
+            string? targetFrameworks = (string?)await props.TargetFrameworks.GetValueAsync();
 
             if (string.IsNullOrWhiteSpace(targetFrameworks))
             {
                 return null;
             }
 
-            return BuildUtilities.GetPropertyValues(targetFrameworks).ToList();
+            return BuildUtilities.GetPropertyValues(targetFrameworks!).ToList();
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Extensibility/ProjectExportProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Extensibility/ProjectExportProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Extensibility
             IProjectService projectService = _projectServiceAccessor.GetProjectService();
 
             UnconfiguredProject? project = projectService?.LoadedUnconfiguredProjects
-                .FirstOrDefault(x => x.FullPath.Equals(projectFilePath, StringComparison.OrdinalIgnoreCase));
+                .FirstOrDefault(x => string.Equals(x.FullPath, projectFilePath, StringComparison.OrdinalIgnoreCase));
 
             return project?.Services.ExportProvider.GetExportedValueOrDefault<T>();
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/ITargetFrameworkProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/ITargetFrameworkProvider.cs
@@ -12,12 +12,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// Parses full tfm or short framework name and returns a corresponding <see cref="ITargetFramework"/>
         /// instance, or <see langword="null" /> if the framework name has an invalid format.
         /// </summary>
-        ITargetFramework? GetTargetFramework(string shortOrFullName);
+        ITargetFramework? GetTargetFramework(string? shortOrFullName);
 
         /// <summary>
         /// Returns the item in <paramref name="otherFrameworks"/> that is most compatible/closest to
         /// <paramref name="targetFramework"/>, or <see langword="null" /> if none are compatible.
         /// </summary>
-        ITargetFramework? GetNearestFramework(ITargetFramework targetFramework, IEnumerable<ITargetFramework> otherFrameworks);
+        ITargetFramework? GetNearestFramework(ITargetFramework? targetFramework, IEnumerable<ITargetFramework>? otherFrameworks);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/OperationProgress/DataProgressTrackerServiceExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/OperationProgress/DataProgressTrackerServiceExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.OperationProgress
         {
             // We deliberately do not want these individual operations in a stage (such as pushing evaluation
             // results to Roslyn) to be visible to the user, so we avoiding specifying a display message.
-            var dataSource = new ProgressTrackerOutputDataSource(project, operationProgressStageId: OperationProgressStageId.IntelliSense, name, displayMessage: null);
+            var dataSource = new ProgressTrackerOutputDataSource(project, operationProgressStageId: OperationProgressStageId.IntelliSense, name, displayMessage: "");
 
             return service.RegisterOutputDataSource(dataSource);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/OperationProgress/ProgressTrackerOutputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/OperationProgress/ProgressTrackerOutputDataSource.cs
@@ -4,7 +4,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.OperationProgress
 {
     internal class ProgressTrackerOutputDataSource : IProgressTrackerOutputDataSource
     {
-        public ProgressTrackerOutputDataSource(ConfiguredProject configuredProject, string operationProgressStageId, string name, string? displayMessage)
+        public ProgressTrackerOutputDataSource(ConfiguredProject configuredProject, string operationProgressStageId, string name, string displayMessage)
         {
             ConfiguredProject = configuredProject;
             OperationProgressStageId = operationProgressStageId;
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.OperationProgress
             get;
         }
 
-        public string? DisplayMessage
+        public string DisplayMessage
         {
             get;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectTreeProviderExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectTreeProviderExtensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             if (relativePath == null)
                 return null;
 
-            string projectFilePath = provider.GetPath(target.Root);
+            string? projectFilePath = provider.GetPath(target.Root);
 
             string rootPath = Path.GetDirectoryName(projectFilePath);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AssemblyInfoProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AssemblyInfoProperties.cs
@@ -71,12 +71,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// <summary>
         /// Get the value of a property.
         /// </summary>
-        public override async Task<string?> GetEvaluatedPropertyValueAsync(string propertyName)
+        public override async Task<string> GetEvaluatedPropertyValueAsync(string propertyName)
         {
             if (_attributeValueProviderMap.ContainsKey(propertyName) &&
                 !await IsAssemblyInfoPropertyGeneratedByBuild(propertyName))
             {
-                return await GetPropertyValueFromSourceAttributeAsync(propertyName);
+                return (await GetPropertyValueFromSourceAttributeAsync(propertyName)) ?? "";
             }
 
             return await base.GetEvaluatedPropertyValueAsync(propertyName);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/DelegatedProjectPropertiesBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/DelegatedProjectPropertiesBase.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public virtual Task<IEnumerable<string>> GetDirectPropertyNamesAsync()
             => DelegatedProperties.GetDirectPropertyNamesAsync();
 
-        public virtual Task<string?> GetEvaluatedPropertyValueAsync(string propertyName)
+        public virtual Task<string> GetEvaluatedPropertyValueAsync(string propertyName)
             => DelegatedProperties.GetEvaluatedPropertyValueAsync(propertyName);
 
         public virtual Task<IEnumerable<string>> GetPropertyNamesAsync()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/DelegatedProjectPropertiesProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/DelegatedProjectPropertiesProviderBase.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             Project = project;
         }
 
-        public virtual string DefaultProjectPath => Project.FullPath;
+        public virtual string? DefaultProjectPath => Project.FullPath;
 
         public event AsyncEventHandler<ProjectPropertyChangedEventArgs> ProjectPropertyChanged
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/TargetFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/TargetFrameworkValueProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public override async Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             ConfigurationGeneral configuration = await _properties.GetConfigurationGeneralPropertiesAsync();
-            string targetFrameworkMoniker = (string)await configuration.TargetFrameworkMoniker.GetValueAsync();
+            string? targetFrameworkMoniker = (string?)await configuration.TargetFrameworkMoniker.GetValueAsync();
 
             if (targetFrameworkMoniker != null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/PropertyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/PropertyExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             Requires.NotNull(property, nameof(property));
 
-            string value = (string)await property.GetValueAsync();
+            string? value = (string?)await property.GetValueAsync();
 
             if (Guid.TryParse(value, out Guid result))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             /// </summary>
             /// <param name="userSuppliedValue"></param>
             /// <returns></returns>
-            public Task<IEnumValue> TryCreateEnumValueAsync(string userSuppliedValue)
+            public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue)
             {
                 throw new NotImplementedException();
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
@@ -44,18 +44,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
             if (projectPath == null)  // Root has DisableAddItem
                 return null;
 
-            string folderName = await GetDefaultAppDesignerFolderNameAsync();
+            string? folderName = await GetDefaultAppDesignerFolderNameAsync();
             if (string.IsNullOrEmpty(folderName))
                 return null; // Developer has set the AppDesigner path to empty
 
             return Path.Combine(projectPath, folderName);
         }
 
-        private async Task<string> GetDefaultAppDesignerFolderNameAsync()
+        private async Task<string?> GetDefaultAppDesignerFolderNameAsync()
         {
             AppDesigner general = await _properties.GetAppDesignerPropertiesAsync();
 
-            return (string)await general.FolderName.GetValueAsync();
+            return (string?)await general.FolderName.GetValueAsync();
         }
 
         private IProjectTree? FindAppDesignerFolder(IProjectTree root)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppManifestSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppManifestSpecialFileProvider.cs
@@ -47,14 +47,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         {
             ConfigurationGeneralBrowseObject configurationGeneral = await _properties.GetConfigurationGeneralBrowseObjectPropertiesAsync();
 
-            string value = (string)await configurationGeneral.ApplicationManifest.GetValueAsync();
-            if (value.Length == 0)
+            string? value = (string?)await configurationGeneral.ApplicationManifest.GetValueAsync();
+            if (string.IsNullOrEmpty(value))
                 return null;
 
-            if (StringComparers.PropertyLiteralValues.Equals(value, "DefaultManifest"))
+            if (StringComparers.PropertyLiteralValues.Equals(value!, "DefaultManifest"))
                 return null;
 
-            if (StringComparers.PropertyLiteralValues.Equals(value, "NoManifest"))
+            if (StringComparers.PropertyLiteralValues.Equals(value!, "NoManifest"))
                 return null;
 
             return value;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -547,7 +547,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 await InitializeAsync(token);
 
                 LogLevel requestedLogLevel = await _projectSystemOptions.GetFastUpToDateLoggingLevelAsync(token);
-                var logger = new BuildUpToDateCheckLogger(logWriter, requestedLogLevel, _configuredProject.UnconfiguredProject.FullPath);
+                var logger = new BuildUpToDateCheckLogger(logWriter, requestedLogLevel, _configuredProject.UnconfiguredProject.FullPath ?? "");
 
                 try
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -300,7 +300,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// For nodes that represent files on disk, this is the project-relative path to that file.
         /// The root node of a project is the absolute path to the project file.
         /// </returns>
-        public override string GetPath(IProjectTree node)
+        public override string? GetPath(IProjectTree node)
         {
             // Needed for graph nodes search
             return node.FilePath;
@@ -528,7 +528,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return null;
             }
 
-            Rule schema = browseObjectsCatalog.GetSchema(dependency.SchemaName);
+            Rule? schema = browseObjectsCatalog.GetSchema(dependency.SchemaName);
 
             string itemSpec = string.IsNullOrEmpty(dependency.OriginalItemSpec)
                 ? dependency.Path

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -341,7 +341,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                             _ = SubmitTreeUpdateAsync(
                                 delegate
                                 {
-                                    IProjectTree dependenciesNode = CreateDependenciesFolder();
+                                    IProjectTree dependenciesNode = CreateDependenciesNode();
 
                                     return Task.FromResult(new TreeUpdateResult(dependenciesNode));
                                 },
@@ -358,7 +358,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     registerFaultHandler: true);
             }
 
-            IProjectTree CreateDependenciesFolder()
+            IProjectTree CreateDependenciesNode()
             {
                 var values = new ReferencesProjectTreeCustomizablePropertyValues
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -373,7 +373,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 // providers to override lower priority providers.
                 foreach (IProjectTreePropertiesProvider provider in _projectTreePropertiesProviders.ExtensionValues())
                 {
-                    provider.CalculatePropertyValues(null, values);
+                    provider.CalculatePropertyValues(ProjectTreeCustomizablePropertyContext.Instance, values);
                 }
 
                 // Note that all the parameters are specified so we can force this call to an
@@ -609,6 +609,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 : base(configuredProject)
             {
             }
+        }
+
+        /// <summary>
+        /// A private implementation of <see cref="IProjectTreeCustomizablePropertyContext"/> used when creating
+        /// the dependencies nodes.
+        /// </summary>
+        private sealed class ProjectTreeCustomizablePropertyContext : IProjectTreeCustomizablePropertyContext
+        {
+            public static readonly ProjectTreeCustomizablePropertyContext Instance = new ProjectTreeCustomizablePropertyContext();
+
+            public string? ItemName => null;
+            public string? ItemType => null;
+            public IImmutableDictionary<string, string>? Metadata => null;
+            public ProjectTreeFlags ParentNodeFlags => ProjectTreeFlags.Empty;
+            public bool ExistsOnDisk => false;
+            public bool IsFolder => false;
+            public bool IsNonFileSystemProjectItem => true;
+            public IImmutableDictionary<string, string>? ProjectTreeSettings => null;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -170,7 +170,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         /// <summary>
-        /// Builds all available sub trees under root: target framework or Dependencies node 
+        /// Builds all available sub trees under root: target framework or Dependencies node
         /// when there is only one target.
         /// </summary>
         private async Task<IProjectTree> BuildSubTreesAsync(
@@ -377,8 +377,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             IProjectTree CreateProjectTreeNode()
             {
-                // For IProjectTree remove ProjectTreeFlags.Common.Reference flag, otherwise CPS would fail to 
-                // map this node to graph node and GraphProvider would be never called. 
+                // For IProjectTree remove ProjectTreeFlags.Common.Reference flag, otherwise CPS would fail to
+                // map this node to graph node and GraphProvider would be never called.
                 // Only IProjectItemTree can have this flag
                 filteredFlags = filteredFlags.Except(DependencyTreeFlags.BaseReferenceFlags);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -134,8 +134,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                             CleanupOldNodes);
 
                         dependenciesTree = shouldAddTargetNode
-                            ? dependenciesTree.Add(node).Parent
-                            : node.Parent;
+                            ? dependenciesTree.Add(node).Parent!
+                            : node.Parent!;
+
+                        Assumes.NotNull(dependenciesTree);
 
                         currentTopLevelNodes.Add(node);
                     }
@@ -247,8 +249,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 currentNodes.Add(subTreeNode);
 
                 rootNode = isNewSubTreeNode
-                    ? rootNode.Add(subTreeNode).Parent
-                    : subTreeNode.Parent;
+                    ? rootNode.Add(subTreeNode).Parent!
+                    : subTreeNode.Parent!;
+
+                Assumes.NotNull(rootNode);
             }
 
             return syncFunc(rootNode, currentNodes);
@@ -303,9 +307,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
                 currentNodes?.Add(dependencyNode);
 
-                rootNode = isNewDependencyNode
+                IProjectTree? parent = isNewDependencyNode
                     ? rootNode.Add(dependencyNode).Parent
                     : dependencyNode.Parent;
+
+                Assumes.NotNull(parent);
+
+                rootNode = parent!;
             }
 
             return currentNodes != null // shouldCleanup

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -157,7 +157,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 }
                 else
                 {
-                    return _telemetryService!.HashValue(_project.FullPath);
+                    return _telemetryService!.HashValue(_project.FullPath!);
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/SDKVersionTelemetryServiceComponent.SDKVersionTelemetryServiceInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/SDKVersionTelemetryServiceComponent.SDKVersionTelemetryServiceInstance.cs
@@ -39,8 +39,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     await _unconfiguredProjectTasksService.ProjectLoadedInHost;
 
                     ConfigurationGeneral projectProperties = await _projectVsServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync();
-                    Task<object>? task = projectProperties?.NETCoreSdkVersion?.GetValueAsync();
-                    string version = task == null ? string.Empty : (string)await task;
+                    Task<object?>? task = projectProperties?.NETCoreSdkVersion?.GetValueAsync();
+                    string? version = task == null ? string.Empty : (string?)await task;
                     string? projectId = await GetProjectIdAsync();
 
                     if (string.IsNullOrEmpty(version) || string.IsNullOrEmpty(projectId))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.ContextTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.ContextTracker.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
                     if (!previousContext.IsCrossTargeting)
                     {
-                        string newTargetFrameworkName = (string)await projectProperties.TargetFramework.GetValueAsync();
+                        string? newTargetFrameworkName = (string?)await projectProperties.TargetFramework.GetValueAsync();
                         ITargetFramework? newTargetFramework = _targetFrameworkProvider.GetTargetFramework(newTargetFrameworkName);
                         if (previousContext.ActiveTargetFramework.Equals(newTargetFramework))
                         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.SnapshotUpdater.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.SnapshotUpdater.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             public SnapshotUpdater(IUnconfiguredProjectCommonServices commonServices, CancellationToken unloadCancellationToken)
             {
                 // Initial snapshot is empty.
-                _currentSnapshot = DependenciesSnapshot.CreateEmpty(commonServices.Project.FullPath);
+                _currentSnapshot = DependenciesSnapshot.CreateEmpty(commonServices.Project.FullPath!);
 
                 // Updates will be published via Dataflow.
                 _source = DataflowBlockSlim.CreateBroadcastBlock<SnapshotChangedEventArgs>("DependenciesSnapshot {1}", skipIntermediateInputData: true);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -294,6 +294,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             ITargetFramework? activeTargetFramework,
             CancellationToken token)
         {
+            Assumes.NotNull(_commonServices.Project.FullPath);
+
             IImmutableSet<string>? projectItemSpecs = GetProjectItemSpecs(catalogs?.Project.ProjectInstance.Items);
 
             _snapshot.TryUpdate(

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectPropertiesContext.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectPropertiesContext.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             public string File => throw new NotImplementedException();
 
-            public string? ItemType { get; set; }
+            public string ItemType { get; set; } = "";
 
             public string? ItemName { get; set; }
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.SubTypeRule.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.SubTypeRule.cs
@@ -47,11 +47,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
                     throw new NotImplementedException();
                 }
 
-                public Task<string?> GetPropertyValueAsync(string propertyName)
+                public Task<string> GetPropertyValueAsync(string propertyName)
                 {
                     if (propertyName == "SubType")
                     {
-                        return Task.FromResult(_tree.SubType);
+                        return Task.FromResult(_tree.SubType ?? "");
                     }
 
                     throw new NotImplementedException();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
@@ -16,6 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             {
                 Children = new Collection<MutableProjectTree>();
                 Visible = true;
+                Caption = "";
                 BrowseObjectProperties = new SubTypeRule(this);
             }
 
@@ -24,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 get;
             }
 
-            public string? Caption
+            public string Caption
             {
                 get;
                 set;
@@ -196,7 +197,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 return subtree;
             }
 
-            IProjectTree IProjectTree.SetBrowseObjectProperties(IRule browseObjectProperties)
+            IProjectTree IProjectTree.SetBrowseObjectProperties(IRule? browseObjectProperties)
             {
                 throw new NotImplementedException();
             }
@@ -206,21 +207,21 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 throw new NotImplementedException();
             }
 
-            IProjectTree IProjectTree.SetExpandedIcon(ProjectImageMoniker expandedIcon)
+            IProjectTree IProjectTree.SetExpandedIcon(ProjectImageMoniker? expandedIcon)
             {
                 ExpandedIcon = expandedIcon;
 
                 return this;
             }
 
-            IProjectTree IProjectTree.SetIcon(ProjectImageMoniker icon)
+            IProjectTree IProjectTree.SetIcon(ProjectImageMoniker? icon)
             {
                 Icon = icon;
 
                 return this;
             }
 
-            IProjectItemTree IProjectTree.SetItem(IProjectPropertiesContext context, IPropertySheet propertySheet, bool isLinked)
+            IProjectItemTree IProjectTree.SetItem(IProjectPropertiesContext context, IPropertySheet? propertySheet, bool isLinked)
             {
                 throw new NotImplementedException();
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreePropertiesProviderExtensions.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreePropertiesProviderExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             foreach (IProjectTree child in tree.Children)
             {
-                tree = ChangePropertyValuesWalkingTree(propertiesProvider, child, projectTreeSettings).Parent;
+                tree = ChangePropertyValuesWalkingTree(propertiesProvider, child, projectTreeSettings).Parent!;
             }
 
             return tree;
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 get { return _tree; }
             }
 
-            public ProjectImageMoniker ExpandedIcon
+            public ProjectImageMoniker? ExpandedIcon
             {
                 get { return _tree.ExpandedIcon; }
                 set { _tree = _tree.SetExpandedIcon(value); }
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 set { _tree = _tree.SetFlags(value); }
             }
 
-            public ProjectImageMoniker Icon
+            public ProjectImageMoniker? Icon
             {
                 get { return _tree.Icon; }
                 set { _tree = _tree.SetIcon(value); }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeProvider.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             get { throw new NotImplementedException(); }
         }
 
-        public bool CanCopy(IImmutableSet<IProjectTree> nodes, IProjectTree receiver, bool deleteOriginal = false)
+        public bool CanCopy(IImmutableSet<IProjectTree> nodes, IProjectTree? receiver, bool deleteOriginal = false)
         {
             throw new NotImplementedException();
         }
@@ -72,10 +72,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
             if (target.IsRoot())
                 return string.Empty;
 
-            return Path.Combine(GetAddNewItemDirectory(target.Parent), target.Caption);
+            return Path.Combine(GetAddNewItemDirectory(target.Parent!), target.Caption);
         }
 
-        public string GetPath(IProjectTree node)
+        public string? GetPath(IProjectTree node)
         {
             return node.FilePath;
         }
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             foreach (IProjectTree node in nodes)
             {
-                node.Parent.Remove(node);
+                node.Parent?.Remove(node);
             }
 
             return Task.CompletedTask;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
@@ -154,8 +154,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
             if (!_options.HasFlag(ProjectTreeWriterOptions.SubType))
                 return;
 
-            _builder.Append(", SubType: ");
-            _builder.Append(tree.BrowseObjectProperties.GetPropertyValueAsync("SubType").Result);
+            if (tree.BrowseObjectProperties != null)
+            {
+                _builder.Append(", SubType: ");
+                _builder.Append(tree.BrowseObjectProperties.GetPropertyValueAsync("SubType").Result);
+            }
 
             if (TagElements)
             {
@@ -210,7 +213,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             WriteIcon("ExpandedIcon", tree.ExpandedIcon);
         }
 
-        private void WriteIcon(string name, ProjectImageMoniker icon)
+        private void WriteIcon(string name, ProjectImageMoniker? icon)
         {
             _builder.AppendFormat(", {0}: {{", name);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemProviderFactory.cs
@@ -37,10 +37,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
                    // Find the node that has the parent folder and add the new node as a child.
                    foreach (var node in inputTree.GetSelfAndDescendentsBreadthFirst())
                    {
-                       string nodeFolderPath = node.IsFolder ? node.FilePath : Path.GetDirectoryName(node.FilePath);
-                       if (nodeFolderPath.TrimEnd(Path.DirectorySeparatorChar).Equals(parentFolder))
+                       string? nodeFolderPath = node.IsFolder ? node.FilePath : Path.GetDirectoryName(node.FilePath);
+                       if (nodeFolderPath?.TrimEnd(Path.DirectorySeparatorChar) == parentFolder)
                        {
-                           if (node.TryFindImmediateChild(fileName, out IProjectTree child) && !child.Flags.IsIncludedInProject())
+                           if (node.TryFindImmediateChild(fileName, out IProjectTree? child) && !child.Flags.IsIncludedInProject())
                            {
                                var newFlags = child.Flags.Remove(ProjectTreeFlags.Common.IncludeInProjectCandidate);
                                child.SetProperties(flags: newFlags);
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                        }
                    }
 
-                   return Task.FromResult<IProjectItem?>(null);
+                   return Task.FromResult<IProjectItem?>(null)!; // TODO remove ! when CPS annotations updated
                });
 
             return mock.Object;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectPropertiesFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectPropertiesFactory.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             mock.Setup(t => t.GetEvaluatedPropertyValueAsync(
                 It.IsIn<string>(propertyNameAndValues.Keys)))
-                 .Returns<string>(k => Task.FromResult(propertyNameAndValues[k]));
+                 .Returns<string>(k => Task.FromResult(propertyNameAndValues[k] ?? ""));
 
             mock.Setup(t => t.GetUnevaluatedPropertyValueAsync(
                 It.IsIn<string>(propertyNameAndValues.Keys)))

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectPropertiesFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectPropertiesFactory.cs
@@ -34,9 +34,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var mock = MockWithProperties(propertyNameAndValues.Keys);
 
-            mock.Setup(t => t.GetEvaluatedPropertyValueAsync(
-                It.IsIn<string>(propertyNameAndValues.Keys)))
-                 .Returns<string>(k => Task.FromResult(propertyNameAndValues[k] ?? ""));
+            // evaluated properties are never null
+            mock.Setup(t => t.GetEvaluatedPropertyValueAsync(It.IsAny<string>()))
+                .Returns<string>(k => Task.FromResult(propertyNameAndValues.TryGetValue(k, out var v) ? v ?? "" : ""));
 
             mock.Setup(t => t.GetUnevaluatedPropertyValueAsync(
                 It.IsIn<string>(propertyNameAndValues.Keys)))

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeProviderFactory.cs
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 {
                     foreach (var node in nodes)
                     {
-                        node.Parent.Remove(node);
+                        node.Parent!.Remove(node);
                     }
                     return Task.CompletedTask;
                 });

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeProviderFactory.cs
@@ -12,11 +12,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
     {
         public static IProjectTreeProvider ImplementGetAddNewItemDirectory(Func<IProjectTree, string> action)
         {
-            static string getPath(IProjectTree tree) => tree.FilePath;
-
             var mock = new Mock<IProjectTreeProvider>();
+
             mock.Setup(p => p.GetPath(It.IsAny<IProjectTree>()))
-                .Returns((Func<IProjectTree, string>)getPath);
+                .Returns((IProjectTree tree) => tree.FilePath);
 
             mock.Setup(p => p.GetAddNewItemDirectory(It.IsAny<IProjectTree>()))
                 .Returns(action);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextMockFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextMockFactory.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
             var context = new IWorkspaceProjectContextMock();
 
             context.SetupGet(c => c.ProjectFilePath)
-                .Returns(project.FullPath);
+                .Returns(project.FullPath!);
 
             if (addDynamicFile != null)
             {
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
             var context = new IWorkspaceProjectContextMock();
 
             context.SetupGet(c => c.ProjectFilePath)
-                .Returns(project.FullPath);
+                .Returns(project.FullPath!);
 
             if (addSourceFile != null)
             {
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
             var context = new Mock<IWorkspaceProjectContext>();
 
             context.SetupGet(c => c.ProjectFilePath)
-                .Returns(project.FullPath);
+                .Returns(project.FullPath!);
 
             if (addMetadataReference != null)
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/UnconfiguredProjectFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/UnconfiguredProjectFactory.cs
@@ -51,7 +51,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             project.Setup(u => u.GetSuggestedConfiguredProjectAsync()).ReturnsAsync(configuredProject);
 
-            project.Setup(u => u.GetFileEncodingAsync()).ReturnsAsync(projectEncoding);
+            if (projectEncoding != null)
+            {
+                project.Setup(u => u.GetFileEncodingAsync()).ReturnsAsync(projectEncoding);
+            }
 
             return project.Object;
         }
@@ -70,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return mock.Object;
         }
 
-        public static UnconfiguredProject ImplementLoadConfiguredProjectAsync(Func<ProjectConfiguration, Task<ConfiguredProject?>> action)
+        public static UnconfiguredProject ImplementLoadConfiguredProjectAsync(Func<ProjectConfiguration, Task<ConfiguredProject>> action)
         {
             var mock = new Mock<UnconfiguredProject>();
             mock.Setup(p => p.LoadConfiguredProjectAsync(It.IsAny<ProjectConfiguration>()))

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/UnconfiguredProjectFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/UnconfiguredProjectFactory.cs
@@ -22,7 +22,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var service = IProjectServiceFactory.Create();
 
-
             var unconfiguredProjectServices = new Mock<UnconfiguredProjectServices>();
             unconfiguredProjectServices.SetupGet<object?>(u => u.HostObject)
                                        .Returns(hostObject);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
@@ -15,12 +15,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public async Task WhenActiveConfigurationChanges_LoadsConfiguredProject(string[] configurationNames)
         {
             var configurationGroups = IConfigurationGroupFactory.CreateFromConfigurationNames(configurationNames);
+            var configuredProject = ConfiguredProjectFactory.Create();
 
             var results = new List<string>();
             var project = UnconfiguredProjectFactory.ImplementLoadConfiguredProjectAsync(configuration =>
             {
                 results.Add(configuration.Name);
-                return Task.FromResult<ConfiguredProject?>(null);
+                return Task.FromResult(configuredProject);
             });
 
             var loader = CreateInstance(project, out ProjectValueDataSource<IConfigurationGroup<ProjectConfiguration>> source);
@@ -36,12 +37,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public async Task WhenProjectUnloading_DoesNotLoadConfiguredProject()
         {
             var tasksService = IUnconfiguredProjectTasksServiceFactory.CreateWithUnloadedProject<ConfiguredProject>();
+            var configuredProject = ConfiguredProjectFactory.Create();
 
             int callCount = 0;
             UnconfiguredProject project = UnconfiguredProjectFactory.ImplementLoadConfiguredProjectAsync(configuration =>
             {
                 callCount++;
-                return Task.FromResult<ConfiguredProject?>(null);
+                return Task.FromResult(configuredProject);
             });
 
             var loader = CreateInstance(project, tasksService, out ProjectValueDataSource<IConfigurationGroup<ProjectConfiguration>> source);
@@ -59,11 +61,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [Fact]
         public async Task InitializeAsync_CanNotInitializeTwice()
         {
+            var configuredProject = ConfiguredProjectFactory.Create();
+
             var results = new List<string>();
             var project = UnconfiguredProjectFactory.ImplementLoadConfiguredProjectAsync(configuration =>
             {
                 results.Add(configuration.Name);
-                return Task.FromResult<ConfiguredProject?>(null);
+                return Task.FromResult(configuredProject);
             });
 
             var loader = CreateInstance(project, out var source);
@@ -93,11 +97,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [Fact]
         public async Task Dispose_WhenInitialized_DisposesSubscription()
         {
+            var configuredProject = ConfiguredProjectFactory.Create();
+
             int callCount = 0;
             UnconfiguredProject project = UnconfiguredProjectFactory.ImplementLoadConfiguredProjectAsync(configuration =>
             {
                 callCount++;
-                return Task.FromResult<ConfiguredProject?>(null);
+                return Task.FromResult(configuredProject);
             });
 
             var loader = CreateInstance(project, out ProjectValueDataSource<IConfigurationGroup<ProjectConfiguration>> source);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsProviderTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var services = IUnconfiguredProjectServicesFactory.Create(activeConfiguredProjectProvider: activeConfiguredProjectProvider, projectConfigurationsService: configurationsService);
             var project = UnconfiguredProjectFactory.ImplementLoadConfiguredProjectAsync((projectConfiguration) =>
             {
-                return Task.FromResult<ConfiguredProject?>(ConfiguredProjectFactory.ImplementProjectConfiguration(projectConfiguration));
+                return Task.FromResult<ConfiguredProject>(ConfiguredProjectFactory.ImplementProjectConfiguration(projectConfiguration));
             });
 
             var dimensionProviders = dimensionNames.Select(name => IActiveConfiguredProjectsDimensionProviderFactory.ImplementDimensionName(name));

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ProjectConfigurationDimensionProviderTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ProjectConfigurationDimensionProviderTestBase.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 
             var provider = CreateInstance(projectXml.Replace("PROP", PropertyName).Replace("DIM", DimensionName));
 
-            var project = UnconfiguredProjectFactory.Create();
+            var project = UnconfiguredProjectFactory.Create(configuredProject: ConfiguredProjectFactory.Create());
             var values = await provider.GetDefaultValuesForDimensionsAsync(project);
 
             Assert.Single(values);
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         {
             var provider = CreateInstance(projectXml.Replace("DIM", DimensionName));
 
-            var project = UnconfiguredProjectFactory.Create();
+            var project = UnconfiguredProjectFactory.Create(configuredProject: ConfiguredProjectFactory.Create());
             var values = await provider.GetDefaultValuesForDimensionsAsync(project);
 
             Assert.Empty(values);
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 
             var provider = CreateInstance(projectXml.Replace("PROP", PropertyName).Replace("DIM", DimensionName));
 
-            var project = UnconfiguredProjectFactory.Create();
+            var project = UnconfiguredProjectFactory.Create(configuredProject: ConfiguredProjectFactory.Create());
             var values = await provider.GetProjectConfigurationDimensionsAsync(project);
 
             Assert.Single(values);
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         {
             var provider = CreateInstance(projectXml.Replace("DIM", DimensionName));
 
-            var project = UnconfiguredProjectFactory.Create();
+            var project = UnconfiguredProjectFactory.Create(configuredProject: ConfiguredProjectFactory.Create());
             var values = await provider.GetProjectConfigurationDimensionsAsync(project);
 
             Assert.Empty(values);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
@@ -129,10 +129,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData(@"[assembly: System.Reflection.AssemblyVersionAttribute(""MyVersion"")]", "AssemblyVersion", "MyVersion")]
         [InlineData(@"[assembly: System.Resources.NeutralResourcesLanguageAttribute(""en-us"")]", "NeutralLanguage", "en-us")]
         // Negative cases
-        [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"")]", "SomeProperty", null)]
-        [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"")]", "Company", null)]
-        [InlineData(@"[assembly: System.Runtime.InteropServices.AssemblyDescriptionAttribute(true)]", "Description", null)]
-        [InlineData(@"[assembly: System.Runtime.AssemblyDescriptionAttribute(""MyDescription"")]", "Description", null)]
+        [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"")]", "SomeProperty", "")]
+        [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"")]", "Company", "")]
+        [InlineData(@"[assembly: System.Runtime.InteropServices.AssemblyDescriptionAttribute(true)]", "Description", "")]
+        [InlineData(@"[assembly: System.Runtime.AssemblyDescriptionAttribute(""MyDescription"")]", "Description", "")]
         public async Task SourceFileProperties_GetEvaluatedPropertyAsync(string code, string propertyName, string expectedValue)
         {
             var provider = CreateProviderForSourceFileValidation(code, out Workspace workspace);
@@ -154,7 +154,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData(@"[assembly: System.Resources.NeutralResourcesLanguageAttribute(""en-us"")]", "NeutralResourcesLanguage", "en-uk", "en-uk")]
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(true)]", "Description", "MyDescription", "MyDescription")]
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription""]", "Description", "", "")]
-        [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription""]", "Description", null, null)]
+        [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription""]", "Description", null, "")]
         public async Task ProjectFileProperties_GetEvaluatedPropertyAsync(string code, string propertyName, string propertyValueInProjectFile, string expectedValue)
         {
             var provider = CreateProviderForProjectFileValidation(code, propertyName, propertyValueInProjectFile, out Workspace workspace);
@@ -198,8 +198,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         [Theory]
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"")]", "Description", "", "NewDescription", "NewDescription")]
-        [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"")]", "Description", null, "", "")]
-        [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"")]", "Description", null, "NewDescription", "NewDescription")]
+        [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"")]", "Description", "", "", "")]
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"")]", "Description", "OldDescription", "NewDescription", "NewDescription")]
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"", ""MyDescription"")]", "Description", "OldDescription", "", "")]
         public async Task ProjectFileProperties_SetPropertyValueAsync(string code, string propertyName, string existingPropertyValue, string propertyValueToSet, string expectedValue)
@@ -269,7 +268,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""2.0.1-beta1"")]", "FileVersion", "2.0.1.0", typeof(FileVersionValueProvider))]
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""2016.2"")]", "FileVersion", "2016.2.0.0", typeof(FileVersionValueProvider))]
         // Version
-        [InlineData(@"", "Version", null, null)]
+        [InlineData(@"", "Version", "", null)]
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""1.1.1"")]", "Version", "1.1.1", null)]
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute("""")]", "Version", "", null)]
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""random"")]", "Version", "random", null)]
@@ -294,15 +293,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         [Theory]
         // PackageId
-        [InlineData("MyApp", "PackageId", null, null)]
+        [InlineData("MyApp", "PackageId", null, "")]
         [InlineData("MyApp", "PackageId", "", "")]
         [InlineData("MyApp", "PackageId", "ExistingValue", "ExistingValue")]
         // Authors
-        [InlineData("MyApp", "Authors", null, null)]
+        [InlineData("MyApp", "Authors", null, "")]
         [InlineData("MyApp", "Authors", "", "")]
         [InlineData("MyApp", "Authors", "ExistingValue", "ExistingValue")]
         // Product
-        [InlineData("MyApp", "Product", null, null)]
+        [InlineData("MyApp", "Product", null, "")]
         [InlineData("MyApp", "Product", "", "")]
         [InlineData("MyApp", "Product", "ExistingValue", "ExistingValue")]
         internal async Task ProjectFileProperties_DefaultValues_GetEvaluatedPropertyAsync(string assemblyName, string propertyName, string existingPropertyValue, string expectedValue)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationManifestValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationManifestValueProviderTests.cs
@@ -25,15 +25,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         [Theory]
-        [InlineData(@"inp.man", "true", @"out.man", @"out.man", null)]
-        [InlineData(@"C:\projectdir\foo.man", "true", @"C:\projectdir\bar.man", @"bar.man", null)]
-        [InlineData(@"C:\projectdir\foo.man", "true", @" a asd ", @" a asd ", null)]
+        [InlineData(@"inp.man", "true", @"out.man", @"out.man", "")]
+        [InlineData(@"C:\projectdir\foo.man", "true", @"C:\projectdir\bar.man", @"bar.man", "")]
+        [InlineData(@"C:\projectdir\foo.man", "true", @" a asd ", @" a asd ", "")]
         [InlineData(@"C:\projectdir\foo.man", null, @"NoManifest", null, "true")]
         [InlineData(@"C:\projectdir\foo.man", null, @"nomANifest", null, "true")]
-        [InlineData(@"C:\projectdir\foo.man", null, @"DefaultManifest", null, null)]
-        [InlineData(@"C:\projectdir\foo.man", null, "", null, null)]
-        [InlineData(@"C:\projectdir\foo.man", null, null, null, null)]
-        public async Task SetApplicationManifest(string appManifestPropValue, string? noManifestPropValue, string? valueToSet, string? expectedAppManifestValue, string? expectedNoManifestValue)
+        [InlineData(@"C:\projectdir\foo.man", null, @"DefaultManifest", null, "")]
+        [InlineData(@"C:\projectdir\foo.man", null, "", null, "")]
+        [InlineData(@"C:\projectdir\foo.man", null, null, null, "")]
+        public async Task SetApplicationManifest(string appManifestPropValue, string? noManifestPropValue, string? valueToSet, string? expectedAppManifestValue, string expectedNoManifestValue)
         {
             var provider = new ApplicationManifestValueProvider(UnconfiguredProjectFactory.Create(filePath: @"C:\projectdir\proj.proj"));
             var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(new Dictionary<string, string?>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var properties = interceptedProvider.GetProperties("path/to/project.testproj", null, null);
 
             // Verify interception for GetEvaluatedPropertyValueAsync.
-            var propertyValue = await properties.GetEvaluatedPropertyValueAsync(MockPropertyName);
+            string? propertyValue = await properties.GetEvaluatedPropertyValueAsync(MockPropertyName);
             Assert.True(getEvaluatedInvoked);
 
             // Verify interception for GetUnevaluatedPropertyValueAsync.
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var properties = interceptedProvider.GetCommonProperties();
 
             // Verify interception for GetEvaluatedPropertyValueAsync.
-            var propertyValue = await properties.GetEvaluatedPropertyValueAsync(MockPropertyName);
+            string? propertyValue = await properties.GetEvaluatedPropertyValueAsync(MockPropertyName);
             Assert.True(getEvaluatedInvoked);
 
             // Verify interception for GetUnevaluatedPropertyValueAsync.
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var properties = interceptedProvider.GetCommonProperties(projectInstance: null);
 
             // Verify interception for GetEvaluatedPropertyValueAsync.
-            var propertyValue = await properties.GetEvaluatedPropertyValueAsync(MockPropertyName);
+            string? propertyValue = await properties.GetEvaluatedPropertyValueAsync(MockPropertyName);
             Assert.True(getEvaluatedInvoked);
 
             // Verify interception for GetUnevaluatedPropertyValueAsync.

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentComposition.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentComposition.cs
@@ -171,7 +171,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
                 if (contractName != null || contractType != null)
                 {
-                    AddContractMetadata(contracts, contractName ?? contractType.FullName, assemblyAttribute.Scope, assemblyAttribute.Provider, assemblyAttribute.Cardinality);
+                    AddContractMetadata(contracts, contractName ?? contractType!.FullName, assemblyAttribute.Scope, assemblyAttribute.Provider, assemblyAttribute.Cardinality);
                 }
             }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/DebugProfileEnumValuesGeneratorTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/DebugProfileEnumValuesGeneratorTests.cs
@@ -65,19 +65,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 new DebugProfileEnumValuesGenerator(moqProfileProvider.Object, threadingService);
 
             Assert.False(generator.AllowCustomValues);
-            IEnumValue result = await generator.TryCreateEnumValueAsync("Profile1");
-            Assert.True(result.Name == "Profile1" && result.DisplayName == "Profile1");
+            IEnumValue? result = await generator.TryCreateEnumValueAsync("Profile1");
+            Assert.True(result!.Name == "Profile1" && result.DisplayName == "Profile1");
             result = await generator.TryCreateEnumValueAsync("MyCommand");
-            Assert.True(result.Name == "MyCommand" && result.DisplayName == "MyCommand");
+            Assert.True(result!.Name == "MyCommand" && result.DisplayName == "MyCommand");
 
             // case sensitive check
             result = await generator.TryCreateEnumValueAsync("mycommand");
             Assert.Null(result);
 
             result = await generator.TryCreateEnumValueAsync("Foo");
-            Assert.True(result.Name == "Foo" && result.DisplayName == "Foo");
+            Assert.True(result!.Name == "Foo" && result.DisplayName == "Foo");
             result = await generator.TryCreateEnumValueAsync("Bar");
-            Assert.True(result.Name == "Bar" && result.DisplayName == "Bar");
+            Assert.True(result!.Name == "Bar" && result.DisplayName == "Bar");
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasic/MapDynamicEnumValuesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasic/MapDynamicEnumValuesProviderTests.cs
@@ -80,9 +80,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic
         }
 
 
-        private static void VerifySameValue(IEnumValue actual, IEnumValue expected, bool checkMapNameOnly = false)
+        private static void VerifySameValue(IEnumValue? actual, IEnumValue expected, bool checkMapNameOnly = false)
         {
-            Assert.True(string.Compare(actual.Name, expected.Name) == 0);
+            Assert.NotNull(actual);
+            Assert.True(string.Compare(actual!.Name, expected.Name) == 0);
 
             if (!checkMapNameOnly)
             {


### PR DESCRIPTION
Fixes #5497

Updates CPS to version 16.1.76 which is the first version to include C# 8 Nullable Reference Type annotations. These annotations require some updates to our code, as seen in this PR.