### PR TITLE
Respect IntegratedConsoleDebugging capability, issue 5592

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -36,10 +36,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         private readonly ProjectProperties _properties;
         private readonly IProjectThreadingService _threadingService;
         private readonly IVsUIService<IVsDebugger10> _debugger;
-        private readonly UnconfiguredProject _project;
+        private readonly ConfiguredProject _project;
 
         [ImportingConstructor]
-        public ConsoleDebugTargetsProvider(UnconfiguredProject project,
+        public ConsoleDebugTargetsProvider(ConfiguredProject project,
                                            IDebugTokenReplacer tokenReplacer,
                                            IFileSystem fileSystem,
                                            IEnvironmentHelper environment,
@@ -204,7 +204,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             string executable, arguments;
 
-            string projectFolder = Path.GetDirectoryName(_project.FullPath);
+            string projectFolder = Path.GetDirectoryName(_project.UnconfiguredProject.FullPath);
             ConfiguredProject configuredProject = await GetConfiguredProjectForDebugAsync();
 
             // If no working directory specified in the profile, we default to output directory. If for some reason the output directory
@@ -391,7 +391,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             // If the working directory is relative, it will be relative to the project root so make it a full path
             if (!string.IsNullOrWhiteSpace(runWorkingDirectory) && !Path.IsPathRooted(runWorkingDirectory))
             {
-                runWorkingDirectory = Path.Combine(Path.GetDirectoryName(_project.FullPath), runWorkingDirectory);
+                runWorkingDirectory = Path.Combine(Path.GetDirectoryName(_project.UnconfiguredProject.FullPath), runWorkingDirectory);
             }
 
             return new Tuple<string, string, string>(runCommand, runArguments, runWorkingDirectory);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -336,7 +336,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             bool useCmdShell = false;
             if (await IsConsoleAppAsync())
             {
-                if (await IsIntegratedConsoleEnabledAsync())
+                var isIntegratedConsoleCapable = (await _project.GetSuggestedConfiguredProjectAsync()).Capabilities.Contains(ProjectCapabilities.IntegratedConsoleDebugging);
+
+                if (isIntegratedConsoleCapable && await IsIntegratedConsoleEnabledAsync())
                 {
                     settings.LaunchOptions |= DebugLaunchOptions.IntegratedConsole;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -336,7 +336,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             bool useCmdShell = false;
             if (await IsConsoleAppAsync())
             {
-                var isIntegratedConsoleCapable = (await _project.GetSuggestedConfiguredProjectAsync()).Capabilities.Contains(ProjectCapabilities.IntegratedConsoleDebugging);
+                var isIntegratedConsoleCapable = _project.Capabilities.Contains(ProjectCapabilities.IntegratedConsoleDebugging);
 
                 if (isIntegratedConsoleCapable && await IsIntegratedConsoleEnabledAsync())
                 {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.IO;
@@ -603,7 +604,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             _mockFS.CreateDirectory(@"c:\test\Project\bin\");
             _mockFS.WriteAllText(@"c:\program files\dotnet\dotnet.exe", "");
 
-            var project = UnconfiguredProjectFactory.Create(filePath: _ProjectFile, scope: scope);
+            var capabilitiesScope = scope ?? IProjectCapabilitiesScopeFactory.Create(capabilities: Enumerable.Empty<string>());
+            var project = UnconfiguredProjectFactory.Create(filePath: _ProjectFile, scope: capabilitiesScope);
 
             var outputTypeEnum = new PageEnumValue(new EnumValue() { Name = outputType });
             var data = new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputTypeProperty, outputTypeEnum);


### PR DESCRIPTION
https://github.com/dotnet/project-system/issues/5592

Don't launch in integrated console if the project doesn't declare `IntegratedConsoleDebugging` capability