### PR TITLE
Make sure screen readers are aware of checkable menu item

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
@@ -35,6 +35,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DefaultDisabled</CommandFlag>
         <CommandFlag>DynamicItemStart</CommandFlag>
+        <CommandFlag>TogglePatternAvailable</CommandFlag>
         <Strings>
           <ButtonText>Web Debugger</ButtonText>
         </Strings>
@@ -176,6 +177,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DefaultDisabled</CommandFlag>
         <CommandFlag>DynamicItemStart</CommandFlag>
+        <CommandFlag>TogglePatternAvailable</CommandFlag>
         <Strings>
           <ButtonText>Framework</ButtonText>
         </Strings>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.Packaging
         new string[] { "SolutionHasProjectCapability:.NET & CPS" }
         )]
 
-    [ProvideMenuResource("Menus.ctmenu", 3)]
+    [ProvideMenuResource("Menus.ctmenu", 4)]
     internal partial class ManagedProjectSystemPackage : AsyncPackage
     {
         public const string ActivationContextGuid = "E7DF1626-44DD-4E8C-A8A0-92EAB6DDC16E";


### PR DESCRIPTION
This makes sure that the Debug profile and framework switchers are known to be checkable, which helps screen readers tell users that. After this change, Before this change, Windows Narrater says "menu item", after this change it says "menu item, unchecked" for unchecked items.

![image](https://user-images.githubusercontent.com/1103906/67728293-d9c61880-fa40-11e9-9575-8b6648a78e95.png)


Fixes our part of: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/642995