### PR TITLE
Better handle empty target frameworks

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -182,14 +182,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Requires.NotNull(activeTargetFramework, nameof(activeTargetFramework));
             Requires.NotNull(dependenciesByTargetFramework, nameof(dependenciesByTargetFramework));
 
-            if (activeTargetFramework.Equals(TargetFramework.Empty))
-            {
-                Requires.Argument(
-                    dependenciesByTargetFramework.Count == 0,
-                    nameof(dependenciesByTargetFramework),
-                    $"Must be empty when {nameof(activeTargetFramework)} is empty.");
-            }
-            else
+            if (!activeTargetFramework.Equals(TargetFramework.Empty))
             {
                 Requires.Argument(
                     dependenciesByTargetFramework.ContainsKey(activeTargetFramework),

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.ContextTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.ContextTracker.cs
@@ -69,6 +69,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     if (!previousContext.IsCrossTargeting)
                     {
                         string? newTargetFrameworkName = (string?)await projectProperties.TargetFramework.GetValueAsync();
+
+                        if (string.IsNullOrEmpty(newTargetFrameworkName) && TargetFramework.Empty.Equals(previousContext.ActiveTargetFramework))
+                        {
+                            // No change
+                            return null;
+                        }
+
                         ITargetFramework? newTargetFramework = _targetFrameworkProvider.GetTargetFramework(newTargetFrameworkName);
                         if (previousContext.ActiveTargetFramework.Equals(newTargetFramework))
                         {


### PR DESCRIPTION
While investigating [AB#719762](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/719762), which uses non-standard "CPS Barebone" project templates, it became clear we do not handle empty target frameworks correctly in some cases.