### PR TITLE
Fix exception on shutdown

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.Packaging
             var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
             Lazy<DebugFrameworksDynamicMenuCommand> debugFrameworksCmd = componentModel.DefaultExportProvider.GetExport<DebugFrameworksDynamicMenuCommand>();
             var solutionService = (SolutionService)componentModel.GetService<ISolutionService>();
-            solutionService.StartListening();
+            await solutionService.InitializeAsync(cancellationToken);
 
             var mcs = (OleMenuCommandService)await GetServiceAsync(typeof(IMenuCommandService));
             mcs.AddCommand(debugFrameworksCmd.Value);


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/5650

OncenInitializedOnceAsync pushes onto a background thread by default, change the approach to just derive from OnceInitializedOnceDisposedAsync and explicitly switch to UI thread.