### PR TITLE
Revert https://github.com/dotnet/project-system/pull/5577

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseRootDesigner.vb
@@ -102,17 +102,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             Next
         End Sub
 
-        ''' <summary>
-        ''' See <see cref="RegisterMenuCommands(ArrayList, Boolean)"/>.
-        ''' </summary>
-        ''' <remarks>This just converts <paramref name="MenuCommands"/> to an <see cref="ArrayList"/> and passes it
-        ''' to <see cref="RegisterMenuCommands(ArrayList, Boolean)"/>. Once we're done refactoring this class to
-        ''' eliminate <see cref="ArrayList"/> that overload will go away.</remarks>
-        Friend Sub RegisterMenuCommands(MenuCommands As List(Of MenuCommand),
-                Optional KeepRegisteredMenuCommands As Boolean = True)
-            RegisterMenuCommands(New ArrayList(MenuCommands), KeepRegisteredMenuCommands)
-        End Sub
-
         Friend Sub RemoveMenuCommands()
             'Iterate backwards to avoid problems removing while iterating
             For i As Integer = MenuCommands.Count - 1 To 0 Step -1

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Category.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Category.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -48,7 +48,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private _showTypeColumnInStringTable As Boolean 'applies only to Display.StringTable
         Private ReadOnly _menuCommand As MenuCommand
         Private _addCommand As EventHandler
-        Private _sorter As IComparer(Of Resource)           ' how to sort resources in the category...
+        Private _sorter As IComparer           ' how to sort resources in the category...
 
 
         '======================================================================
@@ -253,7 +253,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <value></value>
         ''' <remarks></remarks>
-        Public Property Sorter() As IComparer(Of Resource)
+        Public Property Sorter() As IComparer
             Get
                 Return _sorter
             End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/CategoryCollection.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/CategoryCollection.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Strict On
 Option Explicit On
@@ -14,12 +14,20 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     Friend NotInheritable Class CategoryCollection
         Inherits CollectionBase
 
+
+
         'A hashtable list of resources by name.
-        Private ReadOnly _innerHashByName As New Dictionary(Of String, Category)
+        Private ReadOnly _innerHashByName As New Hashtable 'Of String (case-sensitive)
+
+
+
 
         '======================================================================
         '= Properties =                                                       =
         '======================================================================
+
+
+
 
         ''' <summary>
         ''' Searches for a category by its index
@@ -42,9 +50,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks>Does not throw an exception if not found.</remarks>
         Default Public ReadOnly Property Item(ProgrammaticCategoryName As String) As Category
             Get
-                Dim Value As Category = Nothing
-                _innerHashByName.TryGetValue(ProgrammaticCategoryName, Value)
-                Return Value
+                Return DirectCast(_innerHashByName(ProgrammaticCategoryName), Category)
             End Get
         End Property
 
@@ -68,7 +74,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             InnerList.Add(Category)
 
             'Add to the hash table (for indexing by programmatic name)
-            _innerHashByName(Category.ProgrammaticName) = Category
+            _innerHashByName.Add(Category.ProgrammaticName, Category)
         End Sub
 
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
@@ -517,17 +517,23 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks></remarks>
         Private ReadOnly Property GetResourcesToSearch(FindInSelection As Boolean) As Resource()
             Get
-                Dim ResourcesToSearch = New List(Of Resource)(View.ResourceFile.Resources.Count)
+                Dim ResourcesToSearch As ArrayList
 
                 Trace("Getting list of resources to search through")
 
                 'First collect all the resources to search through
                 If FindInSelection Then
-                    Dim SelectedResources = View.GetSelectedResources()
-                    ResourcesToSearch.AddRange(SelectedResources)
+                    Dim SelectedResources() As Resource = View.GetSelectedResources()
+                    ResourcesToSearch = New ArrayList(View.ResourceFile.Resources.Count)
+                    For Each Resource As Resource In SelectedResources
+                        ResourcesToSearch.Add(Resource)
+                    Next
                 Else
-                    Dim AllResources = View.ResourceFile.Resources.Values
-                    ResourcesToSearch.AddRange(AllResources)
+                    ResourcesToSearch = New ArrayList(View.ResourceFile.Resources.Count)
+                    For Each Entry As DictionaryEntry In View.ResourceFile
+                        Dim Resource As Resource = DirectCast(Entry.Value, Resource)
+                        ResourcesToSearch.Add(Resource)
+                    Next
                 End If
 
                 'Now sort them according to category and name

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparer.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparer.vb
@@ -8,19 +8,19 @@ Imports System.Globalization
 Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
     ''' <summary>
-    ''' This is an <see cref="IComparer(Of T)"/> implementation used to sort <see cref="Resource"/>s for UI purposes (ResourceListView and
+    ''' This is an Icomparer implementation used to sort Resources for UI purposes (ResourceListView and
     '''    ResourceStringTable).
     ''' </summary>
     ''' <remarks></remarks>
     Friend NotInheritable Class ResourceComparer
-        Implements IComparer(Of Resource)
+        Implements IComparer
 
         ''' <summary>
-        ''' Sorts a <see cref="List(Of Resource)"/> for UI purposes
+        ''' Sorts an ArrayList of Resources for UI purposes
         ''' </summary>
-        ''' <param name="Resources"><see cref="List(Of Resource)"/> to sort (will be sorted in place)</param>
+        ''' <param name="Resources">ArrayList of Resources to source (will be sorted in place)</param>
         ''' <remarks></remarks>
-        Public Shared Sub SortResources(Resources As List(Of Resource))
+        Public Shared Sub SortResources(Resources As ArrayList)
             Resources.Sort(New ResourceComparer)
         End Sub
 
@@ -31,9 +31,13 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="y">Second object to compare.</param>
         ''' <returns>-1, 0 or 1, depending on whether x is less than, equal to or greater than y, respectively.</returns>
         ''' <remarks>This function gets called by ArrayList.Sort for each pair of resources to be sorted.</remarks>
-        Private Function Compare(x As Resource, y As Resource) As Integer Implements IComparer(Of Resource).Compare
+        Private Function Compare(x As Object, y As Object) As Integer Implements IComparer.Compare
+            Debug.Assert(TypeOf x Is Resource AndAlso TypeOf y Is Resource, "ResourceComparer: expected Resources")
+            Dim Resource1 As Resource = DirectCast(x, Resource)
+            Dim Resource2 As Resource = DirectCast(y, Resource)
+
             'We currently only support sorting alphabetically according to Name.
-            Return String.Compare(x.Name, y.Name, ignoreCase:=True, culture:=CultureInfo.CurrentUICulture)
+            Return String.Compare(Resource1.Name, Resource2.Name, ignoreCase:=True, culture:=CultureInfo.CurrentUICulture)
         End Function
     End Class
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparerForFind.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparerForFind.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -12,10 +12,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' </summary>
     ''' <remarks></remarks>
     Friend NotInheritable Class ResourceComparerForFind
-        Implements IComparer(Of Resource)
+        Implements IComparer
 
-        'A dictionary that maps a Category to its sort order
-        Private ReadOnly _categoryToCategoryOrderHash As New Dictionary(Of Category, Integer)
+        'A hashtable that maps a Category to its sort order
+        Private ReadOnly _categoryToCategoryOrderHash As New Hashtable
 
         'All categories included in the search
         Private ReadOnly _categories As CategoryCollection
@@ -36,7 +36,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             Dim CategoryOrder As Integer = 0
             For Each Category As Category In OrderedCategories
-                _categoryToCategoryOrderHash(Category) = CategoryOrder
+                _categoryToCategoryOrderHash.Add(Category, CategoryOrder)
                 CategoryOrder += 1
             Next
             Debug.Assert(_categoryToCategoryOrderHash.Count = OrderedCategories.Count)
@@ -44,11 +44,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
 
         ''' <summary>
-        ''' Sorts a <see cref="List(Of Resource)"/> for UI purposes
+        ''' Sorts an ArrayList of Resoures for UI purposes
         ''' </summary>
-        ''' <param name="Resources"><see cref="List(Of Resource)"/> to sort (will be sorted in place)</param>
+        ''' <param name="Resources">ArrayList of Resources to source (will be sorted in place)</param>
         ''' <remarks></remarks>
-        Public Sub SortResources(Resources As List(Of Resource))
+        Public Sub SortResources(Resources As ArrayList)
             Resources.Sort(Me)
         End Sub
 
@@ -56,16 +56,20 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Compares two objects and returns a value indicating whether one is less than, equal to or greater than the other.
         ''' </summary>
-        ''' <param name="Resource1">First object to compare.</param>
-        ''' <param name="Resource2">Second object to compare.</param>
+        ''' <param name="x">First object to compare.</param>
+        ''' <param name="y">Second object to compare.</param>
         ''' <returns>-1, 0 or 1, depending on whether x is less than, equal to or greater than y, respectively.</returns>
         ''' <remarks>This function gets called by ArrayList.Sort for each pair of resources to be sorted.</remarks>
-        Private Function Compare(Resource1 As Resource, Resource2 As Resource) As Integer Implements IComparer(Of Resource).Compare
+        Private Function Compare(x As Object, y As Object) As Integer Implements IComparer.Compare
+            Debug.Assert(TypeOf x Is Resource AndAlso TypeOf y Is Resource, "ResourceComparer: expected Resources")
+            Dim Resource1 As Resource = DirectCast(x, Resource)
+            Dim Resource2 As Resource = DirectCast(y, Resource)
+
             Dim category1 As Category = Resource1.GetCategory(_categories)
 
             'First compare by category
-            Dim Resource1CategoryOrder As Integer = _categoryToCategoryOrderHash(category1)
-            Dim Resource2CategoryOrder As Integer = _categoryToCategoryOrderHash(Resource2.GetCategory(_categories))
+            Dim Resource1CategoryOrder As Integer = DirectCast(_categoryToCategoryOrderHash(category1), Integer)
+            Dim Resource2CategoryOrder As Integer = DirectCast(_categoryToCategoryOrderHash(Resource2.GetCategory(_categories)), Integer)
 
             If Resource1CategoryOrder > Resource2CategoryOrder Then
                 Return 1

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -70,10 +70,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private _currentCategory As Category
 
         'Temporary files which can be cleaned up on the next clipboard flush.
-        Private ReadOnly _deleteFilesOnClipboardFlush As New List(Of String)
+        Private ReadOnly _deleteFilesOnClipboardFlush As New ArrayList
 
-        'Temporary files which can be cleaned up when the editor exits.
-        Private ReadOnly _deleteFoldersOnEditorExit As New List(Of String)
+        'Temporary files which can be cleaned up when the editor exists.
+        Private ReadOnly _deleteFoldersOnEditorExit As New ArrayList
 
         'The set of internal resources that we cache for this instance of the resource editor
         Private _cachedResources As CachedResourcesForView
@@ -120,7 +120,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private _inEditingItem As Boolean
 
         ' all menu commands supported by this designer....
-        Private _menuCommands As List(Of MenuCommand)
+        Private _menuCommands As ArrayList
 
         ' ReadOnly Mode
         Private _readOnlyMode As Boolean
@@ -734,7 +734,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             InThisMethod = True
             Try
-                _menuCommands = New List(Of MenuCommand) From {
+                _menuCommands = New ArrayList From {
                     New DesignerMenuCommand(RootDesigner, Constants.MenuConstants.CommandIDResXPlay, AddressOf MenuPlay, AddressOf MenuPlayEnabledHandler,
                     AlwaysCheckStatus:=True),
                     New DesignerMenuCommand(RootDesigner, Constants.MenuConstants.CommandIDVSStd97Open, AddressOf MenuOpen, AddressOf MenuOpenOpenWithEnabledHandler,
@@ -809,7 +809,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         AlwaysCheckStatus:=True))
 
                     'Access modifier combobox
-                    _menuCommands.AddRange(_accessModifierCombobox.GetMenuCommandsToRegister().Cast(Of MenuCommand))
+                    _menuCommands.AddRange(_accessModifierCombobox.GetMenuCommandsToRegister())
 
                 End If
 
@@ -1127,7 +1127,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="CategoryUpdated">The category to change.</param>
         ''' <param name="Sorter"></param>
         ''' <remarks></remarks>
-        Private Sub ChangeSorterForCategory(CategoryUpdated As Category, Sorter As IComparer(Of Resource))
+        Private Sub ChangeSorterForCategory(CategoryUpdated As Category, Sorter As IComparer)
             Debug.Assert(_currentCategory IsNot Nothing)
             If CategoryUpdated Is _currentCategory Then
                 Select Case _currentCategory.CategoryDisplay
@@ -1379,7 +1379,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks></remarks>
         Private Sub HighlightResourceHelper(Resources As ICollection(Of Resource), Field As FindReplace.Field, SelectInPropertyGrid As Boolean, HighlightEntireResource As Boolean)
             Dim NewCategory As Category = Nothing
-            Dim ResourceCollection As New List(Of Resource)
+            Dim ResourceCollection As New ArrayList()
             For Each Resource In Resources
                 If _resourceFile.Contains(Resource) Then
                     Dim CategoryOfResource As Category = Resource.GetCategory(_categories)
@@ -1414,7 +1414,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         If HighlightEntireResource OrElse ResourceCollection.Count <> 1 Then
                             StringTable.HighlightResources(ResourceCollection)
                         Else
-                            StringTable.HighlightResource(ResourceCollection(0), Field)
+                            StringTable.HighlightResource(DirectCast(ResourceCollection(0), Resource), Field)
                         End If
                     Case Else
                         Debug.Fail("Unexpected CategoryDisplay")
@@ -1867,12 +1867,12 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     'Force all names to be unique, both among themselves and within the ResourceFile
 
                     '... First, we create a case-insensitive hashtable with all the resource names in the ResourceFile
-                    Dim ResourceNameTable = New HashSet(Of String)(ResourceFile.Resources.Keys, StringComparers.ResourceNames)
+                    Dim ResourceNameTable As Hashtable = Specialized.CollectionsUtil.CreateCaseInsensitiveHashtable(ResourceFile.Resources)
                     '... Then we add to this list as we check for uniqueness and make name changes...
                     For Each Resource In ResourcesReadyToAdd
                         Dim NewResourceName As String = Resource.Name
                         Dim Append As Integer = 0
-                        While ResourceNameTable.Contains(NewResourceName)
+                        While ResourceNameTable.ContainsKey(NewResourceName)
                             'Munge the name and try again
                             Append += 1
                             NewResourceName = Resource.Name & Append
@@ -1880,7 +1880,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                         'Rename the resource and add it to the name table
                         Resource.NameWithoutUndo = NewResourceName
-                        ResourceNameTable.Add(NewResourceName)
+                        ResourceNameTable.Add(NewResourceName, Resource)
                     Next
 
                     'And finally, add them to the resource file and our view.
@@ -1998,7 +1998,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                 'First, remove all resources from the table or list that belong in the current category.  Need to
                 '  do this first to ensure we don't have the virtual listview trying to get info on missing resources.
-                Dim ResourcesInCurrentCategory As New List(Of Resource)
+                Dim ResourcesInCurrentCategory As New ArrayList
                 For Each Resource In Resources
                     If Resource.GetCategory(_categories) Is _currentCategory Then
                         ResourcesInCurrentCategory.Add(Resource)
@@ -2699,7 +2699,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             'We make a copy of linked resources as well, because if you drag from resource editor to Windows
             '  explorer, Windows will think "move" and try to delete the original source files.  I can't do 
             '  anything about this except to make a temporary copy so that it doesn't matter.
-            Dim ResourceFileNames As New List(Of String)
+            Dim ResourceFileNames As New ArrayList
             Dim TempFolder As String = Nothing
             For Each Resource As Resource In Resources
                 If TempFolder = "" Then
@@ -2749,7 +2749,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Next
             'Build a list of filenames out of the saved/exported files.
             If ResourceFileNames.Count > 0 Then
-                Dim FileNamesArray = ResourceFileNames.ToArray()
+                Dim FileNamesArray(ResourceFileNames.Count - 1) As String
+                For i As Integer = 0 To ResourceFileNames.Count - 1
+                    FileNamesArray(i) = DirectCast(ResourceFileNames(i), String)
+                Next
 
                 '... and add to the data format as the FileDrop format.
                 Data.SetData(DataFormats.FileDrop, False, FileNamesArray)
@@ -3087,7 +3090,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '  disable this scenario.  For drag/drop, we couldn't actually disable the drop (because the VS shell
             '  has the file drop supported style), so the best we can do is ignore any directories when they are
             '  dropped.
-            Dim FilteredFileNames As New List(Of String)
+            Dim FilteredFileNames As New ArrayList
             For Each FileName As String In FileNames
                 If Directory.Exists(FileName) Then
                     'Directory - ignore
@@ -3864,7 +3867,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             Try
                 'Determine the list of filenames to use
-                Dim FileNames As New List(Of String)(Resources.Length)
+                Dim FileNames As New ArrayList(Resources.Length)
                 For Each Resource As Resource In Resources
                     Debug.Assert(Not Resource.IsResXNullRef AndAlso Not Resource.IsLink)
 
@@ -4744,8 +4747,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="FilesToDelete"></param>
         ''' <remarks>Swallows exceptions if the files can't be deleted.  Does not display any UI.</remarks>
-        Private Shared Sub DeleteTemporaryFiles(FilesToDelete As IList(Of String))
-            For Each FileName In FilesToDelete
+        Private Shared Sub DeleteTemporaryFiles(FilesToDelete As IList)
+            For Each FileName As String In FilesToDelete
                 Try
                     If File.Exists(FileName) Then
                         File.Delete(FileName)
@@ -4761,8 +4764,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="FoldersToDelete"></param>
         ''' <remarks>Swallows exceptions if the folders can't be deleted.  Does not display any UI.</remarks>
-        Private Shared Sub DeleteTemporaryFolders(FoldersToDelete As IList(Of String))
-            For Each FolderName In FoldersToDelete
+        Private Shared Sub DeleteTemporaryFolders(FoldersToDelete As IList)
+            For Each FolderName As String In FoldersToDelete
                 Try
                     If Directory.Exists(FolderName) Then
                         Directory.Delete(FolderName)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView_EditorState.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView_EditorState.vb
@@ -181,7 +181,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         For Each Entry As DictionaryEntry In _categorySorter
                             Dim Category As Category = View._categories(CStr(Entry.Key))
                             If Category IsNot Nothing Then
-                                View.ChangeSorterForCategory(Category, DirectCast(Entry.Value, IComparer(Of Resource)))
+                                View.ChangeSorterForCategory(Category, DirectCast(Entry.Value, IComparer))
                             End If
                         Next
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '  Since we're using the listview in virtual mode (in order to accomplish
         '  delay-load of the images from disk), we keep track of the data ourselves.
         '  The base listview notifies us when it needs data to display.
-        Private ReadOnly _virtualResourceList As New List(Of Resource)
+        Private ReadOnly _virtualResourceList As New ArrayList 'Of Resource
 
         'A cache of thumbnails for the listview items that we are displaying.  This has
         '  knowledge of our imagelist, and manages it for us.
@@ -623,7 +623,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="originalSorter"></param>
         ''' <remarks></remarks>
-        Friend Sub RestoreSorter(originalSorter As IComparer(Of Resource))
+        Friend Sub RestoreSorter(originalSorter As IComparer)
             Dim listViewSorter As DetailViewSorter = TryCast(originalSorter, DetailViewSorter)
             If listViewSorter IsNot Nothing Then
                 SortOnColumn(listViewSorter.ColumnIndex, listViewSorter.InReverseOrder)
@@ -1365,7 +1365,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks>
         '''   The resources are added to the end of the list, alphabetized.
         ''' </remarks>
-        Public Sub AddResources(Resources As IList(Of Resource))
+        Public Sub AddResources(Resources As IList)
             UnselectAll()
             Debug.Assert(_virtualResourceList.Count = VirtualListSize)
 
@@ -1375,7 +1375,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             End If
 
             'Alphabetize
-            Dim AlphabetizedResources As New List(Of Resource)(Resources)
+            Dim AlphabetizedResources As New ArrayList(Resources)
             AlphabetizedResources.Sort(_sorter)
 
             '... and add them to the end of the list.
@@ -1436,7 +1436,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' A helper class to sort the resource list in the detail view
         ''' </summary>
         Private Class DetailViewSorter
-            Implements IComparer(Of Resource)
+            Implements IComparer
 
             ' which column is used to sort the list
             Private _columnIndex As Integer
@@ -1474,7 +1474,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             '''  Compare two list items
             ''' </summary>
-            Public Function Compare(x As Resource, y As Resource) As Integer Implements IComparer(Of Resource).Compare
+            Public Function Compare(x As Object, y As Object) As Integer Implements IComparer.Compare
                 Dim ret As Integer = String.Compare(GetColumnValue(x, _columnIndex), GetColumnValue(y, _columnIndex), StringComparison.CurrentCultureIgnoreCase)
                 If ret = 0 AndAlso _columnIndex <> 0 Then
                     ret = String.Compare(GetColumnValue(x, 0), GetColumnValue(y, 0), StringComparison.CurrentCultureIgnoreCase)
@@ -1488,8 +1488,13 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             '''  Get String Value of one column
             ''' </summary>
-            Private Shared Function GetColumnValue(obj As Resource, column As Integer) As String
-                Return GetDetailViewColumn(obj, column)
+            Private Shared Function GetColumnValue(obj As Object, column As Integer) As String
+                If TypeOf obj Is Resource Then
+                    Return GetDetailViewColumn(DirectCast(obj, Resource), column)
+                End If
+
+                Debug.Fail("DetailViewSorter: obj was not a Resource")
+                Return String.Empty
             End Function
 
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
         'A list of all Resource entries that are displayed in this string table (with the exception
         '  of the uncommitted resource, if any)
-        Private ReadOnly _virtualResourceList As New List(Of Resource)
+        Private ReadOnly _virtualResourceList As New ArrayList
 
         'The row that is currently being removed, if any.
         Private _removingRow As DataGridViewRow
@@ -301,7 +301,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             _virtualResourceList.Clear()
 
             'First, create a sorted list of resources that we want to display
-            Dim ResourcesToDisplay As New List(Of Resource)
+            Dim ResourcesToDisplay As New ArrayList
             Dim Categories As CategoryCollection = ResourceFile.RootComponent.RootDesigner.GetView().Categories
             For Each Entry As DictionaryEntry In ResourceFile
                 Dim Resource As Resource = DirectCast(Entry.Value, Resource)
@@ -1517,7 +1517,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="originalSorter"></param>
         ''' <remarks></remarks>
-        Friend Sub RestoreSorter(originalSorter As IComparer(Of Resource))
+        Friend Sub RestoreSorter(originalSorter As IComparer)
             Dim stringSorter As StringTableSorter = TryCast(originalSorter, StringTableSorter)
             If stringSorter IsNot Nothing Then
                 SortOnColumn(stringSorter.ColumnIndex, stringSorter.InReverseOrder)
@@ -1600,7 +1600,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' A helper class to sort the resource list in the Data Grid View
         ''' </summary>
         Private Class StringTableSorter
-            Implements IComparer(Of Resource)
+            Implements IComparer
 
             ' which column is used to sort the list
             Private _columnIndex As Integer
@@ -1638,7 +1638,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             '''  Compare two list items
             ''' </summary>
-            Public Function Compare(x As Resource, y As Resource) As Integer Implements IComparer(Of Resource).Compare
+            Public Function Compare(x As Object, y As Object) As Integer Implements IComparer.Compare
                 Dim ret As Integer = String.Compare(GetColumnValue(x, _columnIndex), GetColumnValue(y, _columnIndex), StringComparison.CurrentCultureIgnoreCase)
                 If ret = 0 AndAlso _columnIndex <> COLUMN_NAME Then
                     ret = String.Compare(GetColumnValue(x, COLUMN_NAME), GetColumnValue(y, COLUMN_NAME), StringComparison.CurrentCultureIgnoreCase)
@@ -1652,13 +1652,15 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             '''  Get String Value of one column
             ''' </summary>
-            Private Shared Function GetColumnValue(obj As Resource, column As Integer) As String
-
-                Dim value As String = GetResourceCellStringValue(obj, column)
-                If value IsNot Nothing Then
-                    Return value
+            Private Shared Function GetColumnValue(obj As Object, column As Integer) As String
+                If TypeOf obj Is Resource Then
+                    Dim value As String = GetResourceCellStringValue(DirectCast(obj, Resource), column)
+                    If value IsNot Nothing Then
+                        Return value
+                    End If
+                Else
+                    Debug.Fail("DetailViewSorter: obj was not a Resource")
                 End If
-
                 Return String.Empty
             End Function
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ThumbnailCache.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ThumbnailCache.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -49,7 +49,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '  replace an old image in the ImageList (without shifting other indices) does not allow you 
         '  to simultaneously change the key.  When we replace an image in the imagelist, we're also
         '  using a different key.
-        Private ReadOnly _keys As New Dictionary(Of Object, Integer)
+        Private ReadOnly _keys As New Hashtable
 
         'An Mru List we maintained to release the most less used item in the ImageList when we need load a new image.
         ' For performance reason, we implement the list table inside an array of structures. Each item contains a point (index)
@@ -314,8 +314,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private Function GetCachedImageListIndexInternal(Key As Object, ByRef Index As Integer) As Boolean
             Dim ThumbnailFound As Boolean
             Debug.Assert(Key IsNot Nothing)
+            Dim IndexAsObject As Object = _keys(Key)
+            Debug.Assert(_keys.ContainsKey(Key) = (IndexAsObject IsNot Nothing))
 
-            If Not _keys.TryGetValue(Key, Index) Then
+            If IndexAsObject Is Nothing Then
                 'Sorry, we no longer have a copy of that thumbnail...  You have to re-add it.
                 ThumbnailFound = False
                 Index = -1
@@ -325,6 +327,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 '  a higher value.
 
                 ThumbnailFound = True
+                Index = DirectCast(IndexAsObject, Integer)
                 Debug.Assert(Index < ThumbnailCount + _reservedImagesCount)
             End If
             Return ThumbnailFound
@@ -468,7 +471,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Do
                 Debug.Assert(_mruList(i).PreviousIndex = prev)
                 If _mruList(i).Key IsNot Nothing Then
-                    Debug.Assert(_keys.ContainsKey(_mruList(i).Key))
+                    Debug.Assert(_keys.Contains(_mruList(i).Key))
                 End If
 
                 count += 1

--- a/src/Microsoft.VisualStudio.Editors/StringComparers.vb
+++ b/src/Microsoft.VisualStudio.Editors/StringComparers.vb
@@ -19,12 +19,6 @@ Namespace Microsoft.VisualStudio
             End Get
         End Property
 
-        Public Shared ReadOnly Property Paths As StringComparer
-            Get
-                Return StringComparer.OrdinalIgnoreCase
-            End Get
-        End Property
-
     End Class
 
 End Namespace


### PR DESCRIPTION
This introduced a bunch of bugs due to behavior differences between hashtables and dictionaries, including the ability to pass null as the key and indexer lookup when the key doesn't exist. I started fixing it but had no confidence that I caught all the changes. 