### PR TITLE
Debug page punctuation

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.Designer.cs
@@ -223,7 +223,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Executable.
+        ///   Looks up a localized string similar to Executable:.
         /// </summary>
         public static string Executable {
             get {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.resx
@@ -196,7 +196,7 @@
     <value>Environment variables:</value>
   </data>
   <data name="Executable" xml:space="preserve">
-    <value>Executable</value>
+    <value>Executable:</value>
   </data>
   <data name="Launch" xml:space="preserve">
     <value>Launch:</value>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.cs.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable</source>
-        <target state="translated">Ke spuštění</target>
+        <source>Executable:</source>
+        <target state="translated">Ke spuštění:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.de.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable</source>
-        <target state="translated">Ausführbare Datei</target>
+        <source>Executable:</source>
+        <target state="translated">Ausführbare Datei:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.es.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable</source>
-        <target state="translated">Archivo ejecutable</target>
+        <source>Executable:</source>
+        <target state="translated">Archivo ejecutable:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.fr.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable</source>
-        <target state="translated">Exécutable</target>
+        <source>Executable:</source>
+        <target state="translated">Exécutable :</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.fr.xlf
@@ -104,7 +104,7 @@
       </trans-unit>
       <trans-unit id="ErrorsMustBeCorrectedPriorToSaving">
         <source>The errors on the page must be corrected prior to saving your changes.</source>
-        <target state="translated">Les erreurs de la page doivent être corrigées avant d’enregistrer vos modifications.</target>
+        <target state="translated">Les erreurs de la page doivent être corrigées avant d'enregistrer vos modifications.</target>
         <note />
       </trans-unit>
       <trans-unit id="AddBtn">
@@ -129,7 +129,7 @@
       </trans-unit>
       <trans-unit id="EnvironmentVariables">
         <source>Environment variables:</source>
-        <target state="translated">Variables d’environnement :</target>
+        <target state="translated">Variables d'environnement :</target>
         <note />
       </trans-unit>
       <trans-unit id="Executable">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.it.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable</source>
-        <target state="translated">Eseguibile</target>
+        <source>Executable:</source>
+        <target state="translated">Eseguibile:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ja.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable</source>
-        <target state="translated">実行可能ファイル</target>
+        <source>Executable:</source>
+        <target state="translated">実行可能ファイル:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ko.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable</source>
-        <target state="translated">실행 파일</target>
+        <source>Executable:</source>
+        <target state="translated">실행 파일:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pl.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable</source>
-        <target state="translated">Plik wykonywalny</target>
+        <source>Executable:</source>
+        <target state="translated">Plik wykonywalny:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pt-BR.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable</source>
-        <target state="translated">Executável</target>
+        <source>Executable:</source>
+        <target state="translated">Executável:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ru.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable</source>
-        <target state="translated">Исполняемый файл</target>
+        <source>Executable:</source>
+        <target state="translated">Исполняемый файл:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.tr.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable</source>
-        <target state="translated">Yürütülebilir</target>
+        <source>Executable:</source>
+        <target state="translated">Yürütülebilir:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hans.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable</source>
-        <target state="translated">可执行文件</target>
+        <source>Executable:</source>
+        <target state="translated">可执行文件:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hant.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable</source>
-        <target state="translated">可執行檔</target>
+        <source>Executable:</source>
+        <target state="translated">可執行檔:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">


### PR DESCRIPTION
Adds a colon to the "Executable" label for consistency:

![image](https://user-images.githubusercontent.com/350947/69016526-24f59a80-09f3-11ea-8308-d8f0da8f7d26.png)

Uses consistent apostrophes in the French translation.

//cc: @tmeschter 