### PR TITLE
More non-generic collection clean-up in Resource Editor

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseRootDesigner.vb
@@ -102,6 +102,17 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             Next
         End Sub
 
+        ''' <summary>
+        ''' See <see cref="RegisterMenuCommands(ArrayList, Boolean)"/>.
+        ''' </summary>
+        ''' <remarks>This just converts <paramref name="MenuCommands"/> to an <see cref="ArrayList"/> and passes it
+        ''' to <see cref="RegisterMenuCommands(ArrayList, Boolean)"/>. Once we're done refactoring this class to
+        ''' eliminate <see cref="ArrayList"/> that overload will go away.</remarks>
+        Friend Sub RegisterMenuCommands(MenuCommands As List(Of MenuCommand),
+                Optional KeepRegisteredMenuCommands As Boolean = True)
+            RegisterMenuCommands(New ArrayList(MenuCommands), KeepRegisteredMenuCommands)
+        End Sub
+
         Friend Sub RemoveMenuCommands()
             'Iterate backwards to avoid problems removing while iterating
             For i As Integer = MenuCommands.Count - 1 To 0 Step -1

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Category.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Category.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -48,7 +48,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private _showTypeColumnInStringTable As Boolean 'applies only to Display.StringTable
         Private ReadOnly _menuCommand As MenuCommand
         Private _addCommand As EventHandler
-        Private _sorter As IComparer           ' how to sort resources in the category...
+        Private _sorter As IComparer(Of Resource)           ' how to sort resources in the category...
 
 
         '======================================================================
@@ -253,7 +253,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <value></value>
         ''' <remarks></remarks>
-        Public Property Sorter() As IComparer
+        Public Property Sorter() As IComparer(Of Resource)
             Get
                 Return _sorter
             End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/CategoryCollection.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/CategoryCollection.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Strict On
 Option Explicit On
@@ -14,20 +14,12 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     Friend NotInheritable Class CategoryCollection
         Inherits CollectionBase
 
-
-
         'A hashtable list of resources by name.
-        Private ReadOnly _innerHashByName As New Hashtable 'Of String (case-sensitive)
-
-
-
+        Private ReadOnly _innerHashByName As New Dictionary(Of String, Category)
 
         '======================================================================
         '= Properties =                                                       =
         '======================================================================
-
-
-
 
         ''' <summary>
         ''' Searches for a category by its index
@@ -50,7 +42,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks>Does not throw an exception if not found.</remarks>
         Default Public ReadOnly Property Item(ProgrammaticCategoryName As String) As Category
             Get
-                Return DirectCast(_innerHashByName(ProgrammaticCategoryName), Category)
+                Dim Value As Category = Nothing
+                _innerHashByName.TryGetValue(ProgrammaticCategoryName, Value)
+                Return Value
             End Get
         End Property
 
@@ -74,7 +68,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             InnerList.Add(Category)
 
             'Add to the hash table (for indexing by programmatic name)
-            _innerHashByName.Add(Category.ProgrammaticName, Category)
+            _innerHashByName(Category.ProgrammaticName) = Category
         End Sub
 
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
@@ -492,7 +492,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '  in multiples.
             Private Const DelayInMilliseconds As Integer = 400
 
-            Private ReadOnly _listeners As New ArrayList 'Of IFileWatchListener
+            Private ReadOnly _listeners As New HashSet(Of IFileWatcherListener)
 
 #If DEBUG Then
             'Hashcode of the last thread we fired notifications on.  Used to verify

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
@@ -219,7 +219,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Private ReadOnly _directoryPath As String
 
             'A list of FileWatcherEntry's, one for each file in this directory being watched.
-            Private _fileWatcherEntries As New Hashtable 'Key=FileName, maps to FileWatcherEntry
+            Private _fileWatcherEntries As New Dictionary(Of String, FileWatcherEntry)(StringComparers.Paths)
 
             'A system FileSystemWatcher class.  This is the actual class that does the watching
             '  on our directory.  It's most efficient to use it on a single directory, since 
@@ -309,11 +309,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Public Sub AddFileListener(FileNameOnly As String, Listener As IFileWatcherListener)
                 FileNameOnly = NormalizeFileName(FileNameOnly)
 
-                Dim Entry As FileWatcherEntry = DirectCast(_fileWatcherEntries(FileNameOnly), FileWatcherEntry)
-                If Entry Is Nothing Then
+                Dim Entry As FileWatcherEntry = Nothing
+                If Not _fileWatcherEntries.TryGetValue(FileNameOnly, Entry) Then
                     'We don't have an entry for this file yet.  Add one now.
                     Entry = New FileWatcherEntry(Me, FileNameOnly)
-                    _fileWatcherEntries.Add(FileNameOnly, Entry)
+                    _fileWatcherEntries(FileNameOnly) = Entry
                 End If
 
                 'Add this listener to the entry
@@ -336,8 +336,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Public Sub RemoveListener(FileNameOnly As String, Listener As IFileWatcherListener)
                 FileNameOnly = NormalizeFileName(FileNameOnly)
 
-                Dim Entry As FileWatcherEntry = CType(_fileWatcherEntries.Item(FileNameOnly), FileWatcherEntry)
-                If Not Entry Is Nothing Then
+                Dim Entry As FileWatcherEntry = Nothing
+
+                If _fileWatcherEntries.TryGetValue(FileNameOnly, Entry) Then
                     Entry.RemoveListener(Listener)
 
                     If Entry.ListenerCount = 0 Then
@@ -367,7 +368,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Debug.Assert(Path.GetDirectoryName(FileNameOnly) = "" AndAlso Not Path.IsPathRooted(FileNameOnly),
                     "DirectoryWatcher does not accept paths with the filename - should be relative to the directory path in DirectoryWatcher")
                 Debug.Assert(Path.GetFileName(FileNameOnly) = FileNameOnly)
-                Return FileNameOnly.ToUpperInvariant()
             End Function
 
 
@@ -386,9 +386,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Dim FileNameThatChanged As String = NormalizeFileName(FileName)
 
                 'Is this file one that we're interested in?
-                If _fileWatcherEntries.ContainsKey(FileNameThatChanged) Then
+                Dim EntryThatChanged As FileWatcherEntry = Nothing
+                If _fileWatcherEntries.TryGetValue(FileNameThatChanged, EntryThatChanged) Then
                     '... Yes.
-                    Dim EntryThatChanged As FileWatcherEntry = CType(_fileWatcherEntries(FileNameThatChanged), FileWatcherEntry)
                     Debug.WriteLineIf(Switches.RSEFileWatcher.TraceVerbose, "    Matched entry: " & EntryThatChanged.ToString)
 
                     'Let the parent file watcher use its synchronization control to

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
@@ -517,23 +517,17 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks></remarks>
         Private ReadOnly Property GetResourcesToSearch(FindInSelection As Boolean) As Resource()
             Get
-                Dim ResourcesToSearch As ArrayList
+                Dim ResourcesToSearch = New List(Of Resource)(View.ResourceFile.Resources.Count)
 
                 Trace("Getting list of resources to search through")
 
                 'First collect all the resources to search through
                 If FindInSelection Then
-                    Dim SelectedResources() As Resource = View.GetSelectedResources()
-                    ResourcesToSearch = New ArrayList(View.ResourceFile.Resources.Count)
-                    For Each Resource As Resource In SelectedResources
-                        ResourcesToSearch.Add(Resource)
-                    Next
+                    Dim SelectedResources = View.GetSelectedResources()
+                    ResourcesToSearch.AddRange(SelectedResources)
                 Else
-                    ResourcesToSearch = New ArrayList(View.ResourceFile.Resources.Count)
-                    For Each Entry As DictionaryEntry In View.ResourceFile
-                        Dim Resource As Resource = DirectCast(Entry.Value, Resource)
-                        ResourcesToSearch.Add(Resource)
-                    Next
+                    Dim AllResources = View.ResourceFile.Resources.Values
+                    ResourcesToSearch.AddRange(AllResources)
                 End If
 
                 'Now sort them according to category and name

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -259,12 +259,12 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
 #Region "Shared fields"
 
-        'Hash of ValueTypeName to PropertyDescriptionCollection
+        'Map of ValueTypeName to PropertyDescriptionCollection
         '  This is the set of properties that we expose in the property sheet for each type of 
         '  Resource.  The set of properties shown is based solely on the value type of the
         '  resource and the type of ResourceTypeEditor that it uses.  Therefore we only need to 
         '  create a unique properties collection for each distinct pairing of these values.
-        Private Shared ReadOnly s_propertyDescriptorCollectionHash As New Hashtable '(Of PropertyDescriptorCollection), key = fully-qualified type names of resource value + resource type editor
+        Private Shared ReadOnly s_propertyDescriptorCollections As New Dictionary(Of String, PropertyDescriptorCollection)
 
         'A list of names which are not recommended for use by the end user (because they cause
         '  compiler errors or other problems).
@@ -2240,9 +2240,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   us the hassle of implementing everything on ICustomDescriptor. Instead, we only override what we need.
         ''' </remarks>
         Friend Function GetProperties() As PropertyDescriptorCollection
-            Dim HashKey As Object = ValueTypeName & "|" & ResourceTypeEditor.GetType.AssemblyQualifiedName
+            Dim Key As String = ValueTypeName & "|" & ResourceTypeEditor.GetType.AssemblyQualifiedName
+            Dim Properties As PropertyDescriptorCollection = Nothing
 
-            If Not s_propertyDescriptorCollectionHash.ContainsKey(HashKey) Then
+            If Not s_propertyDescriptorCollections.TryGetValue(Key, Properties) Then
                 'Register properties: Name, Comment, Filename, Type, Persistence
                 'These are all the same no matter what kind of resource value we're looking at
                 Dim PropertyDescriptorList As New List(Of ResourcePropertyDescriptor) From {
@@ -2276,14 +2277,14 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 End If
 
                 'Create the properties collection
-                Dim Properties As New PropertyDescriptorCollection(PropertyDescriptorList.ToArray())
+                Properties = New PropertyDescriptorCollection(PropertyDescriptorList.ToArray())
 
                 '... and add it to our hash table
-                s_propertyDescriptorCollectionHash.Add(HashKey, Properties)
-                Debug.Assert(s_propertyDescriptorCollectionHash.ContainsKey(HashKey))
+                s_propertyDescriptorCollections.Add(Key, Properties)
+                Debug.Assert(s_propertyDescriptorCollections.ContainsKey(Key))
             End If
 
-            Return DirectCast(s_propertyDescriptorCollectionHash(HashKey), PropertyDescriptorCollection)
+            Return Properties
         End Function
 
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -2245,7 +2245,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             If Not s_propertyDescriptorCollectionHash.ContainsKey(HashKey) Then
                 'Register properties: Name, Comment, Filename, Type, Persistence
                 'These are all the same no matter what kind of resource value we're looking at
-                Dim PropertyDescriptorArrayList As New ArrayList From {
+                Dim PropertyDescriptorList As New List(Of ResourcePropertyDescriptor) From {
                     s_propertyDescriptor_Name,
                     s_propertyDescriptor_Comment,
                     s_propertyDescriptor_Filename_ReadOnly,
@@ -2254,31 +2254,29 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                 '"Encoding" property
                 If ResourceTypeEditor.Equals(ResourceTypeEditors.TextFile) Then
-                    PropertyDescriptorArrayList.Add(s_propertyDescriptor_Encoding)
+                    PropertyDescriptorList.Add(s_propertyDescriptor_Encoding)
                 End If
 
                 '"FileType" property
                 If TypeOf ResourceTypeEditor Is ResourceTypeEditorFileBase Then
-                    PropertyDescriptorArrayList.Add(s_propertyDescriptor_FileType)
+                    PropertyDescriptorList.Add(s_propertyDescriptor_FileType)
                 End If
 
                 '"Persistence" property -  read/write or read/only, depending on the resource type
                 If ResourceTypeEditor.CanChangePersistenceProperty(ParentResourceFile) Then
-                    PropertyDescriptorArrayList.Add(s_propertyDescriptor_Persistence)
+                    PropertyDescriptorList.Add(s_propertyDescriptor_Persistence)
                 Else
-                    PropertyDescriptorArrayList.Add(s_propertyDescriptor_Persistence_ReadOnly)
+                    PropertyDescriptorList.Add(s_propertyDescriptor_Persistence_ReadOnly)
                 End If
 
                 '"Value" property.  We only show this property for strings (we could do it for other types, but there
                 '  turn out to be lots of special exceptions and issues with various types).
                 If ResourceTypeEditor.Equals(ResourceTypeEditors.String) Then
-                    PropertyDescriptorArrayList.Add(s_propertyDescriptor_ValueAsString)
+                    PropertyDescriptorList.Add(s_propertyDescriptor_ValueAsString)
                 End If
 
                 'Create the properties collection
-                Dim PropertyDescriptorArray(PropertyDescriptorArrayList.Count - 1) As PropertyDescriptor
-                PropertyDescriptorArrayList.CopyTo(PropertyDescriptorArray, 0)
-                Dim Properties As New PropertyDescriptorCollection(PropertyDescriptorArray)
+                Dim Properties As New PropertyDescriptorCollection(PropertyDescriptorList.ToArray())
 
                 '... and add it to our hash table
                 s_propertyDescriptorCollectionHash.Add(HashKey, Properties)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -270,7 +270,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '  compiler errors or other problems).
         'Use the UnrecommendedResourceNamesHash property to access these so that they are properly
         '  initialized.
-        Private Shared s_unrecommendedResourceNamesHash As Hashtable  'Of Boolean (key = member name [string])
+        Private Shared s_unrecommendedResourceNames As HashSet(Of String)
 
 #End Region
 
@@ -1983,22 +1983,22 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <value></value>
         ''' <remarks></remarks>
-        Private Shared ReadOnly Property UnrecommendedResourceNamesHash() As Hashtable
+        Private Shared ReadOnly Property UnrecommendedResourceNames() As HashSet(Of String)
             Get
-                If s_unrecommendedResourceNamesHash Is Nothing Then
-                    s_unrecommendedResourceNamesHash = New Hashtable(StringComparer.OrdinalIgnoreCase)
+                If s_unrecommendedResourceNames Is Nothing Then
+                    s_unrecommendedResourceNames = New HashSet(Of String)(StringComparer.OrdinalIgnoreCase)
 
                     'Names which conflict with members of Object will cause compile
                     '  errors, so add those to the unrecommended list.
                     Dim ObjectMembers As MemberInfo() = GetType(Object).GetMembers()
                     For Each Member As MemberInfo In ObjectMembers
-                        If Not s_unrecommendedResourceNamesHash.ContainsKey(Member.Name) Then
-                            s_unrecommendedResourceNamesHash.Add(Member.Name, True)
+                        If Not s_unrecommendedResourceNames.Contains(Member.Name) Then
+                            s_unrecommendedResourceNames.Add(Member.Name)
                         End If
                     Next
                 End If
 
-                Return s_unrecommendedResourceNamesHash
+                Return s_unrecommendedResourceNames
             End Get
         End Property
 
@@ -2044,7 +2044,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             End If
 
             'Is it in our list of unrecommended names?
-            If UnrecommendedResourceNamesHash.ContainsKey(Name) Then
+            If UnrecommendedResourceNames.Contains(Name) Then
                 SetTask(ResourceFile.ResourceTaskType.BadName, My.Resources.Microsoft_VisualStudio_Editors_Designer.GetString(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Task_NonrecommendedName_1Arg, Name), TaskPriority.Low, HelpIDs.Task_NonrecommendedName, TaskErrorCategory.Warning)
                 Exit Sub
             End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparer.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparer.vb
@@ -8,19 +8,19 @@ Imports System.Globalization
 Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
     ''' <summary>
-    ''' This is an Icomparer implementation used to sort Resources for UI purposes (ResourceListView and
+    ''' This is an <see cref="IComparer(Of T)"/> implementation used to sort <see cref="Resource"/>s for UI purposes (ResourceListView and
     '''    ResourceStringTable).
     ''' </summary>
     ''' <remarks></remarks>
     Friend NotInheritable Class ResourceComparer
-        Implements IComparer
+        Implements IComparer(Of Resource)
 
         ''' <summary>
-        ''' Sorts an ArrayList of Resources for UI purposes
+        ''' Sorts a <see cref="List(Of Resource)"/> for UI purposes
         ''' </summary>
-        ''' <param name="Resources">ArrayList of Resources to source (will be sorted in place)</param>
+        ''' <param name="Resources"><see cref="List(Of Resource)"/> to sort (will be sorted in place)</param>
         ''' <remarks></remarks>
-        Public Shared Sub SortResources(Resources As ArrayList)
+        Public Shared Sub SortResources(Resources As List(Of Resource))
             Resources.Sort(New ResourceComparer)
         End Sub
 
@@ -31,13 +31,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="y">Second object to compare.</param>
         ''' <returns>-1, 0 or 1, depending on whether x is less than, equal to or greater than y, respectively.</returns>
         ''' <remarks>This function gets called by ArrayList.Sort for each pair of resources to be sorted.</remarks>
-        Private Function Compare(x As Object, y As Object) As Integer Implements IComparer.Compare
-            Debug.Assert(TypeOf x Is Resource AndAlso TypeOf y Is Resource, "ResourceComparer: expected Resources")
-            Dim Resource1 As Resource = DirectCast(x, Resource)
-            Dim Resource2 As Resource = DirectCast(y, Resource)
-
+        Private Function Compare(x As Resource, y As Resource) As Integer Implements IComparer(Of Resource).Compare
             'We currently only support sorting alphabetically according to Name.
-            Return String.Compare(Resource1.Name, Resource2.Name, ignoreCase:=True, culture:=CultureInfo.CurrentUICulture)
+            Return String.Compare(x.Name, y.Name, ignoreCase:=True, culture:=CultureInfo.CurrentUICulture)
         End Function
     End Class
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparerForFind.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparerForFind.vb
@@ -46,7 +46,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Sorts a <see cref="List(Of Resource)"/> for UI purposes
         ''' </summary>
-        ''' <param name="Resources">ArrayList of Resources to source (will be sorted in place)</param>
+        ''' <param name="Resources"><see cref="List(Of Resource)"/> to sort (will be sorted in place)</param>
         ''' <remarks></remarks>
         Public Sub SortResources(Resources As List(Of Resource))
             Resources.Sort(Me)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparerForFind.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparerForFind.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -14,8 +14,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     Friend NotInheritable Class ResourceComparerForFind
         Implements IComparer
 
-        'A hashtable that maps a Category to its sort order
-        Private ReadOnly _categoryToCategoryOrderHash As New Hashtable
+        'A dictionary that maps a Category to its sort order
+        Private ReadOnly _categoryToCategoryOrderHash As New Dictionary(Of Category, Integer)
 
         'All categories included in the search
         Private ReadOnly _categories As CategoryCollection
@@ -36,7 +36,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             Dim CategoryOrder As Integer = 0
             For Each Category As Category In OrderedCategories
-                _categoryToCategoryOrderHash.Add(Category, CategoryOrder)
+                _categoryToCategoryOrderHash(Category) = CategoryOrder
                 CategoryOrder += 1
             Next
             Debug.Assert(_categoryToCategoryOrderHash.Count = OrderedCategories.Count)
@@ -68,8 +68,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Dim category1 As Category = Resource1.GetCategory(_categories)
 
             'First compare by category
-            Dim Resource1CategoryOrder As Integer = DirectCast(_categoryToCategoryOrderHash(category1), Integer)
-            Dim Resource2CategoryOrder As Integer = DirectCast(_categoryToCategoryOrderHash(Resource2.GetCategory(_categories)), Integer)
+            Dim Resource1CategoryOrder As Integer = _categoryToCategoryOrderHash(category1)
+            Dim Resource2CategoryOrder As Integer = _categoryToCategoryOrderHash(Resource2.GetCategory(_categories))
 
             If Resource1CategoryOrder > Resource2CategoryOrder Then
                 Return 1

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparerForFind.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparerForFind.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' </summary>
     ''' <remarks></remarks>
     Friend NotInheritable Class ResourceComparerForFind
-        Implements IComparer
+        Implements IComparer(Of Resource)
 
         'A dictionary that maps a Category to its sort order
         Private ReadOnly _categoryToCategoryOrderHash As New Dictionary(Of Category, Integer)
@@ -44,11 +44,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
 
         ''' <summary>
-        ''' Sorts an ArrayList of Resoures for UI purposes
+        ''' Sorts a <see cref="List(Of Resource)"/> for UI purposes
         ''' </summary>
         ''' <param name="Resources">ArrayList of Resources to source (will be sorted in place)</param>
         ''' <remarks></remarks>
-        Public Sub SortResources(Resources As ArrayList)
+        Public Sub SortResources(Resources As List(Of Resource))
             Resources.Sort(Me)
         End Sub
 
@@ -56,15 +56,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Compares two objects and returns a value indicating whether one is less than, equal to or greater than the other.
         ''' </summary>
-        ''' <param name="x">First object to compare.</param>
-        ''' <param name="y">Second object to compare.</param>
+        ''' <param name="Resource1">First object to compare.</param>
+        ''' <param name="Resource2">Second object to compare.</param>
         ''' <returns>-1, 0 or 1, depending on whether x is less than, equal to or greater than y, respectively.</returns>
         ''' <remarks>This function gets called by ArrayList.Sort for each pair of resources to be sorted.</remarks>
-        Private Function Compare(x As Object, y As Object) As Integer Implements IComparer.Compare
-            Debug.Assert(TypeOf x Is Resource AndAlso TypeOf y Is Resource, "ResourceComparer: expected Resources")
-            Dim Resource1 As Resource = DirectCast(x, Resource)
-            Dim Resource2 As Resource = DirectCast(y, Resource)
-
+        Private Function Compare(Resource1 As Resource, Resource2 As Resource) As Integer Implements IComparer(Of Resource).Compare
             Dim category1 As Category = Resource1.GetCategory(_categories)
 
             'First compare by category

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -1379,7 +1379,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks></remarks>
         Private Sub HighlightResourceHelper(Resources As ICollection(Of Resource), Field As FindReplace.Field, SelectInPropertyGrid As Boolean, HighlightEntireResource As Boolean)
             Dim NewCategory As Category = Nothing
-            Dim ResourceCollection As New ArrayList()
+            Dim ResourceCollection As New List(Of Resource)
             For Each Resource In Resources
                 If _resourceFile.Contains(Resource) Then
                     Dim CategoryOfResource As Category = Resource.GetCategory(_categories)
@@ -1414,7 +1414,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         If HighlightEntireResource OrElse ResourceCollection.Count <> 1 Then
                             StringTable.HighlightResources(ResourceCollection)
                         Else
-                            StringTable.HighlightResource(DirectCast(ResourceCollection(0), Resource), Field)
+                            StringTable.HighlightResource(ResourceCollection(0), Field)
                         End If
                     Case Else
                         Debug.Fail("Unexpected CategoryDisplay")
@@ -1998,7 +1998,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                 'First, remove all resources from the table or list that belong in the current category.  Need to
                 '  do this first to ensure we don't have the virtual listview trying to get info on missing resources.
-                Dim ResourcesInCurrentCategory As New ArrayList
+                Dim ResourcesInCurrentCategory As New List(Of Resource)
                 For Each Resource In Resources
                     If Resource.GetCategory(_categories) Is _currentCategory Then
                         ResourcesInCurrentCategory.Add(Resource)
@@ -2699,7 +2699,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             'We make a copy of linked resources as well, because if you drag from resource editor to Windows
             '  explorer, Windows will think "move" and try to delete the original source files.  I can't do 
             '  anything about this except to make a temporary copy so that it doesn't matter.
-            Dim ResourceFileNames As New ArrayList
+            Dim ResourceFileNames As New List(Of String)
             Dim TempFolder As String = Nothing
             For Each Resource As Resource In Resources
                 If TempFolder = "" Then
@@ -2749,10 +2749,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Next
             'Build a list of filenames out of the saved/exported files.
             If ResourceFileNames.Count > 0 Then
-                Dim FileNamesArray(ResourceFileNames.Count - 1) As String
-                For i As Integer = 0 To ResourceFileNames.Count - 1
-                    FileNamesArray(i) = DirectCast(ResourceFileNames(i), String)
-                Next
+                Dim FileNamesArray = ResourceFileNames.ToArray()
 
                 '... and add to the data format as the FileDrop format.
                 Data.SetData(DataFormats.FileDrop, False, FileNamesArray)
@@ -3090,7 +3087,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '  disable this scenario.  For drag/drop, we couldn't actually disable the drop (because the VS shell
             '  has the file drop supported style), so the best we can do is ignore any directories when they are
             '  dropped.
-            Dim FilteredFileNames As New ArrayList
+            Dim FilteredFileNames As New List(Of String)
             For Each FileName As String In FileNames
                 If Directory.Exists(FileName) Then
                     'Directory - ignore
@@ -3867,7 +3864,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             Try
                 'Determine the list of filenames to use
-                Dim FileNames As New ArrayList(Resources.Length)
+                Dim FileNames As New List(Of String)(Resources.Length)
                 For Each Resource As Resource In Resources
                     Debug.Assert(Not Resource.IsResXNullRef AndAlso Not Resource.IsLink)
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -1867,12 +1867,12 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     'Force all names to be unique, both among themselves and within the ResourceFile
 
                     '... First, we create a case-insensitive hashtable with all the resource names in the ResourceFile
-                    Dim ResourceNameTable As Hashtable = Specialized.CollectionsUtil.CreateCaseInsensitiveHashtable(ResourceFile.Resources)
+                    Dim ResourceNameTable = New HashSet(Of String)(ResourceFile.Resources.Keys, StringComparers.ResourceNames)
                     '... Then we add to this list as we check for uniqueness and make name changes...
                     For Each Resource In ResourcesReadyToAdd
                         Dim NewResourceName As String = Resource.Name
                         Dim Append As Integer = 0
-                        While ResourceNameTable.ContainsKey(NewResourceName)
+                        While ResourceNameTable.Contains(NewResourceName)
                             'Munge the name and try again
                             Append += 1
                             NewResourceName = Resource.Name & Append
@@ -1880,7 +1880,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                         'Rename the resource and add it to the name table
                         Resource.NameWithoutUndo = NewResourceName
-                        ResourceNameTable.Add(NewResourceName, Resource)
+                        ResourceNameTable.Add(NewResourceName)
                     Next
 
                     'And finally, add them to the resource file and our view.

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -1127,7 +1127,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="CategoryUpdated">The category to change.</param>
         ''' <param name="Sorter"></param>
         ''' <remarks></remarks>
-        Private Sub ChangeSorterForCategory(CategoryUpdated As Category, Sorter As IComparer)
+        Private Sub ChangeSorterForCategory(CategoryUpdated As Category, Sorter As IComparer(Of Resource))
             Debug.Assert(_currentCategory IsNot Nothing)
             If CategoryUpdated Is _currentCategory Then
                 Select Case _currentCategory.CategoryDisplay

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -70,10 +70,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private _currentCategory As Category
 
         'Temporary files which can be cleaned up on the next clipboard flush.
-        Private ReadOnly _deleteFilesOnClipboardFlush As New ArrayList
+        Private ReadOnly _deleteFilesOnClipboardFlush As New List(Of String)
 
-        'Temporary files which can be cleaned up when the editor exists.
-        Private ReadOnly _deleteFoldersOnEditorExit As New ArrayList
+        'Temporary files which can be cleaned up when the editor exits.
+        Private ReadOnly _deleteFoldersOnEditorExit As New List(Of String)
 
         'The set of internal resources that we cache for this instance of the resource editor
         Private _cachedResources As CachedResourcesForView
@@ -4747,8 +4747,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="FilesToDelete"></param>
         ''' <remarks>Swallows exceptions if the files can't be deleted.  Does not display any UI.</remarks>
-        Private Shared Sub DeleteTemporaryFiles(FilesToDelete As IList)
-            For Each FileName As String In FilesToDelete
+        Private Shared Sub DeleteTemporaryFiles(FilesToDelete As IList(Of String))
+            For Each FileName In FilesToDelete
                 Try
                     If File.Exists(FileName) Then
                         File.Delete(FileName)
@@ -4764,8 +4764,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="FoldersToDelete"></param>
         ''' <remarks>Swallows exceptions if the folders can't be deleted.  Does not display any UI.</remarks>
-        Private Shared Sub DeleteTemporaryFolders(FoldersToDelete As IList)
-            For Each FolderName As String In FoldersToDelete
+        Private Shared Sub DeleteTemporaryFolders(FoldersToDelete As IList(Of String))
+            For Each FolderName In FoldersToDelete
                 Try
                     If Directory.Exists(FolderName) Then
                         Directory.Delete(FolderName)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -120,7 +120,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private _inEditingItem As Boolean
 
         ' all menu commands supported by this designer....
-        Private _menuCommands As ArrayList
+        Private _menuCommands As List(Of MenuCommand)
 
         ' ReadOnly Mode
         Private _readOnlyMode As Boolean
@@ -734,7 +734,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             InThisMethod = True
             Try
-                _menuCommands = New ArrayList From {
+                _menuCommands = New List(Of MenuCommand) From {
                     New DesignerMenuCommand(RootDesigner, Constants.MenuConstants.CommandIDResXPlay, AddressOf MenuPlay, AddressOf MenuPlayEnabledHandler,
                     AlwaysCheckStatus:=True),
                     New DesignerMenuCommand(RootDesigner, Constants.MenuConstants.CommandIDVSStd97Open, AddressOf MenuOpen, AddressOf MenuOpenOpenWithEnabledHandler,
@@ -809,7 +809,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         AlwaysCheckStatus:=True))
 
                     'Access modifier combobox
-                    _menuCommands.AddRange(_accessModifierCombobox.GetMenuCommandsToRegister())
+                    _menuCommands.AddRange(_accessModifierCombobox.GetMenuCommandsToRegister().Cast(Of MenuCommand))
 
                 End If
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView_EditorState.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView_EditorState.vb
@@ -181,7 +181,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         For Each Entry As DictionaryEntry In _categorySorter
                             Dim Category As Category = View._categories(CStr(Entry.Key))
                             If Category IsNot Nothing Then
-                                View.ChangeSorterForCategory(Category, DirectCast(Entry.Value, IComparer))
+                                View.ChangeSorterForCategory(Category, DirectCast(Entry.Value, IComparer(Of Resource)))
                             End If
                         Next
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '  Since we're using the listview in virtual mode (in order to accomplish
         '  delay-load of the images from disk), we keep track of the data ourselves.
         '  The base listview notifies us when it needs data to display.
-        Private ReadOnly _virtualResourceList As New ArrayList 'Of Resource
+        Private ReadOnly _virtualResourceList As New List(Of Resource)
 
         'A cache of thumbnails for the listview items that we are displaying.  This has
         '  knowledge of our imagelist, and manages it for us.
@@ -623,7 +623,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="originalSorter"></param>
         ''' <remarks></remarks>
-        Friend Sub RestoreSorter(originalSorter As IComparer)
+        Friend Sub RestoreSorter(originalSorter As IComparer(Of Resource))
             Dim listViewSorter As DetailViewSorter = TryCast(originalSorter, DetailViewSorter)
             If listViewSorter IsNot Nothing Then
                 SortOnColumn(listViewSorter.ColumnIndex, listViewSorter.InReverseOrder)
@@ -1365,7 +1365,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks>
         '''   The resources are added to the end of the list, alphabetized.
         ''' </remarks>
-        Public Sub AddResources(Resources As IList)
+        Public Sub AddResources(Resources As IList(Of Resource))
             UnselectAll()
             Debug.Assert(_virtualResourceList.Count = VirtualListSize)
 
@@ -1375,7 +1375,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             End If
 
             'Alphabetize
-            Dim AlphabetizedResources As New ArrayList(Resources)
+            Dim AlphabetizedResources As New List(Of Resource)(Resources)
             AlphabetizedResources.Sort(_sorter)
 
             '... and add them to the end of the list.
@@ -1436,7 +1436,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' A helper class to sort the resource list in the detail view
         ''' </summary>
         Private Class DetailViewSorter
-            Implements IComparer
+            Implements IComparer(Of Resource)
 
             ' which column is used to sort the list
             Private _columnIndex As Integer
@@ -1474,7 +1474,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             '''  Compare two list items
             ''' </summary>
-            Public Function Compare(x As Object, y As Object) As Integer Implements IComparer.Compare
+            Public Function Compare(x As Resource, y As Resource) As Integer Implements IComparer(Of Resource).Compare
                 Dim ret As Integer = String.Compare(GetColumnValue(x, _columnIndex), GetColumnValue(y, _columnIndex), StringComparison.CurrentCultureIgnoreCase)
                 If ret = 0 AndAlso _columnIndex <> 0 Then
                     ret = String.Compare(GetColumnValue(x, 0), GetColumnValue(y, 0), StringComparison.CurrentCultureIgnoreCase)
@@ -1488,13 +1488,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             '''  Get String Value of one column
             ''' </summary>
-            Private Shared Function GetColumnValue(obj As Object, column As Integer) As String
-                If TypeOf obj Is Resource Then
-                    Return GetDetailViewColumn(DirectCast(obj, Resource), column)
-                End If
-
-                Debug.Fail("DetailViewSorter: obj was not a Resource")
-                Return String.Empty
+            Private Shared Function GetColumnValue(obj As Resource, column As Integer) As String
+                Return GetDetailViewColumn(obj, column)
             End Function
 
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService_Store.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService_Store.vb
@@ -69,7 +69,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '  "serialize" into this store.  The actual values won't be serialized
             '  until we're Close'd, until then this just keeps track of what we
             '  want to serialize.  It will be cleared out when we Close.
-            Private _hashedObjectsToSerialize As Hashtable 'Of ResourceSerializationData
+            Private _resourcesToSerialize As Dictionary(Of Resource, ResourceDataToSerialize)
 
 
             'The actual "serialized" data (binary serialized Resource instances and
@@ -92,7 +92,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' </summary>
             ''' <remarks></remarks>
             Public Sub New()
-                _hashedObjectsToSerialize = New Hashtable
+                _resourcesToSerialize = New Dictionary(Of Resource, ResourceDataToSerialize)
 
                 Trace("Created new store")
             End Sub
@@ -108,26 +108,26 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <remarks></remarks>
             Public Overrides Sub Close()
                 If _serializedState Is Nothing Then
-                    Dim SerializedState As New ArrayList(_hashedObjectsToSerialize.Count)
+                    Dim SerializedState As New ArrayList(_resourcesToSerialize.Count)
 
-                    Trace("Closing Store: serializing {0} objects", _hashedObjectsToSerialize.Count)
+                    Trace("Closing Store: serializing {0} objects", _resourcesToSerialize.Count)
 
                     'Go through each object that we wanted to save anything from...
-                    For Each Entry As DictionaryEntry In _hashedObjectsToSerialize
-                        Dim Data As ResourceDataToSerialize = DirectCast(Entry.Value, ResourceDataToSerialize)
-                        If Data.EntireObject Then
+                    For Each ResourceData In _resourcesToSerialize.Values
+
+                        If ResourceData.EntireObject Then
                             'We're saving the entire Resource object.
                             '  The constructor for SerializedResourceOrProperty will do the
                             '  actual binary serialization for us.
-                            Dim SerializedData As New SerializedResourceOrProperty(Data.Resource)
+                            Dim SerializedData As New SerializedResourceOrProperty(ResourceData.Resource)
                             SerializedState.Add(SerializedData)
                         Else
                             'We're saving individual property values.  Go through each...
-                            For Each Prop As PropertyDescriptor In Data.PropertiesToSerialize
+                            For Each Prop As PropertyDescriptor In ResourceData.PropertiesToSerialize
                                 '... and serialize it.
                                 '  The constructor for SerializedResourceOrProperty will do the
                                 '  actual binary serialization for us.
-                                Dim SerializedData As New SerializedResourceOrProperty(Data.Resource, Prop)
+                                Dim SerializedData As New SerializedResourceOrProperty(ResourceData.Resource, Prop)
                                 SerializedState.Add(SerializedData)
                             Next
                         End If
@@ -136,7 +136,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     'Save what we've serialized, and clear out the old data - it's no longer
                     '  needed.
                     _serializedState = SerializedState
-                    _hashedObjectsToSerialize = Nothing
+                    _resourcesToSerialize = Nothing
                 End If
             End Sub
 
@@ -267,16 +267,16 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <returns>The ResourceDataToSerialize object associated with this Resource.</returns>
             ''' <remarks></remarks>
             Private Function GetResourceSerializationData(Resource As Resource) As ResourceDataToSerialize
-                Dim Data As ResourceDataToSerialize = DirectCast(_hashedObjectsToSerialize(Resource), ResourceDataToSerialize)
-                If Data Is Nothing Then
+                Dim ResourceData As ResourceDataToSerialize = Nothing
+                If Not _resourcesToSerialize.TryGetValue(Resource, ResourceData) Then
                     'No object created for this Resource yet.  Create one now.
-                    Data = New ResourceDataToSerialize(Resource)
-                    _hashedObjectsToSerialize(Resource) = Data
+                    ResourceData = New ResourceDataToSerialize(Resource)
+                    _resourcesToSerialize(Resource) = ResourceData
 
                     Trace("ResourceSerializationService: Adding new ResourceSerializationData to hashed objects to serialize: '{0}'", Resource.Name)
                 End If
 
-                Return Data
+                Return ResourceData
             End Function
 
 #End Region

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
         'A list of all Resource entries that are displayed in this string table (with the exception
         '  of the uncommitted resource, if any)
-        Private ReadOnly _virtualResourceList As New ArrayList
+        Private ReadOnly _virtualResourceList As New List(Of Resource)
 
         'The row that is currently being removed, if any.
         Private _removingRow As DataGridViewRow
@@ -301,7 +301,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             _virtualResourceList.Clear()
 
             'First, create a sorted list of resources that we want to display
-            Dim ResourcesToDisplay As New ArrayList
+            Dim ResourcesToDisplay As New List(Of Resource)
             Dim Categories As CategoryCollection = ResourceFile.RootComponent.RootDesigner.GetView().Categories
             For Each Entry As DictionaryEntry In ResourceFile
                 Dim Resource As Resource = DirectCast(Entry.Value, Resource)
@@ -1517,7 +1517,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="originalSorter"></param>
         ''' <remarks></remarks>
-        Friend Sub RestoreSorter(originalSorter As IComparer)
+        Friend Sub RestoreSorter(originalSorter As IComparer(Of Resource))
             Dim stringSorter As StringTableSorter = TryCast(originalSorter, StringTableSorter)
             If stringSorter IsNot Nothing Then
                 SortOnColumn(stringSorter.ColumnIndex, stringSorter.InReverseOrder)
@@ -1600,7 +1600,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' A helper class to sort the resource list in the Data Grid View
         ''' </summary>
         Private Class StringTableSorter
-            Implements IComparer
+            Implements IComparer(Of Resource)
 
             ' which column is used to sort the list
             Private _columnIndex As Integer
@@ -1638,7 +1638,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             '''  Compare two list items
             ''' </summary>
-            Public Function Compare(x As Object, y As Object) As Integer Implements IComparer.Compare
+            Public Function Compare(x As Resource, y As Resource) As Integer Implements IComparer(Of Resource).Compare
                 Dim ret As Integer = String.Compare(GetColumnValue(x, _columnIndex), GetColumnValue(y, _columnIndex), StringComparison.CurrentCultureIgnoreCase)
                 If ret = 0 AndAlso _columnIndex <> COLUMN_NAME Then
                     ret = String.Compare(GetColumnValue(x, COLUMN_NAME), GetColumnValue(y, COLUMN_NAME), StringComparison.CurrentCultureIgnoreCase)
@@ -1652,15 +1652,13 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             '''  Get String Value of one column
             ''' </summary>
-            Private Shared Function GetColumnValue(obj As Object, column As Integer) As String
-                If TypeOf obj Is Resource Then
-                    Dim value As String = GetResourceCellStringValue(DirectCast(obj, Resource), column)
-                    If value IsNot Nothing Then
-                        Return value
-                    End If
-                Else
-                    Debug.Fail("DetailViewSorter: obj was not a Resource")
+            Private Shared Function GetColumnValue(obj As Resource, column As Integer) As String
+
+                Dim value As String = GetResourceCellStringValue(obj, column)
+                If value IsNot Nothing Then
+                    Return value
                 End If
+
                 Return String.Empty
             End Function
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ThumbnailCache.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ThumbnailCache.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -49,7 +49,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '  replace an old image in the ImageList (without shifting other indices) does not allow you 
         '  to simultaneously change the key.  When we replace an image in the imagelist, we're also
         '  using a different key.
-        Private ReadOnly _keys As New Hashtable
+        Private ReadOnly _keys As New Dictionary(Of Object, Integer)
 
         'An Mru List we maintained to release the most less used item in the ImageList when we need load a new image.
         ' For performance reason, we implement the list table inside an array of structures. Each item contains a point (index)
@@ -314,10 +314,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private Function GetCachedImageListIndexInternal(Key As Object, ByRef Index As Integer) As Boolean
             Dim ThumbnailFound As Boolean
             Debug.Assert(Key IsNot Nothing)
-            Dim IndexAsObject As Object = _keys(Key)
-            Debug.Assert(_keys.ContainsKey(Key) = (IndexAsObject IsNot Nothing))
 
-            If IndexAsObject Is Nothing Then
+            If Not _keys.TryGetValue(Key, Index) Then
                 'Sorry, we no longer have a copy of that thumbnail...  You have to re-add it.
                 ThumbnailFound = False
                 Index = -1
@@ -327,7 +325,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 '  a higher value.
 
                 ThumbnailFound = True
-                Index = DirectCast(IndexAsObject, Integer)
                 Debug.Assert(Index < ThumbnailCount + _reservedImagesCount)
             End If
             Return ThumbnailFound
@@ -471,7 +468,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Do
                 Debug.Assert(_mruList(i).PreviousIndex = prev)
                 If _mruList(i).Key IsNot Nothing Then
-                    Debug.Assert(_keys.Contains(_mruList(i).Key))
+                    Debug.Assert(_keys.ContainsKey(_mruList(i).Key))
                 End If
 
                 count += 1

--- a/src/Microsoft.VisualStudio.Editors/StringComparers.vb
+++ b/src/Microsoft.VisualStudio.Editors/StringComparers.vb
@@ -19,6 +19,12 @@ Namespace Microsoft.VisualStudio
             End Get
         End Property
 
+        Public Shared ReadOnly Property Paths As StringComparer
+            Get
+                Return StringComparer.OrdinalIgnoreCase
+            End Get
+        End Property
+
     End Class
 
 End Namespace


### PR DESCRIPTION
This gets rid of almost all the remaining Hashtables in the Resource Editor, as well as most of the ArrayLists. I'll get the rest of the ArrayLists in another PR.