### PR TITLE
Switch to asynchronous disposal so we don't block project unload

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                                            IProjectThreadingService threadingService,
                                            IDesignTimeInputsDataSource designTimeInputsDataSource,
                                            IVsService<SVsFileChangeEx, IVsAsyncFileChangeEx> fileChangeService)
-             : base(unconfiguredProjectServices, synchronousDisposal: true, registerDataSource: false)
+             : base(unconfiguredProjectServices, synchronousDisposal: false, registerDataSource: false)
         {
             _threadingService = threadingService;
             _designTimeInputsDataSource = designTimeInputsDataSource;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             await finished.Task;
 
             // Dispose the watcher so that internal blocks complete (especially for tests that don't send any file changes)
-            watcher.Dispose();
+            await watcher.DisposeAsync();
 
             // Make sure we watched all of the files we should
             Assert.Equal(watchedFiles, fileChangeService.UniqueFilesWatched);


### PR DESCRIPTION
Fixes [AB#994099](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/994099)

Switch to asynchronous disposal of the file watcher, so project unload isn't blocked. If the file watcher never actually got to process any of its input, then disposal could require a switch to the UI thread in order to get the file watcher service.