### PR TITLE
Hide broken templates for VB WinForms projects too

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilter.cs
@@ -58,7 +58,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
 
             // These item templates are an older style that can't be filtered by capabilities, and use a Wizard that is broken for .NET Core
             if (pszTemplateFile.EndsWith("\\CSControlInheritanceWizard.vsz", StringComparisons.Paths) ||
-                pszTemplateFile.EndsWith("\\CSFormInheritanceWizard.vsz", StringComparisons.Paths))
+                pszTemplateFile.EndsWith("\\CSFormInheritanceWizard.vsz", StringComparisons.Paths) ||
+                pszTemplateFile.EndsWith("\\InheritedControl.vsz", StringComparisons.Paths) ||
+                pszTemplateFile.EndsWith("\\InheritedForm.vsz", StringComparisons.Paths))
             {
                 pfFilter = 1;
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilterTests.cs
@@ -42,6 +42,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
         [Theory]
         [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\CSControlInheritanceWizard.vsz", true })]
         [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\CSFormInheritanceWizard.vsz", true })]
+        [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\InheritedForm.vsz", true })]
+        [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\InheritedControl.vsz", true })]
         [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\Class.vsz", false })]
         [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\ControlLibrary.vsz", false })]
         public void FiltersItemTemplateFiles(string templateDir, bool shouldBeFiltered)


### PR DESCRIPTION
Follow up to #5501 but for the VB templates, which are named slightly differently.

This fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/975632 but I'm not using the fancy AB# notation because I don't what this to close that. Strictly speaking https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/206040?_a=overview is the solution to that work item, this just responds to the change.