### PR TITLE
Depend on .NET Framework 4.8 SDK

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -2,7 +2,7 @@
   "version": "1.0",
   "components": [
     "Microsoft.Component.MSBuild",
-    "Microsoft.Net.Component.4.7.2.SDK",
+    "Microsoft.Net.Component.4.8.SDK",
     "Microsoft.Net.Component.4.7.2.TargetingPack",
     "Microsoft.Net.ComponentGroup.DevelopmentPrerequisites",
     "Microsoft.VisualStudio.Component.CoreEditor",


### PR DESCRIPTION
4.7.2 SDK is no longer installed by default, update to 4.8 to avoid VS wanting to install additonal features.