### PR TITLE
Stop calling non-existent base constructor

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPage.vb
@@ -39,10 +39,6 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
         Private _optionsControl As GeneralOptionPageControl
 
         Public Sub New()
-            ' If we're in a cloud environment we want the settings to be saved to the server
-            ' rather than the local system.
-            MyBase.New(isServerAware:=True)
-
             _optionsControlUpdateSuspender = New Suspender(Sub() _shouldUpdateOptionsControlOnPropertyChange = True)
 
             AddHandler SDKStyleProjectOptionsData.MainInstance.PropertyChanged, AddressOf OptionsDataPropertyChangedHandler


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1019631/.

Currently, our Tools | Options page is not loading. We used to use the `UIElementPage(bool isServerAware)` constructor to specify that the settings handled by our Tools | Options page should be stored back to the server in cloud environments. However, this constructor has been removed in favor of other methods of controlling the storage. At runtime, the page fails to load with a MissingMethodException or something similar.

Here we just remove the call to the now non-existent constructor which should be all we need to get things loading again. A future change will update how we store the settings to the cloud environment, but at the moment we are blocked by https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1023320 (we use settings names with backslashes in them and that is not currently supported).