### PR TITLE
Remove unneeded inheritdoc

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/AbstractExtenderCATIDProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/AbstractExtenderCATIDProvider.cs
@@ -10,7 +10,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
     /// </summary>
     internal abstract class AbstractExtenderCATIDProvider : IExtenderCATIDProvider
     {
-        /// <inheritdoc />
         public string? GetExtenderCATID(ExtenderCATIDType extenderCATIDType, IProjectTree? treeNode)
         {
             // CPS's implementation of ExtenderCATIDType incorrectly treats the same "instances" as distinct items based 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileDebugTargetGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileDebugTargetGenerator.cs
@@ -46,13 +46,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
         private int _dataSourceVersion;
 
-        /// <inheritdoc/>
         public override IComparable DataSourceVersion
         {
             get { return _dataSourceVersion; }
         }
 
-        /// <inheritdoc/>
         public override IReceivableSourceBlock<IProjectVersionedValue<IReadOnlyList<IEnumValue>>> SourceBlock
         {
             get

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/SolutionService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/SolutionService.cs
@@ -14,7 +14,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         private uint _cookie = VSConstants.VSCOOKIE_NIL;
         
-        /// <inheritdoc />
         public bool IsSolutionClosing { get; private set; }
 
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/GraphActionHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/GraphActionHandlerBase.cs
@@ -26,7 +26,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
 
         protected IAggregateDependenciesSnapshotProvider AggregateSnapshotProvider { get; }
 
-        /// <inheritdoc />
         public abstract bool TryHandleRequest(IGraphContext graphContext);
 
         protected IDependenciesGraphViewProvider? FindViewProvider(IDependency dependency)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/ProjectGraphViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/ProjectGraphViewProvider.cs
@@ -84,7 +84,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
         /// Returns true if the updated dependency's path matches the updated snapshot's project path,
         /// meaning the project dependency has changed and we want to try and update.
         /// </summary>
-        /// <inheritdoc />
         public override bool ShouldApplyChanges(string nodeProjectPath, string updatedSnapshotProjectPath, IDependency updatedDependency)
         {
             string dependencyProjectPath = updatedDependency.FullPath;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Extensibility/ProjectExportProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Extensibility/ProjectExportProvider.cs
@@ -20,7 +20,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Extensibility
             _projectServiceAccessor = serviceAccessor;
         }
 
-        /// <inheritdoc />
         public T? GetExport<T>(string projectFilePath) where T : class
         {
             Requires.NotNullOrEmpty(projectFilePath, nameof(projectFilePath));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
@@ -37,16 +37,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
             FriendlyName = moniker;
         }
 
-        /// <inheritdoc />
         public FrameworkName? FrameworkName { get; }
 
-        /// <inheritdoc />
         public string FullName { get; }
 
-        /// <inheritdoc />
         public string ShortName { get; }
 
-        /// <inheritdoc />
         public string FriendlyName { get; }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptingPropertyValueProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptingPropertyValueProviderBase.cs
@@ -11,19 +11,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     /// </summary>
     internal abstract class InterceptingPropertyValueProviderBase : IInterceptingPropertyValueProvider
     {
-        /// <inheritdoc />
         public virtual Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             return Task.FromResult(evaluatedPropertyValue);
         }
 
-        /// <inheritdoc />
         public virtual Task<string> OnGetUnevaluatedPropertyValueAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             return Task.FromResult(unevaluatedPropertyValue);
         }
 
-        /// <inheritdoc />
         public virtual Task<string?> OnSetPropertyValueAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
             return Task.FromResult<string?>(unevaluatedPropertyValue);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/CancellationSeries.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/CancellationSeries.cs
@@ -96,7 +96,6 @@ namespace Microsoft.VisualStudio.Threading.Tasks
             return nextToken;
         }
 
-        /// <inheritdoc />
         public void Dispose()
         {
 #if DEBUG

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskDelayScheduler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskDelayScheduler.cs
@@ -28,13 +28,11 @@ namespace Microsoft.VisualStudio.Threading.Tasks
             _cancellationSeries = new CancellationSeries(originalSourceToken);
         }
 
-        /// <inheritdoc />
         public JoinableTask RunAsyncTask(Func<CancellationToken, Task> operation, CancellationToken token = default)
         {
             return ScheduleAsyncTaskInternal(operation, immediate: true, token);
         }
 
-        /// <inheritdoc />
         public JoinableTask ScheduleAsyncTask(Func<CancellationToken, Task> operation, CancellationToken token = default)
         {
             return ScheduleAsyncTaskInternal(operation, immediate: false, token);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -47,7 +47,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 projectCapabilityCheckProvider: commonServices.Project);
         }
 
-        /// <inheritdoc />
         public async Task<IProjectTree> BuildTreeAsync(
             IProjectTree dependenciesTree,
             DependenciesSnapshot snapshot,
@@ -155,7 +154,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
         }
 
-        /// <inheritdoc />
         public IProjectTree? FindByPath(IProjectTree? root, string path)
         {
             if (root == null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -56,10 +56,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
         }
 
-        /// <inheritdoc />
         public bool IsActive => _stateByFramework != null;
 
-        /// <inheritdoc />
         public void InitializeTargetFrameworkRules(ImmutableArray<ITargetFramework> targetFrameworks, IReadOnlyCollection<string> rules)
         {
             if (_stateByFramework == null)
@@ -85,7 +83,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
         }
 
-        /// <inheritdoc />
         public void ObserveTargetFrameworkRules(ITargetFramework targetFramework, IEnumerable<string> rules)
         {
             if (_stateByFramework == null)
@@ -106,7 +103,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
         }
 
-        /// <inheritdoc />
         public async Task ObserveTreeUpdateCompletedAsync(bool hasUnresolvedDependency)
         {
             if (_stateByFramework == null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/AggregateDependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/AggregateDependenciesSnapshotProvider.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 {
-    /// <inheritdoc />
+    /// <inheritdoc cref="IAggregateDependenciesSnapshotProvider"/>
     [Export(typeof(IAggregateDependenciesSnapshotProvider))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
     internal sealed class AggregateDependenciesSnapshotProvider : IAggregateDependenciesSnapshotProvider
@@ -42,13 +42,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             _snapshotProviderByPath = ImmutableDictionary<string, DependenciesSnapshotProvider>.Empty.WithComparers(StringComparers.Paths);
         }
 
-        /// <inheritdoc />
         public event EventHandler<SnapshotChangedEventArgs>? SnapshotChanged;
 
-        /// <inheritdoc />
         public event EventHandler<SnapshotProviderUnloadingEventArgs>? SnapshotProviderUnloading;
 
-        /// <inheritdoc />
         public IDisposable RegisterSnapshotProvider(DependenciesSnapshotProvider snapshotProvider)
         {
             Requires.NotNull(snapshotProvider, nameof(snapshotProvider));
@@ -118,7 +115,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             }
         }
 
-        /// <inheritdoc />
         public DependenciesSnapshot? GetSnapshot(string projectFilePath)
         {
             Requires.NotNullOrEmpty(projectFilePath, nameof(projectFilePath));
@@ -128,7 +124,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             return provider?.CurrentSnapshot;
         }
 
-        /// <inheritdoc />
         public TargetedDependenciesSnapshot? GetSnapshot(IDependency dependency)
         {
             DependenciesSnapshot? snapshot = GetSnapshot(dependency.FullPath);
@@ -149,7 +144,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             return snapshot.DependenciesByTargetFramework[targetFramework];
         }
 
-        /// <inheritdoc />
         public IReadOnlyCollection<DependenciesSnapshot> GetSnapshots()
         {
             return _snapshotProviderByPath.Values.Select(provider => provider.CurrentSnapshot).ToList();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -207,7 +207,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             }
         }
 
-        /// <inheritdoc />
         protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
         {
             await UpdateProjectContextAndSubscriptionsAsync();
@@ -281,7 +280,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             }
         }
 
-        /// <inheritdoc />
         protected override Task DisposeCoreAsync(bool initialized)
         {
             DisposeCore();
@@ -358,7 +356,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             }
         }
 
-        /// <inheritdoc />
         public async Task<AggregateCrossTargetProjectContext?> GetCurrentAggregateProjectContextAsync()
         {
             if (IsDisposing || IsDisposed)
@@ -371,7 +368,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             return _context.Current;
         }
 
-        /// <inheritdoc />
         public ConfiguredProject? GetConfiguredProject(ITargetFramework target)
         {
             return _context.Current!.GetInnerConfiguredProject(target);


### PR DESCRIPTION
VS will automatically show documentation from interface and base declarations.