### PR TITLE
Pass in RunAnalyzers and RunAnalyzersDuringLiveAnalysis properties to…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
@@ -20,4 +20,12 @@
   <StringProperty Name="MaxSupportedLangVersion"
                   ReadOnly="True"
                   Visible="False" />
+
+  <StringProperty Name="RunAnalyzers"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="RunAnalyzersDuringLiveAnalysis"
+                  ReadOnly="True"
+                  Visible="False" />
 </Rule>


### PR DESCRIPTION
… LanguageService

We recently added project properties for configuring analyzer execution during build and live analysis, see documentation [here](https://docs.microsoft.com/visualstudio/code-quality/disable-code-analysis). Currently, these properties are only respected for NuGet based analyzers. We plan to respect these properties even for VSIX based analyzers, including the built-in IDE code style analyzers. This PR passes the required properties down to the Roslyn langauge service, which will be updated with a Roslyn PR to consume these properties and add this support.