### PR TITLE
Use References folder context menu

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeFlags.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeFlags.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         public static readonly ProjectTreeFlags DependencyFlags
                 = ProjectTreeFlags.Create("Dependency")
-                + ProjectTreeFlags.Create(ProjectTreeFlags.Common.VirtualFolder.ToString()) // TODO why ToString here?
+                + ProjectTreeFlags.Create(ProjectTreeFlags.Common.VirtualFolder)
                 + ProjectTreeFlags.Create(ProjectTreeFlags.Common.BubbleUp)
                 + SupportsRuleProperties
                 + SupportsRemove;
@@ -88,27 +88,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 + GenericDependency;
 
         internal static readonly ProjectTreeFlags TargetNode = ProjectTreeFlags.Create("TargetNode");
-        internal static readonly ProjectTreeFlags SubTreeRootNode = ProjectTreeFlags.Create("SubTreeRootNode");
+        internal static readonly ProjectTreeFlags SubTreeRootNode = ProjectTreeFlags.Create(ProjectTreeFlags.Common.VirtualFolder) +
+                                                                    ProjectTreeFlags.Create(ProjectTreeFlags.Common.ReferencesFolder);
+        
 
-        internal static readonly ProjectTreeFlags AnalyzerSubTreeRootNode = ProjectTreeFlags.Create("AnalyzerSubTreeRootNode");
         internal static readonly ProjectTreeFlags AnalyzerDependency = ProjectTreeFlags.Create("AnalyzerDependency");
 
-        internal static readonly ProjectTreeFlags AssemblySubTreeRootNode = ProjectTreeFlags.Create("AssemblySubTreeRootNode");
         internal static readonly ProjectTreeFlags AssemblyDependency = ProjectTreeFlags.Create("AssemblyDependency");
 
-        internal static readonly ProjectTreeFlags ComSubTreeRootNode = ProjectTreeFlags.Create("ComSubTreeRootNode");
         internal static readonly ProjectTreeFlags ComDependency = ProjectTreeFlags.Create("ComDependency");
 
-        internal static readonly ProjectTreeFlags NuGetSubTreeRootNode = ProjectTreeFlags.Create("NuGetSubTreeRootNode");
         internal static readonly ProjectTreeFlags NuGetDependency = ProjectTreeFlags.Create("NuGetDependency");
         internal static readonly ProjectTreeFlags NuGetPackageDependency = ProjectTreeFlags.Create("NuGetPackageDependency");
         internal static readonly ProjectTreeFlags FrameworkAssembliesNode = ProjectTreeFlags.Create("FrameworkAssembliesNode");
         internal static readonly ProjectTreeFlags FxAssemblyDependency = ProjectTreeFlags.Create("FxAssemblyDependency");
 
-        internal static readonly ProjectTreeFlags FrameworkSubTreeRootNode = ProjectTreeFlags.Create("FrameworkSubTreeRootNode");
         internal static readonly ProjectTreeFlags FrameworkDependency = ProjectTreeFlags.Create("FrameworkDependency");
 
-        internal static readonly ProjectTreeFlags ProjectSubTreeRootNode = ProjectTreeFlags.Create("ProjectSubTreeRootNode");
         internal static readonly ProjectTreeFlags ProjectDependency = ProjectTreeFlags.Create("ProjectDependency");
 
         internal static readonly ProjectTreeFlags SharedProjectFlags
@@ -119,7 +115,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         internal static readonly ProjectTreeFlags ErrorDiagnostic = ProjectTreeFlags.Create("ErrorDiagnostic");
         internal static readonly ProjectTreeFlags WarningDiagnostic = ProjectTreeFlags.Create("WarningDiagnostic");
 
-        internal static readonly ProjectTreeFlags SdkSubTreeRootNode = ProjectTreeFlags.Create("SdkSubTreeRootNode");
         internal static readonly ProjectTreeFlags SdkDependency = ProjectTreeFlags.Create("SdkDependency");
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/SubTreeRootDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/SubTreeRootDependencyModel.cs
@@ -4,12 +4,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class SubTreeRootDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
-            add: DependencyTreeFlags.DependencyFlags +
-                 DependencyTreeFlags.SubTreeRootNode,
-            remove: DependencyTreeFlags.SupportsRuleProperties +
-                    DependencyTreeFlags.SupportsRemove);
-
         public override string ProviderType { get; }
 
         public override DependencyIconSet IconSet { get; }
@@ -17,12 +11,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
         public SubTreeRootDependencyModel(
             string providerType,
             string name,
-            DependencyIconSet iconSet,
-            ProjectTreeFlags flags)
+            DependencyIconSet iconSet)
             : base(
                 name,
                 originalItemSpec: name,
-                flags: flags + s_flagCache.Get(isResolved: true, isImplicit: false),
+                flags: DependencyTreeFlags.SubTreeRootNode,
                 isResolved: true,
                 isImplicit: false,
                 properties: null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AnalyzerRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AnalyzerRuleHandler.cs
@@ -23,8 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 icon: KnownMonikers.CodeInformation,
                 expandedIcon: KnownMonikers.CodeInformation,
                 unresolvedIcon: ManagedImageMonikers.CodeInformationWarning,
-                unresolvedExpandedIcon: ManagedImageMonikers.CodeInformationWarning),
-            DependencyTreeFlags.AnalyzerSubTreeRootNode);
+                unresolvedExpandedIcon: ManagedImageMonikers.CodeInformationWarning));
 
         public AnalyzerRuleHandler()
             : base(AnalyzerReference.SchemaName, ResolvedAnalyzerReference.SchemaName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AssemblyRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AssemblyRuleHandler.cs
@@ -23,8 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 icon: KnownMonikers.Reference,
                 expandedIcon: KnownMonikers.Reference,
                 unresolvedIcon: KnownMonikers.ReferenceWarning,
-                unresolvedExpandedIcon: KnownMonikers.ReferenceWarning),
-            DependencyTreeFlags.AssemblySubTreeRootNode);
+                unresolvedExpandedIcon: KnownMonikers.ReferenceWarning));
 
         public AssemblyRuleHandler()
             : base(AssemblyReference.SchemaName, ResolvedAssemblyReference.SchemaName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ComRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ComRuleHandler.cs
@@ -22,8 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 icon: ManagedImageMonikers.Component,
                 expandedIcon: ManagedImageMonikers.Component,
                 unresolvedIcon: ManagedImageMonikers.ComponentWarning,
-                unresolvedExpandedIcon: ManagedImageMonikers.ComponentWarning),
-            DependencyTreeFlags.ComSubTreeRootNode);
+                unresolvedExpandedIcon: ManagedImageMonikers.ComponentWarning));
 
         public ComRuleHandler()
             : base(ComReference.SchemaName, ResolvedCOMReference.SchemaName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/FrameworkRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/FrameworkRuleHandler.cs
@@ -22,8 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 icon: ManagedImageMonikers.Framework,
                 expandedIcon: ManagedImageMonikers.Framework,
                 unresolvedIcon: ManagedImageMonikers.FrameworkWarning,
-                unresolvedExpandedIcon: ManagedImageMonikers.FrameworkWarning),
-            DependencyTreeFlags.FrameworkSubTreeRootNode);
+                unresolvedExpandedIcon: ManagedImageMonikers.FrameworkWarning));
 
         public FrameworkRuleHandler()
             : base(FrameworkReference.SchemaName, ResolvedFrameworkReference.SchemaName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -23,8 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 icon: ManagedImageMonikers.NuGetGrey,
                 expandedIcon: ManagedImageMonikers.NuGetGrey,
                 unresolvedIcon: ManagedImageMonikers.NuGetGreyWarning,
-                unresolvedExpandedIcon: ManagedImageMonikers.NuGetGreyWarning),
-            DependencyTreeFlags.NuGetSubTreeRootNode);
+                unresolvedExpandedIcon: ManagedImageMonikers.NuGetGreyWarning));
 
         private readonly ITargetFrameworkProvider _targetFrameworkProvider;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ProjectRuleHandler.cs
@@ -29,8 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 icon: KnownMonikers.Application,
                 expandedIcon: KnownMonikers.Application,
                 unresolvedIcon: ManagedImageMonikers.ApplicationWarning,
-                unresolvedExpandedIcon: ManagedImageMonikers.ApplicationWarning),
-            DependencyTreeFlags.ProjectSubTreeRootNode);
+                unresolvedExpandedIcon: ManagedImageMonikers.ApplicationWarning));
 
         public override string ProviderType => ProviderTypeString;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/SdkRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/SdkRuleHandler.cs
@@ -23,8 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 icon: ManagedImageMonikers.Sdk,
                 expandedIcon: ManagedImageMonikers.Sdk,
                 unresolvedIcon: ManagedImageMonikers.SdkWarning,
-                unresolvedExpandedIcon: ManagedImageMonikers.SdkWarning),
-            DependencyTreeFlags.SdkSubTreeRootNode);
+                unresolvedExpandedIcon: ManagedImageMonikers.SdkWarning));
 
         public SdkRuleHandler()
             : base(SdkReference.SchemaName, ResolvedSdkReference.SchemaName)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SubTreeRootDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SubTreeRootDependencyModelTests.cs
@@ -16,13 +16,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 expandedIcon: KnownMonikers.AboutBox,
                 unresolvedIcon: KnownMonikers.AbsolutePosition,
                 unresolvedExpandedIcon: KnownMonikers.AbsolutePosition);
-            var flag = ProjectTreeFlags.Create("MyCustomFlag");
 
             var model = new SubTreeRootDependencyModel(
                 "myProvider",
                 "myRoot",
-                iconSet,
-                flags: flag);
+                iconSet);
 
             Assert.Equal("myProvider", model.ProviderType);
             Assert.Equal("myRoot", model.Path);
@@ -33,14 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.AboutBox, model.ExpandedIcon);
             Assert.Equal(KnownMonikers.AbsolutePosition, model.UnresolvedIcon);
             Assert.Equal(KnownMonikers.AbsolutePosition, model.UnresolvedExpandedIcon);
-            Assert.Equal(
-                flag + 
-                DependencyTreeFlags.GenericResolvedDependencyFlags + 
-                DependencyTreeFlags.DependencyFlags +
-                DependencyTreeFlags.SubTreeRootNode -
-                DependencyTreeFlags.SupportsRuleProperties -
-                DependencyTreeFlags.SupportsRemove,
-                model.Flags);
+            Assert.Equal(DependencyTreeFlags.SubTreeRootNode, model.Flags);
         }
     }
 }


### PR DESCRIPTION
We were using IDM_VS_CTXT_REFERENCE context menu for the Packages/Projects/References node because CPS throught they were "References". We've stopped marking them as as Reference and instead ReferenceFolder, which causes CPS to use the IDM_VS_CTXT_REFERENCEROOT context menu.

Also simplified the number of flags we were using for the nodes - they aren't being used anywhere and we can them back if we need them.

Before:
![image](https://user-images.githubusercontent.com/1103906/65291704-e4ff6c00-db97-11e9-8150-7788bcf95523.png)


After:

![image](https://user-images.githubusercontent.com/1103906/65291640-ab2e6580-db97-11e9-88eb-b83b6f2b0d88.png)
