### PR TITLE
Rename RunSettingsFilePath to avoid clashing with Test Explorer

### DIFF
--- a/build/import/IntegrationTests.targets
+++ b/build/import/IntegrationTests.targets
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <TestResultsDirectory>$(ArtifactsTestResultsDir)</TestResultsDirectory>
-    <RunSettingsFilePath>$(IntermediateOutputPath)$(TargetName)$(TargetExt).runsettings</RunSettingsFilePath>    
+    <RunSettingsFullPath>$(IntermediateOutputPath)$(TargetName)$(TargetExt).runsettings</RunSettingsFullPath>    
   </PropertyGroup>
 
   <Target Name="GenerateRunSettings">
@@ -66,7 +66,7 @@
     </PropertyGroup>
 
     <WriteLinesToFile 
-      File="$(RunSettingsFilePath)"
+      File="$(RunSettingsFullPath)"
       Lines="$(RunSettingsContents)"
       Overwrite="true" 
       />
@@ -111,7 +111,7 @@
     <Delete Files="$(TrxLogFilePath)" />
 
     <Exec
-      Command='"$(VSTestExe)" /Blame /ResultsDirectory:"$(TestResultsDirectory)\" /Settings:"$(RunSettingsFilePath)" /Logger:trx;LogFileName=$(TrxLogFileName) "$(TargetPath)"'
+      Command='"$(VSTestExe)" /Blame /ResultsDirectory:"$(TestResultsDirectory)\" /Settings:"$(RunSettingsFullPath)" /Logger:trx;LogFileName=$(TrxLogFileName) "$(TargetPath)"'
       EnvironmentVariables="$(VSTestExeEnvironment)"
       LogStandardErrorAsError="true"
       StandardOutputImportance="Low"


### PR DESCRIPTION
Test Explorer has started respecting this property - avoid clashing with it to avoid it failing to find this auto-generated file.