### PR TITLE
Do not check for null in MEF constructors

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FSharp/FSharpProjectSelector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FSharp/FSharpProjectSelector.cs
@@ -28,8 +28,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.FSharp
         [ImportingConstructor]
         public FSharpProjectSelector(JoinableTaskContext context)
         {
-            Requires.NotNull(context, nameof(context));
-
             _context = context;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
@@ -24,8 +24,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         [ImportingConstructor]
         public OrderAddItemHintReceiver(IProjectAccessor accessor)
         {
-            Requires.NotNull(accessor, nameof(accessor));
-
             _accessor = accessor;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/SolutionService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/SolutionService.cs
@@ -21,8 +21,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         [ImportingConstructor]
         public SolutionService(JoinableTaskContext context)
         {
-            Requires.NotNull(context, nameof(context));
-
             _context = context;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetectorInitializer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetectorInitializer.cs
@@ -17,8 +17,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         [ImportingConstructor]
         public DotNetCoreProjectCompatibilityDetectorInitializer(IProjectServiceAccessor projectServiceAccessor)
         {
-            Requires.NotNull(projectServiceAccessor, nameof(projectServiceAccessor));
-
             _projectServiceAccessor = projectServiceAccessor;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Xproj/XprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Xproj/XprojProjectFactory.cs
@@ -24,8 +24,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         [ImportingConstructor]
         public XprojProjectFactory(JoinableTaskContext context)
         {
-            Requires.NotNull(context, nameof(context));
-
             _context = context;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -60,9 +60,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [ImportingConstructor]
         public ActiveConfiguredProjectsProvider(IUnconfiguredProjectServices services, UnconfiguredProject project)
         {
-            Requires.NotNull(services, nameof(services));
-            Requires.NotNull(project, nameof(project));
-
             _services = services;
             _project = project;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -24,8 +24,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [ImportingConstructor]
         public AdditionalFilesItemHandler(UnconfiguredProject project)
         {
-            Requires.NotNull(project, nameof(project));
-
             _project = project;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -24,8 +24,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [ImportingConstructor]
         public AnalyzerItemHandler(UnconfiguredProject project)
         {
-            Requires.NotNull(project, nameof(project));
-
             _project = project;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -25,8 +25,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [ImportingConstructor]
         public MetadataReferenceItemHandler(UnconfiguredProject project)
         {
-            Requires.NotNull(project, nameof(project));
-
             _project = project;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -15,7 +15,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [ImportingConstructor]
         public ProjectPropertiesItemHandler(UnconfiguredProject project)
         {
-            Requires.NotNull(project, nameof(project));
         }
 
         public string ProjectEvaluationRule

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -84,11 +84,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             IAggregateDependenciesSnapshotProvider aggregateSnapshotProvider)
             : base(commonServices.ThreadingService.JoinableTaskContext)
         {
-            Requires.NotNull(tasksService, nameof(tasksService));
-            Requires.NotNull(activeConfiguredProjectSubscriptionService, nameof(activeConfiguredProjectSubscriptionService));
-            Requires.NotNull(targetFrameworkProvider, nameof(targetFrameworkProvider));
-            Requires.NotNull(aggregateSnapshotProvider, nameof(aggregateSnapshotProvider));
-
             _commonServices = commonServices;
             _tasksService = tasksService;
             _activeConfiguredProjectSubscriptionService = activeConfiguredProjectSubscriptionService;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandlerTests.cs
@@ -1,22 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
-using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
     public class AdditionalFilesItemHandlerTests : CommandLineHandlerTestBase
     {
-        [Fact]
-        public void Constructor_NullAsProject_ThrowsArgumentNull()
-        {
-            Assert.Throws<ArgumentNullException>("project", () =>
-            {
-                new AdditionalFilesItemHandler(null!);
-            });
-        }
-
         internal override ICommandLineHandler CreateInstance()
         {
             return CreateInstance(null, null);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandlerTests.cs
@@ -1,22 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
-using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
     public class AnalyzerItemHandlerTests : CommandLineHandlerTestBase
     {
-        [Fact]
-        public void Constructor_NullAsProject_ThrowsArgumentNull()
-        {
-            Assert.Throws<ArgumentNullException>("project", () =>
-            {
-                new AnalyzerItemHandler(null!);
-            });
-        }
-
         internal override ICommandLineHandler CreateInstance()
         {
             return CreateInstance(null, null);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.CodeAnalysis.CSharp;
@@ -13,15 +12,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
     public class MetadataReferenceItemHandlerTests : CommandLineHandlerTestBase
     {
-        [Fact]
-        public void Constructor_NullAsProject_ThrowsArgumentNull()
-        {
-            Assert.Throws<ArgumentNullException>("project", () =>
-            {
-                new MetadataReferenceItemHandler(null!);
-            });
-        }
-
         [Fact]
         public void DuplicateMetadataReferencesPushedToWorkspace()
         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandlerTests.cs
@@ -1,20 +1,10 @@
-﻿using System;
-using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+﻿using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
     public class ProjectPropertiesItemHandlerTests : EvaluationHandlerTestBase
     {
-        [Fact]
-        public void Constructor_NullAsProject_ThrowsArgumentNull()
-        {
-            Assert.Throws<ArgumentNullException>("project", () =>
-            {
-                new ProjectPropertiesItemHandler(null!);
-            });
-        }
-
         [Fact]
         public void Handle_WhenPropertyIsChanged_CallsSetProperty()
         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/FSharp/FSharpProjectSelectorTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/FSharp/FSharpProjectSelectorTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Xml.Linq;
 using Xunit;
 
@@ -8,16 +7,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.FSharp
 {
     public class FSharpProjectSelectorTests
     {
-        [Fact]
-        public void Constructor()
-        {
-            Assert.Throws<ArgumentNullException>(() => new FSharpProjectSelector(null!));
-
-#pragma warning disable VSSDK005 // Avoid instantiating JoinableTaskContext
-            new FSharpProjectSelector(new Threading.JoinableTaskContext());
-#pragma warning restore VSSDK005 // Avoid instantiating JoinableTaskContext
-        }
-
         [Theory]
         [InlineData(@"<Project Sdk = ""FSharp.SDK""> </Project>", ProjectType.FSharp)]
         [InlineData(@"<Project ToolsVersion=""15.0""> </Project>", ProjectType.LegacyFSharp)]


### PR DESCRIPTION
The decision was made to stop checking for null in https://github.com/dotnet/project-system/pull/3284, remove more of these that have sneaked in.