### PR TITLE
Set the length of the language version link text

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.vb
@@ -94,6 +94,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         Private Sub SetupLangVersionLinkLabel()
             Dim link = New LinkLabel.Link With {
+                .Length = lnkLabel.Text.Length,
                 .LinkData = My.Resources.Strings.CantSelectLanguageVersionFWLink
             }
             lnkLabel.Links.Add(link)


### PR DESCRIPTION
This ensures that the tab stop on the link is respected. Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/981334