### PR TITLE
Save RunAnalyzersDuringLiveAnalysis in .csproj.user file instead of p…

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.vb
@@ -66,7 +66,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 If m_ControlData Is Nothing Then
                     m_ControlData = New PropertyControlData() {
                         New PropertyControlData(1, "RunAnalyzersDuringBuild", RunAnalyzersDuringBuild, ControlDataFlags.None),
-                        New PropertyControlData(2, "RunAnalyzersDuringLiveAnalysis", RunAnalyzersDuringLiveAnalysis, ControlDataFlags.None)
+                        New PropertyControlData(2, "RunAnalyzersDuringLiveAnalysis", RunAnalyzersDuringLiveAnalysis, ControlDataFlags.PersistedInProjectUserFile)
                     }
                 End If
                 Return m_ControlData

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -413,7 +413,7 @@
     <BoolProperty.DataSource>
       <DataSource HasConfigurationCondition="False"
                   PersistedName="RunAnalyzersDuringLiveAnalysis"
-                  Persistence="ProjectFile"
+                  Persistence="UserFile"
                   SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>
   </BoolProperty>


### PR DESCRIPTION
…roject file

Fixes #5600
Verified that property is saved/updated in .csproj.user file and is also appropriately passed down to the Roslyn language service.