### PR TITLE
Fix re-entrant initialisation

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -188,8 +188,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     return;
                 }
 
-                await InitializeAsync();
-
                 await OnConfiguredProjectEvaluatedAsync(e);
             }
         }


### PR DESCRIPTION
Fixes #5531. 

The initialisation code had a pathway that would attempt to trigger initialisation again. The base class `OnceInitializedOnceDisposedAsync` does not support this re-entrancy.
