### PR TITLE
Suppress "Open in Object Browser" for NuGet packages

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesNodeCommandGroupHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesNodeCommandGroupHandler.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    /// <summary>
+    /// Command handler that provides special handling for standard commands on dependency nodes.
+    /// </summary>
+    /// <remarks>
+    /// CPS provides a handler for the same commands, however it does not know anything special about dependency nodes.
+    /// </remarks>
+    [ExportCommandGroup(VSConstants.CMDSETID.StandardCommandSet2K_string)]
+    [AppliesTo(ProjectCapability.DependenciesTree)]
+    [Order(10)]
+    internal sealed class DependenciesNodeCommandGroupHandler : ICommandGroupHandler
+    {
+        private static readonly CommandStatusResult s_suppressedResult = new CommandStatusResult(handled: true, null, CommandStatus.NotSupported | CommandStatus.Invisible);
+
+        public CommandStatusResult GetCommandStatus(IImmutableSet<IProjectTree> nodes, long commandId, bool focused, string commandText, CommandStatus progressiveStatus)
+        {
+            var cmdId = (VSConstants.VSStd2KCmdID)commandId;
+
+            switch (cmdId)
+            {
+                case VSConstants.VSStd2KCmdID.QUICKOBJECTSEARCH: // Open in Object Browser
+                {
+                    if (nodes.Count == 1)
+                    {
+                        IProjectTree tree = nodes.First();
+
+                        if (tree.Flags.Contains(DependencyTreeFlags.NuGetPackageDependency))
+                        {
+                            // Suppress "Open in Object Browser" for NuGet packages
+                            return s_suppressedResult;
+                        }
+                    }
+
+                    break;
+                }
+            }
+
+            return CommandStatusResult.Unhandled;
+        }
+
+        public bool TryHandleCommand(IImmutableSet<IProjectTree> nodes, long commandId, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SuppressObjectBrowserForPackageReferenceCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SuppressObjectBrowserForPackageReferenceCommand.cs
@@ -7,22 +7,22 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
+    /// <summary>
+    /// Suppresses the "Open in Object Browser" command for NuGet packages.
+    /// </summary>
     [ProjectCommand(VSConstants.CMDSETID.StandardCommandSet2K_string, (long)VSConstants.VSStd2KCmdID.QUICKOBJECTSEARCH)]
     [AppliesTo(ProjectCapability.PackageReferences)]
     [Order(ProjectSystem.Order.Default)]
     internal sealed class SuppressObjectBrowserForPackageReferenceCommand : AbstractSingleNodeProjectCommand
     {
-        private static readonly Task<CommandStatusResult> s_suppressedResult = Task.FromResult(new CommandStatusResult(handled: true, null, CommandStatus.NotSupported | CommandStatus.Invisible));
-        
         protected override Task<CommandStatusResult> GetCommandStatusAsync(IProjectTree node, bool focused, string? commandText, CommandStatus progressiveStatus)
         {
             if (node.Flags.Contains(DependencyTreeFlags.NuGetPackageDependency))
             {
-                // Suppress "Open in Object Browser" for NuGet packages
-                return s_suppressedResult;
+                return GetCommandStatusResult.Suppressed;
             }
-         
-            return CommandStatusResult.Unhandled.AsTask();
+
+            return GetCommandStatusResult.Unhandled;
         }
 
         protected override Task<bool> TryHandleCommandAsync(IProjectTree node, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Input/GetCommandStatusResult.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Input/GetCommandStatusResult.cs
@@ -6,10 +6,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Input
 {
     internal static class GetCommandStatusResult
     {
-        public static Task<CommandStatusResult> Unhandled
-        {
-            get { return CommandStatusResult.Unhandled.AsTask(); }
-        }
+        public static Task<CommandStatusResult> Unhandled { get; } = CommandStatusResult.Unhandled.AsTask();
+
+        public static Task<CommandStatusResult> Suppressed { get; } = Task.FromResult(new CommandStatusResult(handled: true, null, CommandStatus.NotSupported | CommandStatus.Invisible));
 
         public static Task<CommandStatusResult> Handled(string? commandText, CommandStatus status)
         {


### PR DESCRIPTION
Fixes part of #1256.

There's nothing obviously correct to show for NuGet packages themselves in the Object Browser.

Instead we should in future allow the Object Browser to be launched from child nodes representing assemblies within the packages themselves (the other part of #1256).

Legacy doesn't offer Open in Object Browser for packages either, though if using `packages.config` then package assemblies are added directly as references and do work with the Object Browser.