### PR TITLE
Improve text rendering for WPF pages/dialogs

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
@@ -9,7 +9,10 @@
              x:ClassModifier="internal"
              d:DesignHeight="700"
              d:DesignWidth="1000" 
-             d:DataContext="{d:DesignInstance local:DebugPageViewModel}">
+             d:DataContext="{d:DesignInstance local:DebugPageViewModel}"
+             UseLayoutRounding="true"
+             TextOptions.TextFormattingMode="Display"
+             >
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml
@@ -14,7 +14,10 @@
     SizeToContent="Height"
     Loaded="GetProfileNameDialogWindow_Loaded"
     ResizeMode="NoResize"
-    Width="400">
+    Width="400"
+    UseLayoutRounding="true"
+    TextOptions.TextFormattingMode="Display"
+    >
     <Grid x:Uid="MainGrid">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"></RowDefinition>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/DontShowAgainMessageBox.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/DontShowAgainMessageBox.xaml
@@ -8,7 +8,10 @@
         ResizeMode="NoResize"
         WindowStartupLocation="CenterOwner"                    
         Title="{Binding Path=DialogCaption, Mode=OneWay}"
-        Width="500" SizeToContent="Height">
+        Width="500" SizeToContent="Height"
+        UseLayoutRounding="true"
+        TextOptions.TextFormattingMode="Display"
+        >
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/4827

This opts into UseLayoutRounding  and TextOptions.TextFormattingMode="Display" to improve text rendering of these pages/dialogs.

Before:
![image](https://user-images.githubusercontent.com/1103906/69288716-751c6900-0c4e-11ea-8ede-89e0a0876fc3.png)

After:
![image](https://user-images.githubusercontent.com/1103906/69288729-7e0d3a80-0c4e-11ea-81f0-b040f64b307f.png)
