### PR TITLE
Avoid P2P reference notification on solution close

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -33,7 +33,6 @@ namespace Microsoft.VisualStudio.Packaging
         public const string PackageGuid = "860A27C0-B665-47F3-BC12-637E16A1050A";
 
         private IDotNetCoreProjectCompatibilityDetector? _dotNetCoreCompatibilityDetector;
-        private SolutionService? _solutionService;
         private IVsRegisterProjectSelector? _projectSelectorService;
         private uint _projectSelectorCookie = VSConstants.VSCOOKIE_NIL;
 
@@ -53,8 +52,8 @@ namespace Microsoft.VisualStudio.Packaging
 
             var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
             Lazy<DebugFrameworksDynamicMenuCommand> debugFrameworksCmd = componentModel.DefaultExportProvider.GetExport<DebugFrameworksDynamicMenuCommand>();
-            _solutionService = (SolutionService)componentModel.GetService<ISolutionService>();
-            _solutionService.StartListening();
+            var solutionService = (SolutionService)componentModel.GetService<ISolutionService>();
+            solutionService.StartListening();
 
             var mcs = (OleMenuCommandService)await GetServiceAsync(typeof(IMenuCommandService));
             mcs.AddCommand(debugFrameworksCmd.Value);
@@ -85,8 +84,6 @@ namespace Microsoft.VisualStudio.Packaging
                     _projectSelectorService?.UnregisterProjectSelector(_projectSelectorCookie);
                     _projectSelectorCookie = VSConstants.VSCOOKIE_NIL;
                 }
-
-                _solutionService?.Dispose();
             }
 
             base.Dispose(disposing);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/SolutionService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/SolutionService.cs
@@ -1,0 +1,102 @@
+﻿// Copyright(c) Microsoft.All Rights Reserved.Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <inheritdoc cref="ISolutionService"/>
+    [Export(typeof(ISolutionService))]
+    internal sealed class SolutionService : ISolutionService, IVsSolutionEvents, IVsPrioritizedSolutionEvents, IDisposable
+    {
+        private const int StateUninitialized = 0;
+        private const int StateListening = 1;
+        private const int StateDisposed = 2;
+
+        private readonly IVsUIService<IVsSolution> _solution;
+        private readonly JoinableTaskContext _joinableTaskContext;
+
+        private int _state = StateUninitialized;
+        private uint _cookie = VSConstants.VSCOOKIE_NIL;
+        
+        /// <inheritdoc />
+        public bool IsSolutionClosing { get; private set; }
+
+        [ImportingConstructor]
+        public SolutionService(IVsUIService<SVsSolution, IVsSolution> solution, JoinableTaskContext joinableTaskContext)
+        {
+            _solution = solution;
+            _joinableTaskContext = joinableTaskContext;
+        }
+
+        public void StartListening()
+        {
+            Assumes.True(_joinableTaskContext.IsOnMainThread, "Must be called on the UI thread.");
+
+            if (Interlocked.CompareExchange(ref _state, StateListening, StateUninitialized) != StateUninitialized)
+            {
+                return;
+            }
+
+            IVsSolution? solution = _solution.Value;
+            Assumes.Present(solution);
+
+            Verify.HResult(solution.AdviseSolutionEvents(this, out _cookie));
+        }
+
+        public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)                                 => UpdateClosing(false);
+        public int OnBeforeCloseSolution(object pUnkReserved)                                                 => UpdateClosing(true);
+        public int OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)                                    => HResult.OK;
+        public int OnQueryCloseProject(IVsHierarchy pHierarchy, int fRemoving, ref int pfCancel)              => HResult.OK;
+        public int OnBeforeCloseProject(IVsHierarchy pHierarchy, int fRemoved)                                => HResult.OK;
+        public int OnAfterLoadProject(IVsHierarchy pStubHierarchy, IVsHierarchy pRealHierarchy)               => HResult.OK;
+        public int OnQueryUnloadProject(IVsHierarchy pRealHierarchy, ref int pfCancel)                        => HResult.OK;
+        public int OnBeforeUnloadProject(IVsHierarchy pRealHierarchy, IVsHierarchy pStubHierarchy)            => HResult.OK;
+        public int OnQueryCloseSolution(object pUnkReserved, ref int pfCancel)                                => HResult.OK;
+        public int OnAfterCloseSolution(object pUnkReserved)                                                  => HResult.OK;
+
+        public int PrioritizedOnAfterOpenSolution(object pUnkReserved, int fNewSolution)                      => UpdateClosing(false);
+        public int PrioritizedOnBeforeCloseSolution(object pUnkReserved)                                      => UpdateClosing(true);
+        public int PrioritizedOnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)                         => HResult.OK;
+        public int PrioritizedOnBeforeCloseProject(IVsHierarchy pHierarchy, int fRemoved)                     => HResult.OK;
+        public int PrioritizedOnAfterLoadProject(IVsHierarchy pStubHierarchy, IVsHierarchy pRealHierarchy)    => HResult.OK;
+        public int PrioritizedOnBeforeUnloadProject(IVsHierarchy pRealHierarchy, IVsHierarchy pStubHierarchy) => HResult.OK;
+        public int PrioritizedOnAfterCloseSolution(object pUnkReserved)                                       => HResult.OK;
+        public int PrioritizedOnAfterMergeSolution(object pUnkReserved)                                       => HResult.OK;
+        public int PrioritizedOnBeforeOpeningChildren(IVsHierarchy pHierarchy)                                => HResult.OK;
+        public int PrioritizedOnAfterOpeningChildren(IVsHierarchy pHierarchy)                                 => HResult.OK;
+        public int PrioritizedOnBeforeClosingChildren(IVsHierarchy pHierarchy)                                => HResult.OK;
+        public int PrioritizedOnAfterClosingChildren(IVsHierarchy pHierarchy)                                 => HResult.OK;
+        public int PrioritizedOnAfterRenameProject(IVsHierarchy pHierarchy)                                   => HResult.OK;
+        public int PrioritizedOnAfterChangeProjectParent(IVsHierarchy pHierarchy)                             => HResult.OK;
+        public int PrioritizedOnAfterAsynchOpenProject(IVsHierarchy pHierarchy, int fAdded)                   => HResult.OK;
+
+        private HResult UpdateClosing(bool isClosing)
+        {
+            IsSolutionClosing = isClosing;
+            return HResult.OK;
+        }
+
+        public void Dispose()
+        {
+            Assumes.True(_joinableTaskContext.IsOnMainThread, "Must be called on the UI thread.");
+
+            if (Interlocked.CompareExchange(ref _state, StateDisposed, StateListening) != StateListening)
+            {
+                return;
+            }
+
+            if (_cookie != VSConstants.VSCOOKIE_NIL)
+            {
+                IVsSolution? solution = _solution.Value;
+                Assumes.Present(solution);
+
+                Verify.HResult(solution.UnadviseSolutionEvents(_cookie));
+                _cookie = VSConstants.VSCOOKIE_NIL;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/SolutionService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/SolutionService.cs
@@ -36,6 +36,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             Verify.HResult(solution.AdviseSolutionEvents(this, out _cookie));
         }
 
+        // We handle both prioritized and regular before/after events to update state as early as possible,
+        // and ensure we set the value regardless of whether the caller supports one or both interfaces.
+
         public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)                                 => UpdateClosing(false);
         public int OnBeforeCloseSolution(object pUnkReserved)                                                 => UpdateClosing(true);
         public int OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)                                    => HResult.OK;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/SolutionService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/SolutionService.cs
@@ -3,7 +3,6 @@
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
@@ -12,7 +11,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     internal sealed class SolutionService : OnceInitializedOnceDisposed, ISolutionService, IVsSolutionEvents, IVsPrioritizedSolutionEvents, IDisposable
     {
         private readonly IVsUIService<IVsSolution> _solution;
-        private readonly JoinableTaskContext _joinableTaskContext;
 
         private uint _cookie = VSConstants.VSCOOKIE_NIL;
         
@@ -20,10 +18,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         public bool IsSolutionClosing { get; private set; }
 
         [ImportingConstructor]
-        public SolutionService(IVsUIService<SVsSolution, IVsSolution> solution, JoinableTaskContext joinableTaskContext)
+        public SolutionService(IVsUIService<SVsSolution, IVsSolution> solution)
         {
             _solution = solution;
-            _joinableTaskContext = joinableTaskContext;
         }
 
         public void StartListening()
@@ -33,8 +30,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         protected override void Initialize()
         {
-            Assumes.True(_joinableTaskContext.IsOnMainThread, "Must be called on the UI thread.");
-
             IVsSolution? solution = _solution.Value;
             Assumes.Present(solution);
 
@@ -78,8 +73,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             if (!disposing)
                 return;
-
-            Assumes.True(_joinableTaskContext.IsOnMainThread, "Must be called on the UI thread.");
 
             if (_cookie != VSConstants.VSCOOKIE_NIL)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
@@ -128,7 +128,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             IsSolutionClosing = false;
 
-            return HResult.NotImplemented;
+            return HResult.OK;
         }
 
         public int OnQueryCloseSolution(object pUnkReserved, ref int pfCancel)
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             IsSolutionClosing = true;
 
-            return HResult.NotImplemented;
+            return HResult.OK;
         }
 
         public int OnAfterCloseSolution(object pUnkReserved)
@@ -167,14 +167,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             IsSolutionClosing = false;
 
-            return HResult.NotImplemented;
+            return HResult.OK;
         }
 
         public int PrioritizedOnBeforeCloseSolution(object pUnkReserved)
         {
             IsSolutionClosing = true;
 
-            return HResult.NotImplemented;
+            return HResult.OK;
         }
 
         public int PrioritizedOnAfterCloseSolution(object pUnkReserved)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
@@ -14,7 +14,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     ///     <see cref="IUnconfiguredProjectTasksService.ProjectLoadedInHost"/>.
     /// </summary>
     [Export(typeof(ILoadedInHostListener))]
-    internal class VsSolutionEventListener : OnceInitializedOnceDisposedAsync, IVsSolutionEvents, IVsPrioritizedSolutionEvents, ILoadedInHostListener
+    [Export(typeof(ISolutionService))]
+    internal class VsSolutionEventListener : OnceInitializedOnceDisposedAsync, IVsSolutionEvents, IVsPrioritizedSolutionEvents, ILoadedInHostListener, ISolutionService
     {
         private readonly IVsUIService<IVsSolution> _solution;
         private readonly IProjectThreadingService _threadingService;
@@ -27,6 +28,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             _solution = solution;
             _threadingService = threadingService;
         }
+
+        public bool IsSolutionClosing { get; private set; }
 
         public Task StartListeningAsync()
         {
@@ -123,6 +126,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
         {
+            IsSolutionClosing = false;
+
             return HResult.NotImplemented;
         }
 
@@ -133,6 +138,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public int OnBeforeCloseSolution(object pUnkReserved)
         {
+            IsSolutionClosing = true;
+
             return HResult.NotImplemented;
         }
 
@@ -158,11 +165,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public int PrioritizedOnAfterOpenSolution(object pUnkReserved, int fNewSolution)
         {
+            IsSolutionClosing = false;
+
             return HResult.NotImplemented;
         }
 
         public int PrioritizedOnBeforeCloseSolution(object pUnkReserved)
         {
+            IsSolutionClosing = true;
+
             return HResult.NotImplemented;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
@@ -3,9 +3,9 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell.Interop;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
@@ -14,8 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     ///     <see cref="IUnconfiguredProjectTasksService.ProjectLoadedInHost"/>.
     /// </summary>
     [Export(typeof(ILoadedInHostListener))]
-    [Export(typeof(ISolutionService))]
-    internal class VsSolutionEventListener : OnceInitializedOnceDisposedAsync, IVsSolutionEvents, IVsPrioritizedSolutionEvents, ILoadedInHostListener, ISolutionService
+    internal class VsSolutionEventListener : OnceInitializedOnceDisposedAsync, IVsSolutionEvents, IVsPrioritizedSolutionEvents, ILoadedInHostListener
     {
         private readonly IVsUIService<IVsSolution> _solution;
         private readonly IProjectThreadingService _threadingService;
@@ -28,8 +27,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             _solution = solution;
             _threadingService = threadingService;
         }
-
-        public bool IsSolutionClosing { get; private set; }
 
         public Task StartListeningAsync()
         {
@@ -126,9 +123,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
         {
-            IsSolutionClosing = false;
-
-            return HResult.OK;
+            return HResult.NotImplemented;
         }
 
         public int OnQueryCloseSolution(object pUnkReserved, ref int pfCancel)
@@ -138,9 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public int OnBeforeCloseSolution(object pUnkReserved)
         {
-            IsSolutionClosing = true;
-
-            return HResult.OK;
+            return HResult.NotImplemented;
         }
 
         public int OnAfterCloseSolution(object pUnkReserved)
@@ -165,16 +158,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public int PrioritizedOnAfterOpenSolution(object pUnkReserved, int fNewSolution)
         {
-            IsSolutionClosing = false;
-
-            return HResult.OK;
+            return HResult.NotImplemented;
         }
 
         public int PrioritizedOnBeforeCloseSolution(object pUnkReserved)
         {
-            IsSolutionClosing = true;
-
-            return HResult.OK;
+            return HResult.NotImplemented;
         }
 
         public int PrioritizedOnAfterCloseSolution(object pUnkReserved)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ISolutionService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ISolutionService.cs
@@ -4,9 +4,16 @@ using Microsoft.VisualStudio.Composition;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    [ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.OneOrZero)]
+    /// <summary>
+    /// A global service that tracks whether solution-level state.
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.OneOrZero)]
     internal interface ISolutionService
     {
+        /// <summary>
+        /// Gets whether the solution is being closed, which can be useful to avoid doing
+        /// redundant work while tearing down the solution.
+        /// </summary>
         bool IsSolutionClosing { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ISolutionService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ISolutionService.cs
@@ -1,0 +1,12 @@
+﻿// Copyright(c) Microsoft.All Rights Reserved.Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.OneOrZero)]
+    internal interface ISolutionService
+    {
+        bool IsSolutionClosing { get; }
+    }
+}


### PR DESCRIPTION
Fixes #2640.

Currently when a project is closed, the dependencies node notifies any projects that depend upon it to update their dependency tree as that project is no longer resolved.

This is useful when, for example, a subset of projects are unloaded.

However when a solution is being closed there's no need for a project referrer to update its tree in response to unloading projects. Doing so creates a lot of redundant tree updates at a time when we should just be tearing everything down.

This PR avoids doing that redundant work.

After this change, looking in PerfView at an ETL trace, I see almost no activity within the dependencies node during solution close, whereas beforehand there was a moderate amount.