### PR TITLE
Correctly check if the user wants to rename the symbol

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/Renamer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/Renamer.cs
@@ -91,7 +91,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                 return;
 
             // Ask if the user wants to rename the symbol
-            if (await CheckUserConfirmation(oldName)) != true)
+            bool userWantsToRenameSymbol = await CheckUserConfirmation(oldName);
+            if (!userWantsToRenameSymbol)
                 return;
 
             // Try and apply the changes to the current solution

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/Renamer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/Renamer.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                 return;
 
             // Ask if the user wants to rename the symbol
-            if (await CheckUserConfirmation(oldName))
+            if (await CheckUserConfirmation(oldName)) != true)
                 return;
 
             // Try and apply the changes to the current solution


### PR DESCRIPTION
Somewhere along the way the check go reversed so we never actually attempt to do a rename.