### PR TITLE
Clean up untyped collections in the Resource Designer

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
@@ -256,7 +256,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     End If
                 End If
 
-                If _resourcesToSearch IsNot Nothing AndAlso _resourcesToSearch.Length <> View.ResourceFile.ResourcesHashTable.Count Then
+                If _resourcesToSearch IsNot Nothing AndAlso _resourcesToSearch.Length <> View.ResourceFile.Resources.Count Then
                     Debug.Fail("The number of resources has changed, but InvalidateFindLoop() wasn't called.  This must be called when resources are added/removed.")
                     _resourcesToSearch = Nothing 'defensive - force re-generation anyway
                 End If
@@ -524,12 +524,12 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 'First collect all the resources to search through
                 If FindInSelection Then
                     Dim SelectedResources() As Resource = View.GetSelectedResources()
-                    ResourcesToSearch = New ArrayList(View.ResourceFile.ResourcesHashTable.Count)
+                    ResourcesToSearch = New ArrayList(View.ResourceFile.Resources.Count)
                     For Each Resource As Resource In SelectedResources
                         ResourcesToSearch.Add(Resource)
                     Next
                 Else
-                    ResourcesToSearch = New ArrayList(View.ResourceFile.ResourcesHashTable.Count)
+                    ResourcesToSearch = New ArrayList(View.ResourceFile.Resources.Count)
                     For Each Entry As DictionaryEntry In View.ResourceFile
                         Dim Resource As Resource = DirectCast(Entry.Value, Resource)
                         ResourcesToSearch.Add(Resource)
@@ -565,7 +565,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             _currentFieldInCurrentIndex = Field.MinimumValue
 
-            If View.ResourceFile.ResourcesHashTable.Count = 0 Then
+            If View.ResourceFile.Resources.Count = 0 Then
                 'No resources at all.
                 _currentIndex = 0
                 Exit Sub

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -2572,10 +2572,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Fix">If true, the resource names are fixed to be legal identifiers (if not possible, will throw)</param>
         ''' <param name="CheckForDuplicateNames">If true, then the new names are checked to make sure they don't duplicate anything currently in the ResourceFile</param>
         ''' <remarks></remarks>
-        Public Shared Sub CheckResourceIdentifiers(ResourceFile As ResourceFile, Resources As ICollection, Fix As Boolean, CheckForDuplicateNames As Boolean)
+        Public Shared Sub CheckResourceIdentifiers(ResourceFile As ResourceFile, Resources As ICollection(Of Resource), Fix As Boolean, CheckForDuplicateNames As Boolean)
             Dim NewNames(Resources.Count - 1), NewFormattedNames(Resources.Count - 1) As String
             Dim i As Integer = 0
-            For Each Resource As Resource In Resources
+            For Each Resource In Resources
                 NewNames(i) = Resource.Name
                 i += 1
             Next
@@ -2587,7 +2587,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             i = 0
             If Fix Then
-                For Each resource As Resource In Resources
+                For Each resource In Resources
                     If Not resource.Name.Equals(NewFormattedNames(i), StringComparison.Ordinal) Then
                         resource.Name = NewFormattedNames(i)
                     End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -1867,7 +1867,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     'Force all names to be unique, both among themselves and within the ResourceFile
 
                     '... First, we create a case-insensitive hashtable with all the resource names in the ResourceFile
-                    Dim ResourceNameTable As Hashtable = Specialized.CollectionsUtil.CreateCaseInsensitiveHashtable(ResourceFile.ResourcesHashTable)
+                    Dim ResourceNameTable As Hashtable = Specialized.CollectionsUtil.CreateCaseInsensitiveHashtable(ResourceFile.Resources)
                     '... Then we add to this list as we check for uniqueness and make name changes...
                     For Each Resource In ResourcesReadyToAdd
                         Dim NewResourceName As String = Resource.Name

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -128,7 +128,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ' Undo status
         Private _inUndoing As Boolean
         Private _categoryAffected As Category
-        Private _resourcesAffected As Hashtable
+        Private _resourcesAffected As HashSet(Of Resource)
 
         ' Registry path
         Private _registryRoot As String
@@ -1331,7 +1331,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Resources">Resources to highlight</param>
         ''' <param name="SelectInPropertyGrid">If true, the property grid is updated with the new selection.</param>
         ''' <remarks></remarks>
-        Public Sub HighlightResources(Resources As ICollection, SelectInPropertyGrid As Boolean)
+        Public Sub HighlightResources(Resources As ICollection(Of Resource), SelectInPropertyGrid As Boolean)
             HighlightResourceHelper(Resources, 0, True, HighlightEntireResource:=True)
         End Sub
 
@@ -1377,10 +1377,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="SelectInPropertyGrid">If true, update the property grid with the new selection</param>
         ''' <param name="HighlightEntireResource">If true, Field is ignored and the entire resource is highlighted.</param>
         ''' <remarks></remarks>
-        Private Sub HighlightResourceHelper(Resources As ICollection, Field As FindReplace.Field, SelectInPropertyGrid As Boolean, HighlightEntireResource As Boolean)
+        Private Sub HighlightResourceHelper(Resources As ICollection(Of Resource), Field As FindReplace.Field, SelectInPropertyGrid As Boolean, HighlightEntireResource As Boolean)
             Dim NewCategory As Category = Nothing
             Dim ResourceCollection As New ArrayList()
-            For Each Resource As Resource In Resources
+            For Each Resource In Resources
                 If _resourceFile.Contains(Resource) Then
                     Dim CategoryOfResource As Category = Resource.GetCategory(_categories)
                     If NewCategory Is Nothing Then
@@ -1591,7 +1591,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Resources"></param>
         ''' <param name="SelectInPropertyGrid"></param>
         ''' <remarks></remarks>
-        Private Delegate Sub HighlightResourcesDelegate(Resources As ICollection, SelectInPropertyGrid As Boolean)
+        Private Delegate Sub HighlightResourcesDelegate(Resources As ICollection(Of Resource), SelectInPropertyGrid As Boolean)
 
 
         ''' <summary>
@@ -1662,8 +1662,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     'Then add them to the editor.
                     If AddToProject AndAlso Not CopyFileIfExists AndAlso Not AlwaysAddNew Then
                         ' we will replace the file in the project with the external file, and don't add a new resource item if it is already there
-                        Dim ResourcesReadyToAdd As New ArrayList(NewResources.Length) 'Resources which needed to be added
-                        Dim OldResources As New ArrayList(NewResources.Length)
+                        Dim ResourcesReadyToAdd As New List(Of Resource)(NewResources.Length) 'Resources which needed to be added
+                        Dim OldResources As New List(Of Resource)(NewResources.Length)
                         For i As Integer = 0 To NewResources.Length - 1
                             Dim Resource As Resource = NewResources(i)
                             Dim currentPath As String = Resource.AbsoluteLinkPathAndFileName
@@ -1736,7 +1736,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         UnselectAllResources()
                         HighlightResources(OldResources, True)
 
-                        Return CType(OldResources.ToArray(GetType(Resource)), Resource())
+                        Return OldResources.ToArray()
                     Else
                         ' Always Add...
                         AddResources(NewResources, CopyFileIfExists, AddToProject)
@@ -1760,7 +1760,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Forces all names to be unique, if necessary.
         ''' Caller must catch and display exceptions
         ''' </remarks>
-        Public Sub AddResources(NewResources As ICollection, CopyFileIfExists As Boolean, AddToProject As Boolean)
+        Public Sub AddResources(NewResources As ICollection(Of Resource), CopyFileIfExists As Boolean, AddToProject As Boolean)
             If NewResources Is Nothing OrElse NewResources.Count = 0 Then
                 Exit Sub
             End If
@@ -1772,7 +1772,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             'Set up the type resolution context for all the resources in the list.  If they came from copy/paste or drag/drop, they
             '  won't have it set up yet, and we'll need that in order to make changes (like the link path)
-            For Each Resource As Resource In NewResources
+            For Each Resource In NewResources
                 Resource.SetTypeResolutionContext(Me)
                 Resource.SetTypeNameConverter(ResourceFile)
             Next
@@ -1780,7 +1780,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ' Verify whether the resource items are supported by current platform
             ' NOTE: some projects like device projects do not support TIFF files. We don't want the user to add them into the resource, and hit the issue at runtime.
             '  We validate resource here, because a tiff item could be added from an external file, or copy from another resource editor...
-            For Each NewResource As Resource In NewResources
+            For Each NewResource In NewResources
                 Dim Message As String = String.Empty
                 Dim HelpID As String = String.Empty
 
@@ -1800,11 +1800,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 UnselectAllResources()
 
                 'Add the files pointed to by linked resources into the project.
-                Dim ResourcesReadyToAdd As New ArrayList(NewResources.Count) 'Resources which weren't canceled by the user.
+                Dim ResourcesReadyToAdd As New List(Of Resource)(NewResources.Count) 'Resources which weren't canceled by the user.
                 Dim projectBuildBatch As ProjectBatchEdit = Nothing
 
                 Try
-                    For Each Resource As Resource In NewResources
+                    For Each Resource In NewResources
                         If AddToProject AndAlso Resource.IsLink Then
                             If projectBuildBatch Is Nothing Then
                                 ' We should start a batch process if necessary...
@@ -1832,7 +1832,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                                     Resource.AbsoluteLinkPathAndFileName,
                                     CopyFileIfExists)
 
-                                If FinalPathAndFileName = "" Then
+                                If FinalPathAndFileName.Length = 0 Then
                                     'The user canceled (because a file already exists and s/he didn't want to replace it).
                                     'Continue to the next resource.
                                 Else
@@ -1869,7 +1869,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     '... First, we create a case-insensitive hashtable with all the resource names in the ResourceFile
                     Dim ResourceNameTable As Hashtable = Specialized.CollectionsUtil.CreateCaseInsensitiveHashtable(ResourceFile.ResourcesHashTable)
                     '... Then we add to this list as we check for uniqueness and make name changes...
-                    For Each Resource As Resource In ResourcesReadyToAdd
+                    For Each Resource In ResourcesReadyToAdd
                         Dim NewResourceName As String = Resource.Name
                         Dim Append As Integer = 0
                         While ResourceNameTable.ContainsKey(NewResourceName)
@@ -1915,7 +1915,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="NewResources">The resources to add to our display.</param>
         ''' <remarks></remarks>
-        Private Sub AddAndHighlightResourcesInView(NewResources As IList)
+        Private Sub AddAndHighlightResourcesInView(NewResources As IList(Of Resource))
             If NewResources Is Nothing OrElse NewResources.Count = 0 Then
                 Exit Sub
             End If
@@ -1947,8 +1947,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             End If
 
             'Figure out which resources are in the currently (possibly switched category)
-            Dim NewResourcesInCurrentCategory As New ArrayList
-            For Each Resource As Resource In NewResources
+            Dim NewResourcesInCurrentCategory As New List(Of Resource)
+            For Each Resource In NewResources
                 If Resource.GetCategory(_categories) Is _currentCategory Then
                     NewResourcesInCurrentCategory.Add(Resource)
                 End If
@@ -1985,7 +1985,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resources">The resources to remove.</param>
         ''' <remarks></remarks>
-        Public Sub RemoveResources(Resources As ICollection)
+        Public Sub RemoveResources(Resources As ICollection(Of Resource))
             CommitPendingChanges()
 
             If Resources Is Nothing OrElse Resources.Count = 0 Then
@@ -1999,7 +1999,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 'First, remove all resources from the table or list that belong in the current category.  Need to
                 '  do this first to ensure we don't have the virtual listview trying to get info on missing resources.
                 Dim ResourcesInCurrentCategory As New ArrayList
-                For Each Resource As Resource In Resources
+                For Each Resource In Resources
                     If Resource.GetCategory(_categories) Is _currentCategory Then
                         ResourcesInCurrentCategory.Add(Resource)
                     End If
@@ -2011,7 +2011,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Using Transaction As DesignerTransaction = RootDesigner.DesignerHost.CreateTransaction(My.Resources.Microsoft_VisualStudio_Editors_Designer.GetString(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Undo_RemoveResources_1Arg, CStr(Resources.Count)))
 
                     'Finally, remove the resources from the resource file and also dispose of them
-                    For Each Resource As Resource In Resources
+                    For Each Resource In Resources
                         'This call will mark the designer as dirty.
                         _resourceFile.RemoveResource(Resource, DisposeResource:=True)
                     Next
@@ -2096,11 +2096,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     If _resourcesAffected IsNot Nothing Then
                         _resourcesAffected.Clear()
                     Else
-                        _resourcesAffected = New Hashtable()
+                        _resourcesAffected = New HashSet(Of Resource)
                     End If
-                    _resourcesAffected.Add(Resource, Nothing)
+                    _resourcesAffected.Add(Resource)
                 ElseIf Not _resourcesAffected.Contains(Resource) Then
-                    _resourcesAffected.Add(Resource, Nothing)
+                    _resourcesAffected.Add(Resource)
                 End If
             End If
         End Sub
@@ -5521,7 +5521,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                 UnselectAllResources()
                 If _resourcesAffected IsNot Nothing Then
-                    HighlightResources(_resourcesAffected.Keys, True)
+                    HighlightResources(_resourcesAffected, True)
                     _resourcesAffected.Clear()
                 End If
             End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView_EditorState.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView_EditorState.vb
@@ -189,7 +189,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         If _selectedResourceNames IsNot Nothing Then
                             'We have to search for the resources by name.  Some of them may no longer exist.
                             '  We'll select the ones we can still find.
-                            Dim ResourcesToSelect As New ArrayList
+                            Dim ResourcesToSelect As New List(Of Resource)
                             For Each Name As String In _selectedResourceNames
                                 Dim Resource As Resource = View._resourceFile.FindResource(Name)
                                 If Resource IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
@@ -41,7 +41,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private ReadOnly _resourcesHash As Dictionary(Of String, Resource) = Nothing
 
         'an arrayList to keep all meta data, we shouldn't lose them when we save the resource file back...
-        Private ReadOnly _metadataList As ArrayList
+        Private ReadOnly _metadataList As List(Of DictionaryEntry)
 
         'The root component for the resource editor.  Cannot be Nothing.
         Private ReadOnly _rootComponent As ResourceEditorRootComponent
@@ -114,7 +114,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Debug.Assert(ServiceProvider IsNot Nothing)
 
             _resourcesHash = New Dictionary(Of String, Resource)(StringComparers.ResourceNames)
-            _metadataList = New ArrayList
+            _metadataList = New List(Of DictionaryEntry)
 
             _rootComponent = RootComponent
             _serviceProvider = ServiceProvider
@@ -996,7 +996,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 If _metadataList IsNot Nothing AndAlso _metadataList.Count > 0 Then
                     Dim NewWriter As ResXResourceWriter = TryCast(ResXWriter, ResXResourceWriter)
                     If NewWriter IsNot Nothing Then
-                        For Each entry As DictionaryEntry In _metadataList
+                        For Each entry In _metadataList
                             NewWriter.AddMetadata(CStr(entry.Key), entry.Value)
                         Next
                     End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
@@ -58,7 +58,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
         'A list of resources that need to be checked for errors during idle-time
         '  processing.
-        Private ReadOnly _resourcesToDelayCheckForErrors As New ArrayList
+        Private ReadOnly _resourcesToDelayCheckForErrors As New HashSet(Of Resource)
 
         ' Indicate whether we should suspend delay checking temporary...
         Private _delayCheckSuspended As Boolean
@@ -1553,7 +1553,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             End If
 
             If _resourcesToDelayCheckForErrors.Count > 0 Then
-                Dim Resource As Resource = DirectCast(_resourcesToDelayCheckForErrors(0), Resource)
+                Dim Resource As Resource = _resourcesToDelayCheckForErrors(0)
                 Debug.WriteLineIf(Switches.RSEDelayCheckErrors.TraceVerbose, "Delay-check errors: Processing: " & Resource.Name)
 
                 'Check the resource for errors
@@ -1575,7 +1575,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks></remarks>
         Private Sub StopDelayingCheckingForErrors()
             While _resourcesToDelayCheckForErrors.Count > 0
-                RemoveResourceToDelayCheckForErrors(DirectCast(_resourcesToDelayCheckForErrors(0), Resource))
+                RemoveResourceToDelayCheckForErrors(_resourcesToDelayCheckForErrors(0))
             End While
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
@@ -54,8 +54,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private ReadOnly _mainThread As System.Threading.Thread
 
         'Holds a set of tasks for each Resource that has any task list entries.
-        'Hashes key=Resource to ResourceTaskSet.
-        Private ReadOnly _resourceErrorsHash As New Hashtable 'Of Resource To ResourceTaskSet
+        Private ReadOnly _resourceErrorsHash As New Dictionary(Of Resource, ResourceTaskSet)
 
         'A list of resources that need to be checked for errors during idle-time
         '  processing.
@@ -1211,7 +1210,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <returns></returns>
         ''' <remarks></remarks>
         Public Function ResourceHasTasks(Resource As Resource) As Boolean
-            Dim TaskSet As ResourceTaskSet = DirectCast(_resourceErrorsHash(Resource), ResourceTaskSet)
+            Dim TaskSet As ResourceTaskSet = _resourceErrorsHash(Resource)
             If TaskSet Is Nothing Then
                 Return False
             End If
@@ -1237,7 +1236,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <returns></returns>
         ''' <remarks></remarks>
         Public Function GetResourceTaskMessage(Resource As Resource, TaskType As ResourceTaskType) As String
-            Dim TaskSet As ResourceTaskSet = DirectCast(_resourceErrorsHash(Resource), ResourceTaskSet)
+            Dim TaskSet As ResourceTaskSet = _resourceErrorsHash(Resource)
             If TaskSet Is Nothing Then
                 Return Nothing
             End If
@@ -1260,7 +1259,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <returns></returns>
         ''' <remarks></remarks>
         Public Function GetResourceTaskMessages(Resource As Resource) As String
-            Dim TaskSet As ResourceTaskSet = DirectCast(_resourceErrorsHash(Resource), ResourceTaskSet)
+            Dim TaskSet As ResourceTaskSet = _resourceErrorsHash(Resource)
             If TaskSet Is Nothing Then
                 Return Nothing
             End If
@@ -1317,7 +1316,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Dim taskProvider As ErrorListProvider = ErrorListProvider
             If taskProvider IsNot Nothing Then
                 'Get current task set for this resource.  If none, then create one.
-                Dim TaskSet As ResourceTaskSet = DirectCast(_resourceErrorsHash(Resource), ResourceTaskSet)
+                Dim TaskSet As ResourceTaskSet = _resourceErrorsHash(Resource)
                 If TaskSet Is Nothing Then
                     TaskSet = New ResourceTaskSet
                     _resourceErrorsHash.Add(Resource, TaskSet)
@@ -1391,7 +1390,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="TaskType">The type of task list entry to clear, if it exists.</param>
         ''' <remarks></remarks>
         Public Sub ClearResourceTask(Resource As Resource, TaskType As ResourceTaskType)
-            Dim TaskSet As ResourceTaskSet = DirectCast(_resourceErrorsHash(Resource), ResourceTaskSet)
+            Dim TaskSet As ResourceTaskSet = _resourceErrorsHash(Resource)
             If TaskSet Is Nothing Then
                 Exit Sub 'Nothing to clear
             End If
@@ -1436,7 +1435,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Resource">The resource to clear.</param>
         ''' <remarks></remarks>
         Public Sub ClearResourceTasks(Resource As Resource)
-            Dim TaskSet As ResourceTaskSet = DirectCast(_resourceErrorsHash(Resource), ResourceTaskSet)
+            Dim TaskSet As ResourceTaskSet = _resourceErrorsHash(Resource)
             If TaskSet IsNot Nothing Then
                 'Remove all entries for this resource
                 For i As Integer = 0 To TaskSet.Tasks.Length - 1


### PR DESCRIPTION
As I'm looking into splitting the Resource Designer UI from the underlying logic I'm getting tired of looking at all the old-school `Hashtable`s and `ArrayList`s. They also make it harder to understand the code.

This PR replaces a number of these "untyped" collections with the equivalent generic versions.