### PR TITLE
Fix exceptions in the RESX designer

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
@@ -530,8 +530,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Next
                 Else
                     ResourcesToSearch = New ArrayList(View.ResourceFile.Resources.Count)
-                    For Each Entry As DictionaryEntry In View.ResourceFile
-                        Dim Resource As Resource = DirectCast(Entry.Value, Resource)
+                    For Each Resource In View.ResourceFile.Resources.Values
                         ResourcesToSearch.Add(Resource)
                     Next
                 End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
@@ -445,9 +445,12 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Return Nothing
             End If
 
-            Dim Found = _resources(Name)
-            Debug.Assert(Found Is Nothing OrElse Found.ParentResourceFile Is Me)
-            Return Found
+            Dim Resource As Resource = Nothing
+            If _resources.TryGetValue(Name, Resource) Then
+                Debug.Assert(Resource.ParentResourceFile Is Me)
+            End If
+
+            Return Resource
         End Function
 
         ''' <summary>
@@ -847,17 +850,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
 #Region "Reading/Writing/Enumerating"
 
-
-        ''' <summary>
-        ''' Gets an enumerator.  Allows ResourceFile to be used in For Each statements directly.
-        ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
-        Public Function GetEnumerator() As IDictionaryEnumerator
-            Return _resources.GetEnumerator
-        End Function
-
-
         ''' <summary>
         ''' Reads resources from a string (contents of a resx file).
         ''' </summary>
@@ -1210,8 +1202,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <returns></returns>
         ''' <remarks></remarks>
         Public Function ResourceHasTasks(Resource As Resource) As Boolean
-            Dim TaskSet As ResourceTaskSet = _resourceTaskSets(Resource)
-            If TaskSet Is Nothing Then
+            Dim TaskSet As ResourceTaskSet = Nothing
+            If Not _resourceTaskSets.TryGetValue(Resource, TaskSet) Then
                 Return False
             End If
 
@@ -1236,8 +1228,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <returns></returns>
         ''' <remarks></remarks>
         Public Function GetResourceTaskMessage(Resource As Resource, TaskType As ResourceTaskType) As String
-            Dim TaskSet As ResourceTaskSet = _resourceTaskSets(Resource)
-            If TaskSet Is Nothing Then
+            Dim TaskSet As ResourceTaskSet = Nothing
+            If Not _resourceTaskSets.TryGetValue(Resource, TaskSet) Then
                 Return Nothing
             End If
 
@@ -1259,8 +1251,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <returns></returns>
         ''' <remarks></remarks>
         Public Function GetResourceTaskMessages(Resource As Resource) As String
-            Dim TaskSet As ResourceTaskSet = _resourceTaskSets(Resource)
-            If TaskSet Is Nothing Then
+            Dim TaskSet As ResourceTaskSet = Nothing
+            If Not _resourceTaskSets.TryGetValue(Resource, TaskSet) Then
                 Return Nothing
             End If
 
@@ -1316,8 +1308,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Dim taskProvider As ErrorListProvider = ErrorListProvider
             If taskProvider IsNot Nothing Then
                 'Get current task set for this resource.  If none, then create one.
-                Dim TaskSet As ResourceTaskSet = _resourceTaskSets(Resource)
-                If TaskSet Is Nothing Then
+                Dim TaskSet As ResourceTaskSet = Nothing
+                If Not _resourceTaskSets.TryGetValue(Resource, TaskSet) Then
                     TaskSet = New ResourceTaskSet
                     _resourceTaskSets.Add(Resource, TaskSet)
                 End If
@@ -1390,8 +1382,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="TaskType">The type of task list entry to clear, if it exists.</param>
         ''' <remarks></remarks>
         Public Sub ClearResourceTask(Resource As Resource, TaskType As ResourceTaskType)
-            Dim TaskSet As ResourceTaskSet = _resourceTaskSets(Resource)
-            If TaskSet Is Nothing Then
+            Dim TaskSet As ResourceTaskSet = Nothing
+            If Not _resourceTaskSets.TryGetValue(Resource, TaskSet) Then
                 Exit Sub 'Nothing to clear
             End If
 
@@ -1435,8 +1427,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Resource">The resource to clear.</param>
         ''' <remarks></remarks>
         Public Sub ClearResourceTasks(Resource As Resource)
-            Dim TaskSet As ResourceTaskSet = _resourceTaskSets(Resource)
-            If TaskSet IsNot Nothing Then
+            Dim TaskSet As ResourceTaskSet = Nothing
+            If _resourceTaskSets.TryGetValue(Resource, TaskSet) Then
+
                 'Remove all entries for this resource
                 For i As Integer = 0 To TaskSet.Tasks.Length - 1
                     Dim Task As Task = TaskSet.Tasks(i)
@@ -1458,6 +1451,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 #End If
             End If
         End Sub
+
 
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
@@ -416,8 +416,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             'Go through all resources, and pick out the ones which belong to the specified category, 
             '  and add them to our virtual list
             Dim Categories As CategoryCollection = ResourceFile.RootComponent.RootDesigner.GetView().Categories
-            For Each Entry As DictionaryEntry In ResourceFile
-                Dim Resource As Resource = DirectCast(Entry.Value, Resource)
+            For Each Resource In ResourceFile.Resources.Values
                 If Resource.GetCategory(Categories) Is CategoryToFilterOn Then
                     Debug.Assert(Not Resource.ResourceTypeEditor.DisplayInStringTable,
                             "Why are we trying to display this type of resource in a listview?")

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
@@ -303,8 +303,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             'First, create a sorted list of resources that we want to display
             Dim ResourcesToDisplay As New ArrayList
             Dim Categories As CategoryCollection = ResourceFile.RootComponent.RootDesigner.GetView().Categories
-            For Each Entry As DictionaryEntry In ResourceFile
-                Dim Resource As Resource = DirectCast(Entry.Value, Resource)
+            For Each Resource In ResourceFile.Resources.Values
                 If Resource.GetCategory(Categories) Is CategoryToFilterOn Then
                     If Resource.ResourceTypeEditor.DisplayInStringTable Then
                         ResourcesToDisplay.Add(Resource)


### PR DESCRIPTION
Fix a number of exceptions that could occur as the result of replacing `Hashtable` with `Dictionary(Of T, U)`.

1. In ResourceFile.vb, replace indexing into `_resources` with calls to `TryGetValue`. The `Hashtable` indexer would return `null` when the key was not found, but `Dictionary(Of T, U)` throws an exception.
2. Remove `ResourceFile.GetEnumerator`. This used to just return `_resources.GetEnumerator`, and when `resources` was a `Hashtable` the enumerator would output instances of `DictionaryEntry`. The `Dictionary(Of T, U)` enumerator instead outputs `KeyValuePair(Of T, U)`, resulting in type cast exceptions everywhere we tried to enumerate the `ResourceFile`. Rather than update `ResourceFile` to properly support `IEnumerable(Of Resource)` the `GetEnumerator` method has been removed, and all callers have been updated to utilize the `Resources` property instead.