### PR TITLE
Move dependency priority fields to own type

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/AnalyzerDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/AnalyzerDependencyModel.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Imaging;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.RuleHandlers;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
@@ -25,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
         public override DependencyIconSet IconSet => Implicit ? s_implicitIconSet : s_iconSet;
 
-        public override int Priority => Dependency.AnalyzerNodePriority;
+        public override int Priority => GraphNodePriority.Analyzer;
 
         public override string ProviderType => AnalyzerRuleHandler.ProviderTypeString;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/AssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/AssemblyDependencyModel.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using System.Reflection;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.RuleHandlers;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
@@ -29,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
         public override string ProviderType => AssemblyRuleHandler.ProviderTypeString;
 
-        public override int Priority => Dependency.FrameworkAssemblyNodePriority;
+        public override int Priority => GraphNodePriority.FrameworkAssembly;
 
         public override string? SchemaItemType => AssemblyReference.PrimaryDataSourceItemType;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/ComDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/ComDependencyModel.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.RuleHandlers;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
@@ -26,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
         public override string ProviderType => ComRuleHandler.ProviderTypeString;
 
-        public override int Priority => Dependency.ComNodePriority;
+        public override int Priority => GraphNodePriority.ComNodePriority;
 
         public override string? SchemaItemType => ComReference.PrimaryDataSourceItemType;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/DiagnosticDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/DiagnosticDependencyModel.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.RuleHandlers;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
@@ -46,8 +45,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
         public override string Name { get; }
 
         public override int Priority => _severity == DiagnosticMessageSeverity.Error
-            ? Dependency.DiagnosticsErrorNodePriority
-            : Dependency.DiagnosticsWarningNodePriority;
+            ? GraphNodePriority.DiagnosticsError
+            : GraphNodePriority.DiagnosticsWarning;
 
         public override string ProviderType => PackageRuleHandler.ProviderTypeString;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/FrameworkDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/FrameworkDependencyModel.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.RuleHandlers;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
@@ -18,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
         public override DependencyIconSet IconSet => s_iconSet;
 
-        public override int Priority => Dependency.FrameworkReferenceNodePriority;
+        public override int Priority => GraphNodePriority.FrameworkReference;
 
         public override string ProviderType => FrameworkRuleHandler.ProviderTypeString;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/GraphNodePriority.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/GraphNodePriority.cs
@@ -1,0 +1,22 @@
+﻿namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
+{
+    /// <summary>
+    /// Priorities used to order graph nodes.
+    /// Not applicable to top-level nodes.
+    /// When two nodes have the same priority, alphabetical ordering is used to break the tie.
+    /// </summary>
+    internal static class GraphNodePriority
+    {
+        public const int DiagnosticsError = 100;
+        public const int DiagnosticsWarning = 101;
+        public const int UnresolvedReference = 110;
+        public const int Project = 120;
+        public const int Package = 130;
+        public const int FrameworkAssembly = 140;
+        public const int PackageAssembly = 150;
+        public const int Analyzer = 160;
+        public const int ComNodePriority = 170;
+        public const int SdkNodePriority = 180;
+        public const int FrameworkReference = 190;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModel.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Imaging;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.RuleHandlers;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
@@ -24,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
         public override string Name { get; }
 
-        public override int Priority => Resolved ? Dependency.PackageAssemblyNodePriority : Dependency.UnresolvedReferenceNodePriority;
+        public override int Priority => Resolved ? GraphNodePriority.PackageAssembly : GraphNodePriority.UnresolvedReference;
 
         public override string ProviderType => PackageRuleHandler.ProviderTypeString;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageAssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageAssemblyDependencyModel.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Imaging;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.RuleHandlers;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
@@ -24,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
         public override string Name { get; }
 
-        public override int Priority => Resolved ? Dependency.PackageAssemblyNodePriority : Dependency.UnresolvedReferenceNodePriority;
+        public override int Priority => Resolved ? GraphNodePriority.PackageAssembly : GraphNodePriority.UnresolvedReference;
 
         public override string ProviderType => PackageRuleHandler.ProviderTypeString;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageDependencyModel.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.RuleHandlers;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
@@ -32,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
         public override string Name { get; }
 
-        public override int Priority => Resolved ? Dependency.PackageNodePriority : Dependency.UnresolvedReferenceNodePriority;
+        public override int Priority => Resolved ? GraphNodePriority.Package : GraphNodePriority.UnresolvedReference;
 
         public override string ProviderType => PackageRuleHandler.ProviderTypeString;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModel.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public string? FilePath => null;
         public string? SchemaName => null;
         public string? SchemaItemType => null;
-        public int Priority => Dependency.FrameworkAssemblyNodePriority;
+        public int Priority => GraphNodePriority.FrameworkAssembly;
         public ImageMoniker Icon => RegularIcon;
         public ImageMoniker ExpandedIcon => RegularIcon;
         public ProjectTreeFlags Flags => DependencyTreeFlags.FrameworkAssembliesNode;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageUnknownDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageUnknownDependencyModel.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Imaging;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.RuleHandlers;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
@@ -24,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
         public override string Name { get; }
 
-        public override int Priority => Dependency.UnresolvedReferenceNodePriority;
+        public override int Priority => GraphNodePriority.UnresolvedReference;
 
         public override string ProviderType => PackageRuleHandler.ProviderTypeString;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/ProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/ProjectDependencyModel.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Imaging;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.RuleHandlers;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
@@ -27,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
         public override DependencyIconSet IconSet => Implicit ? s_implicitIconSet : s_iconSet;
 
-        public override int Priority => Dependency.ProjectNodePriority;
+        public override int Priority => GraphNodePriority.Project;
 
         public override string ProviderType => ProjectRuleHandler.ProviderTypeString;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/SdkDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/SdkDependencyModel.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.RuleHandlers;
 using Microsoft.VisualStudio.Text;
@@ -29,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
         public override DependencyIconSet IconSet => Implicit ? s_implicitIconSet : s_iconSet;
 
-        public override int Priority => Dependency.SdkNodePriority;
+        public override int Priority => GraphNodePriority.SdkNodePriority;
 
         public override string ProviderType => SdkRuleHandler.ProviderTypeString;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Imaging;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.RuleHandlers;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
@@ -28,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
         public override DependencyIconSet IconSet => Implicit ? s_implicitIconSet : s_iconSet;
 
-        public override int Priority => Dependency.ProjectNodePriority;
+        public override int Priority => GraphNodePriority.Project;
 
         public override string ProviderType => ProjectRuleHandler.ProviderTypeString;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/TargetDependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/TargetDependencyViewModel.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
         public string? FilePath => null;
         public string? SchemaName => null;
         public string? SchemaItemType => null;
-        public int Priority => Dependency.FrameworkAssemblyNodePriority;
+        public int Priority => GraphNodePriority.FrameworkAssembly;
         public ImageMoniker Icon => _hasUnresolvedDependency ? ManagedImageMonikers.LibraryWarning : KnownMonikers.Library;
         public ImageMoniker ExpandedIcon => _hasUnresolvedDependency ? ManagedImageMonikers.LibraryWarning : KnownMonikers.Library;
         public ProjectTreeFlags Flags { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Dependency.cs
@@ -11,21 +11,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 {
     internal sealed class Dependency : IDependency
     {
-        // These priorities are for graph nodes only and are used to group graph nodes 
-        // appropriately in order groups predefined order instead of alphabetically.
-        // Order is not changed for top dependency nodes only for graph hierarchies.
-        public const int DiagnosticsErrorNodePriority = 100;
-        public const int DiagnosticsWarningNodePriority = 101;
-        public const int UnresolvedReferenceNodePriority = 110;
-        public const int ProjectNodePriority = 120;
-        public const int PackageNodePriority = 130;
-        public const int FrameworkAssemblyNodePriority = 140;
-        public const int PackageAssemblyNodePriority = 150;
-        public const int AnalyzerNodePriority = 160;
-        public const int ComNodePriority = 170;
-        public const int SdkNodePriority = 180;
-        public const int FrameworkReferenceNodePriority = 190;
-
         public Dependency(IDependencyModel dependencyModel, ITargetFramework targetFramework, string containingProjectPath)
         {
             Requires.NotNull(dependencyModel, nameof(dependencyModel));

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AnalyzerDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AnalyzerDependencyModelTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.AnalyzerNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.Analyzer, model.Priority);
             Assert.Equal(AnalyzerReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(KnownMonikers.CodeInformation, model.Icon);
             Assert.Equal(KnownMonikers.CodeInformation, model.ExpandedIcon);
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.False(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.AnalyzerNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.Analyzer, model.Priority);
             Assert.Equal(AnalyzerReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(KnownMonikers.CodeInformation, model.Icon);
             Assert.Equal(KnownMonikers.CodeInformation, model.ExpandedIcon);
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.True(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.AnalyzerNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.Analyzer, model.Priority);
             Assert.Equal(AnalyzerReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(ManagedImageMonikers.CodeInformationPrivate, model.Icon);
             Assert.Equal(ManagedImageMonikers.CodeInformationPrivate, model.ExpandedIcon);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AssemblyDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AssemblyDependencyModelTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.FrameworkAssemblyNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.FrameworkAssembly, model.Priority);
             Assert.Equal(AssemblyReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(KnownMonikers.Reference, model.Icon);
             Assert.Equal(KnownMonikers.Reference, model.ExpandedIcon);
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.FrameworkAssemblyNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.FrameworkAssembly, model.Priority);
             Assert.Equal(AssemblyReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(KnownMonikers.Reference, model.Icon);
             Assert.Equal(KnownMonikers.Reference, model.ExpandedIcon);
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.False(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.FrameworkAssemblyNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.FrameworkAssembly, model.Priority);
             Assert.Equal(AssemblyReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(KnownMonikers.Reference, model.Icon);
             Assert.Equal(KnownMonikers.Reference, model.ExpandedIcon);
@@ -127,7 +127,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.True(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.FrameworkAssemblyNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.FrameworkAssembly, model.Priority);
             Assert.Equal(AssemblyReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(ManagedImageMonikers.ReferencePrivate, model.Icon);
             Assert.Equal(ManagedImageMonikers.ReferencePrivate, model.ExpandedIcon);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/ComDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/ComDependencyModelTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.ComNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.ComNodePriority, model.Priority);
             Assert.Equal(ComReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(ManagedImageMonikers.Component, model.Icon);
             Assert.Equal(ManagedImageMonikers.Component, model.ExpandedIcon);
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.False(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.ComNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.ComNodePriority, model.Priority);
             Assert.Equal(ComReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(ManagedImageMonikers.Component, model.Icon);
             Assert.Equal(ManagedImageMonikers.Component, model.ExpandedIcon);
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.True(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.ComNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.ComNodePriority, model.Priority);
             Assert.Equal(ComReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(ManagedImageMonikers.ComponentPrivate, model.Icon);
             Assert.Equal(ManagedImageMonikers.ComponentPrivate, model.ExpandedIcon);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModelTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.False(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.DiagnosticsErrorNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.DiagnosticsError, model.Priority);
             Assert.Null(model.SchemaItemType);
             Assert.Equal(ManagedImageMonikers.ErrorSmall, model.Icon);
             Assert.Equal(ManagedImageMonikers.ErrorSmall, model.ExpandedIcon);
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.False(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.DiagnosticsWarningNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.DiagnosticsWarning, model.Priority);
             Assert.Null(model.SchemaItemType);
             Assert.Equal(ManagedImageMonikers.WarningSmall, model.Icon);
             Assert.Equal(ManagedImageMonikers.WarningSmall, model.ExpandedIcon);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModelTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.PackageAssemblyNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.PackageAssembly, model.Priority);
             Assert.Equal(KnownMonikers.CodeInformation, model.Icon);
             Assert.Equal(KnownMonikers.CodeInformation, model.ExpandedIcon);
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedIcon);
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.False(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.UnresolvedReferenceNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.UnresolvedReference, model.Priority);
             Assert.Equal(KnownMonikers.CodeInformation, model.Icon);
             Assert.Equal(KnownMonikers.CodeInformation, model.ExpandedIcon);
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedIcon);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAssemblyDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAssemblyDependencyModelTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.PackageAssemblyNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.PackageAssembly, model.Priority);
             Assert.Equal(KnownMonikers.Reference, model.Icon);
             Assert.Equal(KnownMonikers.Reference, model.ExpandedIcon);
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedIcon);
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.False(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.UnresolvedReferenceNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.UnresolvedReference, model.Priority);
             Assert.Equal(KnownMonikers.Reference, model.Icon);
             Assert.Equal(KnownMonikers.Reference, model.ExpandedIcon);
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedIcon);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModelTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.PackageNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.Package, model.Priority);
             Assert.Equal(ManagedImageMonikers.NuGetGrey, model.Icon);
             Assert.Equal(ManagedImageMonikers.NuGetGrey, model.ExpandedIcon);
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedIcon);
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.False(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.UnresolvedReferenceNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.UnresolvedReference, model.Priority);
             Assert.Equal(ManagedImageMonikers.NuGetGrey, model.Icon);
             Assert.Equal(ManagedImageMonikers.NuGetGrey, model.ExpandedIcon);
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedIcon);
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.True(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.PackageNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.Package, model.Priority);
             Assert.Equal(ManagedImageMonikers.NuGetGreyPrivate, model.Icon);
             Assert.Equal(ManagedImageMonikers.NuGetGreyPrivate, model.ExpandedIcon);
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedIcon);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModelTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Xunit;
 
@@ -14,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var model = new PackageFrameworkAssembliesViewModel();
 
             Assert.Equal("Framework Assemblies", model.Caption);
-            Assert.Equal(Dependency.FrameworkAssemblyNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.FrameworkAssembly, model.Priority);
             Assert.Equal(KnownMonikers.Library, model.Icon);
             Assert.Equal(KnownMonikers.Library, model.ExpandedIcon);
             Assert.Equal(DependencyTreeFlags.FrameworkAssembliesNode, model.Flags);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageUnknownDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageUnknownDependencyModelTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.UnresolvedReferenceNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.UnresolvedReference, model.Priority);
             Assert.Equal(KnownMonikers.QuestionMark, model.Icon);
             Assert.Equal(KnownMonikers.QuestionMark, model.ExpandedIcon);
             Assert.Equal(KnownMonikers.QuestionMark, model.UnresolvedIcon);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.ProjectNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.Project, model.Priority);
             Assert.Equal(ProjectReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(KnownMonikers.Application, model.Icon);
             Assert.Equal(KnownMonikers.Application, model.ExpandedIcon);
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.False(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.ProjectNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.Project, model.Priority);
             Assert.Equal(ProjectReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(KnownMonikers.Application, model.Icon);
             Assert.Equal(KnownMonikers.Application, model.ExpandedIcon);
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.True(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.ProjectNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.Project, model.Priority);
             Assert.Equal(ProjectReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(ManagedImageMonikers.ApplicationPrivate, model.Icon);
             Assert.Equal(ManagedImageMonikers.ApplicationPrivate, model.ExpandedIcon);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModelTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.SdkNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.SdkNodePriority, model.Priority);
             Assert.Equal(SdkReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(ManagedImageMonikers.Sdk, model.Icon);
             Assert.Equal(ManagedImageMonikers.Sdk, model.ExpandedIcon);
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.False(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.SdkNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.SdkNodePriority, model.Priority);
             Assert.Equal(SdkReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(ManagedImageMonikers.Sdk, model.Icon);
             Assert.Equal(ManagedImageMonikers.Sdk, model.ExpandedIcon);
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.True(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.SdkNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.SdkNodePriority, model.Priority);
             Assert.Equal(SdkReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(ManagedImageMonikers.SdkPrivate, model.Icon);
             Assert.Equal(ManagedImageMonikers.SdkPrivate, model.ExpandedIcon);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SharedProjectDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SharedProjectDependencyModelTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.ProjectNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.Project, model.Priority);
             Assert.Equal(ProjectReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(KnownMonikers.SharedProject, model.Icon);
             Assert.Equal(KnownMonikers.SharedProject, model.ExpandedIcon);
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.False(model.Resolved);
             Assert.False(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.ProjectNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.Project, model.Priority);
             Assert.Equal(ProjectReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(KnownMonikers.SharedProject, model.Icon);
             Assert.Equal(KnownMonikers.SharedProject, model.ExpandedIcon);
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.True(model.Implicit);
             Assert.Equal(properties, model.Properties);
-            Assert.Equal(Dependency.ProjectNodePriority, model.Priority);
+            Assert.Equal(GraphNodePriority.Project, model.Priority);
             Assert.Equal(ProjectReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.Equal(ManagedImageMonikers.SharedProjectPrivate, model.Icon);
             Assert.Equal(ManagedImageMonikers.SharedProjectPrivate, model.ExpandedIcon);


### PR DESCRIPTION
These only apply to graph nodes. This makes their purpose clearer.

Back when `Dependency` implemented `IDependencyModel`, having them on `Dependency` may have made more sense.