### PR TITLE
Suppress numeric suffixes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectItemsSchema.xaml
@@ -64,6 +64,41 @@
     <NameValuePair Name="DefaultMetadata_Generator" Value="MSBuild:Compile" />
   </ContentType>
 
+  <ContentType
+    Name="Manifest"
+    DisplayName="Manifest file"
+    ItemType="None">
+    <NameValuePair Name="SuppressNumericSuffix" Value="true" />
+  </ContentType>
+
+  <ContentType
+    Name="Config"
+    DisplayName="Config file"
+    ItemType="None">
+    <NameValuePair Name="SuppressNumericSuffix" Value="true" />
+  </ContentType>
+
+  <ContentType
+    Name="WindowsResource"
+    DisplayName="Windows Resourcs file"
+    ItemType="None">
+    <NameValuePair Name="SuppressNumericSuffix" Value="true" />
+  </ContentType>
+
+  <ContentType
+    Name="PackageLayout"
+    DisplayName="Package Layout file"
+    ItemType="None">
+    <NameValuePair Name="SuppressNumericSuffix" Value="true" />
+  </ContentType>
+
+  <ContentType
+    Name="AppInstaller"
+    DisplayName="App Installer file"
+    ItemType="None">
+    <NameValuePair Name="SuppressNumericSuffix" Value="true" />
+  </ContentType>
+
   <ContentType Name="XamlAppDef" DisplayName="Workflow definition" ItemType="XamlAppDef" />
 
   <ContentType Name="Resource" DisplayName="Resource" ItemType="Resource" />
@@ -91,6 +126,10 @@
   <FileExtension Name=".xml" ContentType="XML" />
   <FileExtension Name=".mht" ContentType="MHT" />
   <FileExtension Name=".manifest" ContentType="Manifest" />
+  <FileExtension Name=".config" ContentType="Config" />
+  <FileExtension Name=".resw;.resjson" ContentType="WindowsResource" />
+  <FileExtension Name=".packagelayout" ContentType="PackageLayout" />
+  <FileExtension Name=".appinstaller" ContentType="AppInstaller" />
   <FileExtension Name=".rdlc" ContentType="RDLC" />
   <FileExtension Name=".cd" ContentType="ClassDiagram" />
   <FileExtension Name=".licenses" ContentType="Licenses" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectItemsSchema.xaml
@@ -4,33 +4,33 @@
     xmlns="http://schemas.microsoft.com/build/2009/properties">
 
   <ContentType
-      Name="Text"
-      DisplayName="Text file"
-      ItemType="Content">
+    Name="Text"
+    DisplayName="Text file"
+    ItemType="Content">
   </ContentType>
 
   <ContentType
-      Name="XML"
-      DisplayName="Xml file"
-      ItemType="Content">
+    Name="XML"
+    DisplayName="Xml file"
+    ItemType="Content">
   </ContentType>
 
   <ContentType
-      Name="HTML"
-      DisplayName="Html file"
-      ItemType="Content">
+    Name="HTML"
+    DisplayName="Html file"
+    ItemType="Content">
   </ContentType>
 
   <ContentType
-      Name="CSS"
-      DisplayName="Cascading style sheet"
-      ItemType="Content">
+    Name="CSS"
+    DisplayName="Cascading style sheet"
+    ItemType="Content">
   </ContentType>
 
   <ContentType
-      Name="Json"
-      DisplayName="Json file"
-      ItemType="Content">
+    Name="Json"
+    DisplayName="Json file"
+    ItemType="Content">
   </ContentType>
 
   <ContentType
@@ -99,9 +99,15 @@
     <NameValuePair Name="SuppressNumericSuffix" Value="true" />
   </ContentType>
 
-  <ContentType Name="XamlAppDef" DisplayName="Workflow definition" ItemType="XamlAppDef" />
+  <ContentType 
+    Name="XamlAppDef"
+    DisplayName="Workflow definition"
+    ItemType="XamlAppDef" />
 
-  <ContentType Name="Resource" DisplayName="Resource" ItemType="Resource" />
+  <ContentType 
+    Name="Resource"
+    DisplayName="Resource"
+    ItemType="Resource" />
 
   <ItemType Name="None" DisplayName="None"/>
   <ItemType Name="Content" DisplayName="Content" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.cs.xlf
@@ -2,9 +2,34 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../ProjectItemsSchema.xaml">
     <body>
+      <trans-unit id="ContentType|AppInstaller|DisplayName">
+        <source>App Installer file</source>
+        <target state="new">App Installer file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Config|DisplayName">
+        <source>Config file</source>
+        <target state="new">Config file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Manifest|DisplayName">
+        <source>Manifest file</source>
+        <target state="new">Manifest file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|PackageLayout|DisplayName">
+        <source>Package Layout file</source>
+        <target state="new">Package Layout file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContentType|Text|DisplayName">
         <source>Text file</source>
         <target state="translated">Textový soubor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|WindowsResource|DisplayName">
+        <source>Windows Resourcs file</source>
+        <target state="new">Windows Resourcs file</target>
         <note />
       </trans-unit>
       <trans-unit id="ContentType|XML|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.de.xlf
@@ -2,9 +2,34 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../ProjectItemsSchema.xaml">
     <body>
+      <trans-unit id="ContentType|AppInstaller|DisplayName">
+        <source>App Installer file</source>
+        <target state="new">App Installer file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Config|DisplayName">
+        <source>Config file</source>
+        <target state="new">Config file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Manifest|DisplayName">
+        <source>Manifest file</source>
+        <target state="new">Manifest file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|PackageLayout|DisplayName">
+        <source>Package Layout file</source>
+        <target state="new">Package Layout file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContentType|Text|DisplayName">
         <source>Text file</source>
         <target state="translated">Textdatei</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|WindowsResource|DisplayName">
+        <source>Windows Resourcs file</source>
+        <target state="new">Windows Resourcs file</target>
         <note />
       </trans-unit>
       <trans-unit id="ContentType|XML|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.es.xlf
@@ -2,9 +2,34 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../ProjectItemsSchema.xaml">
     <body>
+      <trans-unit id="ContentType|AppInstaller|DisplayName">
+        <source>App Installer file</source>
+        <target state="new">App Installer file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Config|DisplayName">
+        <source>Config file</source>
+        <target state="new">Config file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Manifest|DisplayName">
+        <source>Manifest file</source>
+        <target state="new">Manifest file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|PackageLayout|DisplayName">
+        <source>Package Layout file</source>
+        <target state="new">Package Layout file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContentType|Text|DisplayName">
         <source>Text file</source>
         <target state="translated">Archivo de texto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|WindowsResource|DisplayName">
+        <source>Windows Resourcs file</source>
+        <target state="new">Windows Resourcs file</target>
         <note />
       </trans-unit>
       <trans-unit id="ContentType|XML|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.fr.xlf
@@ -2,9 +2,34 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../ProjectItemsSchema.xaml">
     <body>
+      <trans-unit id="ContentType|AppInstaller|DisplayName">
+        <source>App Installer file</source>
+        <target state="new">App Installer file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Config|DisplayName">
+        <source>Config file</source>
+        <target state="new">Config file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Manifest|DisplayName">
+        <source>Manifest file</source>
+        <target state="new">Manifest file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|PackageLayout|DisplayName">
+        <source>Package Layout file</source>
+        <target state="new">Package Layout file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContentType|Text|DisplayName">
         <source>Text file</source>
         <target state="translated">Fichier texte</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|WindowsResource|DisplayName">
+        <source>Windows Resourcs file</source>
+        <target state="new">Windows Resourcs file</target>
         <note />
       </trans-unit>
       <trans-unit id="ContentType|XML|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.it.xlf
@@ -2,9 +2,34 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../ProjectItemsSchema.xaml">
     <body>
+      <trans-unit id="ContentType|AppInstaller|DisplayName">
+        <source>App Installer file</source>
+        <target state="new">App Installer file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Config|DisplayName">
+        <source>Config file</source>
+        <target state="new">Config file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Manifest|DisplayName">
+        <source>Manifest file</source>
+        <target state="new">Manifest file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|PackageLayout|DisplayName">
+        <source>Package Layout file</source>
+        <target state="new">Package Layout file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContentType|Text|DisplayName">
         <source>Text file</source>
         <target state="translated">File di testo</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|WindowsResource|DisplayName">
+        <source>Windows Resourcs file</source>
+        <target state="new">Windows Resourcs file</target>
         <note />
       </trans-unit>
       <trans-unit id="ContentType|XML|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ja.xlf
@@ -2,9 +2,34 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../ProjectItemsSchema.xaml">
     <body>
+      <trans-unit id="ContentType|AppInstaller|DisplayName">
+        <source>App Installer file</source>
+        <target state="new">App Installer file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Config|DisplayName">
+        <source>Config file</source>
+        <target state="new">Config file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Manifest|DisplayName">
+        <source>Manifest file</source>
+        <target state="new">Manifest file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|PackageLayout|DisplayName">
+        <source>Package Layout file</source>
+        <target state="new">Package Layout file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContentType|Text|DisplayName">
         <source>Text file</source>
         <target state="translated">テキスト ファイル</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|WindowsResource|DisplayName">
+        <source>Windows Resourcs file</source>
+        <target state="new">Windows Resourcs file</target>
         <note />
       </trans-unit>
       <trans-unit id="ContentType|XML|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ko.xlf
@@ -2,9 +2,34 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../ProjectItemsSchema.xaml">
     <body>
+      <trans-unit id="ContentType|AppInstaller|DisplayName">
+        <source>App Installer file</source>
+        <target state="new">App Installer file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Config|DisplayName">
+        <source>Config file</source>
+        <target state="new">Config file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Manifest|DisplayName">
+        <source>Manifest file</source>
+        <target state="new">Manifest file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|PackageLayout|DisplayName">
+        <source>Package Layout file</source>
+        <target state="new">Package Layout file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContentType|Text|DisplayName">
         <source>Text file</source>
         <target state="translated">텍스트 파일</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|WindowsResource|DisplayName">
+        <source>Windows Resourcs file</source>
+        <target state="new">Windows Resourcs file</target>
         <note />
       </trans-unit>
       <trans-unit id="ContentType|XML|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.pl.xlf
@@ -2,9 +2,34 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../ProjectItemsSchema.xaml">
     <body>
+      <trans-unit id="ContentType|AppInstaller|DisplayName">
+        <source>App Installer file</source>
+        <target state="new">App Installer file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Config|DisplayName">
+        <source>Config file</source>
+        <target state="new">Config file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Manifest|DisplayName">
+        <source>Manifest file</source>
+        <target state="new">Manifest file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|PackageLayout|DisplayName">
+        <source>Package Layout file</source>
+        <target state="new">Package Layout file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContentType|Text|DisplayName">
         <source>Text file</source>
         <target state="translated">Plik tekstowy</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|WindowsResource|DisplayName">
+        <source>Windows Resourcs file</source>
+        <target state="new">Windows Resourcs file</target>
         <note />
       </trans-unit>
       <trans-unit id="ContentType|XML|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.pt-BR.xlf
@@ -2,9 +2,34 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ProjectItemsSchema.xaml">
     <body>
+      <trans-unit id="ContentType|AppInstaller|DisplayName">
+        <source>App Installer file</source>
+        <target state="new">App Installer file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Config|DisplayName">
+        <source>Config file</source>
+        <target state="new">Config file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Manifest|DisplayName">
+        <source>Manifest file</source>
+        <target state="new">Manifest file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|PackageLayout|DisplayName">
+        <source>Package Layout file</source>
+        <target state="new">Package Layout file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContentType|Text|DisplayName">
         <source>Text file</source>
         <target state="translated">Arquivo de texto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|WindowsResource|DisplayName">
+        <source>Windows Resourcs file</source>
+        <target state="new">Windows Resourcs file</target>
         <note />
       </trans-unit>
       <trans-unit id="ContentType|XML|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ru.xlf
@@ -2,9 +2,34 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../ProjectItemsSchema.xaml">
     <body>
+      <trans-unit id="ContentType|AppInstaller|DisplayName">
+        <source>App Installer file</source>
+        <target state="new">App Installer file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Config|DisplayName">
+        <source>Config file</source>
+        <target state="new">Config file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Manifest|DisplayName">
+        <source>Manifest file</source>
+        <target state="new">Manifest file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|PackageLayout|DisplayName">
+        <source>Package Layout file</source>
+        <target state="new">Package Layout file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContentType|Text|DisplayName">
         <source>Text file</source>
         <target state="translated">Текстовый файл</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|WindowsResource|DisplayName">
+        <source>Windows Resourcs file</source>
+        <target state="new">Windows Resourcs file</target>
         <note />
       </trans-unit>
       <trans-unit id="ContentType|XML|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.tr.xlf
@@ -2,9 +2,34 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../ProjectItemsSchema.xaml">
     <body>
+      <trans-unit id="ContentType|AppInstaller|DisplayName">
+        <source>App Installer file</source>
+        <target state="new">App Installer file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Config|DisplayName">
+        <source>Config file</source>
+        <target state="new">Config file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Manifest|DisplayName">
+        <source>Manifest file</source>
+        <target state="new">Manifest file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|PackageLayout|DisplayName">
+        <source>Package Layout file</source>
+        <target state="new">Package Layout file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContentType|Text|DisplayName">
         <source>Text file</source>
         <target state="translated">Metin dosyası</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|WindowsResource|DisplayName">
+        <source>Windows Resourcs file</source>
+        <target state="new">Windows Resourcs file</target>
         <note />
       </trans-unit>
       <trans-unit id="ContentType|XML|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.zh-Hans.xlf
@@ -2,9 +2,34 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ProjectItemsSchema.xaml">
     <body>
+      <trans-unit id="ContentType|AppInstaller|DisplayName">
+        <source>App Installer file</source>
+        <target state="new">App Installer file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Config|DisplayName">
+        <source>Config file</source>
+        <target state="new">Config file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Manifest|DisplayName">
+        <source>Manifest file</source>
+        <target state="new">Manifest file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|PackageLayout|DisplayName">
+        <source>Package Layout file</source>
+        <target state="new">Package Layout file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContentType|Text|DisplayName">
         <source>Text file</source>
         <target state="translated">文本文件</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|WindowsResource|DisplayName">
+        <source>Windows Resourcs file</source>
+        <target state="new">Windows Resourcs file</target>
         <note />
       </trans-unit>
       <trans-unit id="ContentType|XML|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.zh-Hant.xlf
@@ -2,9 +2,34 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ProjectItemsSchema.xaml">
     <body>
+      <trans-unit id="ContentType|AppInstaller|DisplayName">
+        <source>App Installer file</source>
+        <target state="new">App Installer file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Config|DisplayName">
+        <source>Config file</source>
+        <target state="new">Config file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|Manifest|DisplayName">
+        <source>Manifest file</source>
+        <target state="new">Manifest file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|PackageLayout|DisplayName">
+        <source>Package Layout file</source>
+        <target state="new">Package Layout file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContentType|Text|DisplayName">
         <source>Text file</source>
         <target state="translated">文字檔</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContentType|WindowsResource|DisplayName">
+        <source>Windows Resourcs file</source>
+        <target state="new">Windows Resourcs file</target>
         <note />
       </trans-unit>
       <trans-unit id="ContentType|XML|DisplayName">


### PR DESCRIPTION
Fixes #5526

This adds file extensions, and corresponding content types, for the files that the legacy project system has in its allow list ([here](https://devdiv.visualstudio.com/DevDiv/_git/VS?path=%2Fsrc%2Fvsproject%2Flangproj%2FCLangHierarchy.cpp&version=GBmaster&line=1666&lineEnd=1666&lineStartColumn=30&lineEndColumn=52&lineStyle=plain)) for not having a number on the end of its generated filename.

This goes with https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/207117?_a=overview, which adds support for the SuppressNumericSuffix metadata, though no harm will come if this is merged before that.