### PR TITLE
Add necessary registrations for project file editing

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -25,6 +25,14 @@ namespace Microsoft.VisualStudio.Packaging
         new string[] { "dotnetcore" },
         new string[] { "SolutionHasProjectCapability:.NET & CPS" }
         )]
+    // Tell the diff window that these files should use the XML editor
+    [ProvideLanguageExtension("{f6819a78-a205-47b5-be1c-675b3c7f0b8e}", ".csproj")]
+    [ProvideLanguageExtension("{f6819a78-a205-47b5-be1c-675b3c7f0b8e}", ".vbproj")]
+    [ProvideLanguageExtension("{f6819a78-a205-47b5-be1c-675b3c7f0b8e}", ".fsproj")]
+    // Tell the diff window that these files are supported and should be editable. The actual content type doesn't matter for this
+    [ProvideDiffSupportedContentType(".csproj", "")]
+    [ProvideDiffSupportedContentType(".vbproj", "")]
+    [ProvideDiffSupportedContentType(".fsproj", "")]
 
     [ProvideMenuResource("Menus.ctmenu", 4)]
     internal partial class ManagedProjectSystemPackage : AsyncPackage

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -25,14 +25,6 @@ namespace Microsoft.VisualStudio.Packaging
         new string[] { "dotnetcore" },
         new string[] { "SolutionHasProjectCapability:.NET & CPS" }
         )]
-    // Tell the diff window that these files should use the XML editor
-    [ProvideLanguageExtension("{f6819a78-a205-47b5-be1c-675b3c7f0b8e}", ".csproj")]
-    [ProvideLanguageExtension("{f6819a78-a205-47b5-be1c-675b3c7f0b8e}", ".vbproj")]
-    [ProvideLanguageExtension("{f6819a78-a205-47b5-be1c-675b3c7f0b8e}", ".fsproj")]
-    // Tell the diff window that these files are supported and should be editable. The actual content type doesn't matter for this
-    [ProvideDiffSupportedContentType(".csproj", "")]
-    [ProvideDiffSupportedContentType(".vbproj", "")]
-    [ProvideDiffSupportedContentType(".fsproj", "")]
 
     [ProvideMenuResource("Menus.ctmenu", 4)]
     internal partial class ManagedProjectSystemPackage : AsyncPackage

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProjectTypeRegistration.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProjectTypeRegistration.cs
@@ -14,6 +14,8 @@ using Microsoft.VisualStudio.ProjectSystem.VS;
     resourcePackageGuid: ManagedProjectSystemPackage.PackageGuid,
     Capabilities = ProjectTypeCapabilities.VisualBasic,
     DisableAsynchronousProjectTreeLoad = true)]
+[assembly: ProvideDiffSupportedContentType(".vbproj", "")]   // Empty string because content type is not important, we just want to tell the diff that the file type is supported
+[assembly: ProvideEditorFactoryMapping("{f6819a78-a205-47b5-be1c-675b3c7f0b8e}", ".vbproj")] // Use the XML editor
 
 // F#
 [assembly: ProjectTypeRegistration(
@@ -25,6 +27,8 @@ using Microsoft.VisualStudio.ProjectSystem.VS;
     resourcePackageGuid: ManagedProjectSystemPackage.PackageGuid,
     Capabilities = ProjectTypeCapabilities.FSharp,
     DisableAsynchronousProjectTreeLoad = true)]
+[assembly: ProvideDiffSupportedContentType(".fsproj", "")]   // Empty string because content type is not important, we just want to tell the diff that the file type is supported
+[assembly: ProvideEditorFactoryMapping("{f6819a78-a205-47b5-be1c-675b3c7f0b8e}", ".fsproj")] // Use the XML editor
 
 // C#
 [assembly: ProjectTypeRegistration(
@@ -36,3 +40,5 @@ using Microsoft.VisualStudio.ProjectSystem.VS;
     resourcePackageGuid: ManagedProjectSystemPackage.PackageGuid,
     Capabilities = ProjectTypeCapabilities.CSharp,
     DisableAsynchronousProjectTreeLoad = true)]
+[assembly: ProvideDiffSupportedContentType(".csproj", "")]   // Empty string because content type is not important, we just want to tell the diff that the file type is supported
+[assembly: ProvideEditorFactoryMapping("{f6819a78-a205-47b5-be1c-675b3c7f0b8e}", ".csproj")] // Use the XML editor

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProvideDiffSupportedContentTypeAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProvideDiffSupportedContentTypeAttribute.cs
@@ -26,7 +26,6 @@ namespace Microsoft.VisualStudio
             key.SetValue(_extension, _contentType);
         }
 
-        //
         public override void Unregister(RegistrationContext context)
         {
             context.RemoveValue(RegistryKey, _extension);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProvideDiffSupportedContentTypeAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProvideDiffSupportedContentTypeAttribute.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    internal class ProvideDiffSupportedContentTypeAttribute : RegistrationAttribute
+    {
+        private const string RegistryKey = @"Diff\SupportedContentTypes";
+
+        private readonly string _contentType;
+        private readonly string _extension;
+
+        public ProvideDiffSupportedContentTypeAttribute(string extension, string contentType)
+        {
+            _extension = extension;
+            _contentType = contentType;
+        }
+
+        public override void Register(RegistrationContext context)
+        {
+            using Key key = context.CreateKey(RegistryKey);
+
+            key.SetValue(_extension, _contentType);
+        }
+
+        //
+        public override void Unregister(RegistrationContext context)
+        {
+            context.RemoveValue(RegistryKey, _extension);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProvideDiffSupportedContentTypeAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProvideDiffSupportedContentTypeAttribute.cs
@@ -5,8 +5,8 @@ using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio
 {
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    internal class ProvideDiffSupportedContentTypeAttribute : RegistrationAttribute
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    internal sealed class ProvideDiffSupportedContentTypeAttribute : RegistrationAttribute
     {
         private const string RegistryKey = @"Diff\SupportedContentTypes";
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProvideEditorFactoryMappingAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProvideEditorFactoryMappingAttribute.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.Packaging
+{
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    internal sealed class ProvideEditorFactoryMappingAttribute : RegistrationAttribute
+    {
+        private readonly ProvideLanguageExtensionAttribute _wrapped;
+
+        public ProvideEditorFactoryMappingAttribute(string editorFactoryGuid, string extension)
+        {
+            _wrapped = new ProvideLanguageExtensionAttribute(editorFactoryGuid, extension);
+        }
+
+        public override void Register(RegistrationContext context)
+        {
+            _wrapped.Register(context);
+        }
+
+        public override void Unregister(RegistrationContext context)
+        {
+            _wrapped.Unregister(context);
+        }
+    }
+}


### PR DESCRIPTION
Part of fixing #4215, this adds the registry keys necessary to tell the diff window what to do with our project files. This is responding to the removal of the temporary registry keys in https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/214544. Since the keys deal with specific .NET project file extensions they belong in this repo.