### PR TITLE
Consider reachability of unresolved children in dependencies node

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -447,7 +447,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
                     if (_treeTelemetryService.IsActive)
                     {
-                        await _treeTelemetryService.ObserveTreeUpdateCompletedAsync(snapshot.HasVisibleUnresolvedDependency);
+                        await _treeTelemetryService.ObserveTreeUpdateCompletedAsync(snapshot.HasReachableVisibleUnresolvedDependency);
                     }
                 }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             dependenciesTree = CleanupOldNodes(dependenciesTree, currentTopLevelNodes);
 
-            ProjectImageMoniker rootIcon = _viewModelFactory.GetDependenciesRootIcon(snapshot.HasVisibleUnresolvedDependency).ToProjectSystemType();
+            ProjectImageMoniker rootIcon = _viewModelFactory.GetDependenciesRootIcon(snapshot.HasReachableVisibleUnresolvedDependency).ToProjectSystemType();
 
             return dependenciesTree.SetProperties(icon: rootIcon, expandedIcon: rootIcon);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/TargetDependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/TargetDependencyViewModel.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
         {
             Caption = snapshot.TargetFramework.FriendlyName;
             Flags = DependencyTreeFlags.TargetNode.Add($"$TFM:{snapshot.TargetFramework.FullName}");
-            _hasUnresolvedDependency = snapshot.HasVisibleUnresolvedDependency;
+            _hasUnresolvedDependency = snapshot.HasReachableVisibleUnresolvedDependency;
         }
 
         public string Caption { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -223,10 +223,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public ImmutableDictionary<ITargetFramework, TargetedDependenciesSnapshot> DependenciesByTargetFramework { get; }
 
         /// <summary>
-        /// Gets whether this snapshot contains at least one unresolved/broken dependency at any level
-        /// for any target framework which is visible.
+        /// Gets whether this snapshot contains at least one unresolved dependency which is both visible
+        /// and reachable from a visible top-level dependency, for any target framework.
         /// </summary>
-        public bool HasVisibleUnresolvedDependency => DependenciesByTargetFramework.Any(x => x.Value.HasVisibleUnresolvedDependency);
+        public bool HasReachableVisibleUnresolvedDependency => DependenciesByTargetFramework.Any(x => x.Value.HasReachableVisibleUnresolvedDependency);
 
         /// <summary>
         /// Finds dependency for given id across all target frameworks.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/UnresolvedProjectReferenceSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/UnresolvedProjectReferenceSnapshotFilter.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             {
                 TargetedDependenciesSnapshot? snapshot = _aggregateSnapshotProvider.GetSnapshot(dependency);
 
-                if (snapshot != null && snapshot.HasVisibleUnresolvedDependency)
+                if (snapshot != null && snapshot.HasReachableVisibleUnresolvedDependency)
                 {
                     context.Accept(dependency.ToUnresolved(ProjectReference.SchemaName));
                     return;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// </summary>
         public static IDependencyViewModel ToViewModel(this IDependency dependency, TargetedDependenciesSnapshot snapshot)
         {
-            bool hasUnresolvedDependency = !dependency.Resolved || snapshot.CheckForUnresolvedDependencies(dependency);
+            bool hasUnresolvedDependency = !dependency.Resolved || snapshot.ShouldAppearUnresolved(dependency);
 
             return new DependencyViewModel(dependency, hasUnresolvedDependency: hasUnresolvedDependency);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -246,11 +246,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public bool HasVisibleUnresolvedDependency { get; }
 
         /// <summary>
-        /// Efficient API for checking if a given dependency has an unresolved child dependency at any level. 
+        /// Gets whether this dependency's node should appear as unresolved in the dependencies tree.
         /// </summary>
         /// <param name="dependency"></param>
         /// <returns>Returns true if given dependency has unresolved child dependency at any level</returns>
-        public bool CheckForUnresolvedDependencies(IDependency dependency)
+        public bool ShouldAppearUnresolved(IDependency dependency)
         {
             lock (SyncLock)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -174,35 +174,160 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Catalogs = catalogs;
             DependenciesWorld = dependenciesWorld;
 
-            bool hasVisibleUnresolvedDependency = false;
-            ImmutableArray<IDependency>.Builder topLevelDependencies = ImmutableArray.CreateBuilder<IDependency>();
+            bool hasVisibleUnresolvedDependency;
 
-            foreach ((string id, IDependency dependency) in dependenciesWorld)
+            // Perform a single pass through dependencies, gathering as much information as possible
+            (TopLevelDependencies, _topLevelDependencyByPath, hasVisibleUnresolvedDependency) = Scan(dependenciesWorld, targetFramework);
+
+            if (hasVisibleUnresolvedDependency)
             {
-                System.Diagnostics.Debug.Assert(
-                    string.Equals(id, dependency.Id),
-                    "dependenciesWorld dictionary entry keys must match their value's ids.");
-
-                if (!dependency.Resolved && dependency.Visible)
-                {
-                    hasVisibleUnresolvedDependency = true;
-                }
-
-                if (dependency.TopLevel)
-                {
-                    topLevelDependencies.Add(dependency);
-
-                    if (!string.IsNullOrEmpty(dependency.Path))
-                    {
-                        _topLevelDependenciesByPathMap.Add(
-                            Dependency.GetID(TargetFramework, dependency.ProviderType, dependency.Path),
-                            dependency);
-                    }
-                }
+                // Walk the dependency graph to find visible, unresolved dependencies which are reachable
+                // from visible top-level dependencies.
+                _hasReachableVisibleUnresolvedById = FindReachableVisibleUnresolvedDependencies();
+            }
+            else
+            {
+                // There are no visible and unresolved dependencies in the snapshot
+                _hasReachableVisibleUnresolvedById = null;
             }
 
-            HasVisibleUnresolvedDependency = hasVisibleUnresolvedDependency;
-            TopLevelDependencies = topLevelDependencies.ToImmutable();
+            return;
+
+            static (ImmutableArray<IDependency> TopLevelDependencies, Dictionary<string, IDependency> topLevelDependencyByPath, bool hasVisibleUnresolvedDependency) Scan(ImmutableDictionary<string, IDependency> dependenciesWorld, ITargetFramework targetFramework)
+            {
+                // TODO use ToImmutableAndFree?
+                ImmutableArray<IDependency>.Builder topLevelDependencies = ImmutableArray.CreateBuilder<IDependency>();
+
+                bool hasVisibleUnresolvedDependency = false;
+                var topLevelDependencyByPath = new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase);
+
+                foreach ((string id, IDependency dependency) in dependenciesWorld)
+                {
+                    System.Diagnostics.Debug.Assert(
+                        string.Equals(id, dependency.Id),
+                        "dependenciesWorld dictionary entry keys must match their value's ids.");
+
+                    if (!dependency.Resolved && dependency.Visible)
+                    {
+                        hasVisibleUnresolvedDependency = true;
+                    }
+
+                    if (dependency.TopLevel)
+                    {
+                        topLevelDependencies.Add(dependency);
+
+                        if (!string.IsNullOrEmpty(dependency.Path))
+                        {
+                            topLevelDependencyByPath.Add(
+                                Dependency.GetID(targetFramework, dependency.ProviderType, dependency.Path),
+                                dependency);
+                        }
+                    }
+                }
+
+                return (topLevelDependencies.ToImmutable(), topLevelDependencyByPath, hasVisibleUnresolvedDependency);
+            }
+
+            IReadOnlyDictionary<string, bool>? FindReachableVisibleUnresolvedDependencies()
+            {
+                // It is possible that there exists a dependency which is both visible and unresolved, yet not
+                // actually present in the tree because one of its ancestors is not visible. Therefore instead
+                // of scanning all dependencies in the snapshot, we walk the dependency graph starting with
+                // top-level visible nodes, and remember those which have at least one visible, unresolved and
+                // reachable descendant.
+
+                bool hasReachableVisibleUnresolvedDependency = false;
+
+                var hasReachableVisibleUnresolvedById = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
+                // 'spine' is a stack containing an enumerator for each level of the graph, which is updated as
+                // we walk the graph. We are working with struct enumerators so need this array. It will grow
+                // if needed.
+                var spine = new ImmutableArray<IDependency>.Enumerator[8];
+                int depth = 0;
+
+                // Start with all top-level dependencies
+                spine[0] = TopLevelDependencies.GetEnumerator();
+
+                while (true)
+                {
+                    ref ImmutableArray<IDependency>.Enumerator level = ref spine[depth];
+
+                    // Move to next item at this level
+                    if (!level.MoveNext())
+                    {
+                        // This level is done, so pop back up a level
+                        depth--;
+
+                        if (depth < 0)
+                        {
+                            // No more levels, so finished tree traversal
+                            break;
+                        }
+
+                        // Resume the previous level
+                        continue;
+                    }
+
+                    // Wvaluate the current dependency
+                    IDependency dependency = level.Current;
+
+                    if (!dependency.Visible)
+                    {
+                        // Skip any hidden nodes
+                        continue;
+                    }
+
+                    if (hasReachableVisibleUnresolvedById.ContainsKey(dependency.Id))
+                    {
+                        // We've already visited this item, so skip it
+                        continue;
+                    }
+
+                    if (!dependency.Resolved)
+                    {
+                        // This node is unresolved
+                        hasReachableVisibleUnresolvedDependency = true;
+
+                        // This node is unresolved, so set it and all items up the spine as unresolved
+                        for (int i = 0; i <= depth; i++)
+                        {
+                            hasReachableVisibleUnresolvedById[spine[i].Current.Id] = true;
+                        }
+                    }
+                    else
+                    {
+                        // This node is resolved, set it to false. If a descendant is later
+                        // found which is visible, reachable and unresolved, then this dependency's
+                        // entry will be updated to 'true' as part of marking all entries in the spine.
+                        hasReachableVisibleUnresolvedById[dependency.Id] = false;
+                    }
+
+                    if (dependency.DependencyIDs.Length != 0)
+                    {
+                        // This dependency has child dependencies, so traverse into them
+                        depth++;
+
+                        if (depth == spine.Length)
+                        {
+                            // Grow the spine
+                            var newSpine = new ImmutableArray<IDependency>.Enumerator[depth << 1];
+                            Array.Copy(spine, newSpine, depth);
+                            spine = newSpine;
+                        }
+
+                        // Enumerate child dependencies
+                        spine[depth] = GetDependencyChildren(dependency).GetEnumerator();
+                    }
+                }
+
+                // If, after all that, all visible and reachable dependencies are resolved, return
+                // null as there is no value in a collection where every entry is false. Consumers
+                // of this collection are local to this class and will null appropriately.
+                return hasReachableVisibleUnresolvedDependency
+                    ? hasReachableVisibleUnresolvedById
+                    : null;
+            }
         }
 
         #endregion
@@ -233,76 +358,52 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// </summary>
         public ImmutableDictionary<string, IDependency> DependenciesWorld { get; }
 
-        private readonly Dictionary<string, IDependency> _topLevelDependenciesByPathMap = new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase);
-        private readonly Dictionary<string, ImmutableArray<IDependency>> _dependenciesChildrenMap = new Dictionary<string, ImmutableArray<IDependency>>(StringComparer.OrdinalIgnoreCase);
-        private readonly Dictionary<string, bool> _unresolvedDescendantsMap = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
-
-        /// <summary>Re-use an existing, private, object reference for locking, rather than allocating a dedicated object.</summary>
-        private object SyncLock => _dependenciesChildrenMap;
+        /// <summary>
+        /// Maps each top-level dependency by its path, where path is composed of targetFramework/providerType/dependencyPath.
+        /// </summary>
+        private readonly Dictionary<string, IDependency> _topLevelDependencyByPath;
+        
+        /// <summary>
+        /// A map whose keys are the IDs of all reachable dependencies, and whose values are <see langword="true" /> if
+        /// the dependency has a reachable, visible, unresolved descendant, otherwise <see langword="false" />.
+        /// If this fields is <see langword="null" /> then there are no reachable visible unresolved dependencies in the
+        /// entire snapshot.
+        /// Any dependency not in this collection will not be displayed in the tree.
+        /// </summary>
+        private readonly IReadOnlyDictionary<string, bool>? _hasReachableVisibleUnresolvedById;
 
         /// <summary>
-        /// Specifies is this snapshot contains at least one unresolved/broken dependency at any level which is visible.
+        /// Gets whether this snapshot contains at least one unresolved dependency which is both visible
+        /// and reachable from a visible top-level dependency.
         /// </summary>
-        public bool HasVisibleUnresolvedDependency { get; }
+        public bool HasReachableVisibleUnresolvedDependency => _hasReachableVisibleUnresolvedById != null;
 
         /// <summary>
         /// Gets whether this dependency's node should appear as unresolved in the dependencies tree.
         /// </summary>
-        /// <param name="dependency"></param>
-        /// <returns>Returns true if given dependency has unresolved child dependency at any level</returns>
+        /// <remarks>
+        /// Returns <see langword="true" /> if, for either <paramref name="dependency"/> or one of its descendants, all of the following are true:
+        /// <list type="number">
+        ///   <item><see cref="IDependency.Visible"/> is <see langword="true" />, and</item>
+        ///   <item><see cref="IDependency.Resolved"/> is <see langword="false" />, and</item>
+        ///   <item>the dependency is reachable via the dependency graph from a visible top-level node, where all intermediate nodes are also visible.</item>
+        /// </list>
+        /// </remarks>
         public bool ShouldAppearUnresolved(IDependency dependency)
         {
-            lock (SyncLock)
+            if (_hasReachableVisibleUnresolvedById == null)
             {
-                if (!_unresolvedDescendantsMap.TryGetValue(dependency.Id, out bool unresolved))
-                {
-                    unresolved = _unresolvedDescendantsMap[dependency.Id] = FindUnresolvedDependenciesRecursive(dependency);
-                }
-
-                return unresolved;
-            }
-
-            bool FindUnresolvedDependenciesRecursive(IDependency parent)
-            {
-                if (parent.DependencyIDs.Length == 0)
-                {
-                    return false;
-                }
-
-                foreach (IDependency child in GetDependencyChildren(parent))
-                {
-                    if (!child.Visible)
-                    {
-                        return false;
-                    }
-
-                    if (!child.Resolved)
-                    {
-                        return true;
-                    }
-
-                    // If the dependency is already in the child map, it is resolved
-                    // Checking here will prevent a stack overflow due to rechecking the same dependencies
-                    if (_dependenciesChildrenMap.ContainsKey(child.Id))
-                    {
-                        return false;
-                    }
-
-                    if (!_unresolvedDescendantsMap.TryGetValue(child.Id, out bool depthFirstResult))
-                    {
-                        depthFirstResult = FindUnresolvedDependenciesRecursive(child);
-                        _unresolvedDescendantsMap[parent.Id] = depthFirstResult;
-                        return depthFirstResult;
-                    }
-
-                    if (depthFirstResult)
-                    {
-                        return true;
-                    }
-                }
-
+                // No reachable dependency in this snapshot is visible and unresolved
                 return false;
             }
+
+            if (_hasReachableVisibleUnresolvedById.TryGetValue(dependency.Id, out bool exists))
+            {
+                return exists;
+            }
+
+            System.Diagnostics.Debug.Fail("Snapshot should not be asked about unreachable dependency, or dependency not in snapshot.");
+            return !dependency.Resolved;
         }
 
         /// <summary>
@@ -312,11 +413,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// <returns>Returns true if there is at least one unresolved dependency with given providerType.</returns>
         public bool CheckForUnresolvedDependencies(string providerType)
         {
+            if (_hasReachableVisibleUnresolvedById == null)
+            {
+                return false;
+            }
+
             foreach ((string _, IDependency dependency) in DependenciesWorld)
             {
                 if (StringComparers.DependencyProviderTypes.Equals(dependency.ProviderType, providerType) &&
                     dependency.Visible &&
-                    !dependency.Resolved)
+                    !dependency.Resolved &&
+                    _hasReachableVisibleUnresolvedById.ContainsKey(dependency.Id))
                 {
                     return true;
                 }
@@ -336,35 +443,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             {
                 return ImmutableArray<IDependency>.Empty;
             }
+            
+            ImmutableArray<IDependency>.Builder children = ImmutableArray.CreateBuilder<IDependency>(dependency.DependencyIDs.Length);
 
-            lock (SyncLock)
+            foreach (string id in dependency.DependencyIDs)
             {
-                if (!_dependenciesChildrenMap.TryGetValue(dependency.Id, out ImmutableArray<IDependency> children))
+                // TODO what if a dependency's child isn't in the snapshot? is that a bug?
+                // TODO why is the ID also considered a path there?
+                if (DependenciesWorld.TryGetValue(id, out IDependency child) || _topLevelDependencyByPath.TryGetValue(id, out child))
                 {
-                    children = _dependenciesChildrenMap[dependency.Id] = BuildChildren();
+                    children.Add(child);
                 }
-
-                return children;
             }
 
-            ImmutableArray<IDependency> BuildChildren()
-            {
-                ImmutableArray<IDependency>.Builder children =
-                    ImmutableArray.CreateBuilder<IDependency>(dependency.DependencyIDs.Length);
-
-                foreach (string id in dependency.DependencyIDs)
-                {
-                    if (DependenciesWorld.TryGetValue(id, out IDependency child) ||
-                        _topLevelDependenciesByPathMap.TryGetValue(id, out child))
-                    {
-                        children.Add(child);
-                    }
-                }
-
-                return children.Count == children.Capacity
-                    ? children.MoveToImmutable()
-                    : children.ToImmutable();
-            }
+            return children.Count == children.Capacity
+                ? children.MoveToImmutable()
+                : children.ToImmutable();
         }
 
         public override string ToString() => $"{TargetFramework.FriendlyName} - {DependenciesWorld.Count} dependencies ({TopLevelDependencies.Length} top level) - {ProjectPath}";

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/DependenciesSnapshotFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/DependenciesSnapshotFactory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             if (hasUnresolvedDependency.HasValue)
             {
-                mock.Setup(x => x.HasVisibleUnresolvedDependency).Returns(hasUnresolvedDependency.Value);
+                mock.Setup(x => x.HasReachableVisibleUnresolvedDependency).Returns(hasUnresolvedDependency.Value);
             }
 
             if (activeTarget != null)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Assert.Same(projectPath, snapshot.ProjectPath);
             Assert.Same(targetFramework, snapshot.ActiveTargetFramework);
             Assert.Same(dependenciesByTargetFramework, snapshot.DependenciesByTargetFramework);
-            Assert.False(snapshot.HasVisibleUnresolvedDependency);
+            Assert.False(snapshot.HasReachableVisibleUnresolvedDependency);
             Assert.Null(snapshot.FindDependency("foo"));
         }
 
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Assert.Same(projectPath, snapshot.ProjectPath);
             Assert.Same(TargetFramework.Empty, snapshot.ActiveTargetFramework);
             Assert.Empty(snapshot.DependenciesByTargetFramework);
-            Assert.False(snapshot.HasVisibleUnresolvedDependency);
+            Assert.False(snapshot.HasReachableVisibleUnresolvedDependency);
             Assert.Null(snapshot.FindDependency("foo"));
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 SchemaItemType = "MySchemaItemType",
                 Priority = 1,
                 Resolved = true,
+                TopLevel = true,
                 IconSet = iconSet
             };
 
@@ -43,6 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 SchemaItemType = "MySchemaItemType",
                 Priority = 1,
                 Resolved = false,
+                TopLevel = true,
                 IconSet = iconSet
             };
 
@@ -57,6 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 SchemaItemType = "MySchemaItemType",
                 Priority = 1,
                 Resolved = true,
+                TopLevel = true,
                 IconSet = iconSet,
                 DependencyIDs = ImmutableArray.Create(dependencyUnresolved.Id)
             };
@@ -66,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             var snapshotUnresolvedChild = TargetedDependenciesSnapshotFactory.ImplementFromDependencies(new[] { dependencyUnresolved, dependencyUnresolvedChild });
 
             Assert.False(snapshotResolved.ShouldAppearUnresolved(dependencyResolved));
-            Assert.False(snapshotUnresolved.ShouldAppearUnresolved(dependencyResolved));
+            Assert.True(snapshotUnresolved.ShouldAppearUnresolved(dependencyUnresolved));
             Assert.True(snapshotUnresolvedChild.ShouldAppearUnresolved(dependencyUnresolvedChild));
 
             var viewModelResolved = dependencyResolved.ToViewModel(snapshotResolved);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
@@ -65,9 +65,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             var snapshotUnresolved      = TargetedDependenciesSnapshotFactory.ImplementFromDependencies(new[] { dependencyUnresolved });
             var snapshotUnresolvedChild = TargetedDependenciesSnapshotFactory.ImplementFromDependencies(new[] { dependencyUnresolved, dependencyUnresolvedChild });
 
-            Assert.False(snapshotResolved.CheckForUnresolvedDependencies(dependencyResolved));
-            Assert.False(snapshotUnresolved.CheckForUnresolvedDependencies(dependencyResolved));
-            Assert.True(snapshotUnresolvedChild.CheckForUnresolvedDependencies(dependencyUnresolvedChild));
+            Assert.False(snapshotResolved.ShouldAppearUnresolved(dependencyResolved));
+            Assert.False(snapshotUnresolved.ShouldAppearUnresolved(dependencyResolved));
+            Assert.True(snapshotUnresolvedChild.ShouldAppearUnresolved(dependencyUnresolvedChild));
 
             var viewModelResolved = dependencyResolved.ToViewModel(snapshotResolved);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -632,7 +632,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         [Fact]
-        public void CheckForUnresolvedDependencies()
+        public void ShouldAppearUnresolved()
         {
             var unresolved = new TestDependency
             {
@@ -658,8 +658,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             var snapshot = TargetedDependenciesSnapshotFactory.ImplementFromDependencies(new IDependency[] { resolvedWithUnresolvedChild, unresolved, resolved });
 
-            Assert.True(snapshot.CheckForUnresolvedDependencies(resolvedWithUnresolvedChild));
-            Assert.False(snapshot.CheckForUnresolvedDependencies(resolved));
+            Assert.True(snapshot.ShouldAppearUnresolved(resolvedWithUnresolvedChild));
+            Assert.False(snapshot.ShouldAppearUnresolved(resolved));
         }
 
         /// <summary>
@@ -667,7 +667,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// https://github.com/dotnet/project-system/issues/3374
         /// </summary>
         [Fact]
-        public void CheckForUnresolvedDependencies_CircularDependency_DoesNotRecurseInfinitely()
+        public void ShouldAppearUnresolved_CircularDependency_DoesNotRecurseInfinitely()
         {
             const string id1 = @"tfm1\xxx\dependency1";
             const string id2 = @"tfm1\xxx\dependency2";
@@ -692,7 +692,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             var snapshot = TargetedDependenciesSnapshotFactory.ImplementFromDependencies(new IDependency[] { dependency1, dependency2 });
 
             // verify it doesn't stack overflow
-            snapshot.CheckForUnresolvedDependencies(dependency1);   
+            snapshot.ShouldAppearUnresolved(dependency1);   
         }
 
         internal sealed class TestDependenciesSnapshotFilter : IDependenciesSnapshotFilter

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Assert.Same(projectPath, snapshot.ProjectPath);
             Assert.Same(targetFramework, snapshot.TargetFramework);
             Assert.Same(catalogs, snapshot.Catalogs);
-            Assert.False(snapshot.HasVisibleUnresolvedDependency);
+            Assert.False(snapshot.HasReachableVisibleUnresolvedDependency);
             Assert.Empty(snapshot.TopLevelDependencies);
             Assert.Empty(snapshot.DependenciesWorld);
             Assert.False(snapshot.CheckForUnresolvedDependencies("foo"));
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Assert.Same(projectPath, snapshot.ProjectPath);
             Assert.Same(targetFramework, snapshot.TargetFramework);
             Assert.Same(catalogs, snapshot.Catalogs);
-            Assert.False(snapshot.HasVisibleUnresolvedDependency);
+            Assert.False(snapshot.HasReachableVisibleUnresolvedDependency);
             Assert.Empty(snapshot.TopLevelDependencies);
             Assert.Empty(snapshot.DependenciesWorld);
             Assert.False(snapshot.CheckForUnresolvedDependencies("foo"));
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Assert.NotSame(previousSnapshot, snapshot);
             Assert.Same(updatedProjectPath, snapshot.ProjectPath);
             Assert.Same(catalogs, snapshot.Catalogs);
-            Assert.True(snapshot.HasVisibleUnresolvedDependency);
+            Assert.False(snapshot.HasReachableVisibleUnresolvedDependency);
             AssertEx.CollectionLength(snapshot.DependenciesWorld, 2);
             AssertEx.CollectionLength(snapshot.TopLevelDependencies, 1);
             Assert.True(resolvedTop.Matches(snapshot.TopLevelDependencies.Single(), targetFramework));
@@ -634,32 +634,109 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         [Fact]
         public void ShouldAppearUnresolved()
         {
-            var unresolved = new TestDependency
+            var unresolvedTopLevel = new TestDependency
             {
                 ProviderType = "Yyy",
-                Id = "tfm1\\yyy\\child",
-                Resolved = false
+                Id = "tfm1\\yyy\\unresolvedTopLevel",
+                Resolved = false,
+                TopLevel = true
             };
 
-            var resolvedWithUnresolvedChild = new TestDependency
+            var unresolvedReachable = new TestDependency
             {
                 ProviderType = "Yyy",
-                Id = "tfm1\\yyy\\1",
+                Id = "tfm1\\yyy\\unresolvedReachable",
+                Resolved = false,
+                TopLevel = false
+            };
+
+            var resolvedUnreachableWithHiddenParent = new TestDependency
+            {
+                ProviderType = "Yyy",
+                Id = "tfm1\\yyy\\resolvedUnreachableWithHiddenParent",
                 Resolved = true,
-                DependencyIDs = ImmutableArray.Create(unresolved.Id)
+                TopLevel = false
             };
 
-            var resolved = new TestDependency
+            var resolvedHiddenParent = new TestDependency
             {
                 ProviderType = "Yyy",
-                Id = "tfm1\\yyy\\2",
-                Resolved = true
+                Id = "tfm1\\yyy\\resolvedHiddenParent",
+                Resolved = true,
+                TopLevel = true,
+                Visible = false,
+                DependencyIDs = ImmutableArray.Create(resolvedUnreachableWithHiddenParent.Id)
             };
 
-            var snapshot = TargetedDependenciesSnapshotFactory.ImplementFromDependencies(new IDependency[] { resolvedWithUnresolvedChild, unresolved, resolved });
+            var resolvedTopLevelWithUnresolvedChild = new TestDependency
+            {
+                ProviderType = "Yyy",
+                Id = "tfm1\\yyy\\resolvedTopLevelWithUnresolvedChild",
+                Resolved = true,
+                TopLevel = true,
+                DependencyIDs = ImmutableArray.Create(unresolvedReachable.Id)
+            };
 
-            Assert.True(snapshot.ShouldAppearUnresolved(resolvedWithUnresolvedChild));
-            Assert.False(snapshot.ShouldAppearUnresolved(resolved));
+            var resolvedTopLevel = new TestDependency
+            {
+                ProviderType = "Yyy",
+                Id = "tfm1\\yyy\\resolvedTopLevel",
+                Resolved = true,
+                TopLevel = true
+            };
+            
+            var resolvedUnreachable = new TestDependency
+            {
+                ProviderType = "Yyy",
+                Id = "tfm1\\yyy\\resolvedUnreachable",
+                Resolved = true,
+                TopLevel = false
+            };
+            
+            var resolvedChildWithVisibleUnresolvedParent = new TestDependency
+            {
+                ProviderType = "Yyy",
+                Id = "tfm1\\yyy\\resolvedChildWithVisibleUnresolvedParent",
+                Resolved = true,
+                TopLevel = false
+            };
+
+            var unresolvedTopLevelWithUnresolvedChild = new TestDependency
+            {
+                ProviderType = "Yyy",
+                Id = "tfm1\\yyy\\unresolvedTopLevelWithUnresolvedChild",
+                Resolved = false,
+                TopLevel = true,
+                DependencyIDs = ImmutableArray.Create(resolvedChildWithVisibleUnresolvedParent.Id)
+            };
+
+            var snapshot = TargetedDependenciesSnapshotFactory.ImplementFromDependencies(new IDependency[]
+            {
+                unresolvedTopLevel, unresolvedReachable, resolvedUnreachableWithHiddenParent, resolvedHiddenParent,
+                resolvedTopLevelWithUnresolvedChild, resolvedTopLevel, resolvedUnreachable, resolvedChildWithVisibleUnresolvedParent,
+                unresolvedTopLevelWithUnresolvedChild
+            });
+
+            Assert.True(snapshot.ShouldAppearUnresolved(unresolvedTopLevel));
+            Assert.True(snapshot.ShouldAppearUnresolved(unresolvedReachable));
+            Assert.True(snapshot.ShouldAppearUnresolved(resolvedTopLevelWithUnresolvedChild));
+            Assert.True(snapshot.ShouldAppearUnresolved(unresolvedTopLevelWithUnresolvedChild));
+            Assert.False(snapshot.ShouldAppearUnresolved(resolvedTopLevel));
+            Assert.False(snapshot.ShouldAppearUnresolved(resolvedChildWithVisibleUnresolvedParent));
+#if DEBUG
+            // These throw in unit tests but assert elsewhere
+            Assert.ThrowsAny<Exception>(() => snapshot.ShouldAppearUnresolved(resolvedUnreachable));
+            Assert.ThrowsAny<Exception>(() => snapshot.ShouldAppearUnresolved(resolvedHiddenParent));
+            Assert.ThrowsAny<Exception>(() => snapshot.ShouldAppearUnresolved(resolvedUnreachableWithHiddenParent));
+            Assert.ThrowsAny<Exception>(() => snapshot.ShouldAppearUnresolved(new TestDependency { Id = "ID", Resolved = false }));
+            Assert.ThrowsAny<Exception>(() => snapshot.ShouldAppearUnresolved(new TestDependency { Id = "ID", Resolved = true }));
+#else
+            Assert.False(snapshot.ShouldAppearUnresolved(resolvedUnreachable));
+            Assert.False(snapshot.ShouldAppearUnresolved(resolvedHiddenParent));
+            Assert.False(snapshot.ShouldAppearUnresolved(resolvedUnreachableWithHiddenParent));
+            Assert.True(snapshot.ShouldAppearUnresolved(new TestDependency { Id = "ID", Resolved = false }));
+            Assert.False(snapshot.ShouldAppearUnresolved(new TestDependency { Id = "ID", Resolved = true }));
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #5539.

Previous logic would display a dependency as unresolved if it had a descendant that was unresolved yet not actually displayed in the tree due to an intermediary node being hidden.

This change determines this status of dependencies by walking the graph from visible top-level nodes.

With this change I believe it's no longer possible to show a dependency or dependency group as unresolved which does not have an unresolved child (or is unresolved itself). I'm really pleased to have gotten rid of this confusing UI state.

Because we now walk the tree, it's no longer necessary to lazily compute and store a bunch of additional information about the snapshot. This means several collections have been removed, along with locks to protect them. There's no locking as state no longer changes after construction.

---

## Before

Empty `netcoreapp3.0` project (on my machine with broken SDK):

![image](https://user-images.githubusercontent.com/350947/65397727-cd252380-ddf5-11e9-9b31-3d0475cc7bdc.png)

And if you add a package reference:

![image](https://user-images.githubusercontent.com/350947/65397743-f1810000-ddf5-11e9-902e-2a808ac67c1d.png)

## After

![image](https://user-images.githubusercontent.com/350947/65413759-78a19880-de35-11e9-9f8a-4db22048601e.png)

And with a package reference:

![image](https://user-images.githubusercontent.com/350947/65413738-6b84a980-de35-11e9-8ec2-3f77c2e594bd.png)
