### PR TITLE
Remove empty documentation elements

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
@@ -150,7 +150,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Disconnect from the owning site
         ''' </summary>
-        ''' <remarks></remarks>
         Public Function Close() As Integer Implements IVsEditorFactory.Close
             _siteProvider = Nothing
             _site = Nothing
@@ -159,7 +158,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Wrapper of COM interface which delegates to Internal
         ''' </summary>
-        ''' <remarks></remarks>
         Private Function IVsEditorFactory_CreateEditorInstance(
                 vscreateeditorflags As UInteger,
                 FileName As String,
@@ -209,7 +207,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <param name="rguidLogicalView"></param>
         ''' <param name="pbstrPhysicalView"></param>
-        ''' <remarks></remarks>
         Public Function MapLogicalView(ByRef rguidLogicalView As Guid, ByRef pbstrPhysicalView As String) As Integer Implements IVsEditorFactory.MapLogicalView
             pbstrPhysicalView = Nothing
 
@@ -229,7 +226,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Called by owning site after creation
         ''' </summary>
         ''' <param name="Site"></param>
-        ''' <remarks></remarks>
         Public Function SetSite(Site As OLE.Interop.IServiceProvider) As Integer Implements IVsEditorFactory.SetSite
             'This same Site already set?  Or Site not yet initialized (= Nothing)?  If so, NOP.
             If _site Is Site Then

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerLoader.vb
@@ -23,7 +23,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
     ''' <summary>
     ''' Designer loader for the ApplicationDesigner
     ''' </summary>
-    ''' <remarks></remarks>
     Public NotInheritable Class ApplicationDesignerLoader
         Inherits BasicDesignerLoader
         Implements IDisposable
@@ -49,7 +48,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' NOTE: Remember to call RemoveService on any service object we don't own, when the Loader is disposed
         '''  Otherwise, the service container will dispose those objects. 
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub Initialize()
             MyBase.Initialize()
 
@@ -89,7 +87,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="Hierarchy"></param>
         ''' <param name="ItemId"></param>
         ''' <param name="punkDocData"></param>
-        ''' <remarks></remarks>
         Public Sub InitializeEx(ServiceProvider As Shell.ServiceProvider, Hierarchy As IVsHierarchy, ItemId As UInteger, punkDocData As Object)
 
             If m_DocDataService IsNot Nothing Then
@@ -117,7 +114,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' it needs an updated version of the file contents).
         ''' </summary>
         ''' <param name="serializationManager"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub PerformFlush(serializationManager As IDesignerSerializationManager)
             Debug.Assert(Modified, "PerformFlush shouldn't get called if the designer's not dirty")
 
@@ -207,7 +203,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Dispose of managed and unmanaged resources
         ''' </summary>
         ''' <param name="disposing">True if calling from Dispose()</param>
-        ''' <remarks></remarks>
         Protected Overloads Sub Dispose(disposing As Boolean)
             If disposing Then
                 LoaderHost.RemoveService(GetType(DesignerDocDataService))

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerPanel.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerPanel.vb
@@ -85,7 +85,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="Hierarchy"></param>
         ''' <param name="ItemId"></param>
         ''' <param name="PropertyPageInfo"></param>
-        ''' <remarks></remarks>
         Public Sub New(View As ApplicationDesignerView, Hierarchy As IVsHierarchy, ItemId As UInteger, PropertyPageInfo As PropertyPageInfo)
             Me.New(View, Hierarchy, ItemId)
 
@@ -105,7 +104,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="View">The owning project designer view</param>
         ''' <param name="Hierarchy"></param>
         ''' <param name="ItemId"></param>
-        ''' <remarks></remarks>
         Public Sub New(View As ApplicationDesignerView, Hierarchy As IVsHierarchy, ItemId As UInteger)
             Debug.Assert(View IsNot Nothing)
             Debug.Assert(Hierarchy IsNot Nothing)
@@ -130,8 +128,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Returns the PropertyPageInfo for this designer panel, if it corresponds to a property page.
         ''' Otherwise returns Nothing.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property PropertyPageInfo() As PropertyPageInfo
             Get
                 Return _propertyPageInfo
@@ -169,8 +165,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Provides a custom view control that can be displayed instead of hosting a designer.  We can display either
         '''   a custom view provider or a hosted designer, but not both at once.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property CustomViewProvider() As CustomViewProvider
             Get
                 Return _customViewProvider
@@ -572,7 +566,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Notify the shell of the current selection so that the Project menus etc. are correct
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub UpdateSelection()
             Common.Switches.TracePDPerfBegin("ApplicationDesignerPanel.UpdateSelection")
             'When we call IVsWindowFrame.Hide() on a tab (when changing to another tab), the shell nulls out the 
@@ -653,9 +646,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Get/set the window frame owned by this panel
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Property VsWindowFrame() As IVsWindowFrame
             Get
                 Return _vsWindowFrame
@@ -679,8 +669,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' The Guid used by the editor for this panel.  For property pages, this is always
         '''   PropPageDesignerView's guid.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property EditorGuid() As Guid
             Get
                 Return _editorGuid
@@ -699,8 +687,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' The Guid used by the object actually represented in this panel.  For property pages,
         '''   this is the guid of the property page.  For all others, this is the same as EditorGuid.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property ActualGuid() As Guid
             Get
                 If _propertyPageInfo IsNot Nothing Then
@@ -714,8 +700,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Physical view guid for the editor
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property PhysicalView() As String
             Get
                 Return _physicalView
@@ -728,8 +712,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The editor's caption
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property EditorCaption() As String
             Get
                 Return _editorCaption
@@ -742,8 +724,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The filename moniker of the file which is being edited by the editor
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property MkDocument() As String
             Get
                 If _mkDocument <> "" Then
@@ -763,8 +743,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The filename moniker of the file which is being edited by the editor
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property CustomMkDocumentProvider() As CustomDocumentMonikerProvider
             Get
                 Return _customMkDocumentProvider
@@ -778,8 +756,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The DocData for the editor
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property DocData() As Object
             Get
                 Return _docData
@@ -792,8 +768,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The DocView for the editor
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property DocView() As Control
             Get
                 Return _docView
@@ -806,8 +780,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Flags to be passed to VsUIShellOpenDocument
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property EditFlags() As UInteger
             Get
                 Return _editFlags
@@ -820,8 +792,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The title that should be used for this panel's tab
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property TabTitle() As String
             Get
                 Return _tabTitle
@@ -843,8 +813,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The name for the tab that is not localized and is seen by QA automation tools
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property TabAutomationName() As String
             Get
                 Return _tabAutomationName
@@ -860,7 +828,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''   same size as the hosting panel (as if it were dock filled).  This sets the native
         '''   window's size to the size of the hosting panel.
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Sub UpdateWindowFrameBounds()
             'Note: don't need to worry about updating size of CustomView because it's set to dock fill
             If VsWindowFrame IsNot Nothing Then
@@ -900,7 +867,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Commits any pending changes on the designer
         ''' </summary>
         ''' <returns>return False if it failed</returns>
-        ''' <remarks></remarks>
         Public Function CommitPendingEdit() As Boolean
             If VsWindowFrame IsNot Nothing Then
                 Dim docViewObject As Object = Nothing
@@ -996,8 +962,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Returns true if this page should show the '*' dirty indicator in its tab
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function IsDirty() As Boolean
             If IsPropertyPage Then
                 'CONSIDER: If we decide to support IVsDocDataContainer, then DocDatas contained by the property
@@ -1030,7 +994,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub PageHostingPanel_HandleCreated(sender As Object, e As EventArgs) Handles _pageHostingPanel.HandleCreated
             If _vsWindowFrame IsNot Nothing Then
                 Debug.Fail("PageHostingPanel handle was recreated after the nested window frame's ParentHwnd property was set to its HWND.  " _
@@ -1045,7 +1008,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Disposes of contained objects
         ''' </summary>
         ''' <param name="disposing"></param>
-        ''' <remarks></remarks>
         Protected Overloads Overrides Sub Dispose(disposing As Boolean)
             If disposing Then
                 ' Dispose managed resources.
@@ -1145,8 +1107,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' to avoid that we just close this property page and leave the app designer open...
         ''' </summary>
         ''' <param name="pgrfSaveOptions"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function OnClose(ByRef pgrfSaveOptions As UInteger) As Integer Implements IVsWindowFrameNotify2.OnClose
             If _inOnClose Then
                 Return NativeMethods.S_OK

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerRootComponent.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerRootComponent.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 Imports System.ComponentModel.Design
@@ -10,7 +10,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
     ''' <summary>
     ''' This class represents the root component of the Application Designer.
     ''' </summary>
-    ''' <remarks></remarks>
     <Designer(GetType(ApplicationDesignerRootDesigner), GetType(IRootDesigner))>
     Public NotInheritable Class ApplicationDesignerRootComponent
         Inherits Component
@@ -26,7 +25,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''   resx file to be edited by the user.
         ''' </summary>
         ''' <value>The associated ResourceEditorRootDesigner.</value>
-        ''' <remarks></remarks>
         Public ReadOnly Property RootDesigner() As ApplicationDesignerRootDesigner
             Get
                 If _rootDesigner Is Nothing Then
@@ -44,8 +42,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The IVsHierarchy associated with the AppDesigner node
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property Hierarchy() As IVsHierarchy
             Get
                 Return _hierarchy
@@ -58,8 +54,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The ItemId associated with the AppDesigner node
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property ItemId() As UInteger
             Get
                 Return _itemId

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerRootDesigner.vb
@@ -13,7 +13,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
     ''' This is the designer for the top-level resource editor component (ApplicationDesigner).  I.e., this
     ''' is the top-level designer.  
     ''' </summary>
-    ''' <remarks></remarks>
     Public NotInheritable Class ApplicationDesignerRootDesigner
         Inherits AppDesDesignerFramework.BaseRootDesigner
         Implements IRootDesigner
@@ -25,7 +24,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Returns the ApplicationDesignerRootComponent component that is being edited by this designer.
         ''' </summary>
         ''' <value>The ApplicationDesignerRootComponent object.</value>
-        ''' <remarks></remarks>
         Public Shadows ReadOnly Property Component() As ApplicationDesignerRootComponent
             Get
                 Dim RootComponent As ApplicationDesignerRootComponent = CType(MyBase.Component, ApplicationDesignerRootComponent)
@@ -60,7 +58,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Disposes of the root designer
         ''' </summary>
         ''' <param name="Disposing"></param>
-        ''' <remarks></remarks>
         Protected Overloads Overrides Sub Dispose(Disposing As Boolean)
             If Disposing Then
                 If _view IsNot Nothing Then
@@ -77,7 +74,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' We currently support only Windows Forms technology (i.e., our designer view, ResourceEditorView,
         ''' inherits from System.Windows.Forms.Control)
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' The view technology we support, which is currently only Windows Forms
         ''' </remarks>
@@ -92,7 +88,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''   our resource editor's designer surface.  In this case, we return an instance of ResourceEditorView.
         ''' </summary>
         ''' <param name="Technology"></param>
-        ''' <returns></returns>
         ''' <remarks>
         '''   The newly-instantiated ResourceEditorView object.
         ''' </remarks>
@@ -114,8 +109,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Wrapper function to expose our UI object
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetView() As ApplicationDesignerView
             Return CType(RootDesigner_GetView(ViewTechnology.Default), ApplicationDesignerView)
         End Function

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
@@ -130,7 +130,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Constructor for the ApplicationDesigner view
         ''' </summary>
         ''' <param name="serviceProvider">The service provider from the root designer.</param>
-        ''' <remarks></remarks>
         Public Sub New(serviceProvider As IServiceProvider)
             MyBase.New()
             SuspendLayout()
@@ -152,11 +151,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             HostingPanel.ResumeLayout(False)
             ResumeLayout(False) 'Don't need to lay out yet - we'll do that at the end of AddTabs
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
-        ''' <remarks></remarks>
         Public Sub InitView()
             Dim WindowFrame As IVsWindowFrame
             Dim Value As Object = Nothing
@@ -268,8 +262,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Retrieves the DTE project object associated with this project designer instance.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property DTEProject() As Project
             Get
                 Return _dteProject
@@ -285,7 +277,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Instance of the loaded IVBPackage
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>Used to persist user data</remarks>
         Private ReadOnly Property Package() As IVBPackage
             Get
@@ -306,8 +297,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Get/set the last viewed tab of for this application page...
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private Property LastShownTab() As Integer
             Get
                 Dim editorsPackage As IVBPackage = Package
@@ -332,7 +321,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Should be called to let the project designer know it's shutting down and should no longer try
         '''   to activate child pages
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub NotifyShuttingDown()
             Common.Switches.TracePDFocus(TraceLevel.Info, "NotifyShuttingDown")
             _okayToActivatePanelsOnFocus = False
@@ -345,7 +333,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="DocCookie"></param>
         ''' <param name="Hierarchy"></param>
         ''' <param name="ItemId"></param>
-        ''' <returns></returns>
         ''' <remarks>Used by view to prompt for saving changes</remarks>
         Private Function IsDocDataDirty(DocCookie As UInteger, ByRef Hierarchy As IVsHierarchy, ByRef ItemId As UInteger) As Boolean
             Dim rdt As IVsRunningDocumentTable = TryCast(GetService(GetType(IVsRunningDocumentTable)), IVsRunningDocumentTable)
@@ -388,7 +375,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Populates the list of documents based on flags argument
         ''' </summary>
         ''' <param name="flags"></param>
-        ''' <value></value>
         ''' <remarks>Used to build table of documents to save</remarks>
         Public ReadOnly Property GetSaveTreeItems(flags As __VSRDTSAVEOPTIONS) As VSSAVETREEITEM()
             Get
@@ -496,7 +482,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Does *not* load them now, but waits to load them on demand.
         ''' </summary>
         ''' <returns>An array of PropertyPageInfo with the loaded property page information.</returns>
-        ''' <remarks></remarks>
         Public Function GetPropertyPages() As PropertyPageInfo()
             Dim LocalRegistry As ILocalRegistry
             LocalRegistry = CType(GetService(GetType(ILocalRegistry)), ILocalRegistry)
@@ -544,8 +529,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Get the max property page size based on the reported page infos
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property GetMaxPropPageSize() As Drawing.Size
             Get
                 Dim MaxSize As Drawing.Size
@@ -598,7 +581,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Obtain the current Config browse object from the project hierarchy
         ''' </summary>
         ''' <returns>The browse object for the currently selected configuration.</returns>
-        ''' <remarks></remarks>
         Private Function GetActiveConfigBrowseObject() As Object
             Return Common.DTEUtils.GetActiveConfiguration(DTEProject, VsCfgProvider)
         End Function
@@ -641,7 +623,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="tabSupported">[Out] True if the given tab is supported by the project</param>
         ''' <param name="fileExists">[Out] True if the given tab's file actually exists currently.  Always false if Not TabSupported.</param>
         ''' <param name="fullPathToProjectItem">[Out] The full path to the given tab's file.  If TabSupported is True but FileExists is False, this value indicates the preferred file and location for the project for this special file.</param>
-        ''' <remarks></remarks>
         Private Sub CheckIfTabSupported(fileId As Integer, ByRef tabSupported As Boolean, ByRef fileExists As Boolean, ByRef fullPathToProjectItem As String)
             tabSupported = False
             fileExists = False
@@ -673,7 +654,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Adds the tab buttons for the App Designer
         ''' </summary>
         ''' <param name="PropertyPages">The list of property pages to display</param>
-        ''' <remarks></remarks>
         Private Sub AddTabs(PropertyPages() As PropertyPageInfo)
             SuspendLayout()
             HostingPanel.SuspendLayout()
@@ -941,8 +921,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Gets the guid list from the specified object
         ''' </summary>
         ''' <param name="BrowseObject"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GetPageGuids(BrowseObject As Object) As Guid()
             If TypeOf BrowseObject Is IVsSpecifyProjectDesignerPages Then
                 Dim CauuidPages() As OleInterop.CAUUID = New OleInterop.CAUUID(1) {}
@@ -988,7 +966,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Called by designer when changes need to be persisted
         ''' </summary>
         ''' <returns>Return true if success </returns>
-        ''' <remarks></remarks>
         Public Function CommitAnyPendingChanges() As Boolean
             If _activePanelIndex >= 0 Then
                 Dim currentPanel As ApplicationDesignerPanel = _designerPanels(_activePanelIndex)
@@ -1005,7 +982,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <param name="Index">Index of Designer panel to show</param>
         ''' <param name="ForceShow">Forces the Show code to go through, even if the current panel is the same as the one requested.</param>
-        ''' <remarks></remarks>
         Private Sub ShowTab(Index As Integer, Optional ForceShow As Boolean = False, Optional ForceActivate As Boolean = False)
 
             Common.Switches.TracePDFocus(TraceLevel.Warning, "ApplicationDesignerView.ShowTab(" & Index & ")")
@@ -1193,7 +1169,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="DefaultButton">Which button should be default?</param>
         ''' <param name="HelpLink">The help link</param>
         ''' <returns>One of the DialogResult values</returns>
-        ''' <remarks></remarks>
 #Disable Warning RS0026 ' Do not add multiple public overloads with optional parameters
         Public Function DsMsgBox(Message As String,
                 Buttons As MessageBoxButtons,
@@ -1213,7 +1188,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <param name="ex">The exception whose text should be displayed.</param>
         ''' <param name="HelpLink">The help link</param>
-        ''' <remarks></remarks>
 #Disable Warning RS0026 ' Do not add multiple public overloads with optional parameters
         Public Sub DsMsgBox(ex As Exception,
                 Optional HelpLink As String = Nothing) Implements IPropertyPageSiteOwner.DsMsgBox
@@ -1228,7 +1202,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Moves to the next or previous tab in the project designer
         ''' </summary>
         ''' <param name="forward">If true, moves forward a tab.  If false, moves back a tab.</param>
-        ''' <remarks></remarks>
         Public Sub SwitchTab(forward As Boolean)
             Dim Index As Integer = _activePanelIndex
             If forward Then
@@ -1248,7 +1221,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Occurs when the user clicks on one of the tab buttons.  Switch to that tab.
         ''' </summary>
         ''' <param name="item"></param>
-        ''' <remarks></remarks>
         Public Overrides Sub OnItemClick(item As ProjectDesignerTabButton)
             OnItemClick(item, reactivatePage:=False)
         End Sub
@@ -1286,7 +1258,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' WndProc for the project designer.
         ''' </summary>
         ''' <param name="m"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub WndProc(ByRef m As Message)
             If m.Msg = Win32Constant.WM_SETFOCUS AndAlso Not _isInPanelWindowFrameShow Then 'in MDI mode this can get hit recursively
                 'We need to intercept WM_SETFOCUS on the project designer to keep WinForms from setting focus to the
@@ -1335,7 +1306,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Calls when the application designer window pane has completely initialized the application designer view (the
         '''   ApplicationDesignerWindowPane controls initialization and population of the view).
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub OnInitializationComplete()
             Common.Switches.TracePDFocus(TraceLevel.Warning, "OnInitializationComplete")
             _initializationComplete = True
@@ -1358,8 +1328,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''   by ApplicationDesignerPanel to delay any window frame activations until after
         '''   initialization.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property InitializationComplete() As Boolean
             Get
                 Return _initializationComplete
@@ -1372,7 +1340,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Queues up a request (via PostMessage) to refresh all of our dirty indicators.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub DelayRefreshDirtyIndicators() Implements IPropertyPageSiteOwner.DelayRefreshDirtyIndicators
             If Not _initializationComplete Then
                 Exit Sub
@@ -1389,7 +1356,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Used by DelayRefreshDirtyIndicators, do not call directly.  Updates the dirty
         '''   indicators for the project designer and all tabs.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub RefreshDirtyIndicatorsHelper()
             Try
                 'First, update all tab dirty indicators
@@ -1428,8 +1394,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Returns true if the project file is dirty
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function IsProjectFileDirty(Project As Project) As Boolean
             Debug.Assert(Project IsNot Nothing)
 
@@ -1462,8 +1426,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Gets the cookie for the project file
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetProjectFileCookie(Project As Project) As UInteger
             Debug.Assert(Project IsNot Nothing)
 
@@ -1499,7 +1461,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''   state as a whole).
         ''' </summary>
         ''' <param name="Dirty">If true, the asterisk is added, if false, it is removed.</param>
-        ''' <remarks></remarks>
         Private Sub SetFrameDirtyIndicator(Dirty As Boolean)
             If Not _projectDesignerDirtyStateInitialized OrElse _lastProjectDesignerDirtyState <> Dirty Then
                 Dim Frame As IVsWindowFrame = WindowFrame
@@ -1615,7 +1576,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Start listening to IVsRunningDocTableEvents events
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub AdviseRunningDocTableEvents()
             Dim rdt As IVsRunningDocumentTable = TryCast(GetService(GetType(IVsRunningDocumentTable)), IVsRunningDocumentTable)
             Debug.Assert(rdt IsNot Nothing, "Couldn't get running document table")
@@ -1628,7 +1588,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Stop listening to IVsRunningDocTableEvents events
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub UnadviseRunningDocTableEvents()
             If _rdtEventsCookie <> 0 Then
                 Dim rdt As IVsRunningDocumentTable = TryCast(GetService(GetType(IVsRunningDocumentTable)), IVsRunningDocumentTable)
@@ -1646,8 +1605,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <param name="docCookie"></param>
         ''' <param name="grfAttribs"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function OnAfterAttributeChange(docCookie As UInteger, grfAttribs As UInteger) As Integer Implements IVsRunningDocTableEvents.OnAfterAttributeChange
             Const InterestingFlags As Long = __VSRDTATTRIB.RDTA_DocDataIsDirty Or __VSRDTATTRIB.RDTA_DocDataIsNotDirty Or __VSRDTATTRIB.RDTA_NOTIFYDOCCHANGEDMASK
             If (grfAttribs And InterestingFlags) <> 0 Then
@@ -1665,8 +1622,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <param name="docCookie"></param>
         ''' <param name="pFrame"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function OnAfterDocumentWindowHide(docCookie As UInteger, pFrame As IVsWindowFrame) As Integer Implements IVsRunningDocTableEvents.OnAfterDocumentWindowHide
             Return NativeMethods.S_OK
         End Function
@@ -1678,8 +1633,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="dwRDTLockType"></param>
         ''' <param name="dwReadLocksRemaining"></param>
         ''' <param name="dwEditLocksRemaining"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function OnAfterFirstDocumentLock(docCookie As UInteger, dwRDTLockType As UInteger, dwReadLocksRemaining As UInteger, dwEditLocksRemaining As UInteger) As Integer Implements IVsRunningDocTableEvents.OnAfterFirstDocumentLock
             Return NativeMethods.S_OK
         End Function
@@ -1688,8 +1641,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Fires after a document in the RDT is saved.
         ''' </summary>
         ''' <param name="docCookie"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function OnAfterSave(docCookie As UInteger) As Integer Implements IVsRunningDocTableEvents.OnAfterSave
             Debug.Assert(_designerPanels IsNot Nothing, "m_DesignerPanels should not be Nothing")
             If _designerPanels IsNot Nothing Then
@@ -1710,8 +1661,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="docCookie"></param>
         ''' <param name="fFirstShow"></param>
         ''' <param name="pFrame"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function OnBeforeDocumentWindowShow(docCookie As UInteger, fFirstShow As Integer, pFrame As IVsWindowFrame) As Integer Implements IVsRunningDocTableEvents.OnBeforeDocumentWindowShow
             Debug.Assert(_designerPanels IsNot Nothing, "m_DesignerPanels should not be Nothing")
             If _designerPanels IsNot Nothing Then
@@ -1740,8 +1689,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="dwRDTLockType"></param>
         ''' <param name="dwReadLocksRemaining"></param>
         ''' <param name="dwEditLocksRemaining"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function OnBeforeLastDocumentUnlock(docCookie As UInteger, dwRDTLockType As UInteger, dwReadLocksRemaining As UInteger, dwEditLocksRemaining As UInteger) As Integer Implements IVsRunningDocTableEvents.OnBeforeLastDocumentUnlock
             Return NativeMethods.S_OK
         End Function
@@ -1751,16 +1698,12 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="Hierarchy"></param>
         ''' <param name="ItemId"></param>
         ''' <param name="MkDocument"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function OnBeforeFirstDocumentLock(Hierarchy As IVsHierarchy, ItemId As UInteger, MkDocument As String) As Integer Implements IVsRunningDocTableEvents4.OnBeforeFirstDocumentLock
             Return NativeMethods.S_OK
         End Function
         ''' <summary>
         ''' Fires after all documents are saved (some of the documents saved may not be in the running document table).
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function OnAfterSaveAll() As Integer Implements IVsRunningDocTableEvents4.OnAfterSaveAll
             'A Save All operation just occurred.  Need to reset the undo/redo clean state of all property pages
             SetUndoRedoCleanStateOnAllPropertyPages()
@@ -1769,7 +1712,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Calls SetUndoRedoCleanState() on each property page
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub SetUndoRedoCleanStateOnAllPropertyPages()
             For i As Integer = 0 To _designerPanels.Length - 1
                 Debug.Assert(_designerPanels(i) IsNot Nothing, "m_DesignerPanels(Index) should not be Nothing")
@@ -1791,8 +1733,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="ItemId"></param>
         ''' <param name="MkDocument"></param>
         ''' <param name="ClosedWithoutSaving"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function OnAfterLastDocumentUnlock(Hierarchy As IVsHierarchy, ItemId As UInteger, MkDocument As String, ClosedWithoutSaving As Integer) As Integer Implements IVsRunningDocTableEvents4.OnAfterLastDocumentUnlock
             Return NativeMethods.S_OK
         End Function
@@ -1803,8 +1743,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Gets the locale ID from the shell
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetLocaleID() As UInteger Implements IPropertyPageSiteOwner.GetLocaleID
             Dim LocaleId As UInteger
             Dim UIHostLocale As IUIHostLocale = DirectCast(GetService(GetType(IUIHostLocale)), IUIHostLocale)

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerWindowPane.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerWindowPane.vb
@@ -38,7 +38,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Creates a new WinformsWindowPane.
         ''' </summary>
         ''' <param name="surface"></param>
-        ''' <remarks></remarks>
         Public Sub New(surface As DesignSurface)
             MyBase.New(surface)
             'Create our view control and hook its focus event.
@@ -103,7 +102,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub OnViewFocus(sender As Object, e As EventArgs)
             'Note: this sub never seems to get hit when controls count > 0
             Common.Switches.TracePDFocus(TraceLevel.Warning, "ApplicationDesignerWindowPane.OnViewFocus (Project Designer's window pane)")
@@ -139,7 +137,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''  design surface.  If there was an error encountered
         '''  it will display the error control.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub PopulateView()
 
             Common.Switches.TracePDFocus(TraceLevel.Warning, "ApplicationDesignerWindowPane.PopulateView")
@@ -237,7 +234,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Sets the active view to the one that matches the given GUID.  If guid is empty or unrecognized, keeps the current tab.
         ''' </summary>
         ''' <param name="LogicalView"></param>
-        ''' <remarks></remarks>
         Private Sub SetActiveView(LogicalView As Guid)
             If AppDesignerView IsNot Nothing Then
                 AppDesignerView.ActiveView = LogicalView
@@ -285,7 +281,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' The OnClose method is called by the base class in response to the ClosePane method on
         '''    IVsWindowPane.  The default implementation calls Dispose()
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnClose()
             MyBase.OnClose() 'Calls Dispose()
         End Sub
@@ -304,7 +299,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Moves to the next tab in the project designer
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub NextTab()
             If AppDesignerView IsNot Nothing Then
                 AppDesignerView.SwitchTab(True)
@@ -314,7 +308,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Moves to the previous tab in the project designer
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub PrevTab()
             If AppDesignerView IsNot Nothing Then
                 AppDesignerView.SwitchTab(False)
@@ -326,8 +319,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Closes the application designer, but first prompts the user which of the open children
         '''   documents s/he wants to save, and saves the ones selected.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function ClosePromptSave() As Integer
             Dim hr As Integer = SaveChildren(__VSRDTSAVEOPTIONS.RDTSAVEOPT_DocClose Or __VSRDTSAVEOPTIONS.RDTSAVEOPT_PromptSave)
             If Not VSErrorHandler.Succeeded(hr) Then
@@ -342,7 +333,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Closes the window frame for the project designer.  Any children with unsaved DocData will be discarded
         '''   without saving.
         ''' </summary>
-        ''' <returns></returns>
         ''' <remarks>
         ''' This will cause the IVsWindowFrameNotify3.OnClose notification on CmdTargetHelper to fire.
         ''' </remarks>
@@ -369,8 +359,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <param name="WindowFrame"></param>
         ''' <param name="flags"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function CloseFrameInternal(WindowFrame As IVsWindowFrame, flags As __FRAMECLOSE) As Integer
             If WindowFrame IsNot Nothing Then
                 Dim hr As Integer = WindowFrame.CloseFrame(Common.NoOverflowCUInt(flags))
@@ -464,7 +452,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Retrieves the IVsUIShell service
         ''' </summary>
-        ''' <remarks></remarks>
         Public ReadOnly Property VsUIShellService() As IVsUIShell
             Get
                 If (_uiShellService Is Nothing) Then
@@ -482,7 +469,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Retrieves the IVsUIShell2 service
         ''' </summary>
-        ''' <remarks></remarks>
         Public ReadOnly Property VsUIShell2Service() As IVsUIShell2
             Get
                 If (_uiShell2Service Is Nothing) Then
@@ -499,7 +485,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Retrieves the IVsUIShell5 service
         ''' </summary>
-        ''' <remarks></remarks>
         Public ReadOnly Property VsUIShell5Service() As IVsUIShell5
             Get
                 If (_uiShell5Service Is Nothing) Then
@@ -541,7 +526,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Clears the viewhelper on the frame (our view helper is a CmdTargetHelper class instance)
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ClearViewHelper()
             Dim WindowFrame As IVsWindowFrame
             WindowFrame = TryCast(GetService(GetType(IVsWindowFrame)), IVsWindowFrame)
@@ -564,7 +548,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Unhook events and prepare for takeoff
         ''' </summary>
         ''' <param name="disposing"></param>
-        ''' <remarks></remarks>
         Protected Overloads Sub Dispose(disposing As Boolean)
             Dim disposedView As Control = _view
 

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerWindowPaneControl.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerWindowPaneControl.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Windows.Forms
 
@@ -21,8 +21,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Selects the next available control and makes it the active control.
         ''' </summary>
         ''' <param name="forward"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overrides Function ProcessTabKey(forward As Boolean) As Boolean
             Common.Switches.TracePDMessageRouting(TraceLevel.Warning, "ApplicationDesignerWindowPaneControl.ProcessTabKey")
 

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/CmdTargetHelper.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/CmdTargetHelper.vb
@@ -13,7 +13,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
     ''' We place an instance of this class into the project designer's window frame's ViewHelper property.
     '''   It allows us to gain access to command routing in the shell and also window frame events
     ''' </summary>
-    ''' <remarks></remarks>
     Public Class CmdTargetHelper
         Implements OleInterop.IOleCommandTarget
         Implements IVsWindowFrameNotify3
@@ -41,7 +40,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="nCmdexecopt">[in] Values taken from the OLECMDEXECOPT enumeration, which describe how the object should execute the command. </param>
         ''' <param name="pvaIn">[unique][in] Pointer to a VARIANTARG structure containing input arguments. Can be NULL. </param>
         ''' <param name="pvaOut">[unique][in,out] Pointer to a VARIANTARG structure to receive command output. Can be NULL. </param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' This method supports the standard return values E_FAIL and E_UNEXPECTED, as well as the following: 
         '''   S_OK 
@@ -153,7 +151,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Saves the project designer and all its child designers
         ''' </summary>
         ''' <returns>An HRESULT</returns>
-        ''' <remarks></remarks>
         Private Function HrSaveProjectDesigner() As Integer
             'Execute a Save for the App Designer (saves all DocData pages)
             Dim hr As Integer = _windowPane.SaveChildren(__VSRDTSAVEOPTIONS.RDTSAVEOPT_ForceSave)
@@ -172,7 +169,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="cCmds">[in] The number of commands in the prgCmds array. </param>
         ''' <param name="prgCmds">[in,out] A caller-allocated array of OLECMD structures that indicate the commands for which the caller needs status information. This method fills the cmdf member of each structure with values taken from the OLECMDF enumeration. </param>
         ''' <param name="pCmdText">[unique][in,out] Pointer to an OLECMDTEXT structure in which to return name and/or status information of a single command. Can be NULL to indicate that the caller does not need this information. </param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' This method supports the standard return values E_FAIL and E_UNEXPECTED, as well as the following: 
         '''   S_OK 
@@ -256,7 +252,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Notifies the VSPackage that a window frame is closing and tells the environment what action to take.
         ''' </summary>
         ''' <param name="pgrfSaveOptions"></param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' Implementers should develop code to notify users and prompt for save and close and relay those decisions to the environment through pgrfSaveOptions.
         ''' </remarks>
@@ -321,8 +316,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="y"></param>
         ''' <param name="w"></param>
         ''' <param name="h"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function OnDockableChange(fDockable As Integer, x As Integer, y As Integer, w As Integer, h As Integer) As Integer Implements IVsWindowFrameNotify3.OnDockableChange
             Return NativeMethods.S_OK
         End Function
@@ -335,8 +328,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="y"></param>
         ''' <param name="w"></param>
         ''' <param name="h"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function OnMove(x As Integer, y As Integer, w As Integer, h As Integer) As Integer Implements IVsWindowFrameNotify3.OnMove
             Return NativeMethods.S_OK
         End Function
@@ -346,8 +337,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Notifies the VSPackage of a change in the window's display state.
         ''' </summary>
         ''' <param name="fShow"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function OnShow(fShow As Integer) As Integer Implements IVsWindowFrameNotify3.OnShow
             'NOTE: In error cases, m_WindowPane.AppDesignerView may be Nothing, so we must guard against
             '  its use.
@@ -373,8 +362,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="y"></param>
         ''' <param name="w"></param>
         ''' <param name="h"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function OnSize(x As Integer, y As Integer, w As Integer, h As Integer) As Integer Implements IVsWindowFrameNotify3.OnSize
             Return NativeMethods.S_OK
         End Function

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/CustomViewProvider.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/CustomViewProvider.vb
@@ -18,20 +18,16 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Returns the view control (if already created)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public MustOverride ReadOnly Property View() As Control
 
         ''' <summary>
         ''' Creates the view control, if it doesn't already exist
         ''' </summary>
-        ''' <remarks></remarks>
         Public MustOverride Sub CreateView()
 
         ''' <summary>
         ''' Close the view control, if not already closed
         ''' </summary>
-        ''' <remarks></remarks>
         Public MustOverride Sub CloseView()
 
 #Region "Dispose/IDisposable"
@@ -44,7 +40,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Disposes of contained objects
         ''' </summary>
         ''' <param name="disposing"></param>
-        ''' <remarks></remarks>
         Protected Overridable Sub Dispose(Disposing As Boolean)
             If Disposing Then
                 ' Dispose managed resources.
@@ -61,15 +56,12 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
     ''' This is a simple, related class that returns the document moniker to use to
     '''   create a view.
     ''' </summary>
-    ''' <remarks></remarks>
     Public MustInherit Class CustomDocumentMonikerProvider
 
         ''' <summary>
         ''' Retrieve the filename to use for the moniker.  The file may or may not exist
         '''   and should be verified by the client.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public MustOverride Function GetDocumentMoniker() As String
 
     End Class

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ErrorControlCustomViewProvider.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ErrorControlCustomViewProvider.vb
@@ -9,7 +9,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
     ''' <summary>
     ''' Provides a custom view for DesignerPanel that creates an Error control for its view.
     ''' </summary>
-    ''' <remarks></remarks>
     Public Class ErrorControlCustomViewProvider
         Inherits CustomViewProvider
 
@@ -22,7 +21,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Constructor
         ''' </summary>
         ''' <param name="ErrorText">The error text to display in the error control.</param>
-        ''' <remarks></remarks>
         Public Sub New(ErrorText As String)
             _errorText = ErrorText
         End Sub
@@ -31,7 +29,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Constructor
         ''' </summary>
         ''' <param name="Exception">The exception to display in the error control.</param>
-        ''' <remarks></remarks>
         Public Sub New(Exception As Exception)
             _exception = Exception
         End Sub
@@ -40,8 +37,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Returns the view control (if already created)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property View() As Control
             Get
                 Return _view
@@ -51,7 +46,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Creates the view control, if it doesn't already exist
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overrides Sub CreateView()
             If _view Is Nothing Then
                 If _exception IsNot Nothing Then
@@ -65,7 +59,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Close the view control, if not already closed
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overrides Sub CloseView()
             If _view IsNot Nothing Then
                 _view.Dispose()
@@ -80,7 +73,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Disposes of contained objects
         ''' </summary>
         ''' <param name="disposing"></param>
-        ''' <remarks></remarks>
         Protected Overloads Overrides Sub Dispose(Disposing As Boolean)
             If Disposing Then
                 ' Dispose managed resources.

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/IVsEditWindowNotify.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/IVsEditWindowNotify.vb
@@ -7,7 +7,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
     ''' <summary>
     '''  The interface was implemented by PropPageDesignerView, the appDesigner view will fire this event when the current designer is activated or deactivated...
     ''' </summary>
-    ''' <remarks></remarks>
     <ComVisible(False)>
     Public Interface IVsEditWindowNotify
         Sub OnActivated(activated As Boolean)

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ProjectDesignerTabButton.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ProjectDesignerTabButton.vb
@@ -36,8 +36,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' True if the dirty indicator should be display
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property DirtyIndicator() As Boolean
             Get
                 Return _dirtyIndicator
@@ -54,8 +52,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Returns the text of the tab button, with the dirty indicator if it is on.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property TextWithDirtyIndicator() As String
             Get
                 'If the dirty indicator is on, append "*" to the text
@@ -73,9 +69,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' The location of the button.  Should not be changed directly except
         '''   by the tab control itself.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
-
         Public Shadows Property Location() As Point
             Get
                 Return MyBase.Location
@@ -110,10 +103,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 parent.Renderer.RenderButton(e.Graphics, Me, Me Is parent.SelectedItem, Me Is parent.HoverItem)
             End If
         End Sub
-
-
-        '''<summary>
-        '''</summary>
         '''<remarks> We need handle OnClick to make Accessibility work... </remarks>
         Protected Overrides Sub OnClick(e As EventArgs)
             MyBase.OnClick(e)

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ProjectDesignerTabControl.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ProjectDesignerTabControl.vb
@@ -43,7 +43,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         '''  Listen for font/color changes from the shell
         ''' </summary>
-        ''' <remarks></remarks>
         Private WithEvents _broadcastMessageEventsHelper As Common.ShellUtil.BroadcastMessageEventsHelper
 
         Public Event ThemeChanged(sender As Object, args As EventArgs)
@@ -103,7 +102,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Initialization
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub Initialize()
             _hostingPanel = New Panel With {
                 .Visible = True,
@@ -129,7 +127,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Create the tab overflow button.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub SetUpOverflowButton()
             'Note: the renderer will position the button, so we don't need to.
             OverflowButton = New ImageButton("Microsoft.VisualStudio.Editors.ApplicationDesigner.OverflowImage", Color.Lime)
@@ -153,8 +150,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''   shell (e.g., colors will default to system or fallback colors instead of using the
         '''   shell's color service). 
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property ServiceProvider() As IServiceProvider
             Get
                 Return _serviceProvider
@@ -215,7 +210,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Called when a non-empty service provider is given to the control.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub OnGotServiceProvider()
             'We now should have access to the color provider service
             OnThemeChanged()
@@ -249,8 +243,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Returns an enumerable set of tab buttons
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property TabButtons() As IEnumerable(Of ProjectDesignerTabButton)
             Get
                 Return _buttonCollection
@@ -261,7 +253,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Clears all the tab buttons off of the control
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub ClearTabs()
             _buttonCollection.Clear()
             InvalidateLayout()
@@ -272,8 +263,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Gets a tab button by index
         ''' </summary>
         ''' <param name="index"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetTabButton(index As Integer) As ProjectDesignerTabButton
             Return _buttonCollection(index)
         End Function
@@ -282,8 +271,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The number of tab buttons, including those not currently visible
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property TabButtonCount() As Integer
             Get
                 Return _buttonCollection.Count
@@ -294,8 +281,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Get the panel that is used to host controls on the right-hand side
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property HostingPanel() As Panel
             Get
                 Return _hostingPanel
@@ -307,7 +292,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Perform layout
         ''' </summary>
         ''' <param name="levent"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnLayout(levent As LayoutEventArgs)
             Common.Switches.TracePDPerfBegin(levent, "ProjectDesignerTabControl.OnLayout()")
 
@@ -322,7 +306,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Causes the layout to be refreshed
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Sub InvalidateLayout()
             PerformLayout()
         End Sub
@@ -333,8 +316,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <param name="Title">The user-friendly, localizable text for the tab that will be displayed.</param>
         ''' <param name="AutomationName">Non-localizable name to be used for QA automation.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function AddTab(Title As String, AutomationName As String) As Integer
             SuspendLayout()
             Dim newIndex As Integer
@@ -363,8 +344,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Tracks the last item for paint logic
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property HoverItem() As ProjectDesignerTabButton
             Get
                 Return _hoverItem
@@ -375,8 +354,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Currently selected button
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property SelectedItem() As ProjectDesignerTabButton
             Get
                 Return _selectedItem
@@ -420,8 +397,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Currently selected button
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property SelectedIndex() As Integer
             Get
                 If _selectedItem Is Nothing Then
@@ -444,7 +419,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Keep painting from happening during WM_PAINT.  We'll paint everything during OnPaintBackground.
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnPaint(e As PaintEventArgs)
         End Sub
 
@@ -453,7 +427,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Everything will paint in the background, except buttons which handle their own painting
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnPaintBackground(e As PaintEventArgs)
             Renderer.RenderBackground(e.Graphics)
         End Sub
@@ -463,7 +436,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Occurs when a button is clicked.
         ''' </summary>
         ''' <param name="item">The tab button which has been clicked.</param>
-        ''' <remarks></remarks>
         Public Overridable Sub OnItemClick(item As ProjectDesignerTabButton)
             OnItemClick(item, reactivatePage:=False)
         End Sub
@@ -481,7 +453,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <param name="e"></param>
         ''' <param name="item"></param>
-        ''' <remarks></remarks>
         Public Sub OnItemEnter(e As EventArgs, item As ProjectDesignerTabButton)
             If _hoverItem IsNot item Then
                 _hoverItem = item
@@ -495,7 +466,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <param name="e"></param>
         ''' <param name="item"></param>
-        ''' <remarks></remarks>
         Public Sub OnItemLeave(e As EventArgs, item As ProjectDesignerTabButton)
             If _hoverItem Is item Then
                 _hoverItem = Nothing
@@ -509,7 +479,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <param name="e"></param>
         ''' <param name="item"></param>
-        ''' <remarks></remarks>
         Public Overridable Sub OnItemGotFocus(e As EventArgs, item As ProjectDesignerTabButton)
         End Sub
 
@@ -524,8 +493,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Retrieves the renderer used for this tab control
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property Renderer() As ProjectDesignerTabRenderer
             Get
                 Return _renderer
@@ -537,7 +504,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub OverflowButton_Click(sender As Object, e As EventArgs) Handles OverflowButton.Click
             'Set up to use VS colors
             If _serviceProvider IsNot Nothing Then
@@ -601,7 +567,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub OverflowMenuItemClick(sender As Object, e As EventArgs)
             Dim MenuItem As ToolStripMenuItem = DirectCast(sender, ToolStripMenuItem)
             Dim Button As ProjectDesignerTabButton = DirectCast(MenuItem.Tag, ProjectDesignerTabButton)
@@ -624,7 +589,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="msg"></param>
         ''' <param name="wparam"></param>
         ''' <param name="lparam"></param>
-        ''' <remarks></remarks>
         Private Sub OnBroadcastMessageEventsHelperBroadcastMessage(msg As UInteger, wParam As IntPtr, lParam As IntPtr) Handles _broadcastMessageEventsHelper.BroadcastMessage
             Select Case msg
                 Case AppDesInterop.Win32Constant.WM_PALETTECHANGED, AppDesInterop.Win32Constant.WM_SYSCOLORCHANGE, AppDesInterop.Win32Constant.WM_THEMECHANGED
@@ -642,7 +606,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''   b) has flatstyle
         '''   c) shows a border only when the mouse hovers over it
         ''' </summary>
-        ''' <remarks></remarks>
         Private Class ImageButton
             Inherits Button
 
@@ -670,7 +633,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             ''' Occurs when the mouse enters the button
             ''' </summary>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Protected Overrides Sub OnMouseEnter(e As EventArgs)
                 MyBase.OnMouseEnter(e)
 
@@ -684,7 +646,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             ''' Occurs when the mouse leaves the button
             ''' </summary>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Protected Overrides Sub OnMouseLeave(e As EventArgs)
                 MyBase.OnMouseLeave(e)
 

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ProjectDesignerTabRenderer.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ProjectDesignerTabRenderer.vb
@@ -122,7 +122,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Constructor.
         ''' </summary>
         ''' <param name="owner">The ProjectDesignerTabControl control which owns and contains this control.</param>
-        ''' <remarks></remarks>
         Public Sub New(owner As ProjectDesignerTabControl)
             Requires.NotNull(owner, NameOf(owner))
 
@@ -139,8 +138,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''   shell (e.g., colors will default to system or fallback colors instead of using the
         '''   shell's color service). 
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property ServiceProvider() As IServiceProvider
             Get
                 Return _serviceProvider
@@ -205,8 +202,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Note: this is not necessarily the same as the currently-selected button, because once a button
         '''   is pulled into the switchable slot, we want it to stay there unless we have to change it.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property PreferredButtonForSwitchableSlot() As ProjectDesignerTabButton
             Get
                 Return _preferredButtonForSwitchableSlot
@@ -226,7 +221,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Creates GDI objects that we keep around, if they have not already been created
         ''' </summary>
         ''' <param name="ForceUpdate">If True, the GDI objects are updated if they have already been created.</param>
-        ''' <remarks></remarks>
         Public Sub CreateGDIObjects(Optional ForceUpdate As Boolean = False)
             If _creatingGDIObjects Then
                 Exit Sub
@@ -313,7 +307,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Computes all layout-related, cached state, if it is not currently valid.
         '''   Otherwise immediately returns.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub UpdateCacheState()
             If _updatingCache Then
                 Exit Sub
@@ -357,8 +350,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Retrieves the width in pixels of the widest text in any of the buttons.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetLargestButtonTextSize() As Size
             'Calculate required text width
             Dim maxTextWidth As Integer = 0
@@ -411,7 +402,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Sets the positions of all the owner's buttons.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub SetButtonPositions()
             'Adjust all the button positions
 
@@ -511,7 +501,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' The main painting routine.
         ''' </summary>
         ''' <param name="g">The Graphics object to paint to.</param>
-        ''' <remarks></remarks>
         Public Sub RenderBackground(g As Graphics)
             CreateGDIObjects()
 

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/PropertyPageInfo.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/PropertyPageInfo.vb
@@ -13,7 +13,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
     ''' <summary>
     ''' This page encapsulates all the data for a property page
     ''' </summary>
-    ''' <remarks></remarks>
     Public Class PropertyPageInfo
         Implements IDisposable
 
@@ -34,7 +33,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <param name="Guid">The GUID to create the property page</param>
         ''' <param name="IsConfigurationDependentPage">Whether or not the page has different values for each configuration (e.g. the Debug page)</param>
-        ''' <remarks></remarks>
         Public Sub New(ParentView As ApplicationDesignerView, Guid As Guid, IsConfigurationDependentPage As Boolean)
             Debug.Assert(Not Guid.Equals(Guid.Empty), "Empty guid?")
             Debug.Assert(ParentView IsNot Nothing)
@@ -49,7 +47,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Disposes of any the doc data
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overloads Sub Dispose() Implements IDisposable.Dispose
             Dispose(True)
         End Sub
@@ -83,8 +80,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The GUID for the property page
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property Guid() As Guid
             Get
                 Return _guid
@@ -95,8 +90,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' True if the page's properties can have different values in different configurations
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property IsConfigPage() As Boolean
             Get
                 Return _isConfigPage
@@ -107,8 +100,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The exception that occurred while loading the page, if any
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property LoadException() As Exception
             Get
                 Return _loadException
@@ -119,7 +110,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Returns the IPropertyPage for the property page
         ''' </summary>
-        ''' <remarks></remarks>
         Public ReadOnly Property ComPropPageInstance() As OleInterop.IPropertyPage
             Get
                 TryLoadPropertyPage()
@@ -131,8 +121,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Returns the PropertyPageSite for the property page
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property Site() As PropertyPageSite
             Get
                 TryLoadPropertyPage()
@@ -231,7 +219,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''   this property tries *not* load the property page if it's not
         '''   already loaded.
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' PERF: This property used a cached version of the title to avoid having to
         '''   instantiate the COM object for the property page.
@@ -266,8 +253,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Gets the current locale ID that's being used by the project designer.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property CurrentLocaleID() As UInteger
             Get
                 Return CType(_parentView, IPropertyPageSiteOwner).GetLocaleID()
@@ -279,8 +264,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Retrieves the name of the registry value name to place into the
         '''   registry for this property page.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property CachedTitleValueName() As String
             Get
                 'We must include both the property page GUID and the locale ID
@@ -293,8 +276,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Attempts to retrieve or set the cached title of this page from the registry.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private Property CachedTitle() As String
             Get
                 Dim KeyPath As String = _parentView.DTEProject.DTE.RegistryRoot & REGKEY_CachedPageTitles

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/PropertyPageSite.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/PropertyPageSite.vb
@@ -12,7 +12,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
     ''' Provides specific limited functionality we need from the owner of the
     '''   property page site (ApplicationDesignerView).
     ''' </summary>
-    ''' <remarks></remarks>
     Public Interface IPropertyPageSiteOwner
         Function GetLocaleID() As UInteger
         Sub DsMsgBox(ex As Exception, Optional HelpLink As String = Nothing)
@@ -24,7 +23,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
     ''' This class provides the IPropertyPageSite implementation for the property pages
     ''' It also drives immediate apply functionality when 
     ''' </summary>
-    ''' <remarks></remarks>
     Public Class PropertyPageSite
         Implements OleInterop.IPropertyPageSite
         Implements IDisposable
@@ -45,7 +43,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="View">An IPropertyPageSiteOwner implementation.  Generally this is the
         '''   ApplicationDesignerView, except for unit testing.</param>
         ''' <param name="PropPage"></param>
-        ''' <remarks></remarks>
         Public Sub New(View As IPropertyPageSiteOwner, PropPage As OleInterop.IPropertyPage)
             Debug.Assert(View IsNot Nothing AndAlso PropPage IsNot Nothing)
             _appDesView = View
@@ -58,8 +55,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' The service provider to delegate to when responding to QueryService requests (for both
         '''   native and managed IServiceProvider).
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property BackingServiceProvider() As IServiceProvider
             Get
                 Return _backingServiceProvider
@@ -190,7 +185,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Commits any pending changes on the page
         ''' </summary>
         ''' <returns>return False if it failed</returns>
-        ''' <remarks></remarks>
         Public Function CommitPendingChanges() As Boolean
             If Not ApplyStatusChange(PROPPAGESTATUS_VALIDATE) Then
                 Return False
@@ -202,7 +196,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Instructs the page site to process a keystroke if it desires.
         ''' </summary>
         ''' <param name="pMsg"></param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' This function can be called by a property page to give the site a chance to a process a message
         '''   before the page does.  Return S_OK to indicate we have handled it, S_FALSE to indicate we did not
@@ -220,7 +213,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Disposes of any the doc data
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overloads Sub Dispose() Implements IDisposable.Dispose
             Dispose(True)
         End Sub
@@ -244,8 +236,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''   it to the service provider passed in through the constructor.
         ''' </summary>
         ''' <param name="serviceType"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetService(serviceType As Type) As Object Implements IServiceProvider.GetService
             'A couple of specific services we delegate to the application designer, but other than
             '  those exceptions, we want the services coming from the passed-in backing service (which
@@ -280,7 +270,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="guidService"></param>
         ''' <param name="riid"></param>
         ''' <param name="ppvObject"></param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' This is important to allow native property pages to get to services
         '''   like the IVsWindowFrame that the property page is hosted in, which is

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/SpecialFileCustomView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/SpecialFileCustomView.vb
@@ -14,7 +14,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
     '''   using IVsProjectSpecialFiles, then the view is changed to display the editor
     '''   for the new file.
     ''' </summary>
-    ''' <remarks></remarks>
     Public Class SpecialFileCustomView
         Inherits Windows.Forms.UserControl
 
@@ -27,7 +26,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''   Used to access the special file ID, etc.
         ''' </summary>
         ''' <param name="ViewProvider"></param>
-        ''' <remarks></remarks>
         Public Sub SetSite(ViewProvider As SpecialFileCustomViewProvider)
             _viewProvider = ViewProvider
             If ViewProvider IsNot Nothing Then
@@ -41,7 +39,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub LinkLabel_LinkClicked(sender As Object, e As Windows.Forms.LinkLabelLinkClickedEventArgs) Handles LinkLabel.LinkClicked
             CreateNewSpecialFile()
         End Sub
@@ -49,7 +46,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Create the special file associated with this view.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub CreateNewSpecialFile()
             If _viewProvider IsNot Nothing Then
                 Debug.Assert(_viewProvider.DesignerView IsNot Nothing)

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/SpecialFileCustomViewProvider.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/SpecialFileCustomViewProvider.vb
@@ -10,7 +10,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
     ''' A provider which can create views of the type SpecialFileCustomView.  See that
     '''   class' description for more information.
     ''' </summary>
-    ''' <remarks></remarks>
     Public Class SpecialFileCustomViewProvider
         Inherits CustomViewProvider
 
@@ -28,7 +27,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="DesignerPanel">The ApplicationDesignerPanel in which this view will be displayed.</param>
         ''' <param name="SpecialFileId">The special file ID to create when the user clicks the link.</param>
         ''' <param name="LinkText">The text of the link message to display.</param>
-        ''' <remarks></remarks>
         Public Sub New(DesignerView As ApplicationDesignerView, DesignerPanel As ApplicationDesignerPanel, SpecialFileId As Integer, LinkText As String)
             Debug.Assert(DesignerView IsNot Nothing)
             _designerView = DesignerView
@@ -41,8 +39,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The text of the link message to display.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property LinkText() As String
             Get
                 Return _linkText
@@ -52,8 +48,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The ApplicationDesignerView which owns this view.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property DesignerView() As ApplicationDesignerView
             Get
                 Return _designerView
@@ -63,8 +57,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The special file ID to create when the user clicks the link.  Used by IVsProjectSpecialFiles.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property SpecialFileId() As Integer
             Get
                 Return _specialFileId
@@ -74,8 +66,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The ApplicationDesignerPanel in which this view will be displayed.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property DesignerPanel() As ApplicationDesignerPanel
             Get
                 Return _designerPanel
@@ -86,8 +76,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Returns the view control (if already created)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property View() As Control
             Get
                 Return _view
@@ -97,7 +85,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Creates the view control, if it doesn't already exist
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overrides Sub CreateView()
             If _view Is Nothing Then
                 Dim NewView As New SpecialFileCustomView
@@ -111,7 +98,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Close the view control, if not already closed
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overrides Sub CloseView()
             If _view IsNot Nothing Then
                 _view.Dispose()
@@ -133,7 +119,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Disposes of contained objects
         ''' </summary>
         ''' <param name="disposing"></param>
-        ''' <remarks></remarks>
         Protected Overloads Overrides Sub Dispose(Disposing As Boolean)
             If Disposing Then
                 ' Dispose managed resources.
@@ -151,7 +136,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
     ''' <summary>
     ''' Returns the document of a special file by calling through the IVsProjectSpecialFiles interface
     ''' </summary>
-    ''' <remarks></remarks>
     Public NotInheritable Class SpecialFileCustomDocumentMonikerProvider
         Inherits CustomDocumentMonikerProvider
 
@@ -164,7 +148,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="DesignerView">The associated ApplicationDesignerView</param>
         ''' <param name="SpecialFileId">The special file ID for IVsProjectSpecialFiles that will be used to
         '''   obtain the document filename</param>
-        ''' <remarks></remarks>
         Public Sub New(DesignerView As ApplicationDesignerView, SpecialFileId As Integer)
             Requires.NotNull(DesignerView, NameOf(DesignerView))
 

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/ArgumentValidation.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/ArgumentValidation.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Namespace Microsoft.VisualStudio.Editors.AppDesCommon
 
@@ -8,8 +8,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' Creates an ArgumentException based on the name of the argument that is invalid.
         ''' </summary>
         ''' <param name="argumentName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function CreateArgumentException(argumentName As String) As Exception
             Return New ArgumentException(String.Format(My.Resources.Designer.General_InvalidArgument_1Arg, argumentName))
         End Function

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/DTEUtils.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/DTEUtils.vb
@@ -10,7 +10,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
     ''' <summary>
     ''' Utilities related to DTE projects and project items
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class DTEUtils
 
         Private Const PROJECTPROPERTY_BUILDACTION As String = "BuildAction"
@@ -18,7 +17,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <summary>
         ''' This is a shared class - disallow instantiation.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub New()
         End Sub
 
@@ -26,8 +24,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' Retrieves the given project item's property, if it exists, else Nothing
         ''' </summary>
         ''' <param name="PropertyName">The name of the property to retrieve.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function GetProjectItemProperty(ProjectItem As ProjectItem, PropertyName As String) As [Property]
             If ProjectItem.Properties Is Nothing Then
                 Return Nothing
@@ -48,8 +44,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' </summary>
         ''' <param name="Project">The DTE project</param>
         ''' <param name="VsCfgProvider">The IVsCfgProvider2 interface instance to look up the active configuration from</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function GetActiveConfiguration(Project As Project, VsCfgProvider As IVsCfgProvider2) As IVsCfg
             Dim VsCfg As IVsCfg = Nothing
             With GetActiveDTEConfiguration(Project)
@@ -63,8 +57,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' Given a DTE project, returns the active DTE configuration object for it
         ''' </summary>
         ''' <param name="Project">The DTE project</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function GetActiveDTEConfiguration(Project As Project) As Configuration
             Try
                 Return Project.ConfigurationManager.ActiveConfiguration
@@ -83,7 +75,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         '''   If this project system doesn't have that property, this call is a NOP.
         ''' </summary>
         ''' <param name="Item">The ProjectItem on which to set the property</param>
-        ''' <remarks></remarks>
         Public Shared Sub SetBuildAction(Item As ProjectItem, BuildAction As VSLangProj.prjBuildAction)
             Dim BuildActionProperty As [Property] = GetProjectItemProperty(Item, PROJECTPROPERTY_BUILDACTION)
             If BuildActionProperty IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/ShellUtil.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/ShellUtil.vb
@@ -15,7 +15,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
     ''' <summary>
     ''' Utilities relating to the Visual Studio shell, services, etc.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ShellUtil
 
         Public Shared ReadOnly ProjectDesignerThemeCategory As New Guid("ef1a2d2c-5d16-4ddb-8d04-79d0f6c1c56e")
@@ -29,8 +28,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <param name="VsUIShell">The IVsUIShell interface that must also implement IVsUIShell2 (if not, or if Nothing, default color is returned)</param>
         ''' <param name="VsSysColorIndex">The color index to look up.</param>
         ''' <param name="DefaultColor">The default color to return if the call fails.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function GetColor(VsUIShell As IVsUIShell, VsSysColorIndex As __VSSYSCOLOREX, DefaultColor As Color) As Color
             Return GetColor(TryCast(VsUIShell, IVsUIShell2), VsSysColorIndex, DefaultColor)
         End Function
@@ -43,8 +40,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <param name="VsUIShell2">The IVsUIShell2 interface to use (if Nothing, default color is returned)</param>
         ''' <param name="VsSysColorIndex">The color index to look up.</param>
         ''' <param name="DefaultColor">The default color to return if the call fails.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function GetColor(VsUIShell2 As IVsUIShell2, VsSysColorIndex As __VSSYSCOLOREX, DefaultColor As Color) As Color
             If VsUIShell2 IsNot Nothing Then
                 Dim abgrValue As UInteger
@@ -94,7 +89,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' </summary>
         ''' <param name="abgrValue">The UInteger COLORREF value</param>
         ''' <returns>The System.Drawing.Color equivalent.</returns>
-        ''' <remarks></remarks>
         Private Shared Function COLORREFToColor(abgrValue As UInteger) As Color
             Return Color.FromArgb(CInt(abgrValue And &HFFUI), CInt((abgrValue And &HFF00UI) >> 8), CInt((abgrValue And &HFF0000UI) >> 16))
         End Function
@@ -105,7 +99,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <param name="Config">The IVsCfg to get the configuration and platform name from.</param>
         ''' <param name="ConfigName">[out] The configuration name.</param>
         ''' <param name="PlatformName">[out] The platform name.</param>
-        ''' <remarks></remarks>
         Public Shared Sub GetConfigAndPlatformFromIVsCfg(Config As IVsCfg, ByRef ConfigName As String, ByRef PlatformName As String)
             Dim DisplayName As String = Nothing
 
@@ -136,7 +129,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         '''   we hide the configuration/platform comboboxes.
         ''' </summary>
         ''' <param name="ProjectHierarchy">The hierarchy to check</param>
-        ''' <remarks></remarks>
         Public Shared Function GetIsSimplifiedConfigMode(ProjectHierarchy As IVsHierarchy) As Boolean
             Try
                 If ProjectHierarchy IsNot Nothing Then
@@ -159,7 +151,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         '''   from then on out).
         ''' </summary>
         ''' <param name="ProjectHierarchy">The project hierarchy to check</param>
-        ''' <remarks></remarks>
         Private Shared Function CanHideConfigurationsForProject(ProjectHierarchy As IVsHierarchy) As Boolean
             Dim ReturnValue As Boolean = False 'If failed to get config value, default to not hiding configs
 
@@ -191,7 +182,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         '''   Tools.Options.
         ''' </summary>
         ''' <param name="DTE">The DTE extensibility object</param>
-        ''' <remarks></remarks>
         Private Shared Function ToolsOptionsShowAdvancedBuildConfigurations(DTE As DTE) As Boolean
             Dim ShowValue As Boolean
             Dim ProjAndSolutionProperties As Properties
@@ -219,8 +209,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         '''   don't support this, returns Nothing (e.g. C++).
         ''' </summary>
         ''' <param name="ProjectHierarchy"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function DTEProjectFromHierarchy(ProjectHierarchy As IVsHierarchy) As Project
             If ProjectHierarchy Is Nothing Then
                 Return Nothing
@@ -239,7 +227,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <summary>
         ''' Wrapper class for IVsShell.OnBroadcastMessage
         ''' </summary>
-        ''' <remarks></remarks>
         Public Class BroadcastMessageEventsHelper
             Implements IVsBroadcastMessageEvents
             Implements IDisposable
@@ -288,8 +275,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             ''' <param name="msg"></param>
             ''' <param name="wParam"></param>
             ''' <param name="lParam"></param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Private Function IVsBroadcastMessageEvents_OnBroadcastMessage(msg As UInteger, wParam As IntPtr, lParam As IntPtr) As Integer Implements IVsBroadcastMessageEvents.OnBroadcastMessage
                 OnBroadcastMessage(msg, wParam, lParam)
                 Return AppDesInterop.NativeMethods.S_OK
@@ -301,7 +286,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             ''' <param name="msg"></param>
             ''' <param name="wParam"></param>
             ''' <param name="lParam"></param>
-            ''' <remarks></remarks>
             Protected Overridable Sub OnBroadcastMessage(msg As UInteger, wParam As IntPtr, lParam As IntPtr)
                 RaiseEvent BroadcastMessage(msg, wParam, lParam)
             End Sub
@@ -343,7 +327,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <summary>
         ''' Monitor and set font when font changes...
         ''' </summary>
-        ''' <remarks></remarks>
         Public NotInheritable Class FontChangeMonitor
             Inherits BroadcastMessageEventsHelper
 
@@ -358,7 +341,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             ''' <param name="sp"></param>
             ''' <param name="ctrl"></param>
             ''' <param name="SetFontInitially">If true, set the font of the provided control when this FontChangeMonitor is created</param>
-            ''' <remarks></remarks>
             Public Sub New(sp As IServiceProvider, ctrl As Control, SetFontInitially As Boolean)
                 MyBase.New(sp)
 
@@ -379,7 +361,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             ''' <param name="msg"></param>
             ''' <param name="wParam"></param>
             ''' <param name="lParam"></param>
-            ''' <remarks></remarks>
             Protected Overrides Sub OnBroadcastMessage(msg As UInteger, wParam As IntPtr, lParam As IntPtr)
                 MyBase.OnBroadcastMessage(msg, wParam, lParam)
 
@@ -397,8 +378,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             ''' <summary>
             ''' Pick current dialog font...
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public Shared ReadOnly Property GetDialogFont(ServiceProvider As IServiceProvider) As Font
                 Get
                     If ServiceProvider IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
@@ -65,8 +65,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' negative numbers to UInt32.  We just want raw bit translation.
         ''' </summary>
         ''' <param name="obj"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function NoOverflowCUInt(obj As Object) As UInteger
             Return NoOverflowCUInt(CLng(obj))
         End Function
@@ -75,8 +73,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' Masks the top 32 bits to get just the lower 32bit number
         ''' </summary>
         ''' <param name="LongValue"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function NoOverflowCUInt(LongValue As Long) As UInteger
             Return CUInt(LongValue And UInteger.MaxValue)
         End Function
@@ -155,7 +151,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         '''  False if a is true and b is false.  Otherwise it returns True (as there's no
         '''   evidence to suggest that the implication is incorrect).
         ''' </summary>
-        ''' <remarks></remarks>
         Public Function Implies(a As Boolean, b As Boolean) As Boolean
             Return Not (a And Not b)
         End Function
@@ -167,8 +162,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         '''   also the inner exception, if any.
         ''' </summary>
         ''' <param name="ex"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function DebugMessageFromException(ex As Exception) As String
 #If DEBUG Then
             Dim ErrorMessage As String = ex.Message & vbCrLf & vbCrLf & vbCrLf & "[SHOWN IN DEBUG ONLY] STACK TRACE:" & vbCrLf & ex.StackTrace
@@ -188,8 +181,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         '''   returns an empty string.
         ''' </summary>
         ''' <param name="Value">The value to turn into a displayable string.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function DebugToString(Value As Object) As String
 #If DEBUG Then
             Dim StringValue As String = ""
@@ -248,7 +239,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' Given an exception, returns True if it is a CheckOut exception.
         ''' </summary>
         ''' <param name="ex">The exception to check rethrow if it's caused by canceling checkout</param>
-        ''' <remarks></remarks>
         Public Function IsCheckoutCanceledException(ex As Exception) As Boolean
             If (TypeOf ex Is CheckoutException AndAlso ex.Equals(CheckoutException.Canceled)) _
                 OrElse
@@ -269,8 +259,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' If the given string is Nothing, return "", else return the original string.
         ''' </summary>
         ''' <param name="Str"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function NothingToEmptyString(Str As String) As String
             If Str Is Nothing Then
                 Return String.Empty
@@ -284,8 +272,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' If the given string is "", return Nothing, else return the original string.
         ''' </summary>
         ''' <param name="Str"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function EmptyStringToNothing(Str As String) As String
             If Str Is Nothing OrElse Str.Length = 0 Then
                 Return Nothing
@@ -300,8 +286,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <param name="Condition">The condition to test.</param>
         ''' <param name="TrueExpression">What to return if the condition is True</param>
         ''' <param name="FalseExpression">What to return if the condition is False</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function IIf(Of T)(Condition As Boolean, TrueExpression As T, FalseExpression As T) As T
             If Condition Then
                 Return TrueExpression
@@ -315,7 +299,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' Set the drop-down width of a combobox wide enough to show the text of all entries in it
         ''' </summary>
         ''' <param name="ComboBox">The combobox to change the width for</param>
-        ''' <remarks></remarks>
         Public Sub SetComboBoxDropdownWidth(ComboBox As ComboBox)
             If ComboBox IsNot Nothing Then
                 ComboBox.DropDownWidth = Math.Max(MeasureMaxTextWidth(ComboBox, ComboBox.Items), ComboBox.Width)
@@ -385,7 +368,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' </summary>
         ''' <param name="HwndParent">The container HWND.</param>
         ''' <param name="First">If True, sets focus to the first control, otherwise the last.</param>
-        ''' <remarks></remarks>
         Public Function FocusFirstOrLastTabItem(HwndParent As IntPtr, First As Boolean) As Boolean
             If HwndParent.Equals(IntPtr.Zero) Then
                 Return False
@@ -436,8 +418,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' Returns a given path with a backslash at the end, if not already there.
         ''' </summary>
         ''' <param name="Path">The path to add a backslash to.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function AppendBackslash(Path As String) As String
             If Path <> "" AndAlso Right(Path, 1) <> IO.Path.DirectorySeparatorChar AndAlso Right(Path, 1) <> IO.Path.AltDirectorySeparatorChar Then
                 Return Path & IO.Path.DirectorySeparatorChar
@@ -459,7 +439,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <param name="MutiSelect">Whether we should support multi-selection</param>
         ''' <param name="NeedThrowError">Throw error when the dialog fails unexpectedly</param>
         ''' <returns>a collection of files</returns>
-        ''' <remarks></remarks>
         Public Function GetFilesViaBrowse(ServiceProvider As IServiceProvider, ParentWindow As IntPtr,
                 InitialDirectory As String, DialogTitle As String,
                 Filter As String, FilterIndex As UInteger, MutiSelect As Boolean,
@@ -603,8 +582,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' </summary>
         ''' <param name="ctrl"></param>
         ''' <param name="items"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function MeasureMaxTextWidth(ctrl As Control, items As IEnumerable) As Integer
             Dim MaxEntryWidth As Integer = 0
             Using g As Graphics = ctrl.CreateGraphics()
@@ -668,8 +645,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             ''' Map a known property page or designer id to telemetry display name to log.
             ''' </summary>
             ''' <param name="guid"></param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Private Shared Function PageGuidToId(guid As Guid) As Byte
                 For i As Integer = 0 To s_sqmOrder.Length - 1
                     If s_sqmOrder(i).Equals(guid) Then

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/switches.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/switches.vb
@@ -145,7 +145,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
     ''' <summary>
     ''' Contains predefined switches for enabling/disabling trace output or code instrumentation.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class Switches
 
         '------------- Resource Editor -------------
@@ -153,49 +152,41 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <summary>
         ''' Trace for the ResourceEditor.FileWatcher class
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared RSEFileWatcher As New TraceSwitch("RSEFileWatcher", "Trace the resource editor FileWatcher class.")
 
         ''' <summary>
         ''' Tracing for the ResourceEditor.ResourceSerializationService class
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared RSEResourceSerializationService As New TraceSwitch("RSEResourceSerializationService", "Trace the resource editor ResourceSerializationService class.")
 
         ''' <summary>
         ''' Track adding and removing resources in the resource editor
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared RSEAddRemoveResources As New TraceSwitch("RSEAddRemoveResources", "Trace adding/removing resources in the resource editor")
 
         ''' <summary>
         ''' Trace virtual mode methods in the resource editor's string table
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared RSEVirtualStringTable As New TraceSwitch("RSEVirtualStringTable", "Trace virtual mode methods in the resource editor's string table")
 
         ''' <summary>
         ''' Trace virtual mode methods in the resource editor's listview
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared RSEVirtualListView As New TraceSwitch("RSEVirtualListView", "Trace virtual mode methods in the resource editor's listview")
 
         ''' <summary>
         ''' Trace the delayed checking of errors in resources
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared RSEDelayCheckErrors As New TraceSwitch("RSEDelayCheckErrors", "Trace the delayed checking of errors in resources")
 
         ''' <summary>
         ''' Disable high-quality options on the Graphics object when creating thumbnails in the resource editor
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared RSEDisableHighQualityThumbnails As New BooleanSwitch("RSEDisableHighQualityThumbnails", "Disable high-quality options on the Graphics object when creating thumbnails in the resource editor")
 
         ''' <summary>
         ''' Trace find/replace in the resource editor
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared RSEFindReplace As New TraceSwitch("RSEFindReplace", "Trace find/replace in the resource editor")
 
 
@@ -207,7 +198,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <summary>
         ''' Trace the showing of context menus via the base control classes in DesignerFramework
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared DFContextMenu As New TraceSwitch("DFContextMenu", "Trace the showing of context menus via the base control classes in DesignerFramework")
 
 
@@ -219,7 +209,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <summary>
         ''' Trace source code control integration behavior in Microsoft.VisualStudio.Editors.dll
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared MSVBE_SCC As New TraceSwitch("MSVBE_SCC", "Trace source code control integration behavior in Microsoft.VisualStudio.Editors.dll")
 
 
@@ -231,80 +220,67 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <summary>
         ''' Trace when the active designer changes in the project designer
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDDesignerActivations As New TraceSwitch("PDDesignerActivations", "Trace when the active designer changes in the project designer")
 
         ''' <summary>
         ''' Trace project designer focus-related events
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDFocus As New TraceSwitch("PDFocus", "Trace project designer focus-related events")
 
         ''' <summary>
         ''' Trace behavior of multiple-value undo and redo
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDUndo As New TraceSwitch("PDUndo", "Trace behavior of multiple-value undo and redo")
 
         ''' <summary>
         ''' Trace the creation and dirtying of properties, apply, etc.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDProperties As New TraceSwitch("PDProperties", "Trace the creation and dirtying of properties in property pages, apply, etc.")
 
         ''' <summary>
         ''' Trace mapping of application type - output type, MyType
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDApplicationType As New TraceSwitch("PDApplicationType", "Trace mapping of application type properties")
 
         ''' <summary>
         ''' Trace the functionality of extender properties
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDExtenders As New TraceSwitch("PDExtenders", "Trace the functionality of extender properties")
 
         ''' <summary>
         ''' Trace configuration setup and changes tracking in the project designer
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDConfigs As New TraceSwitch("PDConfigs", "Trace configuration setup and changes tracking in the project designer")
 
         ''' <summary>
         ''' Trace performance issues for the project designer
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDPerf As New TraceSwitch("PDPerf", "Trace performance issues for the project designer")
 
         ''' <summary>
         ''' Trace command routing (CmdTargetHelper, etc.) in the project designer
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDCmdTarget As New TraceSwitch("PDCmdTarget", "Trace command routing (CmdTargetHelper, etc.) in the project designer")
 
         ''' <summary>
         ''' Always use native ::SetParent() instead of setting the WinForms Parent property for property page hosting.
         ''' This is useful for testing the hosting of pages as it would occur for non-native pages.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDAlwaysUseSetParent As New BooleanSwitch("PDAlwaysUseSetParent", "Always use native ::SetParent() instead of setting the WinForms Parent property for property page hosting")
 
         ''' <summary>
         ''' Traces message routing in the project designer and its property pages
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDMessageRouting As New TraceSwitch("PDMessageRouting", "Traces message routing in the project designer and its property pages")
 
         ''' <summary>
         ''' Overrides the SKU edition value for the project designer
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDSku As New EnumSwitch(Of VSProductSKU.VSASKUEdition)("PDSku", "Overrides the SKU edition value for the project designer")
 
         ''' <summary>
         ''' Overrides the Sub-SKU edition value for the project designer
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDSubSku As New EnumSwitch(Of VSProductSKU.VSASubSKUEdition)("PDSubSku", "Overrides the Sub-SKU edition value for the project designer")
 
         Public Shared PDAddVBWPFApplicationPageToAllProjects As New BooleanSwitch("PDAddVBWPFApplicationPageToAllProjects",
@@ -321,7 +297,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <summary>
         ''' Tracing whenever we read/write .settings and/or app.config files...
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared SDSerializeSettings As New TraceSwitch("SDSerializeSettings", "Serialization/deserialization of settings")
 
         '------------- WCF Tooling -------------
@@ -343,8 +318,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function Format(Message As String, ParamArray FormatArguments() As Object) As String
             If FormatArguments Is Nothing OrElse FormatArguments.Length = 0 Then
                 Return Message
@@ -368,8 +341,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' Formats a Win32 message into a friendly form for debugging/tracing purposes
         ''' </summary>
         ''' <param name="msg"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function FormatWin32Message(msg As Windows.Forms.Message) As String
             Dim str As New StringBuilder()
             Dim MsgType As String = Nothing
@@ -441,7 +412,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <summary>
         ''' A Switch which has a simple enum value (either as integer or string representation)
         ''' </summary>
-        ''' <remarks></remarks>
         Public Class EnumSwitch(Of T)
             Inherits Switch
 
@@ -453,9 +423,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             ''' <summary>
             ''' True iff the switch has a non-empty value
             ''' </summary>
-            ''' <value></value>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public ReadOnly Property ValueDefined() As Boolean
                 Get
                     Return MyBase.Value <> "" AndAlso CInt(Convert.ChangeType(Value, TypeCode.Int32)) <> 0
@@ -465,9 +432,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             ''' <summary>
             ''' Gets/sets the current value of the switch
             ''' </summary>
-            ''' <value></value>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Shadows Property Value() As T
                 Get
                     Return CType([Enum].Parse(GetType(T), MyBase.Value), T)
@@ -481,7 +445,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             ''' Interprets the new (string-based) correctly, based on the string or
             '''   integer representation.
             ''' </summary>
-            ''' <remarks></remarks>
             Protected Overrides Sub OnValueChanged()
                 SwitchSetting = CInt(Convert.ChangeType(Value, TypeCode.Int32))
             End Sub
@@ -497,7 +460,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TraceSCC(Message As String, ParamArray FormatArguments() As Object)
 #If DEBUG Then
@@ -510,7 +472,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDFocus(Level As TraceLevel, Message As String, ParamArray FormatArguments() As Object)
 #If DEBUG Then
@@ -523,7 +484,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDUndo(Message As String, ParamArray FormatArguments() As Object)
 #If DEBUG Then
@@ -537,7 +497,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDProperties(Level As TraceLevel, Message As String, ParamArray FormatArguments() As Object)
 #If DEBUG Then
@@ -551,7 +510,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDExtenders(Level As TraceLevel, Message As String, ParamArray FormatArguments() As Object)
 #If DEBUG Then
@@ -565,7 +523,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDConfigs(TraceLevel As TraceLevel, Message As String, ParamArray FormatArguments() As Object)
 #If DEBUG Then
@@ -586,7 +543,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDPerf(Message As String, ParamArray FormatArguments() As Object)
 #If DEBUG Then
@@ -644,7 +600,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDCmdTarget(TraceLevel As TraceLevel, Message As String, ParamArray FormatArguments() As Object)
 #If DEBUG Then
@@ -659,7 +614,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <param name="TraceLevel"></param>
         ''' <param name="Message"></param>
         ''' <param name="msg"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDMessageRouting(TraceLevel As TraceLevel, Message As String, msg As Windows.Forms.Message)
 #If DEBUG Then
@@ -678,7 +632,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' </summary>
         ''' <param name="TraceLevel"></param>
         ''' <param name="Message"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDMessageRouting(TraceLevel As TraceLevel, Message As String)
 #If DEBUG Then
@@ -689,7 +642,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <summary>
         ''' Traces the access modifier combobox functionality
         ''' </summary>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDAccessModifierCombobox(traceLevel As TraceLevel, message As String)
 #If DEBUG Then
@@ -703,7 +655,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' </summary>
         ''' <param name="tracelevel"></param>
         ''' <param name="message"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Overloads Shared Sub TraceSDSerializeSettings(tracelevel As TraceLevel, message As String)
 #If DEBUG Then
@@ -717,7 +668,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <param name="tracelevel"></param>
         ''' <param name="formatString"></param>
         ''' <param name="parameters"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Overloads Shared Sub TraceSDSerializeSettings(tracelevel As TraceLevel, formatString As String, ParamArray parameters() As Object)
 #If DEBUG Then
@@ -736,7 +686,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' Trace changes to one of the monitored configuration files 
         ''' </summary>
         ''' <param name="tracelevel"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Overloads Shared Sub TraceWCFConfigFileChangeWatch(tracelevel As TraceLevel, formatString As String, ParamArray parameters() As Object)
 #If DEBUG Then
@@ -750,7 +699,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' </summary>
         ''' <param name="tracelevel"></param>
         ''' <param name="message"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Overloads Shared Sub TraceWCFConfigFileChangeWatch(tracelevel As TraceLevel, message As String)
 #If DEBUG Then

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/BaseRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/BaseRootDesigner.vb
@@ -128,7 +128,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         '''  Refreshes the status of all the menus of the current designer. 
         '''  This is called from DesignerMenuCommand after each invoke.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub RefreshMenuStatus()
             For Each MenuItem As MenuCommand In MenuCommands
                 Debug.Assert(MenuItem IsNot Nothing, "MenuItem IsNot Nothing!")

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/DesignUtil.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/DesignUtil.vb
@@ -56,8 +56,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' Get the default caption from IVsUIShell, or fall back to localized resource
         ''' </summary>
         ''' <param name="sp"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function GetDefaultCaption(sp As IServiceProvider) As String
             Dim caption As String = ""
             Dim uiShell As IVsUIShell = Nothing
@@ -77,7 +75,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' </summary>
         ''' <param name="ServiceProvider"></param>
         ''' <param name="keyword"></param>
-        ''' <remarks></remarks>
         Public Shared Sub DisplayTopicFromF1Keyword(ServiceProvider As IServiceProvider, keyword As String)
             If ServiceProvider Is Nothing Then
                 Debug.Fail("NULL serviceprovider - can't show help!")

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/DesignerMessageBox.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/DesignerMessageBox.vb
@@ -28,7 +28,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' <param name="RootDesigner">A root designer inherited from BaseRootDesigner, which has the ability to get services.</param>
         ''' <param name="Caption">The text to display in the title bar of the message box.</param>
         ''' <param name="HelpLink">Link to the help topic for this message box.</param>
-        ''' <remarks></remarks>
 #Disable Warning RS0026 ' Do not add multiple public overloads with optional parameters
         Public Shared Function Show(RootDesigner As BaseRootDesigner, Message As String,
                 Caption As String, Buttons As MessageBoxButtons, Icon As MessageBoxIcon,
@@ -47,7 +46,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' <param name="ex">The exception to include in the message.</param>
         ''' <param name="Caption">The text to display in the title bar of the message box.</param>
         ''' <param name="HelpLink">Link to the help topic for this message box.</param>
-        ''' <remarks></remarks>
 #Disable Warning RS0026 ' Do not add multiple public overloads with optional parameters
         Public Shared Sub Show(ServiceProvider As IServiceProvider, ex As Exception,
                 Caption As String, Optional HelpLink As String = Nothing)
@@ -122,7 +120,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' <param name="Icon">One of the MessageBoxIcon values that specifies which icon to display in the message box.</param>
         ''' <param name="HelpLink">Link to the help topic for this message box.</param>
         ''' <param name="DefaultButton">One of the MessageBoxDefaultButton values that specifies the default button of the message box.</param>
-        ''' <remarks></remarks>
 #Disable Warning RS0026 ' Do not add multiple public overloads with optional parameters
         Public Shared Function Show(ServiceProvider As IServiceProvider, Message As String,
                 Caption As String, Buttons As MessageBoxButtons, Icon As MessageBoxIcon,
@@ -144,7 +141,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' <param name="Icon">One of the MessageBoxIcon values that specifies which icon to display in the message box.</param>
         ''' <param name="HelpLink">Link to the help topic for this message box.</param>
         ''' <param name="DefaultButton">One of the MessageBoxDefaultButton values that specifies the default button of the message box.</param>
-        ''' <remarks></remarks>
         Private Shared Function ShowHelper(ServiceProvider As IServiceProvider, Message As String,
                 Caption As String, Buttons As MessageBoxButtons, Icon As MessageBoxIcon,
                 Optional DefaultButton As MessageBoxDefaultButton = MessageBoxDefaultButton.Button1,

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/DesignerWindowPaneProviderBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/DesignerWindowPaneProviderBase.vb
@@ -22,7 +22,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
     '''   create a DesignerWindowPaneBase
     ''' This allows us to have more control of the WindowPane
     ''' </summary>
-    ''' <remarks></remarks>
     Public Class DeferrableWindowPaneProviderServiceBase
         Inherits WindowPaneProviderService
 
@@ -35,7 +34,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' </summary>
         ''' <param name="provider"></param>
         ''' <param name="SupportToolbox"></param>
-        ''' <remarks></remarks>
         Public Sub New(provider As IServiceProvider, SupportToolbox As Boolean)
             MyBase.New(provider)
             _supportToolbox = SupportToolbox
@@ -51,7 +49,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' that we would get for "free" is to allow us to receive IVsWindowPaneCommit.
         ''' 
         ''' </summary>
-        ''' <remarks></remarks>
         Public Class DesignerWindowPaneBase
             Inherits DesignerWindowPane
             Implements IVsWindowPaneCommit
@@ -73,7 +70,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             ''' </summary>
             ''' <param name="surface"></param>
             ''' <param name="SupportToolbox"></param>
-            ''' <remarks></remarks>
             Public Sub New(surface As DesignSurface, SupportToolbox As Boolean)
                 MyBase.New(surface)
 
@@ -107,8 +103,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             ''' <summary>
             ''' Returns the view control for the window pane.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Protected ReadOnly Property View() As Control
                 Get
                     Return _view
@@ -141,8 +135,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             ''' <summary>
             ''' Retrieves our view.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public Overrides ReadOnly Property Window() As IWin32Window
                 Get
                     ' This should always happen, but in case we never
@@ -161,7 +153,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             ''' <summary>
             ''' Called to disable OLE undo.
             ''' </summary>
-            ''' <remarks></remarks>
             Private Sub DisableUndo()
                 If _undoEngine IsNot Nothing Then
 
@@ -183,7 +174,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             ''' Called when our view is disposed.
             ''' </summary>
             ''' <param name="disposing"></param>
-            ''' <remarks></remarks>
             Protected Overrides Sub Dispose(disposing As Boolean)
 
                 Dim disposedView As Control = _view
@@ -221,7 +211,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             ''' <summary>
             ''' Called to enable OLE undo.
             ''' </summary>
-            ''' <remarks></remarks>
             Private Sub EnableUndo()
 
                 Debug.Assert(_undoEngine Is Nothing, "EnableUndo should only be called once.  Call DisableUndo before calling this again.")
@@ -246,7 +235,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             ''' We override this to enable / disable undo.  The undo engine
             ''' should be disabled if our view is cached for later.
             ''' </summary>
-            ''' <remarks></remarks>
             Protected Overrides Sub OnClose()
                 DisableUndo()
                 MyBase.OnClose()
@@ -257,7 +245,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             ''' We override this to enable / disable undo.  The undo engine
             ''' should be disabled if our view is cached for later.
             ''' </summary>
-            ''' <remarks></remarks>
             Protected Overrides Sub OnCreate()
                 MyBase.OnCreate()
 
@@ -280,7 +267,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             ''' </summary>
             ''' <param name="sender"></param>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Private Sub OnLoaded(sender As Object, e As LoadedEventArgs)
                 PopulateView()
                 EnableUndo()
@@ -294,7 +280,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             ''' </summary>
             ''' <param name="sender"></param>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Private Sub OnSurfaceUnloading(sender As Object, e As EventArgs)
                 DisableUndo()
             End Sub
@@ -309,7 +294,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             ''' </summary>
             ''' <param name="sender"></param>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Private Sub OnSurfaceUnloaded(sender As Object, e As EventArgs)
                 If (_view IsNot Nothing AndAlso _view.Controls.Count > 0) Then
                     Dim ctrl(_view.Controls.Count - 1) As Control
@@ -326,7 +310,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             ''' </summary>
             ''' <param name="sender"></param>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Private Sub OnUndoing(sender As Object, e As EventArgs)
                 If (_view IsNot Nothing AndAlso _view.IsHandleCreated) Then
                     NativeMethods.SendMessage(New HandleRef(_view, _view.Handle), NativeMethods.WM_SETREDRAW, 0, 0)
@@ -341,7 +324,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             ''' </summary>
             ''' <param name="sender"></param>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Private Sub OnUndone(sender As Object, e As EventArgs)
                 If (_view IsNot Nothing AndAlso _view.IsHandleCreated) Then
                     NativeMethods.SendMessage(New HandleRef(_view, _view.Handle), NativeMethods.WM_SETREDRAW, 1, 0)
@@ -357,7 +339,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             ''' </summary>
             ''' <param name="sender"></param>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Private Sub OnViewFocus(sender As Object, e As EventArgs)
                 Common.Switches.TracePDFocus(TraceLevel.Warning, "DeferrableWindowPaneProviderServiceBase.DesignerWindowPaneBase.m_View.OnGotFocus (OnViewFocus)")
                 If (_view IsNot Nothing AndAlso _view.Controls.Count > 0) Then
@@ -386,7 +367,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             '''    design surface.  If there was an error encountered
             '''    it will display the WSOD.
             ''' </summary>
-            ''' <remarks></remarks>
             Private Sub PopulateView()
 
                 _view.SuspendLayout()
@@ -455,8 +435,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             ''' it will forward the command to the view.
             ''' </summary>
             ''' <param name="pfCommitFailed"></param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Function IVsWindowPaneCommit_CommitPendingEdit(ByRef pfCommitFailed As Integer) As Integer Implements IVsWindowPaneCommit.CommitPendingEdit
                 Dim viewAsIVsWindowPaneCommit As IVsWindowPaneCommit = Nothing
                 If Not _loadError AndAlso Surface IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/ErrorControl.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/ErrorControl.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Drawing
 Imports System.Windows.Forms
@@ -10,7 +10,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
     ''' This is a Windows control that is shown when there is an exception loading a designer or property page.
     ''' All it does is display an error message and an error icon.
     ''' </summary>
-    ''' <remarks></remarks>
     Public NotInheritable Class ErrorControl
 
         Private _firstGotFocus As Boolean = True
@@ -32,7 +31,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' Constructor
         ''' </summary>
         ''' <param name="Text">The error text to display</param>
-        ''' <remarks></remarks>
         Public Sub New(Text As String)
             Me.New()
             Me.Text = Text
@@ -43,7 +41,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' Constructor
         ''' </summary>
         ''' <param name="ex">The exception to display</param>
-        ''' <remarks></remarks>
         Public Sub New(ex As Exception)
             Me.New(AppDesCommon.DebugMessageFromException(ex))
         End Sub
@@ -53,7 +50,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' Constructor
         ''' </summary>
         ''' <param name="errors">A list of exceptions or error messages to display</param>
-        ''' <remarks></remarks>
         Public Sub New(errors As ICollection)
             Me.New()
 
@@ -71,8 +67,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' <summary>
         ''' Constructor
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Overrides Property Text() As String
             Get
                 Return ErrorText.Text
@@ -89,7 +83,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ErrorText_GotFocus(sender As Object, e As EventArgs) Handles ErrorText.GotFocus
             If _firstGotFocus Then
                 'The first time a textbox gets focus, WinForms selects all text in it.  That
@@ -105,8 +98,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' Get the preferred size of the control, expanding 
         ''' </summary>
         ''' <param name="proposedSize"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetPreferredSize(proposedSize As Size) As Size
             If proposedSize.Width = 0 Then
                 Return MyBase.GetPreferredSize(proposedSize)

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/SourceCodeControlManager.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/SourceCodeControlManager.vb
@@ -7,7 +7,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
     ''' <summary>
     ''' Provide a convenient way to check out/query edit a set of files. 
     ''' </summary>
-    ''' <remarks></remarks>
     Public NotInheritable Class SourceCodeControlManager
 
 #Region "Private fields"
@@ -28,7 +27,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         '''   
         ''' </summary>
         ''' <param name="sp"></param>
-        ''' <remarks></remarks>
         Public Sub New(sp As IServiceProvider, Hierarchy As IVsHierarchy)
             Requires.NotNull(sp, NameOf(sp))
 
@@ -42,7 +40,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' Add a file to manage SCC status for. 
         ''' </summary>
         ''' <param name="mkDocument"></param>
-        ''' <remarks></remarks>
         Public Sub ManageFile(mkDocument As String)
             _managedFiles(mkDocument) = True
         End Sub
@@ -62,9 +59,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' <summary>
         ''' Get a list of the files currently managed by this service...
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Property ManagedFiles() As List(Of String)
             Get
                 Return New List(Of String)(_managedFiles.Keys)
@@ -96,8 +90,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' Query if all the files are editable. Will not prompt the user - will only report
         ''' if it is OK to edit the file. 
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function AreFilesEditable() As Boolean
             Return QueryEditableFilesInternal(True, False)
         End Function
@@ -110,8 +102,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' </summary>
         ''' <param name="checkOnly">If true, only query if it is OK to edit all managed files without actually checking anything out</param>
         ''' <param name="throwOnFailure">If the method should throw a CheckoutException on failure</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function QueryEditableFilesInternal(checkOnly As Boolean, throwOnFailure As Boolean) As Boolean
             ' Do actual checkout here...
             Return QueryEditableFiles(_serviceProvider, ManagedFiles, throwOnFailure, checkOnly)
@@ -253,8 +243,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' <param name="sp">Service provider. Will be QI:ed for IVsQueryEditQuerySave2</param>
         ''' <param name="files">The set of files to check</param>
         ''' <param name="throwOnFailure">Should we throw if the save fails?</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function QuerySave(sp As IServiceProvider, files As List(Of String), throwOnFailure As Boolean) As Boolean
             Requires.NotNull(sp, NameOf(sp))
             Requires.NotNull(files, NameOf(files))

--- a/src/Microsoft.VisualStudio.AppDesigner/IVbpackage.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/IVbpackage.vb
@@ -28,13 +28,7 @@ Namespace Microsoft.VisualStudio.Editors
 #Disable Warning IDE1006 ' Naming Styles (Compat)
         Public Delegate Function getServiceDelegate(ServiceType As Type) As Object
 #Enable Warning IDE1006 ' Naming Styles
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="GetService"></param>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared ReadOnly Property PackageInstance(GetService As getServiceDelegate) As IVBPackage
             Get
                 If s_editorsPackage Is Nothing Then

--- a/src/Microsoft.VisualStudio.AppDesigner/InternalException.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/InternalException.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 
@@ -10,7 +10,6 @@ Namespace Microsoft.VisualStudio.Editors.Package
     '''   (obviously not very helpful, but it doesn't make sense to localize and doc messages for errors which shouldn't
     '''   be happening).
     ''' </summary>
-    ''' <remarks></remarks>
     <Serializable()>
     Public Class InternalException
         Inherits ApplicationException
@@ -28,7 +27,6 @@ Namespace Microsoft.VisualStudio.Editors.Package
         ''' Constructor
         ''' </summary>
         ''' <param name="Message">The message for the exception.</param>
-        ''' <remarks></remarks>
         Public Sub New(Message As String)
             Me.New(Message, Nothing)
         End Sub
@@ -49,7 +47,6 @@ Namespace Microsoft.VisualStudio.Editors.Package
         ''' </summary>
         ''' <param name="Message">The message for the exception.</param>
         ''' <param name="InnerException">The inner exception, if any (Nothing = none).</param>
-        ''' <remarks></remarks>
         Public Sub New(Message As String, InnerException As Exception)
             MyBase.New(Message, InnerException)
         End Sub
@@ -62,7 +59,6 @@ Namespace Microsoft.VisualStudio.Editors.Package
         ''' </summary>
         ''' <param name="info"></param>
         ''' <param name="context"></param>
-        ''' <remarks></remarks>
         <EditorBrowsable(EditorBrowsableState.Advanced)>
         Protected Sub New(info As System.Runtime.Serialization.SerializationInfo, context As System.Runtime.Serialization.StreamingContext)
             MyBase.New(info, context)

--- a/src/Microsoft.VisualStudio.AppDesigner/MyApplicationPropertiesBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/MyApplicationPropertiesBase.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Namespace Microsoft.VisualStudio.Editors.MyApplication
 
@@ -7,8 +7,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' Returns the set of files that need to be checked out to change the given property
         ''' Must be overriden in sub-class
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overridable Function FilesToCheckOut(CreateIfNotExist As Boolean) As String()
             Return Array.Empty(Of String)
         End Function

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/ConfigurationState.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/ConfigurationState.vb
@@ -14,7 +14,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
     ''' Also listens for changes to the configurations that the user makes outside of the
     '''   project designer and allows the individual pages to get notifications on that.
     ''' </summary>
-    ''' <remarks></remarks>
     Public NotInheritable Class ConfigurationState
         Implements IDisposable
         Implements IVsUpdateSolutionEvents
@@ -62,7 +61,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Selection types for the configuration and platform comboboxes
         ''' </summary>
-        ''' <remarks></remarks>
         Public Enum SelectionTypes
             Normal    'Just a normal entry
             Active    'This is the entry for the currently-active configuration or platform
@@ -100,13 +98,11 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''   changes to configurations/platforms that are not currently supported by our
         '''   undo/redo story.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Event ClearConfigPageUndoRedoStacks()
 
         ''' <summary>
         ''' Raised when the value of the SimplifiedConfigMode property changes.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Event SimplifiedConfigModeChanged()
 
 #End Region
@@ -116,7 +112,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Constructor
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub New(Project As EnvDTE.Project, ProjectHierarchy As IVsHierarchy, View As ApplicationDesigner.ApplicationDesignerView)
             If Project Is Nothing OrElse ProjectHierarchy Is Nothing OrElse View Is Nothing Then
                 Debug.Fail("")
@@ -141,7 +136,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Dispose
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub Dispose() Implements IDisposable.Dispose
             UnadviseEventHandling()
             _project = Nothing
@@ -159,7 +153,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="PlatformSelectionType">The platform selection type to search for.  For more information, see comments for FindItemToSelect.</param>
         ''' <param name="PreferExactMatch">For more information, see comments for FindItemToSelect.</param>
         ''' <param name="FireNotifications">If true, notifications are sent to the pages (but only if the selection actually changed)</param>
-        ''' <remarks></remarks>
         Public Sub ChangeSelection(ConfigName As String, ConfigSelectionType As SelectionTypes, PlatformName As String, PlatformSelectionType As SelectionTypes, PreferExactMatch As Boolean, FireNotifications As Boolean)
             Dim NewSelectedConfigIndex As Integer = FindItemToSelect(_configurationDropdownEntries, _selectedConfigIndex, ConfigName, ConfigSelectionType, PreferExactMatch)
             Dim NewSelectedPlatformIndex As Integer = FindItemToSelect(_platformDropdownEntries, _selectedPlatformIndex, PlatformName, PlatformSelectionType, PreferExactMatch)
@@ -176,7 +169,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="ConfigIndex">The index to select in the configuration list</param>
         ''' <param name="PlatformIndex">The index to select in the platform list</param>
         ''' <param name="FireNotifications">If true, notifications are sent to the pages (but only if the selection actually changed)</param>
-        ''' <remarks></remarks>
         Public Sub ChangeSelection(ConfigIndex As Integer, PlatformIndex As Integer, FireNotifications As Boolean)
             Debug.Assert(ConfigIndex >= 0 AndAlso ConfigIndex < _configurationDropdownEntries.Length)
             Debug.Assert(PlatformIndex >= 0 AndAlso PlatformIndex < _platformDropdownEntries.Length)
@@ -197,8 +189,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Returns the index of the item to be the currently selected item in the configuration dropdown of all
         '''   config-dependent property pages
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property SelectedConfigIndex() As Integer
             Get
                 Return _selectedConfigIndex
@@ -210,8 +200,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Returns the index of the item to be the currently selected item in the platform dropdown of all
         '''   config-dependent property pages        
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property SelectedPlatformIndex() As Integer
             Get
                 Return _selectedPlatformIndex
@@ -232,8 +220,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' All current entries to be displayed in each pages' configuration combobox
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property ConfigurationDropdownEntries() As DropdownItem()
             Get
                 If _platformDropdownEntries Is Nothing OrElse _configurationDropdownEntries Is Nothing Then
@@ -247,8 +233,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' All current entries to be displayed in each pages' platform combobox
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property PlatformDropdownEntries() As DropdownItem()
             Get
                 If _platformDropdownEntries Is Nothing OrElse _configurationDropdownEntries Is Nothing Then
@@ -263,7 +247,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Updates the configuration and platform dropdown entries based on the current
         '''   configurations in the project
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub UpdateDropdownEntries()
             'Populate the dropdowns
             Dim ActiveConfiguration As EnvDTE.Configuration = Common.DTEUtils.GetActiveDTEConfiguration(Project)
@@ -334,8 +317,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Retrieves the project associated with this configuration state
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property Project() As EnvDTE.Project
             Get
                 Debug.Assert(_project IsNot Nothing)
@@ -347,8 +328,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Configuration provider for the project (IVsCfgProvider2)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property VsCfgProvider() As IVsCfgProvider2
             Get
                 Debug.Assert(_vsCfgProvider IsNot Nothing)
@@ -361,8 +340,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Returns whether or not we're in simplified config mode for this project, which means that
         '''   we hide the configuration/platform comboboxes.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property IsSimplifiedConfigMode() As Boolean
             Get
                 Return Common.ShellUtil.GetIsSimplifiedConfigMode(_projectHierarchy)
@@ -375,7 +352,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''   has changed, we check manually on WM_SETFOCUS in the property page designer.  The designer calls us on this
         '''   method for us to do the check.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub CheckForModeChanges()
             Common.Switches.TracePDConfigs("CheckForModeChanges")
             Dim SimplifiedConfigModeCurrent As Boolean = IsSimplifiedConfigMode
@@ -390,7 +366,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Retrieves the current list of all configurations for the project
         ''' </summary>
-        ''' <remarks></remarks>
         Public Function GetAllConfigs() As IVsCfg()
             Dim ConfigCount As UInteger() = New UInteger(0) {} 'Interop declaration requires us to use an array
             VSErrorHandler.ThrowOnFailure(VsCfgProvider.GetCfgs(0, Nothing, ConfigCount, Nothing))
@@ -407,7 +382,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Retrieves the current list of all configuration names for the project
         ''' </summary>
-        ''' <remarks></remarks>
         Private Function GetAllConfigNames() As String()
             Dim NameObject As Object = Project.ConfigurationManager.ConfigurationRowNames()
             Dim NameArray As Array = DirectCast(NameObject, Array)
@@ -423,7 +397,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Retrieves the current list of all configuration platform names for the project
         ''' </summary>
-        ''' <remarks></remarks>
         Private Function GetAllPlatformNames() As String()
             Dim NameObject As Object = Project.ConfigurationManager.PlatformNames()
             Dim NameArray As Array = DirectCast(NameObject, Array)
@@ -453,7 +426,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''     item is the active version of the same config/platform name).  If false, preference is given to the current item
         '''     when searching for a "Normal" selection type.</param>
         ''' <returns>The new index into the ExistingItems array of the found item.</returns>
-        ''' <remarks></remarks>
         Private Shared Function FindItemToSelect(ExistingItems() As DropdownItem, CurrentIndex As Integer, DesiredName As String, DesiredSelectionType As SelectionTypes,
             PreferExactMatch As Boolean
         ) As Integer
@@ -540,7 +512,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Start listening to configuration change events
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub AdviseEventHandling()
             Debug.Assert(_updateSolutionEventsCookie = 0)
             Debug.Assert(_cfgProviderEventsCookie = 0)
@@ -553,7 +524,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Stoplistening to configuration change events
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub UnadviseEventHandling()
             If _updateSolutionEventsCookie <> 0 AndAlso _vsSolutionBuildManager IsNot Nothing Then
                 VSErrorHandler.ThrowOnFailure(_vsSolutionBuildManager.UnadviseUpdateSolutionEvents(_updateSolutionEventsCookie))
@@ -572,7 +542,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="KeepCurrentSelection">If True, then attempts to keep the current selection after the list is updated.  If false, then
         '''   the current "active" configuration and platform will be selected.</param>
-        ''' <remarks></remarks>
         Private Sub UpdateEntriesAndNotifyPages(KeepCurrentSelection As Boolean)
             Dim CurrentConfigName As String = ConfigurationDropdownEntries(_selectedConfigIndex).Name
             Dim CurrentConfigSelectionType As SelectionTypes = ConfigurationDropdownEntries(_selectedConfigIndex).SelectionType
@@ -597,8 +566,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' A configuration name has been added.
         ''' </summary>
         ''' <param name="pszCfgName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function OnCfgNameAdded(pszCfgName As String) As Integer Implements IVsCfgProviderEvents.OnCfgNameAdded
             Try
                 Common.Switches.TracePDConfigs("OnCfgNameAdded: Updating list")
@@ -615,7 +582,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' A configuration name has been deleted.
         ''' </summary>
         ''' <param name="CfgName"></param>
-        ''' <remarks></remarks>
         Public Function OnCfgNameDeleted(CfgName As String) As Integer Implements IVsCfgProviderEvents.OnCfgNameDeleted
             Try
                 Common.Switches.TracePDConfigs("OnCfgNameDeleted: Clearing undo/redo stack")
@@ -637,7 +603,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="OldName"></param>
         ''' <param name="NewName"></param>
-        ''' <remarks></remarks>
         Public Function OnCfgNameRenamed(OldName As String, NewName As String) As Integer Implements IVsCfgProviderEvents.OnCfgNameRenamed
             Try
                 Common.Switches.TracePDConfigs("OnCfgNameRenamed: Clearing undo/redo stack")
@@ -658,7 +623,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' A platform name has been added
         ''' </summary>
         ''' <param name="pszPlatformName"></param>
-        ''' <remarks></remarks>
         Public Function OnPlatformNameAdded(pszPlatformName As String) As Integer Implements IVsCfgProviderEvents.OnPlatformNameAdded
             Try
                 Common.Switches.TracePDConfigs("OnPlatformNameAdded: Updating list")
@@ -675,7 +639,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' A platform name has been deleted
         ''' </summary>
         ''' <param name="pszPlatformName"></param>
-        ''' <remarks></remarks>
         Public Function OnPlatformNameDeleted(pszPlatformName As String) As Integer Implements IVsCfgProviderEvents.OnPlatformNameDeleted
             Try
                 Common.Switches.TracePDConfigs("OnPlatformNameDeleted: Clearing undo/redo stack")
@@ -699,8 +662,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''   active in the solution.
         ''' </summary>
         ''' <param name="pIVsHierarchy"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function OnActiveProjectCfgChange(pIVsHierarchy As IVsHierarchy) As Integer Implements IVsUpdateSolutionEvents.OnActiveProjectCfgChange
             Try
                 If pIVsHierarchy Is Nothing OrElse pIVsHierarchy Is _projectHierarchy Then
@@ -748,7 +709,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' This nested class represents an item in the configuration or platform dropdown listbox
         ''' </summary>
-        ''' <remarks></remarks>
         Public Class DropdownItem
 
             Public Name As String
@@ -759,7 +719,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             ''' </summary>
             ''' <param name="Name">The configuration or platform name</param>
             ''' <param name="SelectionType">Type of entry</param>
-            ''' <remarks></remarks>
             Public Sub New(Name As String, SelectionType As SelectionTypes)
                 Debug.Assert(Name <> "")
                 Debug.Assert([Enum].IsDefined(GetType(SelectionTypes), SelectionType))
@@ -772,8 +731,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             ''' <summary>
             ''' Returns the display string to show in the combobox
             ''' </summary>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public ReadOnly Property DisplayName() As String
                 Get
                     Select Case SelectionType

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/DeferrableWindowPaneProviderService.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/DeferrableWindowPaneProviderService.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel.Design
 
@@ -14,7 +14,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
     '''   instead of the one that the base one provides.
     ''' This allows us to have more control of the WindowPane.
     ''' </summary>
-    ''' <remarks></remarks>
     Public NotInheritable Class DeferrableWindowPaneProviderService
         Inherits AppDesDesignerFramework.DeferrableWindowPaneProviderServiceBase
 
@@ -23,7 +22,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''   to create a PropPageDesignerWindowPane when needed (i.e., its creation is deferred).
         ''' </summary>
         ''' <param name="provider"></param>
-        ''' <remarks></remarks>
         Public Sub New(provider As IServiceProvider)
             MyBase.New(provider, Nothing)
         End Sub
@@ -34,8 +32,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''   property page designer.
         ''' </summary>
         ''' <param name="surface"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function CreateWindowPane(surface As DesignSurface) As DesignerWindowPane
             Return New PropPageDesignerWindowPane(surface)
         End Function

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/MultipleValuesStore.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/MultipleValuesStore.vb
@@ -11,7 +11,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
     ''' for different configurations, to enable undo/redo in "All configurations" and 
     ''' "All Platforms" modes.
     ''' </summary>
-    ''' <remarks></remarks>
     <Serializable()>
     Public Class MultipleValuesStore
 
@@ -31,7 +30,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="Values">The values to persist</param>
         ''' <param name="SelectedConfigName">The selected configuration in the drop-down combobox.  Empty string indicates "All Configurations".</param>
         ''' <param name="SelectedPlatformName">The selected platform in the drop-down combobox.  Empty string indicates "All Platforms".</param>
-        ''' <remarks></remarks>
         Public Sub New(VsCfgProvider As IVsCfgProvider2, Objects() As Object, Values() As Object, SelectedConfigName As String, SelectedPlatformName As String)
             Requires.NotNull(Values, NameOf(Values))
             Requires.NotNull(Objects, NameOf(Objects))
@@ -78,8 +76,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''   configuration names and platforms.
         ''' </summary>
         ''' <param name="VsCfgProvider"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetObjects(VsCfgProvider As IVsCfgProvider2) As Object()
             Debug.Assert(ConfigNames IsNot Nothing AndAlso PlatformNames IsNot Nothing AndAlso Values IsNot Nothing)
             Debug.Assert(Values.Length = ConfigNames.Length AndAlso ConfigNames.Length = PlatformNames.Length, "Huh?")

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerDocData.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerDocData.vb
@@ -52,7 +52,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Constructor
         ''' </summary>
         ''' <param name="BaseProvider"></param>
-        ''' <remarks></remarks>
         Public Sub New(BaseProvider As IServiceProvider)
             'not must init to do here
             _baseProvider = BaseProvider
@@ -61,8 +60,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Creates VsTextBuffer if necessary and returns the instance of VsTextBuffer
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property VsTextStream() As IVsTextBuffer
             Get
                 If _vsTextBuffer IsNot Nothing Then
@@ -112,7 +109,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="riidKey"></param>
         ''' <param name="pvtData"></param>
-        ''' <remarks></remarks>
         Public Function GetData(ByRef riidKey As Guid, ByRef pvtData As Object) As Integer Implements IVsUserData.GetData
             If riidKey.Equals(GetType(IVsUserData).GUID) Then
                 'IID_IVsUserData (GUID_VsBufferMoniker) is the guid used for retrieving MkDocument (filename)
@@ -131,7 +127,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="riidKey"></param>
         ''' <param name="vtData"></param>
-        ''' <remarks></remarks>
         Public Function SetData(ByRef riidKey As Guid, vtData As Object) As Integer Implements IVsUserData.SetData
             If _vsTextBuffer IsNot Nothing Then
                 Return CType(_vsTextBuffer, IVsUserData).SetData(riidKey, vtData)
@@ -267,7 +262,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Returns the IVsTextLines for our virtual buffer
         ''' </summary>
         ''' <param name="ppTextBuffer"></param>
-        ''' <remarks></remarks>
         Public Function GetTextBuffer(ByRef ppTextBuffer As IVsTextLines) As Integer Implements IVsTextBufferProvider.GetTextBuffer
             If TypeOf VsTextStream Is IVsTextLines Then
                 ppTextBuffer = CType(VsTextStream, IVsTextLines)
@@ -280,7 +274,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Locks/Unlocks our buffer
         ''' </summary>
         ''' <param name="fLock"></param>
-        ''' <remarks></remarks>
         Public Function LockTextBuffer(fLock As Integer) As Integer Implements IVsTextBufferProvider.LockTextBuffer
             If fLock = 0 Then
                 Return VsTextStream.UnlockBuffer()
@@ -293,7 +286,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' SetTextBuffer is currently unsupported.
         ''' </summary>
         ''' <param name="pTextBuffer"></param>
-        ''' <remarks></remarks>
         Public Function SetTextBuffer(pTextBuffer As IVsTextLines) As Integer Implements IVsTextBufferProvider.SetTextBuffer
             Debug.Fail("SetTextBuffer not supported in Application Designer!")
         End Function
@@ -305,7 +297,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="riid"></param>
         ''' <param name="ppvSite"></param>
-        ''' <remarks></remarks>
         Public Sub GetSite(ByRef riid As Guid, ByRef ppvSite As IntPtr) Implements OLE.Interop.IObjectWithSite.GetSite
             Dim punk As IntPtr = Marshal.GetIUnknownForObject(_siteProvider)
             Dim hr As Integer
@@ -320,7 +311,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Sets the hosting site for the DocData
         ''' </summary>
         ''' <param name="pUnkSite"></param>
-        ''' <remarks></remarks>
         Public Sub SetSite(pUnkSite As Object) Implements OLE.Interop.IObjectWithSite.SetSite
             If TypeOf pUnkSite Is OLE.Interop.IServiceProvider Then
                 _siteProvider = New Shell.ServiceProvider(DirectCast(pUnkSite, OLE.Interop.IServiceProvider))
@@ -334,7 +324,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Disposes of any the doc data
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overloads Sub Dispose() Implements IDisposable.Dispose
             Dispose(True)
         End Sub
@@ -343,7 +332,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Disposes of contained objects
         ''' </summary>
         ''' <param name="disposing"></param>
-        ''' <remarks></remarks>
         Protected Overloads Sub Dispose(disposing As Boolean)
             If disposing Then
                 ' Dispose managed resources.

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerEditorFactory.vb
@@ -129,7 +129,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Disconnect from the owning site
         ''' </summary>
-        ''' <remarks></remarks>
         Public Function Close() As Integer Implements IVsEditorFactory.Close
             _siteProvider = Nothing
             _site = Nothing
@@ -138,7 +137,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Wrapper of COM interface which delegates to Internal
         ''' </summary>
-        ''' <remarks></remarks>
         Private Function IVsEditorFactory_CreateEditorInstance(
                 vscreateeditorflags As UInteger,
                 FileName As String,
@@ -189,7 +187,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="rguidLogicalView"></param>
         ''' <param name="pbstrPhysicalView"></param>
-        ''' <remarks></remarks>
         Public Function MapLogicalView(ByRef rguidLogicalView As Guid, ByRef pbstrPhysicalView As String) As Integer Implements IVsEditorFactory.MapLogicalView
             pbstrPhysicalView = Nothing
         End Function
@@ -198,7 +195,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Called by owning site after creation
         ''' </summary>
         ''' <param name="Site"></param>
-        ''' <remarks></remarks>
         Public Function SetSite(Site As IServiceProvider) As Integer Implements IVsEditorFactory.SetSite
             'This same Site already set?  Or Site not yet initialized (= Nothing)?  If so, NOP.
             If _site Is Site Then

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerLoader.vb
@@ -11,7 +11,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
     ''' <summary>
     ''' Designer loader for the PropPageDesigner
     ''' </summary>
-    ''' <remarks></remarks>
     Public NotInheritable Class PropPageDesignerLoader
         Inherits BasicDesignerLoader
         Implements IDisposable
@@ -25,7 +24,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''   remove any custom services you add here by overriding
         '''   Dispose.
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub Initialize()
             MyBase.Initialize()
 
@@ -48,7 +46,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="Hierarchy"></param>
         ''' <param name="ItemId"></param>
         ''' <param name="punkDocData"></param>
-        ''' <remarks></remarks>
         Public Sub InitializeEx(ServiceProvider As Shell.ServiceProvider, Hierarchy As IVsHierarchy, ItemId As UInteger, punkDocData As Object)
 
             If punkDocData Is Nothing Then
@@ -69,7 +66,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' it needs an updated version of the file contents).
         ''' </summary>
         ''' <param name="serializationManager"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub PerformFlush(serializationManager As IDesignerSerializationManager)
             Debug.Assert(Modified, "PerformFlush shouldn't get called if the designer's not dirty")
 
@@ -112,7 +108,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Dispose of managed and unmanaged resources
         ''' </summary>
         ''' <param name="disposing">True if calling from Dispose()</param>
-        ''' <remarks></remarks>
         Protected Overloads Sub Dispose(disposing As Boolean)
             If disposing Then
                 ' Dispose of managed resources.

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerRootComponent.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerRootComponent.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 Imports System.ComponentModel.Design
@@ -10,7 +10,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
     ''' <summary>
     ''' This class represents the root component of the Application Designer.
     ''' </summary>
-    ''' <remarks></remarks>
     <Designer(GetType(PropPageDesignerRootDesigner), GetType(IRootDesigner))>
     Public NotInheritable Class PropPageDesignerRootComponent
         Inherits Component
@@ -35,7 +34,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''   resx file to be edited by the user.
         ''' </summary>
         ''' <value>The associated ResourceEditorRootDesigner.</value>
-        ''' <remarks></remarks>
         Public ReadOnly Property RootDesigner() As PropPageDesignerRootDesigner
             Get
                 If _rootDesigner Is Nothing Then
@@ -53,8 +51,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' The IVsHierarchy associated with the AppDesigner node
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property Hierarchy() As IVsHierarchy
             Get
                 Return _hierarchy
@@ -67,8 +63,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' The ItemId associated with the AppDesigner node
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property ItemId() As UInteger
             Get
                 Return _itemId

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerRootDesigner.vb
@@ -12,7 +12,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
     ''' This is the designer for the top-level resource editor component (PropPageDesigner).  I.e., this
     ''' is the top-level designer.  
     ''' </summary>
-    ''' <remarks></remarks>
     Public NotInheritable Class PropPageDesignerRootDesigner
         Inherits AppDesDesignerFramework.BaseRootDesigner
         Implements IRootDesigner
@@ -24,7 +23,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Returns the PropPageDesignerRootComponent component that is being edited by this designer.
         ''' </summary>
         ''' <value>The PropPageDesignerRootComponent object.</value>
-        ''' <remarks></remarks>
         Public Shadows ReadOnly Property Component() As PropPageDesignerRootComponent
             Get
                 Dim RootComponent As PropPageDesignerRootComponent = CType(MyBase.Component, PropPageDesignerRootComponent)
@@ -51,7 +49,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' We currently support only Windows Forms technology (i.e., our designer view, ResourceEditorView,
         ''' inherits from System.Windows.Forms.Control)
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' The view technology we support, which is currently only Windows Forms
         ''' </remarks>
@@ -66,7 +63,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''   our resource editor's designer surface.  In this case, we return an instance of ResourceEditorView.
         ''' </summary>
         ''' <param name="Technology"></param>
-        ''' <returns></returns>
         ''' <remarks>
         '''   The newly-instantiated ResourceEditorView object.
         ''' </remarks>
@@ -85,8 +81,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Wrapper function to expose our UI object
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetView() As PropPageDesignerView
             Return CType(RootDesigner_GetView(ViewTechnology.Default), PropPageDesignerView)
         End Function
@@ -105,7 +99,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Disposes of the root designer
         ''' </summary>
         ''' <param name="Disposing"></param>
-        ''' <remarks></remarks>
         Protected Overloads Overrides Sub Dispose(Disposing As Boolean)
             If Disposing Then
                 If _view IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
@@ -30,7 +30,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
     ''' which let us bubble the notification into the standard component changed mechanism.
     ''' This will cause the normal undo mechanism to be invoked.
     ''' </summary>
-    ''' <remarks></remarks>
     Public NotInheritable Class PropPageDesignerView
         Inherits UserControl
         Implements IVsProjectDesignerPageSite
@@ -262,7 +261,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' View constructor 
         ''' </summary>
         ''' <param name="RootDesigner"></param>
-        ''' <remarks></remarks>
         Public Sub New(RootDesigner As PropPageDesignerRootDesigner)
             Me.New()
             SetSite(RootDesigner)
@@ -307,8 +305,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Property page we host
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property PropPage() As OleInterop.IPropertyPage
             Get
                 Return _loadedPage
@@ -328,7 +324,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Retrieves the IVsUIShell service
         ''' </summary>
-        ''' <remarks></remarks>
         Private ReadOnly Property VsUIShellService() As IVsUIShell
             Get
                 If (_uiShellService Is Nothing) Then
@@ -346,7 +341,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Retrieves the IVsUIShell5 service
         ''' </summary>
-        ''' <remarks></remarks>
         Private ReadOnly Property VsUIShell5Service() As IVsUIShell5
             Get
                 If (_uiShell5Service Is Nothing) Then
@@ -374,8 +368,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' True iff the property page is hosted through native SetParent and not as a Windows Form child control.
         ''' Returns False if the property page is not currently activated
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property IsNativeHostedPropertyPageActivated() As Boolean
             Get
                 Return _isPageActivated AndAlso _isNativeHostedPropertyPage
@@ -386,8 +378,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Gets the browse object for the project.  This is what is passed to SetObjects for
         '''   non-config-dependent pages
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetProjectBrowseObject() As Object
             Dim BrowseObject As Object = Nothing
             VSErrorHandler.ThrowOnFailure(_projectHierarchy.GetProperty(VSITEMID.ROOT, __VSHPROPID.VSHPROPID_BrowseObject, BrowseObject))
@@ -417,7 +407,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="PropPageSite"></param>
         ''' <param name="Hierarchy"></param>
         ''' <param name="IsConfigPage"></param>
-        ''' <remarks></remarks>
         Public Sub Init(DTEProject As EnvDTE.Project, PropPage As OleInterop.IPropertyPage, PropPageSite As PropertyPageSite, Hierarchy As IVsHierarchy, IsConfigPage As Boolean)
             Debug.Assert(_dteProject Is Nothing, "Init() called twice?")
 
@@ -508,7 +497,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub OnUndoEngineUndone(sender As Object, e As EventArgs) Handles _undoEngine.Undone
             'Tell the project designer it needs to refresh its dirty status
             If _loadedPageSite IsNot Nothing Then
@@ -527,7 +515,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub OnDesignerHostTransactionClosed(sender As Object, e As DesignerTransactionCloseEventArgs) Handles _designerHost.TransactionClosed
             If _loadedPageSite IsNot Nothing Then
                 Dim AppDesignerView As ApplicationDesignerView = TryCast(_loadedPageSite.GetService(GetType(ApplicationDesignerView)), ApplicationDesignerView)
@@ -555,7 +542,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="msg"></param>
         ''' <param name="wparam"></param>
         ''' <param name="lparam"></param>
-        ''' <remarks></remarks>
         Private Sub OnBroadcastMessageEventsHelperBroadcastMessage(msg As UInteger, wParam As IntPtr, lParam As IntPtr) Handles _broadcastMessageEventsHelper.BroadcastMessage
             Select Case msg
                 Case Win32Constant.WM_PALETTECHANGED, Win32Constant.WM_SYSCOLORCHANGE, Win32Constant.WM_THEMECHANGED
@@ -585,7 +571,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Show the property page 
         ''' </summary>
         ''' <param name="PropPage"></param>
-        ''' <remarks></remarks>
         Public Sub ActivatePage(PropPage As OleInterop.IPropertyPage)
             Switches.TracePDPerfBegin("PropPageDesignerView.ActivatePage")
             If PropPage Is Nothing Then
@@ -668,7 +653,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Display the error control instead of a property page
         ''' </summary>
         ''' <param name="ex">The exception to retrieve the error message from</param>
-        ''' <remarks></remarks>
         Private Sub DisplayErrorControl(ex As Exception)
 
             UnLoadPage()
@@ -688,7 +672,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Hide and deactivate the property page
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub UnLoadPage()
             _isPageActivated = False
             _isNativeHostedPropertyPage = False
@@ -721,7 +704,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Our site - always of type PropPageDesignerRootDesigner
         ''' </summary>
         ''' <param name="RootDesigner"></param>
-        ''' <remarks></remarks>
         Private Sub SetSite(RootDesigner As PropPageDesignerRootDesigner) 'Implements OLE.Interop.IObjectWithSite.SetSite
             _rootDesigner = RootDesigner
             _broadcastMessageEventsHelper = New ShellUtil.BroadcastMessageEventsHelper(Me)
@@ -732,8 +714,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' GetService helper
         ''' </summary>
         ''' <param name="ServiceType"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shadows Function GetService(ServiceType As Type) As Object Implements IServiceProvider.GetService
             Dim Service As Object
             Service = _rootDesigner.GetService(ServiceType)
@@ -743,8 +723,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Get the size of the hosting client rect for sizing the property page 
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetPageRect() As OleInterop.RECT
             Dim ClientRect As New OleInterop.RECT
             ' We should use DisplayRectangle.Left/Top here, so the child page could work with auto-scroll
@@ -760,7 +738,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Update the hosted property page size
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Sub UpdatePageSize()
             If _loadedPage IsNot Nothing Then
                 Dim RectArray As OleInterop.RECT() = New OleInterop.RECT() {GetPageRect()}
@@ -791,7 +768,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' This is part of the undo host code for the property page.  
         ''' We pass this interface to the property pages implementation of IVsProjectDesignerPage.SetSite
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub OnPropertyChanged(Component As Component, PropDesc As PropertyDescriptor, OldValue As Object, NewValue As Object)
             Dim ChangeService As IComponentChangeService = DirectCast(GetService(GetType(IComponentChangeService)), IComponentChangeService)
             ChangeService.OnComponentChanged(Component, PropDesc, OldValue, NewValue)
@@ -817,7 +793,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' This is part of the undo host code for the property page.  
         ''' We pass this interface to the property pages implementation of IVsProjectDesignerPage.SetSite
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub OnPropertyChanging(Component As Component, PropDesc As PropertyDescriptor)
             Dim ChangeService As IComponentChangeService = DirectCast(GetService(GetType(IComponentChangeService)), IComponentChangeService)
 
@@ -851,7 +826,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="description">The localized description string to use for the transaction.  This will appear as the
         '''   description for the Undo/Redo unit.</param>
-        ''' <returns></returns>
         Public Function GetTransaction(Description As String) As DesignerTransaction Implements IVsProjectDesignerPageSite.GetTransaction
             Dim DesignerHost As IDesignerHost
             DesignerHost = DirectCast(GetService(GetType(IDesignerHost)), IDesignerHost)
@@ -863,7 +837,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Set font for controls on the Configuration panel
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Sub SetDialogFont()
             Font = GetDialogFont()
         End Sub
@@ -871,8 +844,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Pick font to use in this dialog page
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property GetDialogFont() As Font
             Get
                 Dim uiSvc As IUIService = CType(GetService(GetType(IUIService)), IUIService)
@@ -900,7 +871,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="DefaultButton">Which button should be default?</param>
         ''' <param name="HelpLink">The help link</param>
         ''' <returns>One of the DialogResult values</returns>
-        ''' <remarks></remarks>
         Public Function DsMsgBox(Message As String,
                 Buttons As MessageBoxButtons,
                 Icon As MessageBoxIcon,
@@ -916,7 +886,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Displays a designer error message
         ''' </summary>
         ''' <param name="Message"></param>
-        ''' <remarks></remarks>
         Public Sub ShowErrorMessage(Message As String, Optional HelpLink As String = Nothing)
             DsMsgBox(Message, MessageBoxButtons.OK, MessageBoxIcon.Error, HelpLink:=HelpLink)
         End Sub
@@ -927,7 +896,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Sets whether or not the configuration/platform dropdowns are visible
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub SetConfigDropdownVisibility()
             ConfigurationPanel.Visible = Not _configurationState.IsSimplifiedConfigMode()
 
@@ -954,7 +922,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="NewSelectedConfigIndex">New index into the ConfigurationComboBox</param>
         ''' <param name="NewSelectedPlatformIndex">New index into the PlatformComboBox</param>
-        ''' <remarks></remarks>
         Private Sub ChangeSelectedComboBoxIndicesWithoutNotification(NewSelectedConfigIndex As Integer, NewSelectedPlatformIndex As Integer)
             Debug.Assert(Not _ignoreSelectedIndexChanged)
 
@@ -973,7 +940,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub SelectedConfigurationOrPlatformIndexChanged(sender As Object, e As EventArgs) _
                         Handles ConfigurationComboBox.SelectedIndexChanged, PlatformComboBox.SelectedIndexChanged, PlatformComboBox.SelectedIndexChanged
 
@@ -1046,7 +1012,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Raised when the value of the SimplifiedConfigMode property changes.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ConfigurationState_SimplifiedConfigModeChanged()
             SetConfigDropdownVisibility()
 
@@ -1059,7 +1024,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Check if the simplified configs mode property has changed (we do this on WM_SETFOCUS, since there's no notification
         '''   of a change)
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub CheckForModeChanges()
             If _configurationState IsNot Nothing AndAlso _fInitialized AndAlso _needToCheckForModeChanges Then
                 _configurationState.CheckForModeChanges()
@@ -1071,7 +1035,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Updates the configuration and platform combobox dropdown lists and selects the first entry in each list
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub UpdateConfigLists()
             If Not IsConfigPage Then
                 Exit Sub
@@ -1102,8 +1065,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Returns the currently selected config combobox item
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetSelectedConfigItem() As ConfigurationState.DropdownItem
             Debug.Assert(ConfigurationComboBox.SelectedIndex >= 0)
             Debug.Assert(ConfigurationComboBox.Items.Count = _configurationState.ConfigurationDropdownEntries.Length,
@@ -1117,8 +1078,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Returns the currently selected platform combobox item
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetSelectedPlatformItem() As ConfigurationState.DropdownItem
             Debug.Assert(PlatformComboBox.SelectedIndex >= 0)
             Debug.Assert(PlatformComboBox.Items.Count = _configurationState.PlatformDropdownEntries.Length,
@@ -1133,7 +1092,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Determines the set of currently-selected configurations by inspecting the configuration comboboxes, 
         '''   and passes that set of objects to the loaded property page
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub SetObjectsForSelectedConfigs()
             CommitPendingChanges()
 
@@ -1236,7 +1194,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''    for the page properties).
         ''' </summary>
         ''' <param name="Objects"></param>
-        ''' <remarks></remarks>
         Private Sub CallPageSetObjects(Objects() As Object)
             Dim Count As UInteger = 0
             If Objects IsNot Nothing Then
@@ -1257,7 +1214,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ConfigurationComboBox_DropDown(sender As Object, e As EventArgs) Handles ConfigurationComboBox.DropDown
             'Set the drop-down width to handle all the text entries in it
             SetComboBoxDropdownWidth(ConfigurationComboBox)
@@ -1269,7 +1225,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub PlatformComboBox_DropDown(sender As Object, e As EventArgs) Handles PlatformComboBox.DropDown
             'Set the drop-down width to handle all the text entries in it
             SetComboBoxDropdownWidth(PlatformComboBox)
@@ -1416,7 +1371,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' If the object passed in is an enum, then convert it to its underlying type
         ''' </summary>
         ''' <param name="Value">[inout] The value to check and convert in place.</param>
-        ''' <remarks></remarks>
         Private Shared Sub ConvertEnumToUnderlyingType(ByRef Value As Object)
             If Value IsNot Nothing AndAlso Value.GetType().IsEnum Then
                 Value = Convert.ChangeType(Value, Type.GetTypeCode(Value.GetType().UnderlyingSystemType))
@@ -1427,7 +1381,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Returns the selection state of the configuration and platform comboboxes to the pre-undo/redo state.
         ''' </summary>
         ''' <param name="MultiValues">Specifies the selected configuration and platform in the drop-down combobox.</param>
-        ''' <remarks></remarks>
         Private Sub ReselectConfigurationsForUndoRedo(MultiValues As MultipleValuesStore)
             If Not IsConfigPage Then
                 Exit Sub
@@ -1451,7 +1404,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Commits any pending changes on the page
         ''' </summary>
         ''' <returns>return False if it failed</returns>
-        ''' <remarks></remarks>
         Private Function CommitPendingChanges() As Boolean
             Switches.TracePDPerfBegin("PropPageDesignerView.CommitPendingChanges")
             Try
@@ -1482,8 +1434,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''   an immediate apply.
         ''' </summary>
         ''' <param name="pfCommitFailed">[Out] Set to non-zero to indicate that the action should be canceled because the commit failed.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function IVsWindowPaneCommit_CommitPendingEdit(ByRef pfCommitFailed As Integer) As Integer Implements IVsWindowPaneCommit.CommitPendingEdit
             pfCommitFailed = 0
             If Not CommitPendingChanges() Then
@@ -1502,8 +1452,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''   a native-hosted property page's controls.
         ''' </summary>
         ''' <param name="forward"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overrides Function ProcessTabKey(forward As Boolean) As Boolean
             Switches.TracePDMessageRouting(TraceLevel.Warning, "PropPageDesignerView.ProcessTabKey")
 
@@ -1551,8 +1499,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Override Control's ProcessDialogChar in order to allow mnemonics to work.
         ''' </summary>
         ''' <param name="charCode"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overrides Function ProcessDialogChar(charCode As Char) As Boolean
             'Control's version of this function only calls ProcessMnemonic if the window
             '  is top-level, but the control is not top-level as far as WinForms is concerned.
@@ -1593,8 +1539,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Sets the focus to the first (or last) control in the property page.
         ''' </summary>
         ''' <param name="First"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function FocusFirstOrLastPropertyPageControl(First As Boolean) As Boolean
             'Make sure to set the active control as well as doing SetFocus(), or else when
             '  devenv gets focus the focus will not go back to the correct control. 
@@ -1607,8 +1551,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Retrieves the top-most HWND of the property page hosted inside the property page panel
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetPropertyPageTopHwnd() As IntPtr
             If PropertyPagePanel.Handle.Equals(IntPtr.Zero) Then
                 Return IntPtr.Zero
@@ -1643,7 +1585,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Clears all undo and redo entries for this page
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ClearUndoStackForPage()
             'Only need to do this if undo is enabled
             Dim UndoEngine As UndoEngine = TryCast(GetService(GetType(UndoEngine)), UndoEngine)
@@ -1668,7 +1609,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Overridden WndProc
         ''' </summary>
         ''' <param name="m"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub WndProc(ByRef m As Message)
             Dim isSetFocusMessage As Boolean = False
             If m.Msg = Win32Constant.WM_SETFOCUS Then
@@ -1704,8 +1644,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Retrieves the title of the loaded property page
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetPageTitle() As String
             Dim Info As OleInterop.PROPPAGEINFO() = New OleInterop.PROPPAGEINFO(0) {}
             If _loadedPage IsNot Nothing Then
@@ -1720,7 +1658,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Sets the undo/redo level to a "clean" state
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub SetUndoRedoCleanState()
             Dim CurrentUndoUnitsAvailable As Integer
             If TryGetUndoUnitsAvailable(CurrentUndoUnitsAvailable) Then
@@ -1741,8 +1678,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Determines whether the page is dirty in the sense of, "no current changes and the undo stack is at the same
         '''   place as when the user first loaded the page."
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function ShouldShowDirtyIndicator() As Boolean
             If PropPage Is Nothing Then
                 ' This can happen if an exception happened during property page initialization
@@ -1799,7 +1734,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub DisabledMenuCommandHandler(sender As Object, e As EventArgs)
         End Sub
 #End Region
@@ -1809,7 +1743,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <returns>True if the function successfully retrieves the # of undo units available.  False if it
         '''   fails (e.g., the Undo engine is not available, which can happen when the property page didn't 
         '''   load properly, etc.)</returns>
-        ''' <remarks></remarks>
         Private Function TryGetUndoUnitsAvailable(ByRef UndoUnitsAvailable As Integer) As Boolean
             UndoUnitsAvailable = 0
 
@@ -1854,7 +1787,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub PropertyPagePanel_GotFocus(sender As Object, e As EventArgs) Handles PropertyPagePanel.GotFocus
             If _isNativeHostedPropertyPage Then
                 'Since PropertyPagePanel has no child controls that WinForms knows about, we need to

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerWindowPane.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerWindowPane.vb
@@ -22,7 +22,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Creates a new WinformsWindowPane.
         ''' </summary>
         ''' <param name="surface"></param>
-        ''' <remarks></remarks>
         Public Sub New(surface As DesignSurface)
             MyBase.New(surface, SupportToolbox:=False)
         End Sub
@@ -31,8 +30,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Retrieves the PropPageDesignerView associated with this window, if any.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetPropPageDesignerView() As PropPageDesignerView
             If View IsNot Nothing AndAlso View.Controls IsNot Nothing AndAlso View.Controls.Count > 0 Then
                 Return TryCast(View.Controls(0), PropPageDesignerView)
@@ -50,8 +47,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''   tabbing from the property page to the property page designer.
         ''' </summary>
         ''' <param name="m"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overrides Function PreProcessMessage(ByRef m As Message) As Boolean
             Common.Switches.TracePDMessageRouting(TraceLevel.Warning, "PropPageDesignerWindowPane.PreProcessMessage", m)
 

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPagePropertyDescriptor.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPagePropertyDescriptor.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 
@@ -14,7 +14,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
     '''   directly to the propdescriptor (and hence the project).  This allows us exact control of undo and redo and how properties
     '''   are set and got.
     ''' </summary>
-    ''' <remarks></remarks>
     Public NotInheritable Class PropertyPagePropertyDescriptor
         Inherits PropertyDescriptor
 
@@ -30,7 +29,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Constructs a PropertyDescriptor using the wrapped properties property descriptor
         ''' </summary>
         ''' <param name="PropDesc">The property descriptor that is being wrapped.</param>
-        ''' <remarks></remarks>
         Public Sub New(PropDesc As PropertyDescriptor, PropertyName As String)
             MyBase.New(PropDesc)
 
@@ -55,7 +53,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Returns the type of the instance this property is bound to, which is PropPageDesignerRootComponent.
         ''' </summary>
         ''' <value>The component type.</value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property ComponentType() As Type
             Get
                 Return GetType(PropPageDesignerRootComponent)
@@ -67,7 +64,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''  Returns a value indicating whether this property is read-only.
         ''' </summary>
         ''' <value>True if the property is read-only, False otherwise.</value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property IsReadOnly() As Boolean
             Get
                 Return _isReadOnly
@@ -79,7 +75,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Returns the type of the property.
         ''' </summary>
         ''' <value>A Type that represents the type of the property.</value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property PropertyType() As Type
             Get
                 Return _propertyType
@@ -158,8 +153,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Returns the converter for the contained property
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property Converter() As TypeConverter
             Get
                 Return _typeConverter
@@ -169,9 +162,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Returns the name of the property.
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property Name() As String
             Get
                 If _name = "" Then
@@ -187,8 +177,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' be displayed in a properties window.  This will be the same as the property
         ''' name for most properties.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property DisplayName() As String
             Get
                 Return _displayName
@@ -206,8 +194,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Gets an editor of the specified type.
         ''' </summary>
         ''' <param name="editorBaseType"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetEditor(editorBaseType As Type) As Object
             If _propDesc IsNot Nothing Then
                 Return _propDesc.GetEditor(editorBaseType)

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPageSerializationService.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPageSerializationService.vb
@@ -27,7 +27,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
     '''     format best suited for them.
     '''
     ''' </summary>
-    ''' <remarks></remarks>
     Public NotInheritable Class PropertyPageSerializationService
         Inherits ComponentSerializationService
 
@@ -37,7 +36,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''   state for a group of objects.
         ''' </summary>
         ''' <param name="Provider">Ignored.</param>
-        ''' <remarks></remarks>
         Public Sub New(Provider As IServiceProvider)
             'We don't need the service provider, we ignore it.
         End Sub
@@ -49,7 +47,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''  state for a group of objects.
         ''' </summary>
         ''' <returns>An instance of a new serialization store for resources</returns>
-        ''' <remarks></remarks>
         Public Overrides Function CreateStore() As SerializationStore
             Return New PropertyPageSerializationStore()
         End Function
@@ -62,7 +59,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="Stream">The stream to load from.</param>
         ''' <returns>The loaded store for resources.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function LoadStore(Stream As Stream) As SerializationStore
             Requires.NotNull(Stream, NameOf(Stream))
 
@@ -77,7 +73,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="Value">The object (must be a Resource instance) to serialize into the store.</param>
-        ''' <remarks></remarks>
         Public Overrides Sub Serialize(Store As SerializationStore, Value As Object)
             Requires.NotNull(Store, NameOf(Store))
             Requires.NotNull(Value, NameOf(Value))
@@ -111,8 +106,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="OwningObject">The object (must be a Resource instance) whose property (member) you are trying to serialize into the store.</param>
         ''' <param name="Member">The property whose value needs to be serialized into the store.</param>
-        ''' <remarks>
-        ''' </remarks>
         Public Overrides Sub SerializeMember(Store As SerializationStore, OwningObject As Object, Member As MemberDescriptor)
             Requires.NotNull(Store, NameOf(Store))
             Requires.NotNull(OwningObject, NameOf(OwningObject))
@@ -143,7 +136,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="OwningObject">The object (must be a Resource instance) whose property (member) you are trying to serialize into the store.</param>
         ''' <param name="Member">The property whose value needs to be serialized into the store.</param>
-        ''' <remarks></remarks>
         Public Overrides Sub SerializeMemberAbsolute(Store As SerializationStore, OwningObject As Object, Member As MemberDescriptor)
             'This method is intended for properties such as collections which might have had only some of their
             '  members changed.
@@ -161,7 +153,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="Store">The store to serialize into.</param>
         ''' <returns>The set of components that were deserialized.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function Deserialize(Store As SerializationStore) As ICollection
             Requires.NotNull(Store, NameOf(Store))
 
@@ -182,7 +173,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
         ''' <returns>The list of objects that were deserialized.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function Deserialize(Store As SerializationStore, Container As IContainer) As ICollection
             Requires.NotNull(Store, NameOf(Store))
             Requires.NotNull(Container, NameOf(Container))
@@ -210,7 +200,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
-        ''' <remarks></remarks>
         Public Overrides Sub DeserializeTo(Store As SerializationStore, Container As IContainer, ValidateRecycledTypes As Boolean, applyDefaults As Boolean)
             Requires.NotNull(Store, NameOf(Store))
             Requires.NotNull(Container, NameOf(Container))

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPageSerializationService_Store.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPageSerializationService_Store.vb
@@ -48,7 +48,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             ''' <summary>
             ''' Constructor.
             ''' </summary>
-            ''' <remarks></remarks>
             Public Sub New()
                 _hashedObjectsToSerialize = New Hashtable
             End Sub
@@ -66,7 +65,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             '''   from being serialized into it.  Once closed, the serialization store 
             '''   may be saved (or deserialized).
             ''' </summary>
-            ''' <remarks></remarks>
             Public Overrides Sub Close()
                 If _serializedState Is Nothing Then
                     Dim SerializedState As New ArrayList(_hashedObjectsToSerialize.Count)
@@ -111,7 +109,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             ''' </summary>
             ''' <param name="info">Serialization info</param>
             ''' <param name="context">Serialization context</param>
-            ''' <remarks></remarks>
             Private Sub GetObjectData(info As SerializationInfo, context As StreamingContext) Implements ISerializable.GetObjectData
                 info.AddValue(KEY_STATE, _serializedState)
             End Sub
@@ -123,7 +120,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             ''' </summary>
             ''' <param name="Info">Serialization info</param>
             ''' <param name="Context">Serialization context</param>
-            ''' <remarks></remarks>
             Private Sub New(Info As SerializationInfo, Context As StreamingContext)
                 _serializedState = DirectCast(Info.GetValue(KEY_STATE, GetType(ArrayList)), ArrayList)
             End Sub
@@ -137,8 +133,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             ''' Loads our state from a stream.
             ''' </summary>
             ''' <param name="Stream">The stream to load from</param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Shared Function Load(Stream As Stream) As PropertyPageSerializationStore
                 Dim f As New BinaryFormatter
                 Return DirectCast(f.Deserialize(Stream), PropertyPageSerializationStore)
@@ -151,7 +145,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             '''     to different streams.
             ''' </summary>
             ''' <param name="stream">The stream to save to</param>
-            ''' <remarks></remarks>
             Public Overrides Sub Save(Stream As Stream)
                 Close()
 
@@ -168,8 +161,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             ''' Adds a new object serialization to our list of things to serialize.
             ''' </summary>
             ''' <param name="Component">The component to be serialized as an entire object.</param>
-            ''' <remarks>
-            ''' </remarks>
             Public Sub AddObject(Component As PropPageDesignerRootComponent)
                 Debug.Fail("Not supported")
                 Debug.Assert(_serializedState Is Nothing, "Shouldn't be adding more components to serialization store - it's already been serialized")
@@ -212,7 +203,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             ''' </summary>
             ''' <param name="Component">The component from which we want to serialize something.</param>
             ''' <returns>The ComponentDataToSerialize object associated with this Component.</returns>
-            ''' <remarks></remarks>
             Private Function GetComponentSerializationData(Component As PropPageDesignerRootComponent) As DataToSerialize
                 Dim Data As DataToSerialize = DirectCast(_hashedObjectsToSerialize(Component), DataToSerialize)
                 If Data Is Nothing Then
@@ -244,7 +234,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             '''     object to be used.
             ''' </summary>
             ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
-            ''' <remarks></remarks>
             Public Sub DeserializeTo(Container As IContainer)
                 DeserializeHelper(Container)
             End Sub
@@ -257,7 +246,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             '''     that are created that implement IComponent will be added to the container. 
             ''' </summary>
             ''' <returns>The set of components that were deserialized.</returns>
-            ''' <remarks></remarks>
             Public Function Deserialize() As ICollection
                 Return DeserializeHelper(Nothing)
             End Function
@@ -271,7 +259,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             ''' </summary>
             ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
             ''' <returns>The list of objects that were deserialized.</returns>
-            ''' <remarks></remarks>
             Public Function Deserialize(Container As IContainer) As ICollection
                 Return DeserializeHelper(Container)
             End Function
@@ -367,7 +354,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             '''   Component instance (either the entire Resource itself, or a set of
             '''   its properties)
             ''' </summary>
-            ''' <remarks></remarks>
             Private NotInheritable Class DataToSerialize
 
                 'Backing for public properties
@@ -381,7 +367,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' Constructor
                 ''' </summary>
                 ''' <param name="Component">The Component from which we want to serialize stuff.</param>
-                ''' <remarks></remarks>
                 Public Sub New(Component As PropPageDesignerRootComponent)
                     If Component Is Nothing Then
                         Throw AppDesCommon.CreateArgumentException(NameOf(Component))
@@ -395,8 +380,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' <summary>
                 ''' The component from which we want to serialize stuff.
                 ''' </summary>
-                ''' <value></value>
-                ''' <remarks></remarks>
                 Public ReadOnly Property Component() As PropPageDesignerRootComponent
                     Get
                         Return _component
@@ -408,8 +391,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' If True, the entire Component instance should be serialized.  If false,
                 '''   then only the properties in PropertiesToSerialize should be serialized.
                 ''' </summary>
-                ''' <value></value>
-                ''' <remarks></remarks>
                 Public Property IsEntireObject() As Boolean
                     Get
                         Return _isEntireObject
@@ -428,8 +409,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' A list of PropertyDescriptors representing the properties on
                 '''   the Component which should be serialized.
                 ''' </summary>
-                ''' <value></value>
-                ''' <remarks></remarks>
                 Public ReadOnly Property PropertiesToSerialize() As IList
                     Get
                         If _propertiesToSerialize Is Nothing Then
@@ -444,7 +423,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' Adds a property to be serialized to the list.
                 ''' </summary>
                 ''' <param name="Member">The property (must be a PropertyDescriptor) to be serialized.</param>
-                ''' <remarks></remarks>
                 Public Sub AddPropertyToSerialize(Member As MemberDescriptor)
                     Requires.NotNull(Member, NameOf(Member))
 
@@ -466,7 +444,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             ''' <summary>
             ''' Stores a single binary serialized Component instance or Component property value
             ''' </summary>
-            ''' <remarks></remarks>
             <Serializable()>
             Private NotInheritable Class SerializedProperty
 
@@ -524,8 +501,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' <summary>
                 ''' Gets the name of the component from which this was serialized.
                 ''' </summary>
-                ''' <value></value>
-                ''' <remarks></remarks>
                 Public ReadOnly Property ComponentName() As String
                     Get
                         Return _componentName
@@ -537,8 +512,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' Gets the name of the property which was serialized (or Nothing if
                 '''   not a property serialization).
                 ''' </summary>
-                ''' <value></value>
-                ''' <remarks></remarks>
                 Public ReadOnly Property PropertyName() As String
                     Get
                         Return _propertyName
@@ -550,8 +523,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' Returns True iff an entire Component object has been serialized, as opposed
                 '''   to just a property from it.
                 ''' </summary>
-                ''' <returns></returns>
-                ''' <remarks></remarks>
                 Public ReadOnly Property IsEntireComponentObject() As Boolean
                     Get
                         Return (PropertyName = "")
@@ -564,7 +535,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' </summary>
                 ''' <param name="Object">The object to serialize</param>
                 ''' <returns>The binary serialized object.</returns>
-                ''' <remarks></remarks>
                 Private Shared Function SerializeObject([Object] As Object) As Byte()
                     Dim MemoryStream As New MemoryStream
                     Call (New BinaryFormatter).Serialize(MemoryStream, [Object])
@@ -575,7 +545,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' <summary>
                 ''' Deserializes an entire Component instance which has been serialized.
                 ''' </summary>
-                ''' <returns></returns>
                 ''' <remarks>Can only be called if IsEntireComponentObject = True</remarks>
                 Public Function GetEntireComponentObject() As PropPageDesignerRootComponent
                     If Not IsEntireComponentObject() Then
@@ -590,7 +559,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' <summary>
                 ''' Deserializes a property value which has been serialized.
                 ''' </summary>
-                ''' <returns></returns>
                 ''' <remarks>Can only be called if IsEntireComponentObject = False</remarks>
                 Public Function GetPropertyValue() As Object
                     If IsEntireComponentObject() Then

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/ChildPageSite.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/ChildPageSite.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.VisualStudio.ManagedInterfaces.ProjectDesigner
 
@@ -8,7 +8,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' A specialized property page site for hosting child pages from a PropPageUserControlBase page.
     '''   Supports undo and redo as a single transaction on the parent page's Undo stack.
     ''' </summary>
-    ''' <remarks></remarks>
     Public Class ChildPageSite
         Implements IPropertyPageSiteInternal
         Implements IVsProjectDesignerPageSite
@@ -17,7 +16,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' The character that separates the property page type name from the property name in the special mangled
         '''   property names that we create.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Const NestingCharacter As String = ":"
 
         Private ReadOnly _wrappedInternalSite As IPropertyPageSiteInternal 'May *not* be Nothing
@@ -31,7 +29,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="childPage">The child page that is to be hosted (required).</param>
         ''' <param name="wrappedInternalSite">The IPropertyPageSiteInternal site (required).</param>
         ''' <param name="wrappedUndoSite">The IVsProjectDesignerPageSite site (optional).</param>
-        ''' <remarks></remarks>
         Public Sub New(childPage As PropPageUserControlBase, wrappedInternalSite As IPropertyPageSiteInternal, wrappedUndoSite As IVsProjectDesignerPageSite)
             If childPage Is Nothing Then
                 Debug.Fail("childPage missing")
@@ -51,8 +48,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns whether or not the property page hosted in this site should be with 
         '''   immediate-apply mode or not)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property IsImmediateApply() As Boolean Implements IPropertyPageSiteInternal.IsImmediateApply
             Get
                 'Child pages are always non-immediate apply (we wait until the user clicks
@@ -65,8 +60,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Delegate to the wrapped site
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetLocaleID() As Integer Implements IPropertyPageSiteInternal.GetLocaleID
             Return _wrappedInternalSite.GetLocaleID()
         End Function
@@ -75,17 +68,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Delegate to the wrapped site
         ''' </summary>
         ''' <param name="ServiceType"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetService(ServiceType As Type) As Object Implements IPropertyPageSiteInternal.GetService
             Return _wrappedInternalSite.GetService(ServiceType)
         End Function
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="flags"></param>
-        ''' <remarks></remarks>
         Public Sub OnStatusChange(flags As PROPPAGESTATUS) Implements IPropertyPageSiteInternal.OnStatusChange
             ' We do *not* want to propagate this to our internal site - that would cause this change to
             ' be immediately applied, which is not what we want for child (modal) property pages...
@@ -95,7 +81,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Instructs the page site to process a keystroke if it desires.
         ''' </summary>
         ''' <param name="msg"></param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' This function can be called by a property page to give the site a chance to process a message
         '''   before the page does.  Return S_OK to indicate we have handled it, S_FALSE to indicate we did not
@@ -114,8 +99,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Delegate to wrapped undo site.
         ''' </summary>
         ''' <param name="description"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetTransaction(description As String) As ComponentModel.Design.DesignerTransaction Implements IVsProjectDesignerPageSite.GetTransaction
             If _wrappedUndoSite IsNot Nothing Then
                 Return _wrappedUndoSite.GetTransaction(description)
@@ -132,7 +115,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="propertyDescriptor"></param>
         ''' <param name="oldValue"></param>
         ''' <param name="newValue"></param>
-        ''' <remarks></remarks>
         Public Sub OnPropertyChanged(propertyName As String, propertyDescriptor As ComponentModel.PropertyDescriptor, oldValue As Object, newValue As Object) Implements IVsProjectDesignerPageSite.OnPropertyChanged
             If _wrappedUndoSite IsNot Nothing Then
                 _wrappedUndoSite.OnPropertyChanged(MungePropertyName(propertyName), propertyDescriptor, oldValue, newValue)
@@ -145,7 +127,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="propertyName"></param>
         ''' <param name="propertyDescriptor"></param>
-        ''' <remarks></remarks>
         Public Sub OnPropertyChanging(propertyName As String, propertyDescriptor As ComponentModel.PropertyDescriptor) Implements IVsProjectDesignerPageSite.OnPropertyChanging
             If _wrappedUndoSite IsNot Nothing Then
                 _wrappedUndoSite.OnPropertyChanging(MungePropertyName(propertyName), propertyDescriptor)
@@ -158,8 +139,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   property came from.
         ''' </summary>
         ''' <param name="propertyName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MungePropertyName(propertyName As String) As String
             'We need to mark properties as having coming from our hosted page.  We're forwarding undo/redo functionality to the same
             '  undo site (IVsPropertyDesignerPageSite) that handles the parent page, so that we create an undo/redo unit on the

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/ControlDataFlags.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/ControlDataFlags.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 
@@ -7,7 +7,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' <summary>
     ''' Flags which help control the behavior of a PropertyControlData instance.
     ''' </summary>
-    ''' <remarks></remarks>
     <Flags()>
     Public Enum ControlDataFlags
         None = 0                 'No flags

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
@@ -40,7 +40,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     '''   from PropPageUserControlBase).
     ''' It is our internal equivalent of IPropertyPage2.
     ''' </summary>
-    ''' <remarks></remarks>
     <ComVisible(False)>
     Public Interface IPropertyPageInternal
         Sub Apply()
@@ -60,7 +59,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     '''   PropPageUserControlBase, but not useful for those implementing pages without using PropPageUserControlBase).
     ''' It is our internal equivalent of IPropertyPageSite.
     ''' </summary>
-    ''' <remarks></remarks>
     <ComVisible(False)>
     Public Interface IPropertyPageSiteInternal
         Sub OnStatusChange(flags As PROPPAGESTATUS)
@@ -143,7 +141,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Instructs the page site to process a keystroke if it desires.
         ''' </summary>
         ''' <param name="msg"></param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' This function can be called by a property page to give the site a chance to a process a message
         '''   before the page does.  Return S_OK to indicate we have handled it, S_FALSE to indicate we did not
@@ -170,8 +167,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Calls GetService on site first, then on pagesite if service wasn't found
         ''' </summary>
         ''' <param name="ServiceType"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function GetService(ServiceType As Type) As Object Implements IPropertyPageSiteInternal.GetService
             'Proffer the actual IPropertyPageSite as a service
             If ServiceType.Equals(GetType(IPropertyPageSite)) Then
@@ -191,8 +186,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns whether or not the property page hosted in this site should be with 
         '''   immediate-apply mode or not
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property IsImmediateApply() As Boolean Implements IPropertyPageSiteInternal.IsImmediateApply
             Get
                 'Current implementation is always immediate-apply for
@@ -518,7 +511,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Sets the help context into the help service for this property page.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub SetHelpContext()
             If _pageSite IsNot Nothing Then
                 Dim sp As System.IServiceProvider = TryCast(_pageSite, System.IServiceProvider)
@@ -553,7 +545,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' S_OK if the property page handled the accelerator, S_FALSE if the property page handles accelerators, but this one was not useful to it,
         '''   S_NOTIMPL if the property page does not handle accelerators, or E_POINTER if the address in pMsg is not valid. For example, it may be NULL.
         ''' </returns>
-        ''' <remarks></remarks>
         Private Function IPropertyPage2_TranslateAccelerator(pMsg() As MSG) As Integer Implements IPropertyPage2.TranslateAccelerator, IPropertyPage.TranslateAccelerator
             Return TranslateAccelerator(pMsg)
         End Function
@@ -567,7 +558,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' S_OK if the property page handled the accelerator, S_FALSE if the property page handles accelerators, but this one was not useful to it,
         '''   S_NOTIMPL if the property page does not handle accelerators, or E_POINTER if the address in pMsg is not valid. For example, it may be NULL.
         ''' </returns>
-        ''' <remarks></remarks>
         Protected Overridable Function TranslateAccelerator(pMsg() As MSG) As Integer
             If pMsg Is Nothing Then
                 Return NativeMethods.E_POINTER
@@ -686,8 +676,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   use later by Undo and Redo operations.
         ''' </summary>
         ''' <param name="PropertyName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function GetProperty(PropertyName As String) As Object Implements IVsProjectDesignerPage.GetProperty
             Dim Page As IVsProjectDesignerPage = TryCast(_propPage, IVsProjectDesignerPage)
             If Page IsNot Nothing Then
@@ -704,7 +692,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="PropertyName"></param>
         ''' <param name="Value"></param>
-        ''' <remarks></remarks>
         Protected Overridable Sub SetProperty(PropertyName As String, Value As Object) Implements IVsProjectDesignerPage.SetProperty
             Dim Page As IVsProjectDesignerPage = TryCast(_propPage, IVsProjectDesignerPage)
             If (Page IsNot Nothing) Then
@@ -717,7 +704,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Notifies the property page of the IVsProjectDesignerPageSite
         ''' </summary>
         ''' <param name="site"></param>
-        ''' <remarks></remarks>
         Protected Overridable Sub SetSite(site As IVsProjectDesignerPageSite) Implements IVsProjectDesignerPage.SetSite
             Dim Page As IVsProjectDesignerPage = TryCast(_propPage, IVsProjectDesignerPage)
             If Page IsNot Nothing Then
@@ -733,8 +719,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   to SetObjects, but simply whether this property supports multiple-value undo/redo).
         ''' </summary>
         ''' <param name="PropertyName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function SupportsMultipleValueUndo(PropertyName As String) As Boolean Implements IVsProjectDesignerPage.SupportsMultipleValueUndo
             Dim Page As IVsProjectDesignerPage = TryCast(_propPage, IVsProjectDesignerPage)
             If Page IsNot Nothing Then
@@ -756,7 +740,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="Objects">[out] The set of objects (configurations) whose properties should be remembered by Undo</param>
         ''' <param name="Values">[out] The current values of the property for each configuration (corresponding to Objects)</param>
         ''' <returns>True if the property has multiple values to be read.</returns>
-        ''' <remarks></remarks>
         Protected Overridable Function GetPropertyMultipleValues(PropertyName As String, ByRef Objects As Object(), ByRef Values As Object()) As Boolean Implements IVsProjectDesignerPage.GetPropertyMultipleValues
             Dim Page As IVsProjectDesignerPage = TryCast(_propPage, IVsProjectDesignerPage)
             If Page IsNot Nothing Then
@@ -778,7 +761,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="PropertyName"></param>
         ''' <param name="Objects"></param>
         ''' <param name="Values"></param>
-        ''' <remarks></remarks>
         Protected Overridable Sub SetPropertyMultipleValues(PropertyName As String, Objects() As Object, Values() As Object) Implements IVsProjectDesignerPage.SetPropertyMultipleValues
             Dim Page As IVsProjectDesignerPage = TryCast(_propPage, IVsProjectDesignerPage)
             If Page IsNot Nothing Then
@@ -791,7 +773,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Finish all pending validations
         ''' </summary>
         ''' <returns>Return false if validation failed, and the customer wants to fix it (not ignore it)</returns>
-        ''' <remarks></remarks>
         Public Function FinishPendingValidations() As Boolean Implements IVsProjectDesignerPage.FinishPendingValidations
             Dim Page As IVsProjectDesignerPage = TryCast(_propPage, IVsProjectDesignerPage)
             If Page IsNot Nothing Then
@@ -805,7 +786,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Called when the page is activated or deactivated
         ''' </summary>
         ''' <param name="activated"></param>
-        ''' <remarks></remarks>
         Public Sub OnWindowActivated(activated As Boolean) Implements IVsProjectDesignerPage.OnActivated
             Dim Page As IVsProjectDesignerPage = TryCast(_propPage, IVsProjectDesignerPage)
             If Page IsNot Nothing Then
@@ -820,8 +800,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Provides a mechanism for property pages to expose docdatas that need to be saved in the Project Designer
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function GetDocDataCookies() As UInteger() Implements IVsDocDataContainer.GetDocDataCookies
             If TypeOf m_PropPage Is IVsDocDataContainer Then
                 Return DirectCast(m_PropPage, IVsDocDataContainer).GetDocDataCookies()

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageHostDialog.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageHostDialog.vb
@@ -22,8 +22,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Gets the F1 keyword to push into the user context for this property page
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Protected Overrides Property F1Keyword() As String
             Get
                 Dim keyword As String = MyBase.F1Keyword
@@ -169,7 +167,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Constructor.
         ''' </summary>
         ''' <param name="ServiceProvider"></param>
-        ''' <remarks></remarks>
         Public Sub New(ServiceProvider As IServiceProvider, F1Keyword As String)
             MyBase.New(ServiceProvider)
 

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -26,7 +26,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' <summary>
     ''' Base class for managed property pages internal used in VisualStudio
     ''' </summary>
-    ''' <remarks></remarks>
     <ComVisible(False)>
     Public Class PropPageUserControlBase
         Inherits UserControl
@@ -150,7 +149,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Specifies the source or cause of a property change notification
         ''' </summary>
-        ''' <remarks></remarks>
         Public Enum PropertyChangeSource
             Direct    'This property is being changed directly through a PropertyControlData on the page.  Normally should be ignored, the UI will be updated automatically after the change.
             Indirect  'Change was caused indirectly when a PropertyControlData changed a separate property on the page.  For instance, changing the StartupObject property causes the project system to modify several other properties.
@@ -321,7 +319,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         '''  Return a boolean value that indicates whether or not the control supports the color theming service
         ''' </summary>
-        ''' <returns></returns>
         Public Overridable ReadOnly Property SupportsTheming() As Boolean
             Get
                 Return False
@@ -339,7 +336,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   WARNING: It is recommended to turn this off and use AutoScaleMode.Font.
         ''' </summary>
         ''' <value>True if the page should not be scaled automatically</value>
-        ''' <remarks></remarks>
         Protected Property PageRequiresScaling() As Boolean 'CONSIDER: This should be opt-in, not opt-out
             Get
                 Return _pageRequiresScaling
@@ -378,7 +374,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   and keeps the page disabled during break mode.  Once the app stops, the page is set
         '''   to the state requested here.
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Shadows Property Enabled() As Boolean
             Get
                 Return _pageEnabledState
@@ -392,7 +387,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Determines whether the property page is activated
         ''' </summary>
-        ''' <remarks></remarks>
         Protected ReadOnly Property IsActivated() As Boolean
             Get
                 Return _activated
@@ -403,7 +397,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Sets whether the page is actually enabled or disabled, based on the protected Enabled
         '''   property plus internal state, such as whether the project is in run mode.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub SetEnabledState()
             Dim ShouldBeEnabled As Boolean = _pageEnabledState AndAlso _pageEnabledPerDebugMode AndAlso _pageEnabledPerBuildMode AndAlso m_Objects IsNot Nothing
             MyBase.Enabled = ShouldBeEnabled
@@ -449,8 +442,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns the actual site (IPropertyPageSite, rather than IPropertyPageSiteInternal) for the property page
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Protected ReadOnly Property PropertyPageSite() As OLE.Interop.IPropertyPageSite
             Get
                 If _site IsNot Nothing Then
@@ -467,8 +458,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Does a GetService call via the property page site
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Protected ReadOnly Property GetServiceFromPropertyPageSite(ServiceType As Type) As Object
             Get
                 If _site IsNot Nothing Then
@@ -488,7 +477,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Retrieves the object to be used for querying for "common" property values.  The object
         '''   used may vary, depending on the project type and what it supports.
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' See "About 'common' properties" in PropertyControlData for information on "common" properties.
         ''' </remarks>
@@ -515,7 +503,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   passed in to the page through SetObjects.  However, it may be modified by subclasses to contain a superset
         '''   or subset for special purposes.
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Function RawPropertiesObjects(Data As PropertyControlData) As Object()
             Return Data.RawPropertiesObjects
         End Function
@@ -526,7 +513,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   based on the set of objects passed in to the page through SetObjects.  However, it may be modified by subclasses to 
         '''   contain a superset or subset for special purposes.
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Function ExtendedPropertiesObjects(Data As PropertyControlData) As Object()
             Return Data.ExtendedPropertiesObjects
         End Function
@@ -536,8 +522,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' True iff this property page is configuration-specific (like the compile page) instead of
         '''   configuration-independent (like the application pages)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property IsConfigurationSpecificPage() As Boolean
             Get
                 Return _fConfigurationSpecificPage
@@ -550,7 +534,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   ResumePropertyChangeListening calls have been made
         ''' </summary>
         ''' <param name="DispId">The DISPID to ignore changes from.  If DISPID_UNKNOWN, then all property changes will be ignored.</param>
-        ''' <remarks></remarks>
         Public Sub SuspendPropertyChangeListening(DispId As Integer)
             _suspendPropertyChangeListeningDispIds.Add(DispId)
         End Sub
@@ -560,7 +543,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Causes listening to property changes to be resumed after an equal number of
         '''   SuspendPropertyChangeListening/ResumeropertyChangeListening pairs have been made
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub ResumePropertyChangeListening(DispId As Integer)
             _suspendPropertyChangeListeningDispIds.Remove(DispId)
             CheckPlayCachedPropertyChanges()
@@ -570,8 +552,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns true if any property on the current page is currently being changed.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function PropertyOnPageBeingChanged() As Boolean
             Return _suspendPropertyChangeListeningDispIds.Count > 0
         End Function
@@ -580,7 +560,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Gets the list of all raw properties objects from all properties hosted on this page
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' This may be a superset of the objects passed in to SetObjects because some properties can override their
         '''   behavior and display a different set of objects.  These are cached after the first call and not updated
@@ -620,7 +599,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="dispid">The property's DISPID to look up.</param>
         ''' <param name="obj">[out] Returns the property's value, if found.</param>
         ''' <returns>True on success and False if the property is not found.</returns>
-        ''' <remarks></remarks>
         Protected Overridable Function GetProperty(dispid As Integer, ByRef obj As Object) As Boolean
             obj = Nothing
             For Each _controlData As PropertyControlData In ControlData
@@ -649,7 +627,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="PropertyName">The property name of the property to search for.  Required for a common properties
         '''   look-up if this property is not defined as a PropertyControlData on the calling page.  Otherwise it's optional.</param>
         ''' <param name="obj"></param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' The property name and DISPIDs must both refer to the same property.
         ''' </remarks>
@@ -706,7 +683,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Restore the control's current value from the InitialValue (used when the user cancels the dialog)
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overridable Sub RestoreInitialValues()
             Dim InsideInitSave As Boolean = m_fInsideInit
             m_fInsideInit = True
@@ -726,7 +702,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Updates all properties so that they refresh their UI from the property
         '''   store's current values
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overridable Sub RefreshPropertyValues()
             Common.Switches.TracePDProperties(TraceLevel.Warning, "*** [" & [GetType].Name & "] Refreshing all property values")
 
@@ -746,7 +721,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Indicates if the user has selected multiple projects in the Solution Explorer
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>When the user selects multiple projects, certain functionality is disabled</remarks>
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Public ReadOnly Property MultiProjectSelect() As Boolean
@@ -754,12 +728,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Return _multiProjectSelect
             End Get
         End Property
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Protected ReadOnly Property ServiceProvider() As ServiceProvider
             Get
@@ -784,8 +752,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns the DTE object associated with the objects passed to SetObjects.  If there is none, returns Nothing.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Protected ReadOnly Property DTE() As EnvDTE.DTE
             Get
@@ -796,8 +762,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns the EnvDTE.Project object associated with the objects passed to SetObjects.  If there is none, returns Nothing.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Public ReadOnly Property DTEProject() As EnvDTE.Project
             Get
@@ -810,8 +774,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   common project properties in these types of projects.  Should only be used if you are certain of the
         '''   project type.  Otherwise, use CommonPropertiesObject.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Public ReadOnly Property ProjectProperties() As VSLangProj.ProjectProperties
             Get
@@ -850,7 +812,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''  to interpret it as meaning that the project file was checked out and updated, causing a project
         '''  reload.
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Sub EnterProjectCheckoutSection()
             Debug.Assert(_checkoutSectionCount >= 0, "Bad m_CheckoutCriticalSectionCount count")
             _checkoutSectionCount += 1
@@ -883,7 +844,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''    LeaveProjectCheckoutSection()
         '''  End Try
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Sub LeaveProjectCheckoutSection()
             _checkoutSectionCount -= 1
             Debug.Assert(_checkoutSectionCount >= 0, "Mismatched EnterProjectCheckoutSection/LeaveProjectCheckoutSection calls")
@@ -906,9 +866,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' If true, the project has been reloaded between a call to EnterProjectCheckoutSection and 
         '''   LeaveProjectCheckoutSection.  See EnterProjectCheckoutSection() for more information.
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public ReadOnly Property ProjectReloadedDuringCheckout() As Boolean
             Get
                 Return _projectReloadedDuringCheckout
@@ -920,7 +877,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' If true, a call to EnterProjectCheckoutSection has been made, and the matching LeaveProjectCheckoutSection
         '''   call has not yet been made.
         ''' </summary>
-        ''' <remarks></remarks>
         Protected ReadOnly Property IsInProjectCheckoutSection() As Boolean
             Get
                 Return _checkoutSectionCount > 0
@@ -932,7 +888,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Called in a delayed fashion (via PostMessage) after a LeaveProjectCheckoutSection call if the
         '''   project was forcibly reloaded during the project checkout section.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub DelayedDispose()
             'Set this flag back to false so that subclasses which override Dispose() know when it's
             '  safe to Dispose of their controls.
@@ -945,7 +900,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Checks out the project file.  After calling this function, the caller should check
         '''   the ProjectReloaded flag and exit if it's true.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub CheckoutProjectFile(ByRef ProjectReloaded As Boolean)
             Dim SccManager As New AppDesDesignerFramework.SourceCodeControlManager(ServiceProvider, ProjectHierarchy)
             EnterProjectCheckoutSection()
@@ -975,8 +929,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Provides keyword for help system lookup.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function GetF1HelpKeyword() As String
             Return Nothing
         End Function
@@ -985,7 +937,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Implements IPropertyPageInternal.Help
         ''' </summary>
         ''' <param name="HelpDir">Not used.</param>
-        ''' <remarks></remarks>
         Private Sub IProperyPageInternal_Help(HelpDir As String) Implements IPropertyPageInternal.Help
             AppDesDesignerFramework.DesignUtil.DisplayTopicFromF1Keyword(ServiceProvider, GetF1HelpKeyword)
         End Sub
@@ -994,16 +945,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Brings up help for the given help topic
         ''' </summary>
         ''' <param name="HelpTopic">The help string that identifiers the help topic.</param>
-        ''' <remarks></remarks>
         Public Overridable Sub Help(HelpTopic As String)
             AppDesDesignerFramework.DesignUtil.DisplayTopicFromF1Keyword(ServiceProvider, HelpTopic)
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function IsPageDirty() As Boolean Implements IPropertyPageInternal.IsPageDirty
 
             If IsDirty Then
@@ -1023,7 +967,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Removes references to anything that was passed in to SetObjects
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overridable Sub CleanupCOMReferences()
             Dim i As Integer
 
@@ -1058,12 +1001,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 page.SetObjects(Nothing)
             Next page
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="objects"></param>
-        ''' <remarks></remarks>
         Private Sub CheckMultipleProjectsSelected(objects() As Object)
             If objects Is Nothing OrElse objects.Length <= 1 Then
                 'Cannot be multiple projects
@@ -1085,8 +1023,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Given a project Object, retrieves the hierarchy
         ''' </summary>
         ''' <param name="ThisObj"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GetProjectHierarchyFromObject(ThisObj As Object) As IVsHierarchy
 
             Dim Hier As IVsHierarchy = Nothing
@@ -1125,7 +1061,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="DebugMessage">The message to be printed first to trace output.</param>
         ''' <param name="Properties">The properties to print to trace output.</param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Private Shared Sub TraceTypeDescriptorCollection(DebugMessage As String, Properties As PropertyDescriptorCollection)
 #If DEBUG Then
@@ -1139,13 +1074,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
 #End If
         End Sub
-
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="site"></param>
-        ''' <remarks></remarks>
         Private Sub SetPageSite(site As IPropertyPageSiteInternal) Implements IPropertyPageInternal.SetPageSite
             DisconnectDebuggerEvents()
             _site = site
@@ -1177,15 +1106,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Called when the property page's IPropertyPageSite is set.
         ''' </summary>
         ''' <param name="site"></param>
-        ''' <remarks></remarks>
         Protected Overridable Sub OnSetSite(site As OLE.Interop.IPropertyPageSite)
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="dispid"></param>
-        ''' <remarks></remarks>
         Protected Overridable Sub EditProperty(dispid As Integer) Implements IPropertyPageInternal.EditProperty
             Dim cntrl As Control = GetPropertyControl(dispid)
             If cntrl IsNot Nothing Then
@@ -1403,11 +1326,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 
 #Region "Control event handlers for derived form"
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
-        ''' <remarks></remarks>
         Protected Sub AddChangeHandlers()
 
             For Each _controlData As PropertyControlData In ControlData
@@ -1425,8 +1343,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Looks up a control on this page by numeric id and returns it, if found, else returns Nothing.
         ''' </summary>
         ''' <param name="PropertyId"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function GetPropertyControl(PropertyId As Integer) As Control
             For Each ControlData As PropertyControlData In Me.ControlData
                 If ControlData.DispId = PropertyId Then
@@ -1442,7 +1358,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Looks up a PropertyControlData on this page by numeric id and returns it, if found, else returns Nothing.
         ''' </summary>
         ''' <param name="PropertyId"></param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' Whether the PropertyControlData is found or not does not depend on whether the associated property
         '''   is found in the project system or not, but just on whether the PropertyControlData object was
@@ -1489,7 +1404,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' List of PropertyControlData structures which the base class uses
         ''' to read and write property values and initialize the UI.
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>This should normally be overridden in the derived class to provide the page's specific list of
         '''   PropertyControlData.  No need to call the base's default version.
         ''' </remarks>
@@ -1511,8 +1425,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Return a control group which contains the control, return -1 when we can not find one
         ''' </summary>
         ''' <param name="dataControl"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function FindControlGroup(dataControl As Control) As Integer
             Dim group As Control()() = ValidationControlGroups
             If group IsNot Nothing Then
@@ -1532,8 +1444,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Check whether the focus is still in the control group
         ''' </summary>
         ''' <param name="groupID"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function IsFocusInControlGroup(groupID As Integer) As Boolean
             Dim controlList As Control() = ValidationControlGroups(groupID)
             For Each c As Control In controlList
@@ -1548,7 +1458,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' ignore validating one control, it will be removed from delay-validation list
         ''' </summary>
         ''' <param name="dataControl"></param>
-        ''' <remarks></remarks>
         Protected Sub SkipValidating(dataControl As Control)
             If _delayValidationQueue IsNot Nothing Then
                 For Each item As PropertyControlData In ControlData
@@ -1564,7 +1473,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' add a control to the delay-validation list
         ''' </summary>
         ''' <param name="dataControl"></param>
-        ''' <remarks></remarks>
         Protected Sub DelayValidate(dataControl As Control)
             Dim controlGroup As Integer = FindControlGroup(dataControl)
             Debug.Assert(controlGroup >= 0, "The control doesn't belong to a group?")
@@ -1585,7 +1493,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="controlGroup"></param>
         ''' <param name="items"></param>
-        ''' <remarks></remarks>
         Private Sub DelayValidate(controlGroup As Integer, items As ArrayList)
             Dim oldItems As ListDictionary = Nothing
             If _delayValidationGroup < 0 Then
@@ -1623,7 +1530,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="canThrow"></param>
         ''' <returns>return false if the validation failed</returns>
-        ''' <remarks></remarks>
         Protected Function ProcessDelayValidationQueue(canThrow As Boolean) As Boolean
             Dim oldItems As ListDictionary = _delayValidationQueue
 
@@ -1702,7 +1608,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Add event handler to monitor focus
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub HookDelayValidationEvents()
             Dim controlList As Control() = ValidationControlGroups(_delayValidationGroup)
             For Each c As Control In controlList
@@ -1713,7 +1618,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' remove event handler to monitor focus
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub UnhookDelayValidationEvents()
             Dim controlList As Control() = ValidationControlGroups(_delayValidationGroup)
             For Each c As Control In controlList
@@ -1724,7 +1628,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' the event handler to handle focus leaving
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub OnLeavingControlGroup(sender As Object, e As EventArgs)
             PostValidation()
         End Sub
@@ -1732,7 +1635,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Post a message to start validation
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub PostValidation()
             ' NOTE: We always post the message, but start validation only the focus is really out.
             ' We delay check this, so we don't get into the problem when winForm hasn't sync status correctly, which IS a problem in some cases (tab).
@@ -1826,7 +1728,6 @@ NextControl:
         ''' <param name="controlData"></param>
         ''' <param name="message"></param>
         ''' <param name="returnControl"></param>
-        ''' <returns></returns>
         ''' <remarks>Different pages should override it to do the validation</remarks>
         Protected Overridable Function ValidateProperty(controlData As PropertyControlData, ByRef message As String, ByRef returnControl As Control) As ValidationResult
             Return ValidationResult.Succeeded
@@ -1836,7 +1737,6 @@ NextControl:
         ''' <summary>
         ''' Attempts to check out the files which are necessary in order to apply the currently-dirty properties
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub CheckOutFilesForApply()
             Dim Control As Control = Nothing 'The control which caused the exception, if known\
             Dim FirstDirtyControl As Control = Nothing 'The first dirty control
@@ -2224,8 +2124,6 @@ NextControl:
         ''' Get a localized name for the undo transaction.  This name appears in the
         '''   Undo/Redo history dropdown in Visual Studio.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overridable Function GetTransactionDescription() As String
             Dim Description As String
             Dim PropertyNames As String = Nothing
@@ -2276,7 +2174,6 @@ NextControl:
         ''' </summary>
         ''' <param name="PropertyName"></param>
         ''' <param name="PropDesc"></param>
-        ''' <remarks></remarks>
         Public Overridable Sub OnPropertyChanging(PropertyName As String, PropDesc As PropertyDescriptor)
             If _propPageUndoSite IsNot Nothing Then
                 _propPageUndoSite.OnPropertyChanging(PropertyName, PropDesc)
@@ -2291,7 +2188,6 @@ NextControl:
         '''   DTE manipulation by other code).  Required for Undo/Redo support.
         ''' </summary>
         ''' <param name="PropertyName"></param>
-        ''' <remarks></remarks>
         Public Overridable Sub OnPropertyChanged(PropertyName As String, PropDesc As PropertyDescriptor, OldValue As Object, NewValue As Object)
             If _propPageUndoSite IsNot Nothing Then
                 _propPageUndoSite.OnPropertyChanged(PropertyName, PropDesc, OldValue, NewValue)
@@ -2316,7 +2212,6 @@ NextControl:
         ''' Called by ApplyChanges after property values have been updated, 
         ''' but before ILangPropertyProvideBatchUpdate.EndBatch.
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overridable Sub PostApplyPageChanges()
 
         End Sub
@@ -2378,7 +2273,6 @@ NextControl:
         ''' </summary>
         ''' <param name="PropertyName">Name of the property requested.</param>
         ''' <returns>The PropertyDescriptor for the property.</returns>
-        ''' <remarks></remarks>
         Protected Function GetPropertyDescriptor(PropertyName As String) As PropertyDescriptor
             Dim d = m_ObjectsPropertyDescriptorsArray(0)(PropertyName)
 
@@ -2403,7 +2297,6 @@ NextControl:
         ''' Returns the PropertyDescriptor of a common property using the name of the property
         ''' </summary>
         ''' <param name="PropertyName"></param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' See "About 'common' properties" in PropertyControlData for information on "common" properties.
         ''' </remarks>
@@ -2417,7 +2310,6 @@ NextControl:
         '''   control on the property page as it has been edited by the user).
         ''' No type conversion is performed on the return value.
         ''' </summary>
-        ''' <returns></returns>
         ''' <remarks>
         ''' Must be a common property.
         ''' See "About 'common' properties" in PropertyControlData for information on "common" properties.
@@ -2438,7 +2330,6 @@ NextControl:
         '''   control on the property page as it has been edited by the user).
         ''' No type conversion is performed on the return value.
         ''' </summary>
-        ''' <returns></returns>
         ''' <remarks>
         ''' This must be a common property.
         ''' See "About 'common' properties" in PropertyControlData for information on "common" properties.
@@ -2453,7 +2344,6 @@ NextControl:
         '''   in the control on the property page as it has been edited by the user).
         ''' The value retrieved is converted using the property's type converter.
         ''' </summary>
-        ''' <returns></returns>
         ''' <remarks>
         ''' Must be a common property.
         ''' See "About 'common' properties" in PropertyControlData for information on "common" properties.
@@ -2468,7 +2358,6 @@ NextControl:
         '''   in the control on the property page as it has been edited by the user).
         ''' The value retrieved is converted using the property's type converter.
         ''' </summary>
-        ''' <returns></returns>
         ''' <remarks>
         ''' Must be a common property.
         ''' See "About 'common' properties" in PropertyControlData for information on "common" properties.
@@ -2553,8 +2442,6 @@ NextControl:
         ''' Gets the current value of the given property in the UI
         ''' </summary>
         ''' <param name="name"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function GetControlValue(name As String) As Object
             Dim pcd As PropertyControlData = GetPropertyControlData(name)
             Return pcd.GetControlValue()
@@ -2565,8 +2452,6 @@ NextControl:
         '''   perform any type conversions.
         ''' </summary>
         ''' <param name="name"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function GetControlValueNative(name As String) As Object
             Dim pcd As PropertyControlData = GetPropertyControlData(name)
             Return pcd.GetControlValueNative()
@@ -2579,8 +2464,6 @@ NextControl:
         '''   PropertyControlData.MissingProperty is returned.
         ''' </summary>
         ''' <param name="Descriptor">The property descriptor for the property to get the value from</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function TryGetNonCommonPropertyValue(Descriptor As PropertyDescriptor) As Object
             Dim extenders As Object() = m_ExtendedObjects
             Return PropertyControlData.TryGetNonCommonPropertyValueNative(Descriptor, extenders)
@@ -2594,7 +2477,6 @@ NextControl:
         '''   changes will be applied later when requested.
         ''' </summary>
         ''' <param name="sender"></param>
-        ''' <remarks></remarks>
         Protected Sub ApplyChanges(sender As Object)
             If m_fInsideInit Then
                 Return
@@ -2630,7 +2512,6 @@ NextControl:
         '''   dirty, only the last SetDirty() call should pass in True for ReadyToApply.  Doing it this way will cause all of the properties
         '''   to be changed in the same undo/redo transaction (apply batches up all current changes into a single transaction).
         ''' </param>
-        ''' <remarks></remarks>
         Public Sub SetDirty(ReadyToApply As Boolean)
             If m_fInsideInit Then
                 Return
@@ -2660,7 +2541,6 @@ NextControl:
         '''   dirty, only the last SetDirty() call should pass in True for ReadyToApply.  Doing it this way will cause all of the properties
         '''   to be changed in the same undo/redo transaction (apply batches up all current changes into a single transaction).
         ''' </param>
-        ''' <remarks></remarks>
         Public Sub SetDirty(sender As Object, ReadyToApply As Boolean)
             If m_fInsideInit Then
                 Return
@@ -2729,7 +2609,6 @@ NextControl:
         '''   dirty, only the last SetDirty() call should pass in True for ReadyToApply.  Doing it this way will cause all of the properties
         '''   to be changed in the same undo/redo transaction (apply batches up all current changes into a single transaction).
         ''' </param>
-        ''' <remarks></remarks>
         Protected Sub SetDirty(dispid As Integer, ReadyToApply As Boolean)
             If m_fInsideInit Then
                 Return
@@ -2757,8 +2636,6 @@ NextControl:
         ''' Returns whether the property associated with the given control has been dirtied.
         ''' </summary>
         ''' <param name="sender"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function GetDirty(sender As Object) As Boolean
             Debug.Assert(TypeOf sender Is Control, "Unexpected object type")
 
@@ -2776,7 +2653,6 @@ NextControl:
         ''' <summary>
         ''' Clears the dirty bit for all properties on this page
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Sub ClearIsDirty()
             IsDirty = False
             For Each _controlData As PropertyControlData In ControlData
@@ -2788,8 +2664,6 @@ NextControl:
         ''' <summary>
         ''' Returns true iff any property on this page is dirty
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function IsAnyPropertyDirty() As Boolean
             For Each _controlData As PropertyControlData In ControlData
                 If _controlData.IsDirty Then
@@ -2803,7 +2677,6 @@ NextControl:
         ''' Enables or disables all controls associated with properties on this page.  The default implementation
         '''   uses the information already in the PropertyControlData for the page.
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overridable Sub EnableAllControls(enabled As Boolean)
             For Each _controlData As PropertyControlData In ControlData
                 _controlData.EnableControls(enabled)
@@ -2813,7 +2686,6 @@ NextControl:
         ''' <summary>
         ''' Calls Initialize on all PropertyControlData for this page
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Sub InitializeAllProperties()
 #If DEBUG Then
             'Verify that PropertyControlData DISPIDs are unique
@@ -2836,7 +2708,6 @@ NextControl:
         ''' Override this method to return a property descriptor for user-defined properties in a page.
         ''' </summary>
         ''' <param name="PropertyName">The property to return a property descriptor for.</param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' This method must be overridden to handle all user-defined properties defined in a page.  The easiest way to implement
         '''   this is to return a new instance of the UserPropertyDescriptor class, which was created for that purpose.
@@ -2850,8 +2721,6 @@ NextControl:
         ''' </summary>
         ''' <param name="PropertyName"></param>
         ''' <param name="Value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overridable Function ReadUserDefinedProperty(PropertyName As String, ByRef Value As Object) As Boolean
             Return False
         End Function
@@ -2861,8 +2730,6 @@ NextControl:
         ''' </summary>
         ''' <param name="PropertyName"></param>
         ''' <param name="Value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overridable Function WriteUserDefinedProperty(PropertyName As String, Value As Object) As Boolean
             Return False
         End Function
@@ -2879,8 +2746,6 @@ NextControl:
         ''' <summary>
         ''' Indicates whether this property page is dirty or not.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         <Browsable(False)>
         Public Property IsDirty() As Boolean
             Get
@@ -2915,7 +2780,6 @@ NextControl:
         ''' Use to display Error message through the VSShellService
         ''' </summary>
         ''' <param name="ex">The exception to get the error message from</param>
-        ''' <remarks></remarks>
         Public Sub ShowErrorMessage(ex As Exception)
             ShowErrorMessage(ex, ex.HelpLink)
         End Sub
@@ -2925,7 +2789,6 @@ NextControl:
         ''' </summary>
         ''' <param name="ex">The exception to get the error message from</param>
         ''' <param name="HelpLink">The help link to use</param>
-        ''' <remarks></remarks>
         Protected Sub ShowErrorMessage(ex As Exception, HelpLink As String)
             Dim Caption As String = My.Resources.Designer.APPDES_Title
             AppDesDesignerFramework.DesignerMessageBox.Show(ServiceProvider, "", ex, Caption, HelpLink)
@@ -2935,7 +2798,6 @@ NextControl:
         ''' Use to display Error message through the VSShellService
         ''' </summary>
         ''' <param name="errorMessage">The error message to display</param>
-        ''' <remarks></remarks>
         Protected Sub ShowErrorMessage(errorMessage As String)
             ShowErrorMessage(errorMessage, "")
         End Sub
@@ -2945,7 +2807,6 @@ NextControl:
         ''' </summary>
         ''' <param name="errorMessage">The error message to display</param>
         ''' <param name="ex">The exception to include in the message.  The exception's message will be on a second line after errorMessage.</param>
-        ''' <remarks></remarks>
         Protected Sub ShowErrorMessage(errorMessage As String, ex As Exception)
             Dim Caption As String = My.Resources.Designer.APPDES_Title
             AppDesDesignerFramework.DesignerMessageBox.Show(ServiceProvider, errorMessage, ex, Caption)
@@ -2956,17 +2817,10 @@ NextControl:
         ''' </summary>
         ''' <param name="errorMessage">The error message to display</param>
         ''' <param name="HelpLink">The help link to use</param>
-        ''' <remarks></remarks>
         Protected Sub ShowErrorMessage(errorMessage As String, HelpLink As String)
             Dim Caption As String = My.Resources.Designer.APPDES_Title
             AppDesDesignerFramework.DesignerMessageBox.Show(ServiceProvider, errorMessage, Caption, MessageBoxButtons.OK, MessageBoxIcon.Error, MessageBoxDefaultButton.Button1, HelpLink)
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         <Browsable(False),
         DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Protected ReadOnly Property VsUIShellService() As IVsUIShell
@@ -2977,12 +2831,6 @@ NextControl:
                 Return _uiShellService
             End Get
         End Property
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         <Browsable(False),
         DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Protected ReadOnly Property VsUIShell2Service() As IVsUIShell2
@@ -3001,12 +2849,6 @@ NextControl:
                 Return _uiShell2Service
             End Get
         End Property
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Protected ReadOnly Property VsUIShell5Service() As IVsUIShell5
             Get
                 If (_uiShell5Service Is Nothing) Then
@@ -3028,7 +2870,6 @@ NextControl:
         ''' Adds the given file to the project
         ''' </summary>
         ''' <param name="FileName">Full path to the file to add</param>
-        ''' <remarks></remarks>
         Protected Overloads Function AddFileToProject(FileName As String) As EnvDTE.ProjectItem
             Return AddFileToProject(FileName, True)
         End Function
@@ -3038,7 +2879,6 @@ NextControl:
         ''' </summary>
         ''' <param name="FileName">Full path to the file to add</param>
         ''' <param name="CopyFile">If true, the file is copied to the project using DTEProject.AddFromFileCopy, otherwise DTEProject.AddFromFile is used</param>
-        ''' <remarks></remarks>
         Protected Overloads Function AddFileToProject(FileName As String, CopyFile As Boolean) As EnvDTE.ProjectItem
             Dim ProjectItems As EnvDTE.ProjectItems = DTEProject.ProjectItems
             Return AddFileToProject(DTEProject.ProjectItems, FileName, CopyFile)
@@ -3095,8 +2935,6 @@ NextControl:
         ''' Returns the PropPageHostDialog that is hosting the given page.
         ''' </summary>
         ''' <param name="ChildPage"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GetPropPageHostDialog(ChildPage As PropPageUserControlBase) As PropPageHostDialog
             Return TryCast(ChildPage.ParentForm, PropPageHostDialog)
         End Function
@@ -3107,7 +2945,6 @@ NextControl:
         ''' <param name="title">Title to be shown for the property page.</param>
         ''' <param name="PageType">Type of property page class to be instantiated.</param>
         ''' <returns>DialogResult returned from the host dialog.</returns>
-        ''' <remarks></remarks>
         Protected Function ShowChildPage(Title As String, PageType As Type) As DialogResult
             Return ShowChildPage(Title, PageType, Nothing)
         End Function
@@ -3119,7 +2956,6 @@ NextControl:
         ''' <param name="PageType">Type of property page class to be instantiated.</param>
         ''' <param name="F1Keyword">Help keyword.  If empty or Nothing, the property page itself will be queried for the help topic.</param>
         ''' <returns>DialogResult returned from the host dialog.</returns>
-        ''' <remarks></remarks>
         Protected Function ShowChildPage(Title As String, PageType As Type, F1Keyword As String) As DialogResult
             Dim Page As PropPageUserControlBase
 
@@ -3199,7 +3035,6 @@ NextControl:
         ''' <param name="DialogTitle">The title to use for the browse dialog.</param>
         ''' <param name="NewValue">The newly-selected directory, relative to the project directory, if True was returned.  Always returned with a backslash at the end.</param>
         ''' <returns>True if the user selected a directory, otherwise False.</returns>
-        ''' <remarks></remarks>
         Protected Function GetDirectoryViaBrowseRelativeToProject(InitialDirectory As String, DialogTitle As String, ByRef NewValue As String) As Boolean
             Return GetDirectoryViaBrowseRelative(InitialDirectory, GetProjectPath(), DialogTitle, NewValue)
         End Function
@@ -3212,7 +3047,6 @@ NextControl:
         ''' <param name="DialogTitle">The title to use for the browse dialog.</param>
         ''' <param name="NewRelativePath">The newly-selected directory, relative to BasePath, if True was returned.  Always returned with a backslash at the end.</param>
         ''' <returns>True if the user selected a directory, otherwise False.</returns>
-        ''' <remarks></remarks>
         Protected Function GetDirectoryViaBrowseRelative(RelativeInitialDirectory As String, BasePath As String, DialogTitle As String, ByRef NewRelativePath As String) As Boolean
             RelativeInitialDirectory = Trim(RelativeInitialDirectory)
             BasePath = Trim(BasePath)
@@ -3242,7 +3076,6 @@ NextControl:
         ''' <param name="DialogTitle">The title to use for the browse dialog.</param>
         ''' <param name="NewValue">The newly-selected directory, if True was returned.  Always returned with a backslash at the end.</param>
         ''' <returns>True if the user selected a directory, otherwise False.</returns>
-        ''' <remarks></remarks>
         Protected Function GetDirectoryViaBrowse(InitialDirectory As String, DialogTitle As String, ByRef NewValue As String) As Boolean
             Dim Success As Boolean
 
@@ -3322,7 +3155,6 @@ NextControl:
         ''' <param name="NewValue">The newly-selected file, if True was returned.</param>
         ''' <param name="Filter"></param>
         ''' <returns>True if the user selected a file, otherwise False.</returns>
-        ''' <remarks></remarks>
         Protected Function GetFileViaBrowse(InitialDirectory As String, ByRef NewValue As String, Filter As String) As Boolean
             Dim fileNames As ArrayList = Common.GetFilesViaBrowse(ServiceProvider, Handle, InitialDirectory, My.Resources.Designer.PPG_SelectFileTitle, Filter, 0, False)
             If fileNames IsNot Nothing AndAlso fileNames.Count = 1 Then
@@ -3336,8 +3168,6 @@ NextControl:
         ''' <summary>
         ''' Gets the project's path
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function GetProjectPath() As String
             Return CStr(GetCommonPropertyValueNative("FullPath")) 'CONSIDER: This won't work for all project types, e.g. ASP.NET when project path is a URL
         End Function
@@ -3346,8 +3176,6 @@ NextControl:
         ''' Returns a project-relative path, given an absolute path.
         ''' </summary>
         ''' <param name="DirectoryPath">File or Directory path to make relative</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function GetProjectRelativeDirectoryPath(DirectoryPath As String) As String
             Return GetRelativeDirectoryPath(GetProjectPath(), DirectoryPath)
         End Function
@@ -3356,8 +3184,6 @@ NextControl:
         ''' Returns a project-relative path to a file, given an absolute path.
         ''' </summary>
         ''' <param name="FilePath">File or Directory path to make relative</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function GetProjectRelativeFilePath(FilePath As String) As String
             Return GetRelativeFilePath(GetProjectPath(), FilePath)
         End Function
@@ -3370,8 +3196,6 @@ NextControl:
         ''' </summary>
         ''' <param name="BasePath">The base path (with or without backslash at the end)</param>
         ''' <param name="DirectoryPath">The full path to the directory (with or without backslash at the end)</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function GetRelativeDirectoryPath(BasePath As String, DirectoryPath As String) As String
             Dim RelativePath As String = ""
 
@@ -3408,8 +3232,6 @@ NextControl:
         ''' </summary>
         ''' <param name="BasePath">The base path.</param>
         ''' <param name="FilePath">The full path.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function GetRelativeFilePath(BasePath As String, FilePath As String) As String
             Debug.Assert(VB.Right(FilePath, 1) <> Path.DirectorySeparatorChar AndAlso VB.Right(FilePath, 1) <> Path.AltDirectorySeparatorChar, "Passed in a directory instead of a file to RelativeFilePath")
 
@@ -3434,7 +3256,6 @@ NextControl:
         ''' If there is a DTEProject associated with the objects passed in to SetObjects, returns the kind of project
         '''   that it is (a GUID as a string).  Otherwise, returns empty string.
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' Don't cache this as it can change with a SetObjects call.
         ''' </remarks>
@@ -3453,7 +3274,6 @@ NextControl:
         ''' If there is a DTEProject associated with the objects passed in to SetObjects, returns the language of project
         '''   that it is (a GUID as a string).  Otherwise, returns empty string.
         ''' </summary>
-        ''' <value></value>
         Protected ReadOnly Property ProjectLanguage() As String
             Get
                 Debug.Assert(_dteProject IsNot Nothing, "Can't get ProjectLanguage because DTEProject not available")
@@ -3470,8 +3290,6 @@ NextControl:
         ''' <summary>
         ''' Returns True iff the project associated with the properties being displayed is a VB project.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function IsVBProject() As Boolean
             Return String.Equals(ProjectLanguage, EnvDTE.CodeModelLanguageConstants.vsCMLanguageVB, StringComparison.OrdinalIgnoreCase)
         End Function
@@ -3479,8 +3297,6 @@ NextControl:
         ''' <summary>
         ''' Returns True iff the project associated with the properties being displayed is a C# project.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function IsCSProject() As Boolean
             Return String.Equals(ProjectLanguage, EnvDTE.CodeModelLanguageConstants.vsCMLanguageCSharp, StringComparison.OrdinalIgnoreCase)
         End Function
@@ -3505,7 +3321,6 @@ NextControl:
         ''' </summary>
         ''' <param name="EncodedPropertyName">The property name to search, which may contain a prefix indicating it
         '''   should be found in a child page.</param>
-        ''' <returns></returns>
         ''' <remarks>See the ChildPageSite class for more information.</remarks>
         Private Function GetNestedPropertyControlData(EncodedPropertyName As String) As PropertyControlData
             If EncodedPropertyName Is Nothing Then
@@ -3534,8 +3349,6 @@ NextControl:
         '''   use later by Undo and Redo operations.
         ''' </summary>
         ''' <param name="PropertyName">The name of the property whose current value is being queried.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function IVsProjectDesignerPage_GetPropertyValue(PropertyName As String) As Object Implements IVsProjectDesignerPage.GetProperty
             'Return the last saved value, not the current edit
             Dim Data As PropertyControlData = GetNestedPropertyControlData(PropertyName)
@@ -3585,7 +3398,6 @@ NextControl:
         ''' </summary>
         ''' <param name="PropertyName">The name of the property whose current value should be changed.</param>
         ''' <param name="Value">The value to set into the given property.</param>
-        ''' <remarks></remarks>
         Protected Overridable Sub IVsProjectDesignerPage_SetPropertyValue(PropertyName As String, Value As Object) Implements IVsProjectDesignerPage.SetProperty
             Debug.Assert(Not PropertyControlData.IsSpecialValue(Value))
             Dim _ControlData As PropertyControlData = GetNestedPropertyControlData(PropertyName)
@@ -3612,8 +3424,6 @@ NextControl:
         '''   to SetObjects, but simply whether this property supports multiple-value undo/redo).
         ''' </summary>
         ''' <param name="PropertyName">The name of the property.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function IVsProjectDesignerPage_SupportsMultipleValueUndo(PropertyName As String) As Boolean Implements IVsProjectDesignerPage.SupportsMultipleValueUndo
             Dim Data As PropertyControlData = GetNestedPropertyControlData(PropertyName)
             If Data Is Nothing Then
@@ -3632,8 +3442,6 @@ NextControl:
         '''   to SetObjects, but simply whether this property supports multiple-value undo/redo).
         ''' </summary>
         ''' <param name="Data">The PropertyControlData to check for support.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function SupportsMultipleValueUndo(Data As PropertyControlData) As Boolean
             If Data Is Nothing Then
                 Throw New ArgumentNullException
@@ -3654,7 +3462,6 @@ NextControl:
         ''' <param name="Objects">[out] The set of objects (configurations) whose properties should be remembered by Undo</param>
         ''' <param name="Values">[out] The current values of the property for each configuration (corresponding to Objects)</param>
         ''' <returns>True if the property has multiple values to be read.</returns>
-        ''' <remarks></remarks>
         Protected Overridable Function IVsProjectDesignerPage_GetPropertyMultipleValues(PropertyName As String, ByRef Objects As Object(), ByRef Values As Object()) As Boolean Implements IVsProjectDesignerPage.GetPropertyMultipleValues
             Dim Data As PropertyControlData = GetNestedPropertyControlData(PropertyName)
             If Data Is Nothing OrElse Data.IsMissing Then
@@ -3688,7 +3495,6 @@ NextControl:
         ''' <param name="propertyName">The name of the property whose values (across multiple configurations) should be changed.</param>
         ''' <param name="objects">The set of objects (configurations) which should have their value changed for the given property.</param>
         ''' <param name="values">The set of new values which correspond to the set of objects passed in.</param>
-        ''' <remarks></remarks>
         Protected Overridable Sub IVsProjectDesignerPage_SetPropertyValueMultipleValues(PropertyName As String, Objects() As Object, Values() As Object) Implements IVsProjectDesignerPage.SetPropertyMultipleValues
             If Objects Is Nothing OrElse Objects.Length = 0 OrElse Values Is Nothing OrElse Values.Length <> Objects.Length Then
                 Debug.Fail("unexpected")
@@ -3722,7 +3528,6 @@ NextControl:
         ''' Provides the property page undo site to the property page
         ''' </summary>
         ''' <param name="site"></param>
-        ''' <remarks></remarks>
         Private Sub IVsProjectDesignerPage_SetSite(Site As IVsProjectDesignerPageSite) Implements IVsProjectDesignerPage.SetSite
             _propPageUndoSite = Site
         End Sub
@@ -3731,7 +3536,6 @@ NextControl:
         ''' <summary>
         ''' Finish all pending validations
         ''' </summary>
-        ''' <returns></returns>
         ''' <remarks>
         ''' Return false if validation failed, and the customer wants to fix it (not ignore it)
         ''' </remarks>
@@ -3744,7 +3548,6 @@ NextControl:
         ''' Called when the page is activated or deactivated
         ''' </summary>
         ''' <param name="activated">True if the page has been activated, or False if it has been deactivated.</param>
-        ''' <remarks></remarks>
         Private Sub OnActivated(activated As Boolean) Implements IVsProjectDesignerPage.OnActivated
             If _activated <> activated Then
                 _activated = activated
@@ -3756,7 +3559,6 @@ NextControl:
         ''' Called when the page is activated or deactivated
         ''' </summary>
         ''' <param name="activated"></param>
-        ''' <remarks></remarks>
         Protected Overridable Sub OnPageActivated(activated As Boolean)
         End Sub
 
@@ -3770,8 +3572,6 @@ NextControl:
         ''' <summary>
         ''' Pick font to use in this dialog page
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Protected ReadOnly Property GetDialogFont() As Font
             Get
                 If ServiceProvider IsNot Nothing Then
@@ -3791,19 +3591,12 @@ NextControl:
         ''' <summary>
         ''' Set font and scale page accordingly
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overridable Sub ScaleWindowToCurrentFont()
             SetDialogFont(PageRequiresScaling)
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="msg"></param>
         ''' <param name="wParam"></param>
         ''' <param name="lParam"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function OnBroadcastMessage(msg As UInteger, wParam As IntPtr, lParam As IntPtr) As Integer Implements IVsBroadcastMessageEvents.OnBroadcastMessage
             If msg = WM_SETTINGCHANGE Then
                 If IsHandleCreated Then
@@ -3827,7 +3620,6 @@ NextControl:
         ''' <summary>
         ''' Set font and scale page accordingly
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overridable Sub SetDialogFont(ScaleDialog As Boolean)
             If ManualPageScaling Then
                 Exit Sub
@@ -3964,7 +3756,6 @@ NextControl:
         ''' <summary>
         ''' Causes the property descriptors to refresh their cache of standard values
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overridable Sub RefreshPropertyStandardValues()
             'This can be accomplished by doing a GetProperty on the objects in question.  They'll automatically
             '  update the caches of related PropertyDescriptors
@@ -4056,8 +3847,6 @@ NextControl:
         ''' <summary>
         ''' Gets the F1 keyword to push into the user context for this property page
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetHelpContextF1Keyword() As String Implements IPropertyPageInternal.GetHelpContextF1Keyword
             Return GetF1HelpKeyword()
         End Function
@@ -4068,8 +3857,6 @@ NextControl:
         ''' <summary>
         ''' Determines whether the entire property page should be disabled while building.  Override to change default behavior.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Protected Overridable ReadOnly Property DisableOnBuild() As Boolean
             Get
                 Return True
@@ -4079,8 +3866,6 @@ NextControl:
         ''' <summary>
         ''' Determines whether the entire property page should be disabled while in debugging mode.  Override to change default behavior.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Protected Overridable ReadOnly Property DisableOnDebug() As Boolean
             Get
                 Return True
@@ -4090,8 +3875,6 @@ NextControl:
         ''' <summary>
         ''' Determines if the given mode should cause us to be disabled.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function DisableWhenDebugMode(mode As DBGMODE) As Boolean
             Return (mode <> DBGMODE.DBGMODE_Design)
         End Function
@@ -4100,7 +3883,6 @@ NextControl:
         ''' <summary>
         ''' Hook up with the debugger event mechanism to determine current debug mode
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ConnectDebuggerEvents()
             If DisableOnDebug AndAlso ServiceProvider IsNot Nothing AndAlso _vsDebuggerEventsCookie = 0 Then
                 If _vsDebugger Is Nothing Then
@@ -4123,7 +3905,6 @@ NextControl:
         ''' <summary>
         ''' Unhook event notification for debugger 
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub DisconnectDebuggerEvents()
             If _vsDebugger IsNot Nothing AndAlso _vsDebuggerEventsCookie <> 0 Then
                 VSErrorHandler.ThrowOnFailure(_vsDebugger.UnadviseDebuggerEvents(_vsDebuggerEventsCookie))
@@ -4135,7 +3916,6 @@ NextControl:
         ''' <summary>
         ''' Hook up event notifications for broadcast messages (e.g. font/size changes)
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ConnectBroadcastMessages()
             If ManualPageScaling Then
                 'Not need if we're not automatically scaling the page
@@ -4157,7 +3937,6 @@ NextControl:
         ''' <summary>
         ''' Unhook event notifications for broadcast messages (e.g. font/size changes)
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub DisconnectBroadcastMessages()
             If _cookieBroadcastMessages <> 0 AndAlso _vsShellForUnadvisingBroadcastMessages IsNot Nothing Then
                 VSErrorHandler.ThrowOnFailure(_vsShellForUnadvisingBroadcastMessages.UnadviseBroadcastMessages(_cookieBroadcastMessages))
@@ -4170,7 +3949,6 @@ NextControl:
         ''' Enable or disable the page based on debug mode
         ''' </summary>
         ''' <param name="mode"></param>
-        ''' <remarks></remarks>
         Private Sub UpdateDebuggerStatus(mode As DBGMODE)
             If DisableOnDebug AndAlso DisableWhenDebugMode(mode) Then
                 _pageEnabledPerDebugMode = False
@@ -4185,7 +3963,6 @@ NextControl:
         ''' </summary>
         ''' <param name="scope"></param>
         ''' <param name="action"></param>
-        ''' <remarks></remarks>
         Private Sub BuildBegin(scope As EnvDTE.vsBuildScope, action As EnvDTE.vsBuildAction) Handles _buildEvents.OnBuildBegin
             Debug.Assert(DisableOnBuild, "Why did we get a BuildBegin event when we shouldn't be listening?")
             _pageEnabledPerBuildMode = False
@@ -4197,7 +3974,6 @@ NextControl:
         ''' </summary>
         ''' <param name="scope"></param>
         ''' <param name="action"></param>
-        ''' <remarks></remarks>
         Private Sub BuildDone(scope As EnvDTE.vsBuildScope, action As EnvDTE.vsBuildAction) Handles _buildEvents.OnBuildDone
             Debug.Assert(DisableOnBuild, "Why did we get a BuildDone event when we shouldn't be listening?")
             _pageEnabledPerBuildMode = True
@@ -4207,7 +3983,6 @@ NextControl:
         ''' <summary>
         ''' Start listening to build events and set our initial build status
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ConnectBuildEvents()
             If DisableOnBuild Then
                 If _dte IsNot Nothing Then
@@ -4237,7 +4012,6 @@ NextControl:
         ''' <summary>
         ''' Stop listening for build events
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub DisconnectBuildEvents()
             _buildEvents = Nothing
         End Sub
@@ -4250,7 +4024,6 @@ NextControl:
         ''' <summary>
         ''' Start listening to project property change notifications
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ConnectPropertyNotify()
             'Unhook all old property notification sinks
             DisconnectPropertyNotify()
@@ -4294,7 +4067,6 @@ NextControl:
         ''' </summary>
         ''' <param name="EventSource">The object to try listening to property changes on.</param>
         ''' <param name="DebugSourceName">A debug name for the source</param>
-        ''' <remarks></remarks>
         Private Sub AttemptConnectPropertyNotifyObject(EventSource As Object, DebugSourceName As String)
             Dim Listener As PropertyListener = PropertyListener.TryCreate(Me, EventSource, DebugSourceName, _projectHierarchy, TypeOf EventSource Is IVsCfgBrowseObject)
             If Listener IsNot Nothing Then
@@ -4306,7 +4078,6 @@ NextControl:
         ''' <summary>
         ''' Stop listening to project property change notifications
         ''' </summary> 'we persist this without the root namespace
-        ''' <remarks></remarks>
         Private Sub DisconnectPropertyNotify()
             For Each Listener As PropertyListener In _propertyListeners
                 Listener.Dispose()
@@ -4423,7 +4194,6 @@ NextControl:
         '''   that were queued up during an apply or property change.  If so, then it
         '''   sends those notifications off.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub CheckPlayCachedPropertyChanges()
             Common.Switches.TracePDProperties(TraceLevel.Verbose, "PlayCachedPropertyChanges()")
             If _fIsApplying OrElse PropertyOnPageBeingChanged() Then
@@ -4478,7 +4248,6 @@ NextControl:
         ''' Used for debug tracing of OnLayout events... 
         ''' </summary>
         ''' <param name="levent"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnLayout(levent As LayoutEventArgs)
             Common.Switches.TracePDPerfBegin(levent, "PropPageUserControlBase.OnLayout()")
             MyBase.OnLayout(levent)

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyControlData.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyControlData.vb
@@ -14,7 +14,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' <summary>
     ''' Class that provides basic read/write of property values to/from the project system
     ''' </summary>
-    ''' <remarks></remarks>
     <DebuggerDisplay("{PropertyName}, InitialValue={InitialValue}, IsDirty={IsDirty}")>
     Public Class PropertyControlData
 
@@ -82,8 +81,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control">The form control from which to get the data (or Nothing if none is associated with this PropertyControlData)</param>
         ''' <param name="prop">The property descriptor associated with this PropertyControlData, or Nothing if none</param>
         ''' <param name="value">The value to set into the control's UI (may be Indeterminate or MissingProperty</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Delegate Function SetDelegate(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
 
         ''' <summary>
@@ -93,8 +90,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control">The form control from which to get the data (or Nothing if none is associated with this PropertyControlData)</param>
         ''' <param name="prop">The property descriptor associated with this PropertyControlData, or Nothing if none</param>
         ''' <param name="value">[out] Should be filled in with the value from the control.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Delegate Function GetDelegate(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
 
         ''' <summary>
@@ -106,8 +101,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="prop">The property descriptor associated with this PropertyControlData, or Nothing if none</param>
         ''' <param name="values">The array of values to set into the control's UI.  May not be Nothing, and individual values will not be Indeterminate or MissingProperty.
         '''   Callee is responsible for determining how to deal with multiple values.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Delegate Function MultiValueSetDelegate(control As Control, prop As PropertyDescriptor, Values() As Object) As Boolean
 
         ''' <summary>
@@ -120,8 +113,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="Values">Should be filled in with an array containing the values from the control.  The length of the array must match
         '''   that of RawPropertiesObjects, and must not contain Nothing, Indeterminate or MissingProperty values.
         ''' </param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Delegate Function MultiValueGetDelegate(control As Control, prop As PropertyDescriptor, ByRef Values() As Object) As Boolean
 
 #End Region
@@ -134,7 +125,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="name">The property name.  See comments at top of PropertyControlData.vb.</param>
         ''' <param name="FormControl">The control, if any, which is automatically managed by this class instance to correspond to the property's value.  May be Nothing.</param>
         ''' <param name="flags">Additional flags.</param>
-        ''' <remarks></remarks>
         Public Sub New(id As Integer, name As String, FormControl As Control, flags As ControlDataFlags)
             Call Me.New(id, name, FormControl, Nothing, Nothing, flags)
         End Sub
@@ -145,7 +135,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="id">The DISPID of the property.  See comments at top of PropertyControlData.vb.</param>
         ''' <param name="name">The property name.  See comments at top of PropertyControlData.vb.</param>
         ''' <param name="FormControl">The control, if any, which is automatically managed by this class instance to correspond to the property's value.  May be Nothing.</param>
-        ''' <remarks></remarks>
         Public Sub New(id As Integer, name As String, FormControl As Control)
             Call Me.New(id, name, FormControl, Nothing, Nothing, ControlDataFlags.None)
         End Sub
@@ -159,7 +148,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="setter">The setter delegate, if any, which provides manual handling of getting and setting the property value into the control in the UI.  Note that this is a separate issue of whether a property is user-persisted.  May be Nothing.</param>
         ''' <param name="getter">The getter delegate, if any, which provides manual handling of getting and setting the property value into the control in the UI.  Note that this is a separate issue of whether a property is user-persisted.  May be Nothing.</param>
         ''' <param name="flags">Additional flags.</param>
-        ''' <remarks></remarks>
         Public Sub New(id As Integer, name As String, FormControl As Control, setter As SetDelegate, getter As GetDelegate, flags As ControlDataFlags)
             Call Me.New(id, name, FormControl, setter, getter, flags, Nothing)
         End Sub
@@ -170,7 +158,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="id">The DISPID of the property.  See comments at top of PropertyControlData.vb.</param>
         ''' <param name="name">The property name.  See comments at top of PropertyControlData.vb.</param>
         ''' <param name="FormControl">The control, if any, which is automatically managed by this class instance to correspond to the property's value.  May be Nothing.</param>
-        ''' <remarks></remarks>
         Public Sub New(id As Integer, name As String, FormControl As Control, AssocControls As Control())
             Call Me.New(id, name, FormControl, Nothing, Nothing, Nothing, Nothing, ControlDataFlags.None, AssocControls)
         End Sub
@@ -183,7 +170,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="FormControl">The control, if any, which is automatically managed by this class instance to correspond to the property's value.  May be Nothing.</param>
         ''' <param name="setter">The setter delegate, if any, which provides manual handling of getting and setting the property value into the control in the UI.  Note that this is a separate issue of whether a property is user-persisted.  May be Nothing.</param>
         ''' <param name="getter">The getter delegate, if any, which provides manual handling of getting and setting the property value into the control in the UI.  Note that this is a separate issue of whether a property is user-persisted.  May be Nothing.</param>
-        ''' <remarks></remarks>
         Public Sub New(id As Integer, name As String, FormControl As Control, setter As SetDelegate, getter As GetDelegate)
             Call Me.New(id, name, FormControl, setter, getter, ControlDataFlags.None, Nothing)
         End Sub
@@ -197,7 +183,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="setter">The setter delegate, if any, which provides manual handling of getting and setting the property value into the control in the UI.  Note that this is a separate issue of whether a property is user-persisted.  May be Nothing.</param>
         ''' <param name="getter">The getter delegate, if any, which provides manual handling of getting and setting the property value into the control in the UI.  Note that this is a separate issue of whether a property is user-persisted.  May be Nothing.</param>
         ''' <param name="flags">Additional flags.</param>
-        ''' <remarks></remarks>
         Public Sub New(id As Integer, name As String, FormControl As Control, setter As MultiValueSetDelegate, getter As MultiValueGetDelegate, flags As ControlDataFlags, AssocControls As Control())
             Me.New(id, name, FormControl, Nothing, Nothing, setter, getter, flags, AssocControls)
         End Sub
@@ -209,7 +194,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="name">The property name.  See comments at top of PropertyControlData.vb.</param>
         ''' <param name="FormControl">The control, if any, which is automatically managed by this class instance to correspond to the property's value.  May be Nothing.</param>
         ''' <param name="flags">Additional flags.</param>
-        ''' <remarks></remarks>
         Public Sub New(id As Integer, name As String, FormControl As Control, flags As ControlDataFlags, AssocControls As Control())
             Me.New(id, name, FormControl, Nothing, Nothing, Nothing, Nothing, flags, AssocControls)
         End Sub
@@ -223,7 +207,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="setter">The setter delegate, if any, which provides manual handling of getting and setting the property value into the control in the UI.  Note that this is a separate issue of whether a property is user-persisted.  May be Nothing.</param>
         ''' <param name="getter">The getter delegate, if any, which provides manual handling of getting and setting the property value into the control in the UI.  Note that this is a separate issue of whether a property is user-persisted.  May be Nothing.</param>
         ''' <param name="flags">Additional flags.</param>
-        ''' <remarks></remarks>
         Public Sub New(id As Integer, name As String, FormControl As Control, setter As SetDelegate, getter As GetDelegate, flags As ControlDataFlags, AssocControls As Control())
             Me.New(id, name, FormControl, setter, getter, Nothing, Nothing, flags, AssocControls)
         End Sub
@@ -240,7 +223,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="multiValueGetter">The multi-value getter delegate, if any.  See comments for MultiValueGetDelegate.  May be Nothing.</param>
         ''' <param name="flags">Additional flags.</param>
         ''' <param name="AssociatedControls">An array of associated controls which should be enabled/disabled along with the FormControl if a property is not supported in a given project system.  May be Nothing.</param>
-        ''' <remarks></remarks>
         Protected Sub New(id As Integer, name As String, FormControl As Control, setter As SetDelegate, getter As GetDelegate, multiValueSetter As MultiValueSetDelegate, multiValueGetter As MultiValueGetDelegate, flags As ControlDataFlags, AssociatedControls As Control())
             If id < 0 Then 'Don't allow DISPID_UNKNOWN (-1) etc
                 Debug.Fail("Property ID must be non-negative")
@@ -276,9 +258,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' The DISPID that corresponds to the property in the project.  See comments at top of PropertyControlData.vb.
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public ReadOnly Property DispId() As Integer
             Get
                 Return _dispId
@@ -290,9 +269,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''  are looked up by name (not DISPID).  This allows project flavors to hide one property and add another with the same name but
         '''  a different DISPID in order to "override" a property.
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public ReadOnly Property PropertyName() As String
             Get
                 Return _propertyName
@@ -302,8 +278,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns the page where this property is hosted.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Protected ReadOnly Property PropPage() As PropPageUserControlBase
             Get
                 Return m_PropPage
@@ -315,8 +289,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Retrieves the object to be used for querying for common property values.  The object
         '''   used may vary, depending on the project type and what it supports.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Protected ReadOnly Property CommonPropertiesObject() As Object
             Get
                 Debug.Assert(m_PropPage IsNot Nothing, "PropertyControlData not initialized?")
@@ -330,7 +302,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   passed in to the page through SetObjects.  However, it may be modified by subclasses to contain a superset
         '''   or subset for special purposes.
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' Calls to this property are called once by the PropPageUserControlBase after each SetObjects call, and may
         '''   be cached after that.  Properties should return the same set of values when given the same set of 
@@ -350,8 +321,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   based on the set of objects passed in to the page through SetObjects.  However, it may be modified by subclasses to 
         '''   contain a superset or subset for special purposes.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Overridable ReadOnly Property ExtendedPropertiesObjects() As Object()
             Get
                 Debug.Assert(m_PropPage IsNot Nothing, "PropertyControlData not initialized?")
@@ -363,9 +332,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' The control, if any, which is automatically managed by this class instance to correspond to the property's value.  May be Nothing.
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public ReadOnly Property FormControl() As Control
             Get
                 Return m_FormControl
@@ -377,8 +343,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' True iff this property is user-persisted (i.e., rather than getting/setting it directly through the project
         '''   system, the storage/retrieval of the property's value is handled by the page).
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property IsUserPersisted() As Boolean
             Get
                 Return ((Flags And ControlDataFlags.UserPersisted) <> 0)
@@ -418,8 +382,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Note that this is *not* equivalent to whether or not the property is configuration-dependent - no properties on
         '''   a non-configuration-page are "common" properties, even though they are non-configuration-dependent
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property IsCommonProperty() As Boolean
             Get
                 Return ((Flags And ControlDataFlags.CommonProperty) = ControlDataFlags.CommonProperty)
@@ -438,8 +400,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns true iff this property is configuration-specific.  This is not the opposite of
         '''   a "common" property (but all common properties are non-configuration-specific).
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property IsConfigurationSpecificProperty() As Boolean
             Get
                 Debug.Assert(m_PropPage IsNot Nothing)
@@ -460,8 +420,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' True iff this property instance is currently dirty
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property IsDirty() As Boolean
             Get
                 Return ((Flags And ControlDataFlags.Dirty) = ControlDataFlags.Dirty)
@@ -513,8 +471,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   property represented by this class instance is missing in the current
         '''   project.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Public Shared ReadOnly Property MissingProperty() As Object
             Get
@@ -539,8 +495,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   property has different values in the currently selected configurations
         '''   and therefore cannot be determined.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Public Shared ReadOnly Property Indeterminate() As Object
             Get
@@ -553,8 +507,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   property has different values in the currently selected configurations
         '''   and therefore cannot be determined.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property IsIndeterminate() As Boolean
             Get
 #If DEBUG Then
@@ -569,8 +521,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   property represented by this class instance is missing in the current
         '''   project.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property IsMissing() As Boolean
             Get
 #If DEBUG Then
@@ -584,8 +534,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns true iff the value is the special indeterminate or missing
         '''   property value.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function IsSpecialValue() As Boolean
             Return IsSpecialValue(InitialValue)
         End Function
@@ -594,8 +542,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns true iff the given value is the special indeterminate or missing
         '''   property value.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function IsSpecialValue(Value As Object) As Boolean
             Return (Value Is s_missingValue) OrElse (Value Is s_indeterminateValue)
         End Function
@@ -619,8 +565,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   will have the value IndeterminateValue (and m_AllInitialValues will contain the array of differing values).
         '''   If the property was not found, this will have the value MissingValue.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property InitialValue() As Object
             Get
                 Return _initialValue
@@ -633,8 +577,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   for this property.  Generally only stored if the values were actually different.  Otherwise, this may
         '''   simply be Nothing.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property AllInitialValues() As Object()
             Get
                 Debug.Assert(_allInitialValues Is Nothing OrElse _allInitialValues.Length = RawPropertiesObjects.Length AndAlso _allInitialValues.Length = ExtendedPropertiesObjects.Length,
@@ -651,8 +593,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   as each element.  Never returns Nothing, but always returns an array of the same size
         '''   as RawPropertiesObjects.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property AllInitialValuesExpanded() As Object()
             Get
                 Dim Values() As Object = AllInitialValues
@@ -679,7 +619,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   that the same value is being persisted for all objects (configurations).
         ''' </summary>
         ''' <param name="InitialValue">The value to set as the initial value.</param>
-        ''' <remarks></remarks>
         Public Sub SetInitialValues(InitialValue As Object)
             _initialValue = InitialValue
             _allInitialValues = Nothing
@@ -692,7 +631,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="InitialValue">The single initial value to set into m_InitialValue</param>
         ''' <param name="AllInitialValues">All initial values for all objects (configurations).  May be Nothing if all values are
         '''   the same as the single initial value, or if InitialValue is IsMissing.</param>
-        ''' <remarks></remarks>
         Public Sub SetInitialValues(InitialValue As Object, AllInitialValues As Object())
             If AllInitialValues IsNot Nothing AndAlso AllInitialValues.Length = 0 Then
                 Throw Common.CreateArgumentException(NameOf(AllInitialValues))
@@ -712,7 +650,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   set as well.
         ''' </summary>
         ''' <param name="AllInitialValues"></param>
-        ''' <remarks></remarks>
         Public Sub SetInitialValues(AllInitialValues As Object())
             Requires.NotNull(AllInitialValues, NameOf(AllInitialValues))
 
@@ -728,7 +665,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Sets up the property descriptor by searching for the property in the objects passed to us.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overridable Sub Initialize(PropertyPage As PropPageUserControlBase)
             Debug.Assert(PropertyPage IsNot Nothing)
             m_Initializing = True
@@ -785,7 +721,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Initializes the value for the property by getting the value from the project system
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overridable Sub InitPropertyValue()
             Dim prop As PropertyDescriptor
             Dim Value As Object = Nothing
@@ -845,7 +780,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Updates the UI for the property's control (if any), using the current value in Me.InitialValue
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overridable Sub InitPropertyUI()
             Dim value As Object
             Dim Handled As Boolean
@@ -931,7 +865,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Enables or disables the given control associated with this property (but never
         '''   enables a control when it has been disabled by a project flavor).
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub EnableAssociatedControl(control As Control, Enabled As Boolean)
             EnableAssociatedControls(New Control() {control}, Enabled)
         End Sub
@@ -941,7 +874,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Enables or disables all the controls associated with this property (but never
         '''   enables a control when it has been disabled by a project flavor).
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub EnableAssociatedControls(controls() As Control, Enabled As Boolean)
             If Not _controlsCanBeEnabled Then
                 'A flavor has disabled this property or made it readonly - we shouldn't enable the controls even
@@ -960,7 +892,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Enables or disables all the controls associated with this property (but never
         '''   enables a control when it has been disabled by a project flavor).
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub EnableControls(Enabled As Boolean)
             'Enable or disable the main control
             If FormControl IsNot Nothing Then
@@ -979,7 +910,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   disables it.
         ''' </summary>
         ''' <param name="controls"></param>
-        ''' <remarks></remarks>
         Private Shared Sub SetControlsReadOnly(controls() As Control)
             If controls IsNot Nothing Then
                 For Each control As Control In controls
@@ -998,7 +928,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="Controls">The controls to hide.  May be Nothing or empty.</param>
         ''' <param name="Hide">If True, the controls are hidden, else they're disabled</param>
-        ''' <remarks></remarks>
         Protected Shared Sub HideOrDisableControls(Controls() As Control, Hide As Boolean)
             If Controls IsNot Nothing Then
                 For Each Control As Control In Controls
@@ -1017,7 +946,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   User pages handle this by specifying ControlDataFlags.UserPersisted, and overriding
         '''   PropPageUserControlBase.WriteUserDefinedProperty, ReadUserDefinedProperty and GetUserDefinedPropertyDescriptor.
         ''' </summary>
-        ''' <returns></returns>
         ''' <remarks>
         ''' This is normally overridden in the property page, which this method delegates to, and
         '''    not in this class.
@@ -1040,7 +968,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="PropertyName"></param>
         ''' <param name="Value"></param>
-        ''' <returns></returns>
         ''' <remarks>Used only for non-standard properties.  Note that this is completely independent of whether a custom
         '''   getter and setter are defined (they control reading a value from and writing it to a control's UI, while this
         '''   mechanism handles persisting and depersisting the property value in the project or other storage once it's 
@@ -1060,7 +987,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="PropertyName"></param>
         ''' <param name="Value"></param>
-        ''' <returns></returns>
         ''' <remarks>Used only for non-standard properties.  Note that this is completely independent of whether a custom
         '''   getter and setter are defined (they control reading a value from and writing it to a control's UI, while this
         '''   mechanism handles persisting and depersisting the property value in the project or other storage once it's 
@@ -1196,8 +1122,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Retrieves all current values of a property, for controls which support multiple-value get.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetControlValueMultipleValues() As Object()
             'Get the current values from the UI
             Dim values() As Object = Nothing
@@ -1227,8 +1151,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="control"></param>
         ''' <param name="_TypeConverter"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetControlValue(control As Control, _TypeConverter As TypeConverter) As Object
 
             Dim StringText As String
@@ -1350,8 +1272,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   PropertyControlData.MissingProperty is returned.
         ''' </summary>
         ''' <param name="Extenders">The list of extenders to pass to the descriptor's GetValue function</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overridable Function TryGetPropertyValueNative(Extenders As Object()) As Object
             If IsCommonProperty Then
                 Try
@@ -1373,8 +1293,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="Descriptor">The property descriptor for the property to get the value from</param>
         ''' <param name="Extenders">The list of extenders to pass to the descriptor's GetValue function</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function TryGetNonCommonPropertyValueNative(Descriptor As PropertyDescriptor, Extenders As Object()) As Object
             Dim Value As Object = Nothing
 
@@ -1410,7 +1328,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   that value is returned.  If they differ, PropertyControlData.Inderminate is returned.  If the property descriptor is missing,
         '''   PropertyControlData.MissingProperty is returned.
         ''' </param>
-        ''' <remarks></remarks>
         Public Overridable Sub GetAllPropertyValuesNative(Extenders As Object(), ByRef Values As Object(), ByRef ValueOrIndeterminate As Object)
             GetAllPropertyValuesNative(PropDesc, Extenders, Values, ValueOrIndeterminate)
         End Sub
@@ -1428,7 +1345,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   that value is returned.  If they differ, PropertyControlData.Inderminate is returned.  If the property descriptor is missing,
         '''   PropertyControlData.MissingProperty is returned.
         ''' </param>
-        ''' <remarks></remarks>
         Public Shared Sub GetAllPropertyValuesNative(Descriptor As PropertyDescriptor, Extenders As Object(), ByRef Values As Object(), ByRef ValueOrIndeterminate As Object)
             Requires.NotNull(Extenders, NameOf(Extenders))
 
@@ -1462,8 +1378,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   or else return Indeterminate
         ''' </summary>
         ''' <param name="Values"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function GetValueOrIndeterminateFromArray(Values() As Object) As Object
             'Determine if all the values are the same or not
             Requires.NotNull(Values, NameOf(Values))
@@ -1498,8 +1412,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   visible in the property page's control, which the user may have edited).
         ''' No type conversion takes place.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overridable Function GetPropertyValueNative(Extender As Object) As Object
             Debug.Assert(PropDesc IsNot Nothing, "Calling GetPropertyValueNative() on a property that could not be found [PropDesc Is Nothing]")
 
@@ -1518,8 +1430,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="Descriptor">The type descriptor to get the property value from.</param>
         ''' <param name="Extender">The extender objects to use.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Shared Function GetNonCommonPropertyValueNative(Descriptor As PropertyDescriptor, Extender As Object) As Object
             Debug.Assert(Descriptor IsNot Nothing, "Calling GetPropertyValueNative() on a property that could not be found [Descriptor Is Nothing]")
             Debug.Assert(Extender IsNot Nothing)
@@ -1535,7 +1445,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' The value is first converted using the property's type converter.
         ''' </summary>
         ''' <param name="Value"></param>
-        ''' <remarks></remarks>
         Public Overridable Sub SetPropertyValue(Value As Object)
             m_PropPage.SuspendPropertyChangeListening(DispId)
             Try
@@ -1582,7 +1491,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' The value is not converted using any type converter.
         ''' </summary>
         ''' <param name="Value"></param>
-        ''' <remarks></remarks>
         Public Overridable Sub SetPropertyValueNative(Value As Object)
             m_PropPage.SuspendPropertyChangeListening(DispId)
 
@@ -1631,7 +1539,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="Objects">The objects to set the values on</param>
         ''' <param name="Values">The values to set into the property for each of the objects (configurations)</param>
-        ''' <remarks></remarks>
         Public Overridable Sub SetPropertyValueNativeMultipleValues(Objects As Object(), Values As Object())
             If IsUserPersisted Then
                 'No need to handle this case, it is not currently supported
@@ -1681,7 +1588,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="Descriptor">The property descriptor to invoke SetValue on</param>
         ''' <param name="Component">The component whose property should be changed</param>
         ''' <param name="Value">The new value to set the given property to</param>
-        ''' <remarks></remarks>
         Protected Shared Sub PropertyDescriptorSetValue(Descriptor As PropertyDescriptor, Component As Object, Value As Object)
             Dim Helper As New PropertyDescriptorSetValueHelper
             Helper.SetValue(Descriptor, Component, Value)
@@ -1692,7 +1598,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Helper class for PropertyDescriptorSetValue - detects if a PropertyDescriptor.SetValue
         '''   fails due to a canceled checkout...
         ''' </summary>
-        ''' <remarks></remarks>
         Private Class PropertyDescriptorSetValueHelper
             Private _valueChangedWasFired As Boolean
 
@@ -1703,7 +1608,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             ''' <param name="Descriptor"></param>
             ''' <param name="Component"></param>
             ''' <param name="Value"></param>
-            ''' <remarks></remarks>
             Public Sub SetValue(Descriptor As PropertyDescriptor, Component As Object, Value As Object)
                 'Hook up to detect if ValueChanged is fired
                 Descriptor.AddValueChanged(Component, AddressOf ValueChanged)
@@ -1739,7 +1643,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             ''' Helper function for PropertyDescriptorSetValue - handles the OnValueChanged
             '''   event for the property descriptor as it's being set.
             ''' </summary>
-            ''' <remarks></remarks>
             Private Sub ValueChanged(sender As Object, e As EventArgs)
                 Debug.Assert(Not _valueChangedWasFired, "OnValueChanged() fired multiple times?")
                 _valueChangedWasFired = True
@@ -1754,8 +1657,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   same value for a given property (i.e., it does not depend on whether multiple configurations have currently been passed in
         '''   to SetObjects, but simply whether this property supports multiple-value undo/redo).
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overridable Function SupportsMultipleValueUndo() As Boolean
             If IsUserPersisted Then
                 'Not currently supported: User-persisted properties that have per-config values
@@ -1799,7 +1700,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="Descriptor">The descriptor for the common property.</param>
         ''' <param name="ProjectCommonPropertiesObject">The project object from which to query the property value.</param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' This must be a common property.
         ''' See comments "About 'common' properties"
@@ -1816,7 +1716,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   control on the property page as it has been edited by the user).
         ''' No type conversion is performed on the return value.
         ''' </summary>
-        ''' <returns></returns>
         ''' <remarks>
         ''' This must be a common property.
         ''' See comments "About 'common' properties"
@@ -1835,7 +1734,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="Descriptor">The descriptor for the common property.</param>
         ''' <param name="ProjectCommonPropertiesObject">The project object from which to query the property value.</param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' See comments "About 'common' properties"
         ''' </remarks>
@@ -1916,7 +1814,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   This is done after a non-immediate (child) property page is canceled in order to restore
         '''   the page's original values into the control.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overridable Sub RestoreInitialValue()
             If Not IsDirty Then
                 Return
@@ -1952,7 +1849,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   dirty, only the last SetDirty() call should pass in True for ReadyToApply.  Doing it this way will cause all of the properties
         '''   to be changed in the same undo/redo transaction (apply batches up all current changes into a single transaction).
         ''' </param>
-        ''' <remarks></remarks>
         Protected Sub SetDirty(ReadyToApply As Boolean)
             IsDirty = True
             m_PropPage.SetDirty(ReadyToApply)
@@ -1965,7 +1861,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub Control_TextChanged(sender As Object, e As EventArgs)
             'We don't want to apply change while the user might still be typing in the textbox, therefore
             '  we use ReadyToApply:=False
@@ -1978,7 +1873,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub Control_TextUpdated(sender As Object, e As EventArgs)
             'We don't want to apply change while the user might still be typing in the textbox, therefore
             '  we use ReadyToApply:=False
@@ -1991,7 +1885,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub Control_LostFocus(sender As Object, e As EventArgs)
             'If the user leaves the property page to, say, a tool window, we will receive the 
             '  notification here.  If the page is dirty (s/he has typed something into the 
@@ -2006,7 +1899,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub Control_Validated(sender As Object, e As EventArgs)
             If IsDirty Then
                 SetDirty(True)
@@ -2018,7 +1910,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overridable Sub ComboBox_SelectionChangeCommitted(sender As Object, e As EventArgs)
             SetDirty(True)
         End Sub
@@ -2028,26 +1919,15 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ComboBox_DropDown(sender As Object, e As EventArgs)
             'We need to make sure the drop-down list is wide enough for its contents
             Common.SetComboBoxDropdownWidth(DirectCast(sender, ComboBox))
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub CheckBox_CheckStateChanged(sender As Object, e As EventArgs)
             SetDirty(True)
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
-        ''' <remarks></remarks>
         Public Overridable Sub AddChangeHandlers()
 
             If (FormControl IsNot Nothing) AndAlso Not IsUserHandledEvents Then
@@ -2172,7 +2052,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Calls OnPropertyChanging on the PropPageUserControlBase for this property.  This is required for Undo/Redo
         '''   support.
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overridable Sub OnPropertyChanging()
             m_PropPage.OnPropertyChanging(PropertyName, PropDesc)
         End Sub
@@ -2184,7 +2063,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="OldValue">The property's previous value.</param>
         ''' <param name="NewValue">The property's new value.</param>
-        ''' <remarks></remarks>
         Protected Overridable Sub OnPropertyChanged(OldValue As Object, NewValue As Object)
             m_PropPage.OnPropertyChanged(PropertyName, PropDesc, OldValue, NewValue)
         End Sub
@@ -2194,8 +2072,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns a list of files which should be checked out before trying to change this property's
         '''   value.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overridable Function FilesToCheckOut() As String()
             Const PERUSER_EXTENSION As String = ".user" 'Project .user file extension
 
@@ -2240,8 +2116,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="PSFFILEID"></param>
         ''' <param name="CreateIfNotExist"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetSpecialFile(psfFileId As Integer, CreateIfNotExist As Boolean) As String
             If m_PropPage Is Nothing OrElse m_PropPage.ProjectHierarchy Is Nothing Then
                 Debug.Fail("Unexpected null")
@@ -2277,8 +2151,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="Object1"></param>
         ''' <param name="Object2"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function ObjectsAreEqual(Object1 As Object, Object2 As Object) As Boolean
             If Object1 Is Nothing AndAlso TypeOf Object2 Is String Then
                 Object1 = String.Empty

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyListener.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyListener.vb
@@ -16,7 +16,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' <summary>
     ''' Listens for property changes on a particular object.
     ''' </summary>
-    ''' <remarks></remarks>
     Public Class PropertyListener
         Implements OLE.Interop.IPropertyNotifySink
         Implements ILangInactiveCfgPropertyNotifySink
@@ -36,7 +35,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="PropPage">The property page to notify when a property changes</param>
         ''' <param name="EventSource">The object to try listening to property changes on.</param>
         ''' <param name="DebugSourceName">For debugging purposes: name of the properties object that is being listened to.</param>
-        ''' <remarks></remarks>
         Private Sub New(PropPage As PropPageUserControlBase, EventSource As Object, DebugSourceName As String)
             _propPage = PropPage
 #If DEBUG Then
@@ -57,7 +55,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   This is not necessary or possible for non-configuration-specific pages - we always listen to common property changes.
         ''' </param>
         ''' <returns>If it succeeds, a valid listener is created.  If it fails, Nothing is returned.</returns>
-        ''' <remarks></remarks>
         Public Shared Function TryCreate(PropPage As PropPageUserControlBase, EventSource As Object, DebugSourceName As String, ProjectHierarchy As IVsHierarchy, ListenToInactiveConfigs As Boolean) As PropertyListener
             Debug.Assert(ProjectHierarchy IsNot Nothing)
             Common.Switches.TracePDProperties(TraceLevel.Info, "Attempting to hook up IPropertyNotifySink to object '" & DebugSourceName & "' of type " & TypeName(EventSource))
@@ -138,7 +135,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' IDisposable support
         ''' </summary>
         ''' <param name="Disposing"></param>
-        ''' <remarks></remarks>
         Private Overloads Sub Dispose(Disposing As Boolean)
             If Disposing Then
                 If _cookieActiveCfg IsNot Nothing Then
@@ -159,7 +155,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' IDisposable support
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overloads Sub Dispose() Implements IDisposable.Dispose
             ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
             Dispose(True)
@@ -170,7 +165,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' IDisposable support
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub Finalize()
             ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
             Dispose(False)
@@ -184,8 +178,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns true iff the given source supports IConnectionPointContainer
         ''' </summary>
         ''' <param name="EventSource"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function SupportsConnectionPointContainer(EventSource As Object) As Boolean
             If EventSource IsNot Nothing Then
                 If TypeOf EventSource Is OLE.Interop.IConnectionPointContainer OrElse TypeOf EventSource Is ComTypes.IConnectionPointContainer Then
@@ -254,8 +246,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="dispid"></param>
         ''' <param name="wszConfigName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function OnChanged(dispid As Integer, wszConfigName As String) As Integer Implements ILangInactiveCfgPropertyNotifySink.OnChanged
             Dim DebugSourceName As String = Nothing
 #If DEBUG Then

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyPageException.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyPageException.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Runtime.Serialization
 
@@ -9,7 +9,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     '''   intended to be shown to the end user in an error dialog, rather than to be
     '''   programmatically manipulated (although that of course is possible).
     ''' </summary>
-    ''' <remarks></remarks>
     <Serializable()>
     Public Class PropertyPageException
         Inherits ApplicationException

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/ValidationException.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/ValidationException.vb
@@ -7,7 +7,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' <summary>
     ''' The exception will be thrown when validation failed...
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class ValidationException
         Inherits ApplicationException
 

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/ValidationResult.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/ValidationResult.vb
@@ -7,7 +7,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     '''   Warning means this can be postponed for delay-validation
     '''   Failed means the user must fix this before leaving the page/field...
     ''' </summary>
-    ''' <remarks></remarks>
     Public Enum ValidationResult
         Succeeded = 0
         Warning = 1

--- a/src/Microsoft.VisualStudio.AppDesigner/Resources/Resources.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Resources/Resources.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Namespace My.Resources
 
@@ -10,8 +10,6 @@ Namespace My.Resources
         ''' Just returns the input string unless there are arguments, in which case it calls String.Format.
         ''' </summary>
         ''' <param name="s"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         <ComponentModel.EditorBrowsable(ComponentModel.EditorBrowsableState.Never)>
         Public Shared Function GetString(s As String, ParamArray Arguments() As Object) As String
             If Arguments Is Nothing OrElse Arguments.Length = 0 Then

--- a/src/Microsoft.VisualStudio.AppDesigner/VSProductSKU.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/VSProductSKU.vb
@@ -52,9 +52,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns the product SKU as an enum.
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared ReadOnly Property ProductSKU() As VSASKUEdition
             Get
                 EnsureInited()
@@ -65,9 +62,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns the product Sub-SKU as an enum.
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared ReadOnly Property ProductSubSKU() As VSASubSKUEdition
             Get
                 EnsureInited()
@@ -78,7 +72,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns True iff this is a Standard SKU
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>From a macro in vsappid.idl</remarks>
         Public Shared ReadOnly Property IsStandard() As Boolean
             Get
@@ -91,8 +84,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns True iff this is a VSTO SKU
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Shared ReadOnly Property IsVSTO() As Boolean
             Get
                 EnsureInited()
@@ -103,7 +94,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns True iff this is a Professional SKU
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>From a macro in vsappid.idl</remarks>
         Public Shared ReadOnly Property IsProfessional() As Boolean
             Get
@@ -116,7 +106,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns True iff this is an Express SKU
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>From a macro in vsappid.idl</remarks>
         Public Shared ReadOnly Property IsExpress() As Boolean
             Get
@@ -129,7 +118,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns True iff this is an Academic SKU
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>From a macro in vsappid.idl</remarks>
         Public Shared ReadOnly Property IsAcademic() As Boolean
             Get
@@ -142,7 +130,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns True iff this is an Enterprise SKU
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>From a macro in vsappid.idl</remarks>
         Public Shared ReadOnly Property IsEnterprise() As Boolean
             Get
@@ -155,8 +142,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns True iff this is a VB SKU
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Shared ReadOnly Property IsVB() As Boolean
             Get
                 EnsureInited()
@@ -168,8 +153,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns True iff this is a VC SKU
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Shared ReadOnly Property IsVC() As Boolean
             Get
                 EnsureInited()
@@ -183,7 +166,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Makes sure that our information on the current SKU has been read, and reads it if not
         ''' </summary>
-        ''' <remarks></remarks>
         Private Shared Sub EnsureInited()
             If s_productSKU = VSASKUEdition.None Then
                 If Common.VBPackageInstance IsNot Nothing Then
@@ -197,7 +179,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Reads information on the current SKU
         ''' </summary>
         ''' <param name="ServiceProvider"></param>
-        ''' <remarks></remarks>
         Private Shared Sub Init(ServiceProvider As IServiceProvider)
             Dim VsAppIdService As IVsAppId
             Dim objSKU As Object = Nothing

--- a/src/Microsoft.VisualStudio.AppDesigner/interop/NativeMethods.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/interop/NativeMethods.vb
@@ -287,8 +287,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesInterop
         ''' <summary>
         ''' The GetNextDlgTabItem function retrieves a handle to the first control that has the WS_TABSTOP style that precedes (or follows) the specified control. 
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         <PreserveSig()> Public Declare Auto Function _
             GetNextDlgTabItem _
                 Lib "user32" (hDlg As IntPtr, hCtl As IntPtr, bPrevious As Boolean) As IntPtr

--- a/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AddImportsDialogService.vb
+++ b/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AddImportsDialogService.vb
@@ -14,7 +14,6 @@ Namespace Microsoft.VisualStudio.Editors.AddImports
         ''' Constructor
         ''' </summary>
         ''' <param name="packageServiceProvider"></param>
-        ''' <remarks></remarks>
         Friend Sub New(packageServiceProvider As IServiceProvider)
             Requires.NotNull(packageServiceProvider, NameOf(packageServiceProvider))
             _serviceProvider = packageServiceProvider

--- a/src/Microsoft.VisualStudio.Editors/Common/ArgumentValidation.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/ArgumentValidation.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Namespace Microsoft.VisualStudio.Editors.Common
 
@@ -8,8 +8,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Creates an ArgumentException based on the name of the argument that is invalid.
         ''' </summary>
         ''' <param name="argumentName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function CreateArgumentException(argumentName As String) As Exception
             Return New ArgumentException(String.Format(My.Resources.Microsoft_VisualStudio_Editors_Designer.General_InvalidArgument_1Arg, argumentName))
         End Function

--- a/src/Microsoft.VisualStudio.Editors/Common/CodeMarkers.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/CodeMarkers.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Namespace Microsoft.VisualStudio.Editors.Common
 
@@ -6,7 +6,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
     ''' This interface wraps the code marker class in a way that it can be replaced by a mock
     '''   for unit testing.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Interface ICodeMarkers
         Sub CodeMarker(nTimerID As Integer)
     End Interface
@@ -14,7 +13,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
     ''' <summary>
     ''' Standard implementation of ICodeMarker, which hooks in to the real VS code marker utility.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class CodeMarkers
         Implements ICodeMarkers
 

--- a/src/Microsoft.VisualStudio.Editors/Common/CodeModelUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/CodeModelUtils.vb
@@ -8,7 +8,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
     ''' <summary>
     ''' Utilities related to the code model and code dom
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class CodeModelUtils
 
         ' When you want an exception that has no error message and 
@@ -20,7 +19,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <summary>
         ''' This is a shared class - disallow instantiation.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub New()
         End Sub
 
@@ -34,7 +32,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="AllowMatchToOnlyEventName">If true, and no function matches both by handled event and name, 
         '''   will return any function that handles the given event, regardless of name</param>
         ''' <returns>The function which handles the given event and (optionally) has the given name.</returns>
-        ''' <remarks></remarks>
         Public Shared Function FindEventHandler(Elements As CodeElements, EventName As String, EventHandlerFunctionName As String, AllowMatchToOnlyEventName As Boolean) As CodeFunction
             Dim ExistingHandler As CodeFunction
 
@@ -125,7 +122,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Navigates to the given function in the code editor.
         ''' </summary>
         ''' <param name="Func">The function to navigate to.</param>
-        ''' <remarks></remarks>
         Public Shared Sub NavigateToFunction(Func As CodeFunction)
             Try
                 'Ensure the document is activated
@@ -154,7 +150,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="CodeNamespace">The namespace to search through</param>
         ''' <param name="ClassName">The class name to search for</param>
         ''' <returns>The CodeClass if found, otherwise Nothing.</returns>
-        ''' <remarks></remarks>
         Public Shared Function FindCodeClass(CodeNamespace As CodeNamespace, ClassName As String) As CodeClass
             For Each Element As CodeElement In CodeNamespace.Members
                 If Element.Kind = vsCMElement.vsCMElementClass Then
@@ -176,7 +171,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="NamespaceName">The namespace name to search for</param>
         ''' <param name="ClassName">The class name to search for</param>
         ''' <returns>The CodeClass if found, otherwise Nothing.</returns>
-        ''' <remarks></remarks>
         Public Shared Function FindCodeClass(CodeElements As CodeElements, NamespaceName As String, ClassName As String) As CodeClass
             For Each Element As CodeElement In CodeElements
                 If Element.Kind = vsCMElement.vsCMElementNamespace Then

--- a/src/Microsoft.VisualStudio.Editors/Common/DTEUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/DTEUtils.vb
@@ -12,7 +12,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
     ''' <summary>
     ''' Utilities related to DTE projects and project items
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class DTEUtils
 
         Public Const PROJECTPROPERTY_CUSTOMTOOL As String = "CustomTool"
@@ -24,7 +23,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <summary>
         ''' This is a shared class - disallow instantiation.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub New()
         End Sub
 
@@ -35,7 +33,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="ProjectItems">The collection of ProjectItem to check</param>
         ''' <param name="Name">The key to check for.</param>
         ''' <returns>The ProjectItem for the given key, if found, else Nothing.  Throws exceptions only in unexpected cases.</returns>
-        ''' <remarks></remarks>
         Public Shared Function QueryProjectItems(ProjectItems As ProjectItems, Name As String) As ProjectItem
             Return ResourceEditor.ResourcesFolderService.QueryProjectItems(ProjectItems, Name)
         End Function
@@ -45,7 +42,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="ProjectItems">The ProjectItems collection to check.  Must refer to a physical folder on disk.</param>
         ''' <returns>The directory name of the collection on disk.</returns>
-        ''' <remarks></remarks>
         Public Shared Function GetFolderNameFromProjectItems(ProjectItems As ProjectItems) As String
             Return ResourceEditor.ResourcesFolderService.GetFolderNameFromProjectItems(ProjectItems)
         End Function
@@ -54,7 +50,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Get the current EnvDTE.Project instance for the project containing the .settings
         ''' file
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Shared Function EnvDTEProject(VsHierarchy As IVsHierarchy) As Project
             Dim ProjectObj As Object = Nothing
             VSErrorHandler.ThrowOnFailure(VsHierarchy.GetProperty(VSITEMID.ROOT, __VSHPROPID.VSHPROPID_ExtObject, ProjectObj))
@@ -66,8 +61,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="VsHierarchy"></param>
         ''' <param name="ItemId"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function ProjectItemFromItemId(VsHierarchy As IVsHierarchy, ItemId As UInteger) As ProjectItem
             Dim ExtensibilityObject As Object = Nothing
             VSErrorHandler.ThrowOnFailure(VsHierarchy.GetProperty(CUInt(ItemId), CInt(__VSHPROPID.VSHPROPID_ExtObject), ExtensibilityObject))
@@ -81,8 +74,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="ProjectItems">The ProjectItems node to search through</param>
         ''' <param name="Extension">The extension to search for, including the period.  E.g. ".resx"</param>
         ''' <param name="SearchChildren">If True, the search will continue to children.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function FindAllFilesWithExtension(ProjectItems As ProjectItems, Extension As String, SearchChildren As Boolean) As List(Of ProjectItem)
             Dim ResXFiles As New List(Of ProjectItem)
             For Each Item As ProjectItem In ProjectItems
@@ -102,7 +93,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Get the file name from a project item.
         ''' </summary>
         ''' <param name="ProjectItem"></param>
-        ''' <returns></returns>
         ''' <remarks>If the item contains of multiple files, the first one is returned</remarks>
         Public Shared Function FileNameFromProjectItem(ProjectItem As ProjectItem) As String
             If ProjectItem Is Nothing Then
@@ -123,8 +113,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Retrieves the given project item's property, if it exists, else Nothing
         ''' </summary>
         ''' <param name="PropertyName">The name of the property to retrieve.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function GetProjectItemProperty(ProjectItem As ProjectItem, PropertyName As String) As [Property]
             If ProjectItem.Properties Is Nothing Then
                 Return Nothing
@@ -143,8 +131,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Retrieves the given project's property, if it exists, else Nothing
         ''' </summary>
         ''' <param name="PropertyName">The name of the property to retrieve.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function GetProjectProperty(Project As Project, PropertyName As String) As [Property]
             If Project.Properties Is Nothing Then
                 Return Nothing
@@ -164,7 +150,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         '''   If this project system doesn't have that property, this call is a NOP.
         ''' </summary>
         ''' <param name="Item">The ProjectItem on which to set the property</param>
-        ''' <remarks></remarks>
         Public Shared Sub SetBuildAction(Item As ProjectItem, BuildAction As VSLangProj.prjBuildAction)
             Dim BuildActionProperty As [Property] = GetProjectItemProperty(Item, PROJECTPROPERTY_BUILDACTION)
             If BuildActionProperty IsNot Nothing Then
@@ -177,7 +162,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         '''   If this project system doesn't have that property, returns prjBuildActionNone.
         ''' </summary>
         ''' <param name="Item">The ProjectItem on which to set the property</param>
-        ''' <remarks></remarks>
         Public Shared Function GetBuildAction(Item As ProjectItem) As VSLangProj.prjBuildAction
             Dim BuildActionProperty As [Property] = GetProjectItemProperty(Item, PROJECTPROPERTY_BUILDACTION)
             If BuildActionProperty IsNot Nothing Then
@@ -209,7 +193,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         '''   If this project system doesn't have that property, returns "".
         ''' </summary>
         ''' <param name="Item">The ProjectItem on which to set the property</param>
-        ''' <remarks></remarks>
         Public Shared Function GetBuildActionAsString(Item As ProjectItem) As String
             Dim BuildActionProperty As [Property] = GetProjectItemProperty(Item, PROJECTPROPERTY_MSBUILD_ITEMTYPE)
             If BuildActionProperty IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/Common/ListViewComparer.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/ListViewComparer.vb
@@ -12,7 +12,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
     ''' - Sort the ListView based on the current column or the first column if current column values are equal.
     ''' - Shared method to handle a column click event and sort the list view.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class ListViewComparer
         Implements IComparer
 

--- a/src/Microsoft.VisualStudio.Editors/Common/ProjectBatchEdit.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/ProjectBatchEdit.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Strict On
 Option Explicit On
@@ -25,10 +25,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
 
         Private ReadOnly _projectBuildSystem As IVsProjectBuildSystem
         Private _batchCount As Integer
-
-
-        ''' <summary>
-        ''' </summary>
         ''' <param name="projectHierarchy"> The VS project object</param>
         ''' <param name="startBatch">If true, we start a batch process immediately</param>
         Friend Sub New(projectHierarchy As IVsHierarchy, Optional startBatch As Boolean = True)

--- a/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
@@ -14,7 +14,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
     ''' <summary>
     ''' Utilities relating to the Visual Studio shell, services, etc.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ShellUtil
 
 
@@ -25,8 +24,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="VsUIShell">The IVsUIShell interface that must also implement IVsUIShell2 (if not, or if Nothing, default color is returned)</param>
         ''' <param name="VsSysColorIndex">The color index to look up.</param>
         ''' <param name="DefaultColor">The default color to return if the call fails.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function GetColor(VsUIShell As IVsUIShell, VsSysColorIndex As __VSSYSCOLOREX, DefaultColor As Color) As Color
             Return GetColor(TryCast(VsUIShell, IVsUIShell2), VsSysColorIndex, DefaultColor)
         End Function
@@ -39,8 +36,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="VsUIShell2">The IVsUIShell2 interface to use (if Nothing, default color is returned)</param>
         ''' <param name="VsSysColorIndex">The color index to look up.</param>
         ''' <param name="DefaultColor">The default color to return if the call fails.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function GetColor(VsUIShell2 As IVsUIShell2, VsSysColorIndex As __VSSYSCOLOREX, DefaultColor As Color) As Color
             If VsUIShell2 IsNot Nothing Then
                 Dim abgrValue As UInteger
@@ -60,7 +55,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="abgrValue">The UInteger COLORREF value</param>
         ''' <returns>The System.Drawing.Color equivalent.</returns>
-        ''' <remarks></remarks>
         Private Shared Function COLORREFToColor(abgrValue As UInteger) As Color
             Return Color.FromArgb(CInt(abgrValue And &HFFUI), CInt((abgrValue And &HFF00UI) >> 8), CInt((abgrValue And &HFF0000UI) >> 16))
         End Function
@@ -69,8 +63,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <summary>
         ''' Retrieves the window that should be used as the owner of all dialogs and messageboxes.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function GetDialogOwnerWindow(serviceProvider As IServiceProvider) As IWin32Window
             Dim dialogOwner As IWin32Window = Nothing
             Dim UIService As IUIService = DirectCast(serviceProvider.GetService(GetType(IUIService)), IUIService)
@@ -89,7 +81,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="Config">The IVsCfg to get the configuration and platform name from.</param>
         ''' <param name="ConfigName">[out] The configuration name.</param>
         ''' <param name="PlatformName">[out] The platform name.</param>
-        ''' <remarks></remarks>
         Public Shared Sub GetConfigAndPlatformFromIVsCfg(Config As IVsCfg, ByRef ConfigName As String, ByRef PlatformName As String)
             Dim DisplayName As String = Nothing
 
@@ -120,7 +111,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         '''   we hide the configuration/platform comboboxes.
         ''' </summary>
         ''' <param name="ProjectHierarchy">The hierarchy to check</param>
-        ''' <remarks></remarks>
         Public Shared Function GetIsSimplifiedConfigMode(ProjectHierarchy As IVsHierarchy) As Boolean
             Try
                 If ProjectHierarchy IsNot Nothing Then
@@ -143,7 +133,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         '''   from then on out).
         ''' </summary>
         ''' <param name="ProjectHierarchy">The project hierarchy to check</param>
-        ''' <remarks></remarks>
         Private Shared Function CanHideConfigurationsForProject(ProjectHierarchy As IVsHierarchy) As Boolean
             Dim ReturnValue As Boolean = False 'If failed to get config value, default to not hiding configs
 
@@ -175,7 +164,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         '''   Tools.Options.
         ''' </summary>
         ''' <param name="DTE">The DTE extensibility object</param>
-        ''' <remarks></remarks>
         Private Shared Function ToolsOptionsShowAdvancedBuildConfigurations(DTE As DTE) As Boolean
             Dim ShowValue As Boolean
             Dim ProjAndSolutionProperties As Properties
@@ -203,8 +191,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         '''   don't support this, returns Nothing (e.g. C++).
         ''' </summary>
         ''' <param name="ProjectHierarchy"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function DTEProjectFromHierarchy(ProjectHierarchy As IVsHierarchy) As Project
             If ProjectHierarchy Is Nothing Then
                 Return Nothing
@@ -226,8 +212,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="sp"></param>
         ''' <param name="project"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function VsHierarchyFromDTEProject(sp As IServiceProvider, project As Project) As IVsHierarchy
             Debug.Assert(sp IsNot Nothing)
             If sp Is Nothing OrElse project Is Nothing Then
@@ -251,8 +235,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Returns the IVsCfgProvider2 for the given project hierarchy
         ''' </summary>
         ''' <param name="ProjectHierarchy"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function GetConfigProvider(ProjectHierarchy As IVsHierarchy) As IVsCfgProvider2
             'CONSIDER: This will not work for all project types because they do not support this property.
             Dim ConfigProvider As Object = Nothing
@@ -266,8 +248,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Given a hierarchy, determine if this is a devices project...
         ''' </summary>
         ''' <param name="hierarchy"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function IsDeviceProject(hierarchy As IVsHierarchy) As Boolean
             If hierarchy Is Nothing Then
                 Debug.Fail("I can't determine if this is a devices project from a NULL hierarchy!?")
@@ -287,7 +267,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="hierarchy"></param>
         ''' <returns>true if it is a venus project</returns>
-        ''' <remarks></remarks>
         Friend Shared Function IsVenusProject(hierarchy As IVsHierarchy) As Boolean
 
             If hierarchy Is Nothing Then
@@ -314,8 +293,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Is this a web (Venus WSP or WAP project)
         ''' </summary>
         ''' <param name="hierarchy"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function IsWebProject(hierarchy As IVsHierarchy) As Boolean
             Const WebAppProjectGuid As String = "{349c5851-65df-11da-9384-00065b846f21}"
 
@@ -366,10 +343,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
             End Try
             Return False
         End Function
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="fileName">IN: name of the file to get the document info from</param>
         ''' <param name="rdt">IN: Running document table to find the info in</param>
         ''' <param name="hierarchy">OUT: Hierarchy that the document was found in</param>
@@ -377,7 +350,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="readLocks">OUT: Number of read locks for the document</param>
         ''' <param name="editLocks">OUT: Number of edit locks on the document</param>
         ''' <param name="docCookie">OUT: A cookie for the doc, 0 if the doc isn't found in the RDT</param>
-        ''' <remarks></remarks>
         Friend Shared Sub GetDocumentInfo(fileName As String, rdt As IVsRunningDocumentTable, ByRef hierarchy As IVsHierarchy, ByRef readLocks As UInteger, ByRef editLocks As UInteger, ByRef itemid As UInteger, ByRef docCookie As UInteger)
             Requires.NotNull(fileName, NameOf(fileName))
             Requires.NotNull(rdt, NameOf(rdt))
@@ -435,7 +407,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <returns>
         ''' The list of items that are to be checked out
         ''' </returns>
-        ''' <remarks></remarks>
         Friend Shared Function FileNameAndGeneratedFileName(projectitem As ProjectItem,
                                                             Optional suffix As String = ".Designer",
                                                             Optional requireExactlyOneChild As Boolean = True,
@@ -493,7 +464,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <summary>
         ''' Wrapper class for IVsShell.OnBroadcastMessage
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Class BroadcastMessageEventsHelper
             Implements IVsBroadcastMessageEvents
             Implements IDisposable
@@ -542,8 +512,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
             ''' <param name="msg"></param>
             ''' <param name="wParam"></param>
             ''' <param name="lParam"></param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Private Function IVsBroadcastMessageEvents_OnBroadcastMessage(msg As UInteger, wParam As IntPtr, lParam As IntPtr) As Integer Implements IVsBroadcastMessageEvents.OnBroadcastMessage
                 OnBroadcastMessage(msg, wParam, lParam)
                 Return Interop.NativeMethods.S_OK
@@ -555,7 +523,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
             ''' <param name="msg"></param>
             ''' <param name="wParam"></param>
             ''' <param name="lParam"></param>
-            ''' <remarks></remarks>
             Protected Overridable Sub OnBroadcastMessage(msg As UInteger, wParam As IntPtr, lParam As IntPtr)
                 RaiseEvent BroadcastMessage(msg, wParam, lParam)
             End Sub
@@ -597,7 +564,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <summary>
         ''' Monitor and set font when font changes...
         ''' </summary>
-        ''' <remarks></remarks>
         Friend NotInheritable Class FontChangeMonitor
             Inherits BroadcastMessageEventsHelper
 
@@ -612,7 +578,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
             ''' <param name="sp"></param>
             ''' <param name="ctrl"></param>
             ''' <param name="SetFontInitially">If true, set the font of the provided control when this FontChangeMonitor is created</param>
-            ''' <remarks></remarks>
             Public Sub New(sp As IServiceProvider, ctrl As Control, SetFontInitially As Boolean)
                 MyBase.New(sp)
 
@@ -633,7 +598,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
             ''' <param name="msg"></param>
             ''' <param name="wParam"></param>
             ''' <param name="lParam"></param>
-            ''' <remarks></remarks>
             Protected Overrides Sub OnBroadcastMessage(msg As UInteger, wParam As IntPtr, lParam As IntPtr)
                 MyBase.OnBroadcastMessage(msg, wParam, lParam)
 
@@ -651,8 +615,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
             ''' <summary>
             ''' Pick current dialog font...
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Friend Shared ReadOnly Property GetDialogFont(ServiceProvider As IServiceProvider) As Font
                 Get
                     If ServiceProvider IsNot Nothing Then
@@ -676,7 +638,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="hierarchy">Hierarchy to check if the custom tool is registered for</param>
         ''' <param name="customToolName">Name of custom tool to look for</param>
         ''' <returns>True if registered, false otherwise</returns>
-        ''' <remarks></remarks>
         Friend Shared Function IsCustomToolRegistered(hierarchy As IVsHierarchy, customToolName As String) As Boolean
             Requires.NotNull(hierarchy, NameOf(hierarchy))
             Requires.NotNull(customToolName, NameOf(customToolName))
@@ -716,8 +677,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="pHier"></param>
         ''' <param name="itemId"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function IsDefaultNamespaceRename(pHier As IVsHierarchy, itemId As UInteger) As Boolean
             ' result <<== out
             Dim result As Object = Nothing
@@ -735,8 +694,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="serviceProvider"></param>
         ''' <param name="hierarchy"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function CreateTypeResolutionService(serviceProvider As IServiceProvider, hierarchy As IVsHierarchy) As System.ComponentModel.Design.ITypeResolutionService
             Dim dynamicTypeService As Shell.Design.DynamicTypeService =
                     TryCast(serviceProvider.GetService(
@@ -759,8 +716,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="VsSysColorIndex"></param>
         ''' <param name="DefaultColor"></param>
         ''' <param name="UseVSTheme">Whether to use VS Shell to map the right color or just use the default one.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function GetVSColor(VsSysColorIndex As __VSSYSCOLOREX3, DefaultColor As Color, Optional UseVSTheme As Boolean = True) As Color
             If Not UseVSTheme Then
                 Return DefaultColor

--- a/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
@@ -95,7 +95,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="obj"></param>
         ''' <param name="value"></param>
         ''' <return> return true if the variant is an integer type value</return>
-        ''' <remarks></remarks>
         Public Function TryConvertVariantToInt(obj As Object, ByRef value As Integer) As Boolean
             If obj Is Nothing Then
                 Return False
@@ -127,8 +126,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' negative numbers to UInt32.  We just want raw bit translation.
         ''' </summary>
         ''' <param name="obj"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function NoOverflowCUInt(obj As Object) As UInteger
             Return NoOverflowCUInt(CLng(obj))
         End Function
@@ -137,8 +134,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Masks the top 32 bits to get just the lower 32bit number
         ''' </summary>
         ''' <param name="LongValue"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function NoOverflowCUInt(LongValue As Long) As UInteger
             Return CUInt(LongValue And UInteger.MaxValue)
         End Function
@@ -257,7 +252,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         '''  False if a is true and b is false.  Otherwise it returns True (as there's no
         '''   evidence to suggest that the implication is incorrect).
         ''' </summary>
-        ''' <remarks></remarks>
         Public Function Implies(a As Boolean, b As Boolean) As Boolean
             Return Not (a And Not b)
         End Function
@@ -269,8 +263,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         '''   also the inner exception, if any.
         ''' </summary>
         ''' <param name="ex"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function DebugMessageFromException(ex As Exception) As String
 #If DEBUG Then
             Dim ErrorMessage As String = ex.Message & vbCrLf & vbCrLf & vbCrLf & "[SHOWN IN DEBUG ONLY] STACK TRACE:" & vbCrLf & ex.StackTrace
@@ -290,8 +282,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         '''   returns an empty string.
         ''' </summary>
         ''' <param name="Value">The value to turn into a displayable string.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function DebugToString(Value As Object) As String
 #If DEBUG Then
             Dim StringValue As String = ""
@@ -353,7 +343,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Given an exception, returns True if it is a CheckOut exception.
         ''' </summary>
         ''' <param name="ex">The exception to check rethrow if it's caused by canceling checkout</param>
-        ''' <remarks></remarks>
         Public Function IsCheckoutCanceledException(ex As Exception) As Boolean
             If (TypeOf ex Is CheckoutException AndAlso ex.Equals(CheckoutException.Canceled)) _
                 OrElse
@@ -374,8 +363,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' If the given string is Nothing, return "", else return the original string.
         ''' </summary>
         ''' <param name="Str"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function NothingToEmptyString(Str As String) As String
             If Str Is Nothing Then
                 Return String.Empty
@@ -389,8 +376,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' If the given string is "", return Nothing, else return the original string.
         ''' </summary>
         ''' <param name="Str"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function EmptyStringToNothing(Str As String) As String
             If Str Is Nothing OrElse Str.Length = 0 Then
                 Return Nothing
@@ -405,8 +390,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         '''   is malformed, it returns the original file path.
         ''' </summary>
         ''' <param name="Path">The path to get the full path from.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetFullPathTolerant(Path As String) As String
             Try
                 Return IO.Path.GetFullPath(Path)
@@ -425,7 +408,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="Namespace1">First namespace or name.  May be Nothing.</param>
         ''' <param name="Namespace2">Second namespace or name.  May be Nothing.</param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' Do not use this function to add a namespace onto a class (if the class name is empty, it will
         '''   return just the root namespace).  Instead, use AddNamespace for that.
@@ -449,7 +431,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         '''   returns empty.
         ''' </summary>
         ''' <param name="ClassName">The class name to prepend the namespace to.</param>
-        ''' <returns></returns>
         ''' <remarks>Handles values of Nothing, never returns Nothing.</remarks>
         Public Function AddNamespace([Namespace] As String, ClassName As String) As String
             If ClassName = "" Then
@@ -471,7 +452,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="FullyQualifiedNamespace">The fully-qualified namespace to remove the namespace from</param>
         ''' <param name="RootNamespace">The current root namespace to remove if it exists.</param>
         ''' <returns>FullyQualifiedNamespace without the root namespace.</returns>
-        ''' <remarks></remarks>
         Public Function RemoveRootNamespace(FullyQualifiedNamespace As String, RootNamespace As String) As String
             Dim RootNamespaceLength As Integer = 0
 
@@ -514,7 +494,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         '''       "Metafiles (*.wmf, *.emf)|*.wmf;*.emf"
         ''' 
         ''' </returns>
-        ''' <remarks></remarks>
         Public Function CreateDialogFilter(FilterText As String, ParamArray Extensions() As String) As String
             Dim Filter As New StringBuilder
             Dim i As Integer
@@ -557,8 +536,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <summary>
         ''' Returns a localized "All Files (*.*)|*.*" dialog filter string.  Can be used with CombineDialogFilters.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetAllFilesDialogFilter() As String
             'We don't use CreateDialogFilter because we don't want *.* to be part of the user-friendly portion.
             '  We only want:  All Files|*.*
@@ -570,8 +547,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Give a set of filter lines for file dialogs (e.g., by using CreateSingleDialogFilter), combines them all into a single filter.
         ''' </summary>
         ''' <param name="Filters">The individual filter entries</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function CombineDialogFilters(ParamArray Filters() As String) As String
             Dim CombinedFilter As New StringBuilder
 
@@ -594,8 +569,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="Condition">The condition to test.</param>
         ''' <param name="TrueExpression">What to return if the condition is True</param>
         ''' <param name="FalseExpression">What to return if the condition is False</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function IIf(Of T)(Condition As Boolean, TrueExpression As T, FalseExpression As T) As T
             If Condition Then
                 Return TrueExpression
@@ -609,7 +582,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Set the drop-down width of a combobox wide enough to show the text of all entries in it
         ''' </summary>
         ''' <param name="ComboBox">The combobox to change the width for</param>
-        ''' <remarks></remarks>
         Public Sub SetComboBoxDropdownWidth(ComboBox As ComboBox)
             If ComboBox IsNot Nothing Then
                 ComboBox.DropDownWidth = Math.Max(MeasureMaxTextWidth(ComboBox, ComboBox.Items), ComboBox.Width)
@@ -639,8 +611,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="ctrl"></param>
         ''' <param name="items"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function MeasureMaxTextWidth(ctrl As Control, items As IEnumerable) As Integer
             Dim MaxEntryWidth As Integer = 0
             Using g As Graphics = ctrl.CreateGraphics()
@@ -666,8 +636,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Returns a given path with a backslash at the end, if not already there.
         ''' </summary>
         ''' <param name="Path">The path to add a backslash to.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function AppendBackslash(Path As String) As String
             If Path <> "" AndAlso Right(Path, 1) <> IO.Path.DirectorySeparatorChar AndAlso Right(Path, 1) <> IO.Path.AltDirectorySeparatorChar Then
                 Return Path & IO.Path.DirectorySeparatorChar
@@ -688,7 +656,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="MutiSelect">Whether we should support multi-selection</param>
         ''' <param name="NeedThrowError">Throw error when the dialog fails unexpectedly</param>
         ''' <returns>a collection of files</returns>
-        ''' <remarks></remarks>
         Friend Function GetFilesViaBrowse(ServiceProvider As IServiceProvider, ParentWindow As IntPtr,
                 InitialDirectory As String, DialogTitle As String,
                 Filter As String, FilterIndex As UInteger, MutiSelect As Boolean,
@@ -1079,8 +1046,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Get the service provider associated with a hierarchy...
         ''' </summary>
         ''' <param name="pHier"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function ServiceProviderFromHierarchy(pHier As IVsHierarchy) As ServiceProvider
             If pHier IsNot Nothing Then
                 Dim OLEServiceProvider As OLE.Interop.IServiceProvider = Nothing
@@ -1120,7 +1085,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="HwndParent">The container HWND.</param>
         ''' <param name="First">If True, sets focus to the first control, otherwise the last.</param>
-        ''' <remarks></remarks>
         Public Function FocusFirstOrLastTabItem(HwndParent As IntPtr, First As Boolean) As Boolean
             If HwndParent.Equals(IntPtr.Zero) Then
                 Return False
@@ -1192,8 +1156,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="ItemId"></param>
         ''' <param name="IncludeRootNamespace"></param>
         ''' <param name="SupportCustomToolNamespace"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function GeneratedCodeNamespace(Hierarchy As IVsHierarchy, ItemId As UInteger, IncludeRootNamespace As Boolean, SupportCustomToolNamespace As Boolean) As String
             ' Try to get the root namespace property (if VB)
             Dim RootNamespace As String = ""
@@ -1303,8 +1265,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         '''     added before the targetPlatform is changed from 3.0 to 2.0.
         ''' </summary>
         ''' <param name="Hierarchy"></param>
-        ''' <return></return>
-        ''' <remarks></remarks>
         Private Function IsWCFReferenceValidInProject(Hierarchy As IVsHierarchy) As Boolean
             Requires.NotNull(Hierarchy, NameOf(Hierarchy))
 
@@ -1332,8 +1292,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' This function check whether Web Reference is supported by default.
         ''' </summary>
         ''' <param name="Hierarchy"></param>
-        ''' <return></return>
-        ''' <remarks></remarks>
         Friend Function IsWebReferenceSupportedByDefaultInProject(Hierarchy As IVsHierarchy) As Boolean
             Requires.NotNull(Hierarchy, NameOf(Hierarchy))
 
@@ -1359,8 +1317,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Is this a VB project?
         ''' </summary>
         ''' <param name="Hierarchy"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function IsVbProject(Hierarchy As IVsHierarchy) As Boolean
             Requires.NotNull(Hierarchy, NameOf(Hierarchy))
 
@@ -1379,8 +1335,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Get Framework version number
         ''' </summary>
         ''' <param name="Hierarchy"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function GetProjectTargetFrameworkVersion(Hierarchy As IVsHierarchy) As UInteger
             ' Get ".Net version" using TargetFrameworkMoniker property
             Dim objVersionNumber As Object = Nothing
@@ -1406,7 +1360,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="Hierarchy"></param>
         ''' <returns>True is the current Framework Profile is Client</returns>
-        ''' <remarks></remarks>
         Friend Function IsClientFrameworkSubset(Hierarchy As IVsHierarchy) As Boolean
             Debug.Assert(Hierarchy IsNot Nothing, "Hierarchy is required")
             Dim service As MultiTargetService = New MultiTargetService(Hierarchy, VSConstants.VSITEMID_ROOT, False)
@@ -1466,8 +1419,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
             ''' to report back to SQM what the values are...
             ''' </summary>
             ''' <param name="guid"></param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Friend Shared Function PageGuidToId(guid As Guid) As Byte
                 For i As Integer = 0 To s_sqmOrder.Length - 1
                     If s_sqmOrder(i).Equals(guid) Then
@@ -1499,7 +1450,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' from our unit tests. By changing the m_instance field, we can take provide fake implementations
         ''' of functions that otherwise would require significant mocking...
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Class Helper
 
             Public Overridable Function ServiceProviderFromHierarchy(pHier As IVsHierarchy) As IServiceProvider ' Microsoft.VisualStudio.Shell.ServiceProvider
@@ -1515,8 +1465,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         '''   \r\n and reverse \n\r to \r\n
         ''' </summary>
         ''' <param name="text"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function NormalizeLineEndings(text As String) As String
             If text = "" Then
                 Return text
@@ -1637,8 +1585,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Determines whether the given hierarchy is an appcontainer project
         ''' </summary>
         ''' <param name="hierarchy"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function IsAppContainerProject(hierarchy As IVsHierarchy) As Boolean
 
             Dim propertyValue As Object = Nothing
@@ -1665,8 +1611,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' mscorlib.dll and Microsoft.VisualBasic.dll.
         ''' </summary>
         ''' <param name="Reference"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function IsImplicitlyAddedReference(Reference As VSLangProj.Reference) As Boolean
             If Reference Is Nothing Then
                 Debug.Fail("Reference shouldn't be Nothing")

--- a/src/Microsoft.VisualStudio.Editors/Common/switches.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/switches.vb
@@ -143,7 +143,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
     ''' <summary>
     ''' Contains predefined switches for enabling/disabling trace output or code instrumentation.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class Switches
 
         '------------- Resource Editor -------------
@@ -151,49 +150,41 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <summary>
         ''' Trace for the ResourceEditor.FileWatcher class
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared RSEFileWatcher As New TraceSwitch("RSEFileWatcher", "Trace the resource editor FileWatcher class.")
 
         ''' <summary>
         ''' Tracing for the ResourceEditor.ResourceSerializationService class
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared RSEResourceSerializationService As New TraceSwitch("RSEResourceSerializationService", "Trace the resource editor ResourceSerializationService class.")
 
         ''' <summary>
         ''' Track adding and removing resources in the resource editor
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared RSEAddRemoveResources As New TraceSwitch("RSEAddRemoveResources", "Trace adding/removing resources in the resource editor")
 
         ''' <summary>
         ''' Trace virtual mode methods in the resource editor's string table
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared RSEVirtualStringTable As New TraceSwitch("RSEVirtualStringTable", "Trace virtual mode methods in the resource editor's string table")
 
         ''' <summary>
         ''' Trace virtual mode methods in the resource editor's listview
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared RSEVirtualListView As New TraceSwitch("RSEVirtualListView", "Trace virtual mode methods in the resource editor's listview")
 
         ''' <summary>
         ''' Trace the delayed checking of errors in resources
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared RSEDelayCheckErrors As New TraceSwitch("RSEDelayCheckErrors", "Trace the delayed checking of errors in resources")
 
         ''' <summary>
         ''' Disable high-quality options on the Graphics object when creating thumbnails in the resource editor
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared RSEDisableHighQualityThumbnails As New BooleanSwitch("RSEDisableHighQualityThumbnails", "Disable high-quality options on the Graphics object when creating thumbnails in the resource editor")
 
         ''' <summary>
         ''' Trace find/replace in the resource editor
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared RSEFindReplace As New TraceSwitch("RSEFindReplace", "Trace find/replace in the resource editor")
 
 
@@ -205,7 +196,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <summary>
         ''' Trace the showing of context menus via the base control classes in DesignerFramework
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared DFContextMenu As New TraceSwitch("DFContextMenu", "Trace the showing of context menus via the base control classes in DesignerFramework")
 
 
@@ -217,7 +207,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <summary>
         ''' Trace source code control integration behavior in Microsoft.VisualStudio.Editors.dll
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared MSVBE_SCC As New TraceSwitch("MSVBE_SCC", "Trace source code control integration behavior in Microsoft.VisualStudio.Editors.dll")
 
 
@@ -229,80 +218,67 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <summary>
         ''' Trace when the active designer changes in the project designer
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDDesignerActivations As New TraceSwitch("PDDesignerActivations", "Trace when the active designer changes in the project designer")
 
         ''' <summary>
         ''' Trace project designer focus-related events
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDFocus As New TraceSwitch("PDFocus", "Trace project designer focus-related events")
 
         ''' <summary>
         ''' Trace behavior of multiple-value undo and redo
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDUndo As New TraceSwitch("PDUndo", "Trace behavior of multiple-value undo and redo")
 
         ''' <summary>
         ''' Trace the creation and dirtying of properties, apply, etc.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDProperties As New TraceSwitch("PDProperties", "Trace the creation and dirtying of properties in property pages, apply, etc.")
 
         ''' <summary>
         ''' Trace mapping of application type - output type, MyType
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDApplicationType As New TraceSwitch("PDApplicationType", "Trace mapping of application type properties")
 
         ''' <summary>
         ''' Trace the functionality of extender properties
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDExtenders As New TraceSwitch("PDExtenders", "Trace the functionality of extender properties")
 
         ''' <summary>
         ''' Trace configuration setup and changes tracking in the project designer
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDConfigs As New TraceSwitch("PDConfigs", "Trace configuration setup and changes tracking in the project designer")
 
         ''' <summary>
         ''' Trace performance issues for the project designer
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDPerf As New TraceSwitch("PDPerf", "Trace performance issues for the project designer")
 
         ''' <summary>
         ''' Trace command routing (CmdTargetHelper, etc.) in the project designer
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDCmdTarget As New TraceSwitch("PDCmdTarget", "Trace command routing (CmdTargetHelper, etc.) in the project designer")
 
         ''' <summary>
         ''' Always use native ::SetParent() instead of setting the WinForms Parent property for property page hosting.
         ''' This is useful for testing the hosting of pages as it would occur for non-native pages.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDAlwaysUseSetParent As New BooleanSwitch("PDAlwaysUseSetParent", "Always use native ::SetParent() instead of setting the WinForms Parent property for property page hosting")
 
         ''' <summary>
         ''' Traces message routing in the project designer and its property pages
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDMessageRouting As New TraceSwitch("PDMessageRouting", "Traces message routing in the project designer and its property pages")
 
         ''' <summary>
         ''' Overrides the SKU edition value for the project designer
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDSku As New EnumSwitch(Of VSProductSKU.VSASKUEdition)("PDSku", "Overrides the SKU edition value for the project designer")
 
         ''' <summary>
         ''' Overrides the Sub-SKU edition value for the project designer
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared PDSubSku As New EnumSwitch(Of VSProductSKU.VSASubSKUEdition)("PDSubSku", "Overrides the Sub-SKU edition value for the project designer")
 
         Public Shared PDAddVBWPFApplicationPageToAllProjects As New BooleanSwitch("PDAddVBWPFApplicationPageToAllProjects",
@@ -319,7 +295,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <summary>
         ''' Tracing whenever we read/write .settings and/or app.config files...
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared SDSerializeSettings As New TraceSwitch("SDSerializeSettings", "Serialization/deserialization of settings")
 
         '------------- WCF Tooling -------------
@@ -341,8 +316,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function Format(Message As String, ParamArray FormatArguments() As Object) As String
             If FormatArguments Is Nothing OrElse FormatArguments.Length = 0 Then
                 Return Message
@@ -366,8 +339,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Formats a Win32 message into a friendly form for debugging/tracing purposes
         ''' </summary>
         ''' <param name="msg"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function FormatWin32Message(msg As Windows.Forms.Message) As String
             Dim str As New System.Text.StringBuilder()
             Dim MsgType As String = Nothing
@@ -439,7 +410,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <summary>
         ''' A Switch which has a simple enum value (either as integer or string representation)
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Class EnumSwitch(Of T)
             Inherits Switch
 
@@ -451,9 +421,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
             ''' <summary>
             ''' True iff the switch has a non-empty value
             ''' </summary>
-            ''' <value></value>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public ReadOnly Property ValueDefined() As Boolean
                 Get
                     Return MyBase.Value <> "" AndAlso CInt(Convert.ChangeType(Value, TypeCode.Int32)) <> 0
@@ -463,9 +430,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
             ''' <summary>
             ''' Gets/sets the current value of the switch
             ''' </summary>
-            ''' <value></value>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Shadows Property Value() As T
                 Get
                     Return CType([Enum].Parse(GetType(T), MyBase.Value), T)
@@ -479,7 +443,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
             ''' Interprets the new (string-based) correctly, based on the string or
             '''   integer representation.
             ''' </summary>
-            ''' <remarks></remarks>
             Protected Overrides Sub OnValueChanged()
                 SwitchSetting = CInt(Convert.ChangeType(Value, TypeCode.Int32))
             End Sub
@@ -495,7 +458,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TraceSCC(Message As String, ParamArray FormatArguments() As Object)
 #If DEBUG Then
@@ -508,7 +470,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDFocus(Level As TraceLevel, Message As String, ParamArray FormatArguments() As Object)
 #If DEBUG Then
@@ -521,7 +482,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDUndo(Message As String, ParamArray FormatArguments() As Object)
 #If DEBUG Then
@@ -535,7 +495,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDProperties(Level As TraceLevel, Message As String, ParamArray FormatArguments() As Object)
 #If DEBUG Then
@@ -549,7 +508,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDExtenders(Level As TraceLevel, Message As String, ParamArray FormatArguments() As Object)
 #If DEBUG Then
@@ -563,7 +521,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDConfigs(TraceLevel As TraceLevel, Message As String, ParamArray FormatArguments() As Object)
 #If DEBUG Then
@@ -584,7 +541,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDPerf(Message As String, ParamArray FormatArguments() As Object)
 #If DEBUG Then
@@ -642,7 +598,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="Message"></param>
         ''' <param name="FormatArguments"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDCmdTarget(TraceLevel As TraceLevel, Message As String, ParamArray FormatArguments() As Object)
 #If DEBUG Then
@@ -657,7 +612,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="TraceLevel"></param>
         ''' <param name="Message"></param>
         ''' <param name="msg"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDMessageRouting(TraceLevel As TraceLevel, Message As String, msg As Windows.Forms.Message)
 #If DEBUG Then
@@ -676,7 +630,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="TraceLevel"></param>
         ''' <param name="Message"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDMessageRouting(TraceLevel As TraceLevel, Message As String)
 #If DEBUG Then
@@ -687,7 +640,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <summary>
         ''' Traces the access modifier combobox functionality
         ''' </summary>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub TracePDAccessModifierCombobox(traceLevel As TraceLevel, message As String)
 #If DEBUG Then
@@ -701,7 +653,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="tracelevel"></param>
         ''' <param name="message"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Overloads Shared Sub TraceSDSerializeSettings(tracelevel As TraceLevel, message As String)
 #If DEBUG Then
@@ -715,7 +666,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="tracelevel"></param>
         ''' <param name="formatString"></param>
         ''' <param name="parameters"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Overloads Shared Sub TraceSDSerializeSettings(tracelevel As TraceLevel, formatString As String, ParamArray parameters() As Object)
 #If DEBUG Then
@@ -734,7 +684,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' Trace changes to one of the monitored configuration files 
         ''' </summary>
         ''' <param name="tracelevel"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Overloads Shared Sub TraceWCFConfigFileChangeWatch(tracelevel As TraceLevel, formatString As String, ParamArray parameters() As Object)
 #If DEBUG Then
@@ -748,7 +697,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="tracelevel"></param>
         ''' <param name="message"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Overloads Shared Sub TraceWCFConfigFileChangeWatch(tracelevel As TraceLevel, message As String)
 #If DEBUG Then

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
@@ -15,7 +15,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     ''' <summary>
     ''' Gets the language-dependent terminology for Public/Friend
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class AccessModifierConverter
         Private ReadOnly _converter As TypeConverter
 
@@ -40,8 +39,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Gets the language-dependent terminology for Public/Friend
         ''' </summary>
         ''' <param name="accessibility"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function ConvertToString(accessibility As Access) As String
             Select Case accessibility
                 Case Access.Friend
@@ -178,7 +175,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''   when the designer is not focused and the command gets routed through 
         '''   the package.
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Class DesignerMenuCommandForwarder
 
 
@@ -240,7 +236,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <returns>
             ''' The first command at the head of the queue, or NULL if no the queue is empty
             ''' </returns>
-            ''' <remarks></remarks>
             Protected Shared Function GetMenuCommandAtHeadOfInternalList(cmdId As CommandID) As DesignerMenuCommand
                 Dim list As LinkedList(Of DesignerMenuCommand) = Nothing
                 If (Not s_packageCommandForwarderLists.TryGetValue(cmdId, list)) OrElse list Is Nothing OrElse list.Count = 0 Then
@@ -254,7 +249,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' Add a menu command forwarder to our internal LIFO queue. 
             ''' If the command is in the list, but isn't the first command, we move it to the head of the list
             ''' </summary>
-            ''' <remarks></remarks>
             Protected Shared Sub AddMenuCommandForwarderToInternalList(cmdId As CommandID, command As DesignerMenuCommand)
                 Dim list As LinkedList(Of DesignerMenuCommand) = Nothing
 
@@ -275,7 +269,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' Remove a menu command forwarder from our internal LIFO queue. 
             ''' </summary>
-            ''' <remarks></remarks>
             Protected Shared Sub RemoveMenuCommandForwarderFromInternalList(cmdId As CommandID, command As DesignerMenuCommand)
                 Dim list As LinkedList(Of DesignerMenuCommand) = Nothing
                 If s_packageCommandForwarderLists.TryGetValue(cmdId, list) Then
@@ -305,7 +298,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''   the user turns on code generation, we want to also set the custom tool namespace to the
         '''   default for VB (My.Resources).
         ''' </param>
-        ''' <remarks></remarks>
         Public Sub New(rootDesigner As BaseRootDesigner, serviceProvider As IServiceProvider, projectItem As EnvDTE.ProjectItem, namespaceToOverrideIfCustomToolIsEmpty As String)
             Requires.NotNull(rootDesigner, NameOf(rootDesigner))
             Requires.NotNull(projectItem, NameOf(projectItem))
@@ -322,7 +314,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="accessibility"></param>
         ''' <param name="customToolValue"></param>
-        ''' <remarks></remarks>
         Public Sub AddCodeGeneratorEntry(accessibility As AccessModifierConverter.Access, customToolValue As String)
             Debug.Assert([Enum].IsDefined(GetType(AccessModifierConverter.Access), accessibility))
 
@@ -337,7 +328,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="displayName"></param>
         ''' <param name="customToolValue"></param>
-        ''' <remarks></remarks>
         Public Sub AddCodeGeneratorEntry(displayName As String, customToolValue As String)
             Dim entry As New CodeGeneratorWithName(displayName, customToolValue)
             _codeGeneratorEntries.Add(entry)
@@ -352,7 +342,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''   AddCodeGeneratorEntry will automatically be added here, too.
         ''' </summary>
         ''' <param name="customToolValue"></param>
-        ''' <remarks></remarks>
         Public Sub AddRecognizedCustomToolValue(customToolValue As String)
             If Not _recognizedCustomToolValues.Contains(customToolValue) Then
                 _recognizedCustomToolValues.Add(customToolValue)
@@ -387,8 +376,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''   property in this project, returns False.
         ''' </summary>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function TryGetCustomToolPropertyValue(ByRef value As String) As Boolean
             value = Nothing
 
@@ -456,7 +443,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''   there's an error.
         ''' </summary>
         ''' <param name="value"></param>
-        ''' <remarks></remarks>
         Private Sub TrySetCustomToolValue(value As String)
             Try
                 Dim ToolProperty As EnvDTE.Property = DTEUtils.GetProjectItemProperty(_projectItem, DTEUtils.PROJECTPROPERTY_CUSTOMTOOL)
@@ -521,8 +507,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Is the AccessModifier combobox on the settings designer toolbar enabled?
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function ShouldBeEnabled() As Boolean
             If Not IsDesignerEditable() Then
                 Return False
@@ -556,8 +540,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Demand check if the custom tools that we know about are registered for the current project system.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable ReadOnly Property CustomToolRegistered() As Boolean
             Get
                 If Not _customToolsRegistered.HasValue Then

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
@@ -94,8 +94,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Indicate if it is OK to edit the current set of managed files from a SCC perspective...
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Overridable Function OkToEdit() As Boolean
             If _readOnlyMode Then
                 Return False
@@ -111,8 +109,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Indicate if we are managing a dynamic set of files (if the set of files to check out as a result of editing 
         ''' the primary file changes over time)
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
         ''' <remarks>
         ''' This can be used by editors that sometimes add files to the project system to either specify the project file (if the 
         ''' file isn't in the project and needs to be added) or the newly added file. One example is the settings designer's handling
@@ -127,9 +123,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Get the list of files that you want to check out in the ManualCheckout
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Overridable ReadOnly Property FilesToCheckOut() As List(Of String)
             Get
                 Dim projItem As EnvDTE.ProjectItem = ProjectItem
@@ -143,7 +136,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="ReadOnlyMode"></param>
         ''' <param name="Message"></param>
-        ''' <remarks></remarks>
         Friend Sub SetReadOnlyMode(ReadOnlyMode As Boolean, Message As String)
             _readOnlyMode = ReadOnlyMode
             _readOnlyPrompt = Message
@@ -160,7 +152,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''   additional work, such as checking out a file from source
         '''   code control.
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnModifying()
             Switches.TraceSCC("BaseDesignerLoader.OnModifying()")
 
@@ -224,7 +215,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Provide a WindowPaneProviderService. Override if you want to provide a different provider pane
         ''' </summary>
         ''' <returns>A window pane provider service or NULL to indicate that no provider should be registered</returns>
-        ''' <remarks></remarks>
         Protected Overridable Function GetWindowPaneProviderService() As Shell.Design.WindowPaneProviderService
             Try
                 If _paneProviderService Is Nothing Then
@@ -330,7 +320,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Dispose any resources owned by this instance
         ''' </summary>
         ''' <param name="Disposing"></param>
-        ''' <remarks></remarks>
         Protected Overridable Overloads Sub Dispose(Disposing As Boolean)
             If Disposing Then
                 Disconnect()
@@ -421,7 +410,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' have a loader host here.
         ''' This is the place where we add services!
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub Initialize()
             MyBase.Initialize()
 
@@ -579,7 +567,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' OnDesignerLoadCompleted will be called when we finish loading the designer
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overridable Sub OnDesignerLoadCompleted()
         End Sub
 
@@ -613,7 +600,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Indicates whether the window frame for this designer loader's designer should support the shell toolbox.
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' For performance reasons, this defaults to false.  If the designer should support the toolbox, override
         '''   this and return True.
@@ -628,7 +614,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Run the custom tool (if any)
         ''' </summary>
         ''' <param name="flushBeforeRun">If true, flush before running the custom tool</param>
-        ''' <remarks></remarks>
         Friend Overridable Sub RunSingleFileGenerator(flushBeforeRun As Boolean)
             If flushBeforeRun Then
                 HandleFlush(Nothing)
@@ -703,7 +688,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Called when the document's window is activated or deactivated
         ''' </summary>
         ''' <param name="Activated">True if the document window has been activated, False if deactivated.</param>
-        ''' <remarks></remarks>
         Protected Overridable Sub OnDesignerWindowActivated(Activated As Boolean)
         End Sub
 
@@ -712,7 +696,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Start listening to RDT events
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub AdviseRunningDocTableEvents()
             If _rdt IsNot Nothing Then
                 VSErrorHandler.ThrowOnFailure(_rdt.AdviseRunningDocTableEvents(Me, _rdtEventsCookie))
@@ -722,7 +705,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Stop listening to RDT events
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub UnadviseRunningDocTableEvents()
             If _rdtEventsCookie <> 0 Then
                 If _rdt IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerView.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Windows.Forms
 
@@ -28,7 +28,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''  to interpret it as meaning that the project file was checked out and updated, causing a project
         '''  reload.
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Friend Sub EnterProjectCheckoutSection()
             Debug.Assert(_checkoutSectionCount >= 0, "Bad m_CheckoutCriticalSectionCount count")
             _checkoutSectionCount += 1
@@ -60,7 +59,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''    LeaveProjectCheckoutSection()
         '''  End Try
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Friend Sub LeaveProjectCheckoutSection()
             _checkoutSectionCount -= 1
             Debug.Assert(_checkoutSectionCount >= 0, "Mismatched EnterProjectCheckoutSection/LeaveProjectCheckoutSection calls")
@@ -84,9 +82,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' If true, the project has been reloaded between a call to EnterProjectCheckoutSection and 
         '''   LeaveProjectCheckoutSection.  See EnterProjectCheckoutSection() for more information.
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Friend ReadOnly Property ProjectReloadedDuringCheckout() As Boolean
             Get
                 Return _projectReloadedDuringCheckout
@@ -98,7 +93,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' If true, a call to EnterProjectCheckoutSection has been made, and the matching LeaveProjectCheckoutSection
         '''   call has not yet been made.
         ''' </summary>
-        ''' <remarks></remarks>
         Protected ReadOnly Property IsInProjectCheckoutSection() As Boolean
             Get
                 Return _checkoutSectionCount > 0
@@ -110,7 +104,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Dispose
         ''' </summary>
         ''' <param name="disposing"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub Dispose(disposing As Boolean)
             If disposing Then
                 If IsInProjectCheckoutSection Then
@@ -137,7 +130,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Called in a delayed fashion (via PostMessage) after a LeaveProjectCheckoutSection call if the
         '''   project was forcibly reloaded during the project checkout section.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub DelayedMyBaseDispose()
             'Set this flag back to false so that subclasses which override Dispose() know when it's
             '  safe to Dispose of their controls.

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseEditorFactory.vb
@@ -94,8 +94,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Creates a new native TextBuffer by CoCreating it from COM.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function CreateNewTextStreamBuffer() As IVsTextStream
             Dim LocalRegistry As ILocalRegistry = CType(_serviceProvider.GetService(GetType(ILocalRegistry)), ILocalRegistry)
             Dim TextStreamInstance As IVsTextStream = Nothing
@@ -135,8 +133,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''   compatible, it uses that.  Otherwise it creates a new native TextBuffer.
         ''' </summary>
         ''' <param name="ExistingDocData">The existing DocData pointer, if any</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function GetOrCreateDocDataForNewEditor(ExistingDocData As Object) As Object
             Dim TextStreamInstance As IVsTextStream
 
@@ -166,7 +162,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Called in base classes when the editor factory is sited.  Before this time, ServiceProvider will not be available (and
         '''   should not be assumed afterwards).
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overridable Sub OnSited()
         End Sub
 
@@ -174,7 +169,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Provides the (constant) GUID for the subclassed editor factory.
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' Must be overridden.  Be sure to use the same GUID on the GUID attribute
         '''   attached to the inheriting class.
@@ -185,8 +179,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Provides the (constant) GUID for the command UI.  This is the guid used in the
         '''   CTC file for keybindings, toolbars, etc.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Protected MustOverride ReadOnly Property CommandUIGuid() As Guid
 
 
@@ -309,7 +301,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="Caption"></param>
         ''' <param name="CmdUIGuid"></param>
         ''' <param name="Canceled"></param>
-        ''' <remarks></remarks>
         Protected Overridable Sub CreateEditorInstance(VsCreateEditorFlags As UInteger,
                 FileName As String,
                 PhysicalView As String,
@@ -457,7 +448,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Returns the ServiceProvider
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' Will not be available before OnSited is called.
         ''' </remarks>
@@ -480,7 +470,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Called by the VS shell when it first initializes us.  
         ''' </summary>
         ''' <param name="Site">The Site that will own this editor factory</param>
-        ''' <remarks></remarks>
         Private Sub SetSiteInternal(Site As Object)
             'This same Site already set?  Or Site not yet initialized (= Nothing)?  If so, NOP.
             If _site Is Site Then

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseRootDesigner.vb
@@ -139,7 +139,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''  Refreshes the status of all the menus of the current designer. 
         '''  This is called from DesignerMenuCommand after each invoke.
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Sub RefreshMenuStatus()
             For Each MenuItem As MenuCommand In MenuCommands
                 Debug.Assert(MenuItem IsNot Nothing, "MenuItem IsNot Nothing!")

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignUtil.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignUtil.vb
@@ -88,8 +88,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Get the default caption from IVsUIShell, or fall back to localized resource
         ''' </summary>
         ''' <param name="sp"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function GetDefaultCaption(sp As IServiceProvider) As String
             Dim caption As String = ""
             Dim uiShell As IVsUIShell = Nothing
@@ -109,7 +107,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="ServiceProvider"></param>
         ''' <param name="keyword"></param>
-        ''' <remarks></remarks>
         Friend Shared Sub DisplayTopicFromF1Keyword(ServiceProvider As IServiceProvider, keyword As String)
             If ServiceProvider Is Nothing Then
                 Debug.Fail("NULL serviceprovider - can't show help!")
@@ -183,7 +180,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="Number">The IntPtr to get the word from</param>
         ''' <returns>The signed hi word</returns>
-        ''' <remarks></remarks>
         Public Shared Function SignedHiWord(Number As IntPtr) As Integer
             Return (CType(Number, Integer) >> 16) And &HFFFF
         End Function
@@ -194,7 +190,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="Number">The IntPtr to get the word from</param>
         ''' <returns>The signed lo word</returns>
-        ''' <remarks></remarks>
         Public Shared Function SignedLoWord(Number As IntPtr) As Integer
             Return (CType(Number, Integer) And &HFFFF)
         End Function
@@ -205,7 +200,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="m">Window's message.</param>
         ''' <returns>The context event args to use for raising the event.</returns>
-        ''' <remarks></remarks>
         Public Shared Function GetContextMenuMouseEventArgs(ByRef m As Message) As MouseEventArgs
             Dim x As Integer = SignedLoWord(m.LParam)
             Dim y As Integer = SignedHiWord(m.LParam)
@@ -226,8 +220,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' by allowing "." embedded in the string and zero length strings...
         ''' </summary>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function GenerateValidLanguageIndependentNamespace(value As String) As String
             If value = "" Then
                 Return value
@@ -244,7 +236,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Generate a valid language independent identifier from the given string value
         ''' </summary>
         ''' <param name="value"></param>
-        ''' <returns></returns>
         ''' <remarks>Will throw an ArgumentException if it fails</remarks>
         Friend Shared Function GenerateValidLanguageIndependentIdentifier(value As String) As String
             Const replacementChar As Char = "_"c
@@ -299,8 +290,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Try to get the encoding used by a DocData
         ''' </summary>
         ''' <param name="dd"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function GetEncoding(dd As Shell.Design.Serialization.DocData) As System.Text.Encoding
             ' Try to get the encoding of the textbuffer that we are going to write to...
             Try

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerDataGridView.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerDataGridView.vb
@@ -18,7 +18,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     '''   
     '''   DesignerDataGridView is our control inherited from DataGridView.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class DesignerDataGridView
         Inherits DataGridView
 
@@ -38,7 +37,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Constructor
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub New()
             BackColor = SystemColors.Window
             ForeColor = SystemColors.WindowText
@@ -59,7 +57,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Indicate that we are about to begin edit due to a click on a cell.
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Friend Overridable Sub OnCellClickBeginEdit(e As System.ComponentModel.CancelEventArgs)
             RaiseEvent CellClickBeginEdit(Me, e)
         End Sub
@@ -87,7 +84,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' before showing the context menu... 
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnMouseDown(e As MouseEventArgs)
             Dim ht As HitTestInfo = HitTest(e.X, e.Y)
 
@@ -171,8 +167,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' (they normally do a clear cell, which is bad for comboboxcolumns...)
         ''' </summary>
         ''' <param name="m"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overrides Function ProcessKeyMessage(ByRef m As Message) As Boolean
             Dim ke As New KeyEventArgs(CType(CInt(m.WParam) Or ModifierKeys, Keys))
 
@@ -206,8 +200,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' (they normally do a clear cell, which is bad for comboboxcolumns...)
         ''' </summary>
         ''' <param name="keyData"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         <Security.Permissions.UIPermission(Security.Permissions.SecurityAction.LinkDemand, Window:=Security.Permissions.UIPermissionWindow.AllWindows)>
         Protected Overrides Function ProcessDialogKey(keyData As Keys) As Boolean
             Const CtrlD0 As Keys = Keys.D0 Or Keys.Control
@@ -226,7 +218,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Extremely simple cell template that enables a hybrid of EditCellOnF2OrKeyDown and EditOnEnter mode
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Class EditOnClickDataGridViewComboBoxCell
             Inherits DataGridViewComboBoxCell
 
@@ -272,7 +263,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Extremely simple cell template that enables a hybrid of EditCellOnF2OrKeyDown and EditOnEnter mode
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Class EditOnClickDataGridViewTextBoxCell
             Inherits DataGridViewTextBoxCell
 

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerListView.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerListView.vb
@@ -17,7 +17,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     '''   
     '''   DesignerListView is our control inherited from ListView.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class DesignerListView
         Inherits ListView
 
@@ -30,7 +29,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Public Event ContextMenuShow(sender As Object, e As MouseEventArgs)
 
 

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerMenuCommand.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerMenuCommand.vb
@@ -182,7 +182,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     ''' and another to fill the combobox with items. This is a helper class that you can register with 
     ''' the OleMenuCommandService in order to fill your combobox
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class DesignerCommandBarComboBoxFiller
         Inherits DesignerMenuCommand
 
@@ -196,7 +195,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="designer">Root designer associated with this command</param>
         ''' <param name="commandId">CommandID with GUID/id as specified for the command in the CTC file</param>
         ''' <param name="getter">Delegate that returns a list of strings to fill the combobox with</param>
-        ''' <remarks></remarks>
         Public Sub New(designer As BaseRootDesigner, commandId As CommandID, getter As ItemsGetter)
             MyBase.New(designer, commandId, AddressOf CommandHandler)
 
@@ -213,7 +211,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Mapping from the Exec to the getter delegate
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub InstanceCommandHandler(e As Shell.OleMenuCmdEventArgs)
             If e Is Nothing Then
                 Throw New ArgumentNullException
@@ -231,7 +228,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Shared Sub CommandHandler(sender As Object, e As EventArgs)
             Dim oleEventArgs As Shell.OleMenuCmdEventArgs = TryCast(e, Shell.OleMenuCmdEventArgs)
             Dim cmdSender As DesignerCommandBarComboBoxFiller = TryCast(sender, DesignerCommandBarComboBoxFiller)
@@ -267,7 +263,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="commandId"></param>
         ''' <param name="currentTextGetter">Delegate to get the current text in the combobox</param>
         ''' <param name="currentTextSetter">Delegate to set the current text in the combobox</param>
-        ''' <remarks></remarks>
         Public Sub New(designer As BaseRootDesigner, commandId As CommandID, currentTextGetter As CurrentTextGetter, currentTextSetter As CurrentTextSetter, enabledHandler As CheckCommandStatusHandler)
             MyBase.New(designer, commandId, AddressOf CommandHandler, enabledHandler)
             If currentTextGetter Is Nothing OrElse currentTextSetter Is Nothing Then
@@ -284,7 +279,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Mapping from the Exec to the getter delegate
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub InstanceCommandHandler(e As Shell.OleMenuCmdEventArgs)
             If e.InValue Is Nothing Then
                 ' Request to get the current text...
@@ -304,7 +298,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Shared Sub CommandHandler(sender As Object, e As EventArgs)
             Dim oleEventArgs As Shell.OleMenuCmdEventArgs = TryCast(e, Shell.OleMenuCmdEventArgs)
             Dim cboSender As DesignerCommandBarComboBox = TryCast(sender, DesignerCommandBarComboBox)
@@ -354,7 +347,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     ''' Helper class to handle a group of commands where only one should be checked (latched)
     ''' (similar to how radio buttons work)
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class LatchedCommandGroup
 
         Private ReadOnly _commands As New Dictionary(Of Integer, MenuCommand)
@@ -364,7 +356,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="Id">A unique (within the group) id of the command</param>
         ''' <param name="Command">The command to add</param>
-        ''' <remarks></remarks>
         Public Sub Add(Id As Integer, Command As MenuCommand)
             _commands(Id) = Command
         End Sub
@@ -372,8 +363,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Get the collection of commands that are in this group
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property Commands() As ICollection
             Get
                 Return _commands.Values
@@ -399,7 +388,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Make the command associated with the given ID the only checked command in the group
         ''' </summary>
         ''' <param name="Id"></param>
-        ''' <remarks></remarks>
         Public Sub Check(Id As Integer)
             Dim CommandToCheck As MenuCommand = Nothing
             If Not _commands.TryGetValue(Id, CommandToCheck) Then

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerMessageBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerMessageBox.vb
@@ -27,7 +27,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="RootDesigner">A root designer inherited from BaseRootDesigner, which has the ability to get services.</param>
         ''' <param name="Caption">The text to display in the title bar of the message box.</param>
         ''' <param name="HelpLink">Link to the help topic for this message box.</param>
-        ''' <remarks></remarks>
         Friend Shared Function Show(RootDesigner As BaseRootDesigner, Message As String,
                 Caption As String, Buttons As MessageBoxButtons, Icon As MessageBoxIcon,
                 Optional DefaultButton As MessageBoxDefaultButton = MessageBoxDefaultButton.Button1,
@@ -44,7 +43,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="ex">The exception to include in the message.</param>
         ''' <param name="Caption">The text to display in the title bar of the message box.</param>
         ''' <param name="HelpLink">Link to the help topic for this message box.</param>
-        ''' <remarks></remarks>
         Friend Shared Sub Show(ServiceProvider As IServiceProvider, ex As Exception,
                 Caption As String, Optional HelpLink As String = Nothing)
             Show(ServiceProvider, Nothing, ex, Caption, HelpLink)
@@ -115,7 +113,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="Icon">One of the MessageBoxIcon values that specifies which icon to display in the message box.</param>
         ''' <param name="HelpLink">Link to the help topic for this message box.</param>
         ''' <param name="DefaultButton">One of the MessageBoxDefaultButton values that specifies the default button of the message box.</param>
-        ''' <remarks></remarks>
         Friend Shared Function Show(ServiceProvider As IServiceProvider, Message As String,
                 Caption As String, Buttons As MessageBoxButtons, Icon As MessageBoxIcon,
                 Optional DefaultButton As MessageBoxDefaultButton = MessageBoxDefaultButton.Button1,
@@ -135,7 +132,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="Icon">One of the MessageBoxIcon values that specifies which icon to display in the message box.</param>
         ''' <param name="HelpLink">Link to the help topic for this message box.</param>
         ''' <param name="DefaultButton">One of the MessageBoxDefaultButton values that specifies the default button of the message box.</param>
-        ''' <remarks></remarks>
         Private Shared Function ShowHelper(ServiceProvider As IServiceProvider, Message As String,
                 Caption As String, Buttons As MessageBoxButtons, Icon As MessageBoxIcon,
                 Optional DefaultButton As MessageBoxDefaultButton = MessageBoxDefaultButton.Button1,

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerToolbarPanel.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerToolbarPanel.vb
@@ -12,7 +12,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     ''' <summary>
     ''' Host window for MSO toolbars
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class DesignerToolbarPanel
         Inherits Panel
         Implements IVsToolWindowToolbar
@@ -35,7 +34,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Constructor
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub New()
             MyBase.New()
             Margin = New Padding(0)
@@ -46,7 +44,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Tell the shell that our toolbar should be the active toolbar
         ''' </summary>
         ''' <param name="h"></param>
-        ''' <remarks></remarks>
         Public Sub Activate(h As IntPtr)
             ' It seems that designers don't set the active secondary toolbar when activated -
             ' this should take care of that!
@@ -59,7 +56,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="uiShell"></param>
         ''' <param name="guid">GUID for the toolbar as specified in the CTC file</param>
         ''' <param name="id">Id for the toolbar as specified in the CTC file</param>
-        ''' <remarks></remarks>
         Public Sub SetToolbar(uiShell As IVsUIShell, guid As Guid, id As UInteger)
             If uiShell Is Nothing Then
                 Throw New ArgumentNullException()
@@ -85,7 +81,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' need to associate the new window handle with the toolbar
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnHandleCreated(e As EventArgs)
             MyBase.OnHandleCreated(e)
             If _associateToolbarOnHandleCreate Then
@@ -98,7 +93,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' with the toolbar host (and delete the new toolbar host)
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnHandleDestroyed(e As EventArgs)
             MyBase.OnHandleDestroyed(e)
             If _toolbarHost IsNot Nothing Then
@@ -114,7 +108,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Associate the current window handle with the toolbar host
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub InternalAssociateToolbarWithHandle()
             Debug.Assert(IsHandleCreated, "No handle created when calling InternaleAssociateToolbarWithHandle")
             If _uiShell IsNot Nothing Then
@@ -130,7 +123,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Tell the toolbar that we host that it needs to update its size
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnSizeChanged(e As EventArgs)
             MyBase.OnSizeChanged(e)
             If _toolbarHost IsNot Nothing Then
@@ -143,7 +135,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' WndProc for the DesignerToolbarPanel
         ''' </summary>
         ''' <param name="m"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub WndProc(ByRef m As Message)
             If m.Msg = Win32Constant.WM_SETFOCUS Then
                 'The DesignerToolbarPanel should never get focus, but the hosted
@@ -175,8 +166,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' The toolbar's border is the same as our client rectangle
         ''' </summary>
         ''' <param name="borders"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetBorder(borders() As OLE.Interop.RECT) As Integer Implements IVsToolWindowToolbar.GetBorder
             Dim rect As Drawing.Rectangle = Bounds
 
@@ -193,8 +182,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Set our size based on what the toolbar wants
         ''' </summary>
         ''' <param name="borders"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function SetBorderSpace(borders() As OLE.Interop.RECT) As Integer Implements IVsToolWindowToolbar.SetBorderSpace
             Debug.Assert(borders IsNot Nothing)
             Debug.Assert(borders.Length = 1)
@@ -210,7 +197,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Cleanup
         ''' </summary>
         ''' <param name="disposing"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub Dispose(disposing As Boolean)
             If disposing Then
                 If _toolbarHost IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerTypeDiscoveryService.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerTypeDiscoveryService.vb
@@ -10,7 +10,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     ''' The DesignerTypeDiscoveryService differs from the "normal" VS Type Discovery service
     ''' in that it filters out types defined in the current project
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class DesignerTypeDiscoveryService
         Implements ComponentModel.Design.ITypeDiscoveryService
 
@@ -22,7 +21,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="sp"></param>
         ''' <param name="hierarchy"></param>
-        ''' <remarks></remarks>
         Public Sub New(sp As IServiceProvider, hierarchy As IVsHierarchy)
             Requires.NotNull(sp, NameOf(sp))
             Requires.NotNull(hierarchy, NameOf(hierarchy))
@@ -43,8 +41,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Get all known types, excluding types in the current project
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overridable Function GetReferencedTypes() As ICollection(Of Type)
             Return GetReferencedTypes(GetType(Object), False)
         End Function
@@ -54,8 +50,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="baseType">Only return types inheriting from this class</param>
         ''' <param name="shouldExcludeGlobalTypes">Exclude types in the GAC?</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overridable Function GetReferencedTypes(baseType As Type, shouldExcludeGlobalTypes As Boolean) As List(Of Type)
             Dim dynamicTypeService As Shell.Design.DynamicTypeService =
                 DirectCast(_serviceProvider.GetService(GetType(Shell.Design.DynamicTypeService)), Shell.Design.DynamicTypeService)
@@ -97,8 +91,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="provider"></param>
         ''' <param name="hierarchy"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function GetProjectOutputs(provider As IServiceProvider, hierarchy As IVsHierarchy) As String()
             Try
                 Dim buildManager As IVsSolutionBuildManager = TryCast(provider.GetService(GetType(IVsSolutionBuildManager)), IVsSolutionBuildManager)
@@ -140,8 +132,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="typeResolutionService"></param>
         ''' <param name="projectOutput"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function AssemblyFromProjectOutput(typeResolutionService As ComponentModel.Design.ITypeResolutionService, projectOutput As String) As System.Reflection.Assembly
             Requires.NotNull(typeResolutionService, NameOf(typeResolutionService))
 

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerWindowPaneProviderBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerWindowPaneProviderBase.vb
@@ -22,7 +22,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     '''   create a DesignerWindowPaneBase
     ''' This allows us to have more control of the WindowPane
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class DeferrableWindowPaneProviderServiceBase
         Inherits WindowPaneProviderService
 
@@ -35,7 +34,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="provider"></param>
         ''' <param name="SupportToolbox"></param>
-        ''' <remarks></remarks>
         Friend Sub New(provider As IServiceProvider, SupportToolbox As Boolean)
             MyBase.New(provider)
             _supportToolbox = SupportToolbox
@@ -51,7 +49,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' that we would get for "free" is to allow us to receive IVsWindowPaneCommit.
         ''' 
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Class DesignerWindowPaneBase
             Inherits DesignerWindowPane
             Implements IVsWindowPaneCommit
@@ -73,7 +70,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' </summary>
             ''' <param name="surface"></param>
             ''' <param name="SupportToolbox"></param>
-            ''' <remarks></remarks>
             Public Sub New(surface As DesignSurface, SupportToolbox As Boolean)
                 MyBase.New(surface)
 
@@ -107,8 +103,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' Returns the view control for the window pane.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Protected ReadOnly Property View() As Control
                 Get
                     Return _view
@@ -141,8 +135,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' Retrieves our view.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public Overrides ReadOnly Property Window() As IWin32Window
                 Get
                     ' This should always happen, but in case we never
@@ -161,7 +153,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' Called to disable OLE undo.
             ''' </summary>
-            ''' <remarks></remarks>
             Private Sub DisableUndo()
                 If _undoEngine IsNot Nothing Then
 
@@ -183,7 +174,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' Called when our view is disposed.
             ''' </summary>
             ''' <param name="disposing"></param>
-            ''' <remarks></remarks>
             Protected Overrides Sub Dispose(disposing As Boolean)
 
                 Dim disposedView As Control = _view
@@ -221,7 +211,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' Called to enable OLE undo.
             ''' </summary>
-            ''' <remarks></remarks>
             Private Sub EnableUndo()
 
                 Debug.Assert(_undoEngine Is Nothing, "EnableUndo should only be called once.  Call DisableUndo before calling this again.")
@@ -246,7 +235,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' We override this to enable / disable undo.  The undo engine
             ''' should be disabled if our view is cached for later.
             ''' </summary>
-            ''' <remarks></remarks>
             Protected Overrides Sub OnClose()
                 DisableUndo()
                 MyBase.OnClose()
@@ -257,7 +245,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' We override this to enable / disable undo.  The undo engine
             ''' should be disabled if our view is cached for later.
             ''' </summary>
-            ''' <remarks></remarks>
             Protected Overrides Sub OnCreate()
                 MyBase.OnCreate()
 
@@ -274,7 +261,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' </summary>
             ''' <param name="sender"></param>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Private Sub OnLoaded(sender As Object, e As LoadedEventArgs)
                 PopulateView()
                 EnableUndo()
@@ -288,7 +274,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' </summary>
             ''' <param name="sender"></param>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Private Sub OnSurfaceUnloading(sender As Object, e As EventArgs)
                 DisableUndo()
             End Sub
@@ -303,7 +288,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' </summary>
             ''' <param name="sender"></param>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Private Sub OnSurfaceUnloaded(sender As Object, e As EventArgs)
                 If (_view IsNot Nothing AndAlso _view.Controls.Count > 0) Then
                     Dim ctrl(_view.Controls.Count - 1) As Control
@@ -320,7 +304,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' </summary>
             ''' <param name="sender"></param>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Private Sub OnUndoing(sender As Object, e As EventArgs)
                 If (_view IsNot Nothing AndAlso _view.IsHandleCreated) Then
                     NativeMethods.SendMessage(New HandleRef(_view, _view.Handle), NativeMethods.WM_SETREDRAW, 0, 0)
@@ -335,7 +318,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' </summary>
             ''' <param name="sender"></param>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Private Sub OnUndone(sender As Object, e As EventArgs)
                 If (_view IsNot Nothing AndAlso _view.IsHandleCreated) Then
                     NativeMethods.SendMessage(New HandleRef(_view, _view.Handle), NativeMethods.WM_SETREDRAW, 1, 0)
@@ -351,7 +333,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' </summary>
             ''' <param name="sender"></param>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Private Sub OnViewFocus(sender As Object, e As EventArgs)
                 Switches.TracePDFocus(TraceLevel.Warning, "DeferrableWindowPaneProviderServiceBase.DesignerWindowPaneBase.m_View.OnGotFocus (OnViewFocus)")
                 If (_view IsNot Nothing AndAlso _view.Controls.Count > 0) Then
@@ -380,7 +361,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             '''    design surface.  If there was an error encountered
             '''    it will display the WSOD.
             ''' </summary>
-            ''' <remarks></remarks>
             Private Sub PopulateView()
 
                 _view.SuspendLayout()
@@ -449,8 +429,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' it will forward the command to the view.
             ''' </summary>
             ''' <param name="pfCommitFailed"></param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Function IVsWindowPaneCommit_CommitPendingEdit(ByRef pfCommitFailed As Integer) As Integer Implements IVsWindowPaneCommit.CommitPendingEdit
                 Dim viewAsIVsWindowPaneCommit As IVsWindowPaneCommit = Nothing
                 If Not _loadError AndAlso Surface IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/ErrorControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/ErrorControl.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Drawing
 Imports System.Windows.Forms
@@ -10,7 +10,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     ''' This is a Windows control that is shown when there is an exception loading a designer or property page.
     ''' All it does is display an error message and an error icon.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ErrorControl
 
         Private _firstGotFocus As Boolean = True
@@ -32,7 +31,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Constructor
         ''' </summary>
         ''' <param name="Text">The error text to display</param>
-        ''' <remarks></remarks>
         Friend Sub New(Text As String)
             Me.New()
             Me.Text = Text
@@ -43,7 +41,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Constructor
         ''' </summary>
         ''' <param name="ex">The exception to display</param>
-        ''' <remarks></remarks>
         Friend Sub New(ex As Exception)
             Me.New(Common.DebugMessageFromException(ex))
         End Sub
@@ -53,7 +50,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Constructor
         ''' </summary>
         ''' <param name="errors">A list of exceptions or error messages to display</param>
-        ''' <remarks></remarks>
         Friend Sub New(errors As ICollection)
             Me.New()
 
@@ -71,8 +67,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Constructor
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Overrides Property Text() As String
             Get
                 Return ErrorText.Text
@@ -89,7 +83,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ErrorText_GotFocus(sender As Object, e As EventArgs) Handles ErrorText.GotFocus
             If _firstGotFocus Then
                 'The first time a textbox gets focus, WinForms selects all text in it.  That
@@ -105,8 +98,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Get the preferred size of the control, expanding 
         ''' </summary>
         ''' <param name="proposedSize"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetPreferredSize(proposedSize As Size) As Size
             If proposedSize.Width = 0 Then
                 Return MyBase.GetPreferredSize(proposedSize)

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationService.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationService.vb
@@ -19,7 +19,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''   state for a group of objects.
         ''' </summary>
         ''' <param name="Provider">.</param>
-        ''' <remarks></remarks>
         Public Sub New(Provider As IServiceProvider)
             _serviceProvider = Provider
         End Sub
@@ -30,7 +29,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''  state for a group of objects.
         ''' </summary>
         ''' <returns>An instance of a new serialization store for objects</returns>
-        ''' <remarks></remarks>
         Public Overrides Function CreateStore() As SerializationStore
             Return New GenericComponentSerializationStore
         End Function
@@ -43,7 +41,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="Stream">The stream to load from.</param>
         ''' <returns>The loaded store for objects.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function LoadStore(Stream As Stream) As SerializationStore
             Requires.NotNull(Stream, NameOf(Stream))
 
@@ -58,7 +55,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="Value">The object to serialize into the store.</param>
-        ''' <remarks></remarks>
         Public Overrides Sub Serialize(Store As SerializationStore, Value As Object)
             Requires.NotNull(Store, NameOf(Store))
             Requires.NotNull(Value, NameOf(Value))
@@ -119,7 +115,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="OwningObject">The object whose property (member) you are trying to serialize into the store.</param>
         ''' <param name="Member">The property whose value needs to be serialized into the store.</param>
-        ''' <remarks></remarks>
         Public Overrides Sub SerializeMemberAbsolute(Store As SerializationStore, OwningObject As Object, Member As MemberDescriptor)
             'This method is intended for properties such as collections which might have had only some of their
             '  members changed.
@@ -135,7 +130,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="Store">The store to serialize into.</param>
         ''' <returns>The set of components that were deserialized.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function Deserialize(Store As SerializationStore) As ICollection
             Requires.NotNull(Store, NameOf(Store))
 
@@ -156,7 +150,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
         ''' <returns>The list of objects that were deserialized.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function Deserialize(Store As SerializationStore, Container As IContainer) As ICollection
             Requires.NotNull(Store, NameOf(Store))
             Requires.NotNull(Container, NameOf(Container))
@@ -184,7 +177,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
-        ''' <remarks></remarks>
         Public Overrides Sub DeserializeTo(Store As SerializationStore, Container As IContainer, ValidateRecycledTypes As Boolean, applyDefaults As Boolean)
             Requires.NotNull(Store, NameOf(Store))
             Requires.NotNull(Container, NameOf(Container))
@@ -200,7 +192,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Get/set the service provider
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>Not used by this class, may be useful for derived classes</remarks>
         Protected Property ServiceProvider() As IServiceProvider
             Get

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationStore.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationStore.vb
@@ -50,7 +50,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''   from being serialized into it.  Once closed, the serialization store 
         '''   may be saved (or deserialized).
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overrides Sub Close()
             If _serializedState Is Nothing Then
                 Dim SerializedState As New ArrayList(_hashedObjectsToSerialize.Count)
@@ -92,7 +91,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="info">Serialization info</param>
         ''' <param name="context">Serialization context</param>
-        ''' <remarks></remarks>
         <Security.Permissions.SecurityPermission(Security.Permissions.SecurityAction.Demand, SerializationFormatter:=True)>
         Public Sub GetObjectData(info As SerializationInfo, context As StreamingContext) Implements ISerializable.GetObjectData
             info.AddValue(KEY_STATE, _serializedState)
@@ -105,7 +103,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="Info">Serialization info</param>
         ''' <param name="Context">Serialization context</param>
-        ''' <remarks></remarks>
         Private Sub New(Info As SerializationInfo, Context As StreamingContext)
             _serializedState = DirectCast(Info.GetValue(KEY_STATE, GetType(ArrayList)), ArrayList)
         End Sub
@@ -118,8 +115,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Loads our state from a stream.
         ''' </summary>
         ''' <param name="Stream">The stream to load from</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function Load(Stream As Stream) As GenericComponentSerializationStore
             Dim f As New BinaryFormatter
             Return DirectCast(f.Deserialize(Stream), GenericComponentSerializationStore)
@@ -132,7 +127,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''     to different streams.
         ''' </summary>
         ''' <param name="stream">The stream to save to</param>
-        ''' <remarks></remarks>
         Public Overrides Sub Save(Stream As Stream)
             Close()
 
@@ -200,7 +194,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="Component">The component from which we want to serialize something.</param>
         ''' <returns>The DataToSerialize object associated with this component.</returns>
-        ''' <remarks></remarks>
         Private Function GetSerializationData(Component As Object) As ObjectData
             Dim Data As ObjectData
             If _hashedObjectsToSerialize.ContainsKey(Component) Then
@@ -233,7 +226,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''     object to be used.
         ''' </summary>
         ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
-        ''' <remarks></remarks>
         Friend Sub DeserializeTo(Container As IContainer)
             DeserializeHelper(Container, True)
         End Sub
@@ -246,7 +238,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''     that are created that implement IComponent will be added to the container. 
         ''' </summary>
         ''' <returns>The set of components that were deserialized.</returns>
-        ''' <remarks></remarks>
         Friend Function Deserialize() As ICollection
             Return DeserializeHelper(Nothing, False)
         End Function
@@ -260,7 +251,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
         ''' <returns>The list of objects that were deserialized.</returns>
-        ''' <remarks></remarks>
         Friend Function Deserialize(Container As IContainer) As ICollection
             Return DeserializeHelper(Container, False)
         End Function
@@ -274,7 +264,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="RecycleInstances">If True, we are applying property changes to existing
         '''   instances of components (this is always the case for Undo/Redo).</param>
         ''' <returns>The objects which have been serialized.</returns>
-        ''' <remarks></remarks>
         Private Function DeserializeHelper(Container As IContainer, RecycleInstances As Boolean) As ICollection
             Dim NewObjects As New ArrayList(_serializedState.Count)
 
@@ -343,7 +332,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''   object instance. (either the entire object itself, or a set of
         '''   its properties)
         ''' </summary>
-        ''' <remarks></remarks>
         <Serializable()>
         Protected Class ObjectData
 
@@ -357,7 +345,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' Constructor
             ''' </summary>
             ''' <param name="Value">The component from which we want to serialize stuff.</param>
-            ''' <remarks></remarks>
             Public Sub New(Value As Object)
                 Requires.NotNull(Value, NameOf(Value))
 
@@ -382,8 +369,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' Get tha name of this object
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property Name() As String
                 Get
                     Return _objectName
@@ -393,8 +378,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' The object from which we want to serialize stuff.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property Value() As Object
                 Get
                     Return _value
@@ -406,8 +389,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' If True, the entire Resource instance should be serialized.  If false,
             '''   then only the properties in PropertiesToSerialize should be serialized.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public Property IsEntireObject() As Boolean
                 Get
                     Return _isEntireObject
@@ -425,8 +406,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' A list of PropertyDescriptors representing the properties on
             '''   the Resource which should be serialized.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property Members() As ArrayList
                 Get
                     If _members Is Nothing Then
@@ -447,7 +426,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''   Resource instance (either the entire Resource itself, or a set of
         '''   its properties)
         ''' </summary>
-        ''' <remarks></remarks>
         <Serializable()>
         Private Class SerializedObjectData
 
@@ -460,7 +438,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' Constructor
             ''' </summary>
             ''' <param name="Value">The component from which we want to serialize stuff.</param>
-            ''' <remarks></remarks>
             Friend Sub New(Value As ObjectData)
                 Requires.NotNull(Value, NameOf(Value))
 
@@ -472,7 +449,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' Constructor
             ''' </summary>
             ''' <param name="Value">The component from which we want to serialize stuff.</param>
-            ''' <remarks></remarks>
             Public Sub New(Value As ObjectData, [Property] As PropertyDescriptor)
                 Requires.NotNull(Value, NameOf(Value))
                 Requires.NotNull([Property], NameOf([Property]))
@@ -486,8 +462,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' If True, the entire Resource instance should be serialized.  If false,
             '''   then only the properties in PropertiesToSerialize should be serialized.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Friend ReadOnly Property IsEntireObject() As Boolean
                 Get
                     Return _propertyName = ""

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/SourceCodeControlManager.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/SourceCodeControlManager.vb
@@ -7,7 +7,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     ''' <summary>
     ''' Provide a convenient way to check out/query edit a set of files. 
     ''' </summary>
-    ''' <remarks></remarks>
     Public NotInheritable Class SourceCodeControlManager
 
 #Region "Private fields"
@@ -28,7 +27,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''   
         ''' </summary>
         ''' <param name="sp"></param>
-        ''' <remarks></remarks>
         Public Sub New(sp As IServiceProvider, Hierarchy As IVsHierarchy)
             Requires.NotNull(sp, NameOf(sp))
             _serviceProvider = sp
@@ -41,7 +39,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Add a file to manage SCC status for. 
         ''' </summary>
         ''' <param name="mkDocument"></param>
-        ''' <remarks></remarks>
         Public Sub ManageFile(mkDocument As String)
             _managedFiles(mkDocument) = True
         End Sub
@@ -61,9 +58,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Get a list of the files currently managed by this service...
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Property ManagedFiles() As List(Of String)
             Get
                 Return New List(Of String)(_managedFiles.Keys)
@@ -95,8 +89,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Query if all the files are editable. Will not prompt the user - will only report
         ''' if it is OK to edit the file. 
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function AreFilesEditable() As Boolean
             Return QueryEditableFilesInternal(True, False)
         End Function
@@ -109,8 +101,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="checkOnly">If true, only query if it is OK to edit all managed files without actually checking anything out</param>
         ''' <param name="throwOnFailure">If the method should throw a CheckoutException on failure</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function QueryEditableFilesInternal(checkOnly As Boolean, throwOnFailure As Boolean) As Boolean
             ' Do actual checkout here...
             Return QueryEditableFiles(_serviceProvider, ManagedFiles, throwOnFailure, checkOnly)
@@ -252,8 +242,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="sp">Service provider. Will be QI:ed for IVsQueryEditQuerySave2</param>
         ''' <param name="files">The set of files to check</param>
         ''' <param name="throwOnFailure">Should we throw if the save fails?</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function QuerySave(sp As IServiceProvider, files As List(Of String), throwOnFailure As Boolean) As Boolean
             Requires.NotNull(sp, NameOf(sp))
             Requires.NotNull(files, NameOf(files))

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/ToolStripImageComboBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/ToolStripImageComboBox.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -12,7 +12,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     ''' This class is a toolstrip item that contains a combobox which is capable
     '''   of holding images and having a different font for each entry in it.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class ToolStripImageComboBox
         Inherits ToolStripComboBox
 
@@ -40,7 +39,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' The collection class that we return for the Items property.  This simply
         '''   makes it possible to use code like ImageComboBox.Items.Add(...)
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Shadows Class ObjectCollection
             'The actual underlying combobox
             Private m_UnderlyingComboBox As ComboBox
@@ -50,7 +48,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' Constructor
             ''' </summary>
             ''' <param name="UnderlyingComboBox">The actual underlying combobox control that we're wrapping with our collection</param>
-            ''' <remarks></remarks>
             Friend Sub New(ByVal UnderlyingComboBox As ComboBox)
                 Debug.Assert(UnderlyingComboBox IsNot Nothing)
                 m_UnderlyingComboBox = UnderlyingComboBox
@@ -64,7 +61,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <param name="ItemImage">The image for this combobox entry (Nothing is acceptable)</param>
             ''' <param name="UserData">[Optional] User-defined data for this combobox entry</param>
             ''' <returns>The newly-inserted ImageComboBoxItem</returns>
-            ''' <remarks></remarks>
             Public Function Add(ByVal ItemText As String, ByVal ItemImage As Image, Optional ByVal UserData As Object = Nothing) As ImageComboBoxItem
                 Dim Item As New ImageComboBoxItem(m_UnderlyingComboBox, ItemText, ItemImage, UserData)
                 m_UnderlyingComboBox.Items.Add(Item)
@@ -76,8 +72,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' Retrieves an item from the collection
             ''' </summary>
             ''' <param name="Index">Zero-based index of the item</param>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Default Public ReadOnly Property Item(ByVal Index As Integer) As ImageComboBoxItem
                 Get
                     Return DirectCast(m_UnderlyingComboBox.Items(Index), ImageComboBoxItem)
@@ -88,8 +82,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' Count of the number of items in this collection
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property Count() As Integer
                 Get
                     Return m_UnderlyingComboBox.Items.Count
@@ -100,8 +92,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' Gets an enumerator for this collection
             ''' </summary>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Function GetEnumerator() As System.Collections.IEnumerator
                 Return m_UnderlyingComboBox.Items.GetEnumerator()
             End Function
@@ -115,7 +105,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Represents a single item in the image combo box
         ''' </summary>
-        ''' <remarks></remarks>
         Public Class ImageComboBoxItem
             'Backing fields for public properties
             Private m_Text As String
@@ -133,7 +122,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <param name="Text">The text for this combobox entry</param>
             ''' <param name="Image">The image for this combobox entry (Nothing is acceptable)</param>
             ''' <param name="UserData">[Optional] User-defined data for this combobox entry</param>
-            ''' <remarks></remarks>
             Public Sub New(ByVal Parent As ComboBox, ByVal Text As String, ByVal Image As Image, Optional ByVal UserData As Object = Nothing)
                 Debug.Assert(Parent IsNot Nothing)
                 m_Text = Text
@@ -146,8 +134,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' Converts the item to a string.
             ''' </summary>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Overrides Function ToString() As String
                 Return m_Text
             End Function
@@ -156,8 +142,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' The text for this combobox entry
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public Property Text() As String
                 Get
                     Return m_Text
@@ -172,8 +156,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' The image for this combobox entry.  May be Nothing.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public Property Image() As Image
                 Get
                     Return m_Image
@@ -190,8 +172,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' User-defined data for this combobox entry.  May be Nothing.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public Property UserData() As Object
                 Get
                     Return m_UserData
@@ -205,8 +185,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' The font for this combobox entry.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public Property Font() As Font
                 Get
                     If m_Font Is Nothing Then
@@ -229,7 +207,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             '''   is, causes the combobox to refresh itself (because something in
             '''   the item has changed)
             ''' </summary>
-            ''' <remarks></remarks>
             Private Sub RefreshComboBoxIfShowingThisItem()
                 If m_Parent.DroppedDown OrElse m_Parent.SelectedItem Is Me Then
                     m_Parent.Refresh()
@@ -245,7 +222,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Constructor.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub New()
             MyBase.New()
 
@@ -263,7 +239,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Items property.  Allows stuff like ImageComboBox.Items.Add(...)
         ''' </summary>
-        ''' <remarks></remarks>
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)> Public Shadows ReadOnly Property Items() As ObjectCollection
             Get
                 Return m_ImageComboItems
@@ -276,8 +251,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''   size.
         ''' </summary>
         ''' <param name="ConstrainingSize">The size that must be fit into.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetPreferredSize(ByVal ConstrainingSize As Size) As Size
             Dim BasePreferredSize As Size = MyBase.GetPreferredSize(ConstrainingSize)
 
@@ -326,7 +299,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Event handler for when the combobox is dropped down.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ImageComboBox_DropDown(ByVal sender As Object, ByVal e As System.EventArgs) Handles Me.DropDown
             SetDropdownHeight()
         End Sub
@@ -337,7 +309,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ImageComboBox_MeasureItem(ByVal sender As Object, ByVal e As System.Windows.Forms.MeasureItemEventArgs) Handles UnderlyingComboBox.MeasureItem
             If e.Index >= 0 Then
                 Dim Size As Size = GetItemSize(e.Index, e.Graphics)
@@ -352,7 +323,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ImageComboBox_DrawItem(ByVal sender As Object, ByVal e As System.Windows.Forms.DrawItemEventArgs) Handles UnderlyingComboBox.DrawItem
             'Index = 0 if there are no entries
             If e.Index >= 0 Then
@@ -389,8 +359,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="Index">Index of the item to measure</param>
         ''' <param name="Graphics">The graphics object to use for measuring</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetItemSize(ByVal Index As Integer, ByVal Graphics As Graphics) As Size
             Dim Item As ImageComboBoxItem = Items(Index)
             Dim TextSize As SizeF = Graphics.MeasureString(Item.Text, Item.Font, New PointF(0, 0), StringFormat.GenericDefault)

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/UserCanceledException.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/UserCanceledException.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Strict On
 Option Explicit On
@@ -9,7 +9,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     ''' an exception is thrown when the customer cancel an operation. 
     '''  We need specialize it, because we don't need pop an error message when this happens
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class UserCanceledException
         Inherits ApplicationException
 

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
@@ -21,7 +21,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
     ''' <summary>
     ''' Generator for strongly MyApplication class
     ''' </summary>
-    ''' <remarks></remarks>
     <Guid("4d35b437-4197-4241-8d24-8ac3ab6f0e0c")>
     Public NotInheritable Class MyApplicationCodeGenerator
         Implements IVsSingleFileGenerator, IObjectWithSite, System.IServiceProvider, IVsRefactorNotify
@@ -37,9 +36,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' Returns a type for System.Diagnostics.DebuggerStepThrough so that we can create
         ''' attribute-declarations for the CodeDom to spit them out.
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared ReadOnly Property DebuggerStepThroughAttribute() As Type
             Get
                 Return GetType(DebuggerStepThroughAttribute)
@@ -51,7 +47,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' Get the default extension for the generated class.
         ''' </summary>
         ''' <param name="pbstrDefaultExtension"></param>
-        ''' <remarks></remarks>
         Private Function DefaultExtension(ByRef pbstrDefaultExtension As String) As Integer Implements IVsSingleFileGenerator.DefaultExtension
             If CodeDomProvider IsNot Nothing Then
                 ' For some reason some the code providers seem to be inconsistent in the way that they 
@@ -77,7 +72,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <param name="rgbOutputFileContents"></param>
         ''' <param name="pcbOutput"></param>
         ''' <param name="pGenerateProgress"></param>
-        ''' <remarks></remarks>
         Private Function Generate(wszInputFilePath As String, bstrInputFileContents As String, wszDefaultNamespace As String, rgbOutputFileContents() As IntPtr, ByRef pcbOutput As UInteger, pGenerateProgress As IVsGeneratorProgress) As Integer Implements IVsSingleFileGenerator.Generate
             Dim BufPtr As IntPtr
             Try
@@ -313,7 +307,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <param name="Member">The type member to add the attribute to</param>
         ''' <param name="AttributeType">The type of the attribute, e.g. GetType(System.Diagnostics.DebuggerStepThroughAttribute)</param>
         ''' <param name="PrependGlobal">If true, then "Global." is prepended to the attribute name</param>
-        ''' <remarks></remarks>
         Private Shared Sub AddAttribute(Member As CodeTypeMember, AttributeType As Type, PrependGlobal As Boolean)
 
             If Member.CustomAttributes Is Nothing Then
@@ -374,7 +367,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <param name="FieldName">The name of the field for the left-hand side of the assignment</param>
         ''' <param name="RootNamespace">The root namespace, if any (including empty string if none), or else Nothing if reference should be declared without using the root namespace.</param>
         ''' <param name="FormNameWithoutRootNamespace">The name of the form, without the root namespace.</param>
-        ''' <remarks></remarks>
         Private Shared Sub AddDefaultFormAssignment(Method As CodeMemberMethod, FieldName As String, RootNamespace As String, FormNameWithoutRootNamespace As String)
             '
             '  GENERATED CODE:
@@ -414,7 +406,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' Demand-create a CodeDomProvider corresponding to my projects current language
         ''' </summary>
         ''' <value>A CodeDomProvider</value>
-        ''' <remarks></remarks>
         Private Property CodeDomProvider() As CodeDomProvider
             Get
                 If _codeDomProvider Is Nothing Then
@@ -792,7 +783,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' </summary>
         ''' <param name="serviceType">The type of service requested</param>
         ''' <returns>An instance of the service, or nothing if service not found</returns>
-        ''' <remarks></remarks>
         Private Function GetService(serviceType As Type) As Object Implements System.IServiceProvider.GetService
             If ServiceProvider IsNot Nothing Then
                 Return ServiceProvider.GetService(serviceType)
@@ -804,8 +794,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Demand-create service provider from my site
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property ServiceProvider() As ServiceProvider
             Get
                 If _serviceProvider Is Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
@@ -131,7 +131,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
     ''' <summary>
     ''' Our implementation of IVsMyAppManager
     ''' </summary>
-    ''' <remarks></remarks>
     <ComVisible(True), Guid("29255174-ccb9-434d-8489-dae5b912b1d3"), CLSCompliant(False)>
     <Obsolete("MyApplication is automatically managed by the property pages. All usage of this class can be removed.")>
     Public NotInheritable Class MyApplicationManager
@@ -183,7 +182,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Public Event PropertyChanged(sender As Object, e As PropertyChangedEventArgs) Implements INotifyPropertyChanged.PropertyChanged
 #End Region
 
@@ -238,7 +236,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Constructor.
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Sub New()
 
         End Sub
@@ -247,7 +244,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' Initialization.  Called by the project system before requesting the MyApplicationProperties object.
         ''' </summary>
         ''' <param name="ProjectHierarchy"></param>
-        ''' <remarks></remarks>
         Friend Sub Init(ProjectHierarchy As IVsHierarchy)
             If _initialized Then Return
 
@@ -331,7 +327,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Attempts to check out the doc data, if it is not already checked out.  This should be done prior to any property change.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub CheckOutDocData()
             Debug.Assert(_serviceProvider IsNot Nothing, "m_ServiceProvider is nothing")
 
@@ -346,7 +341,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Request the custom tool for MyApplication.myapp to be run 
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Sub RunCustomTool() Implements IMyApplicationPropertiesInternal.RunCustomTool
             Dim item As ProjectItem = MyAppProjectItem
             If item IsNot Nothing Then
@@ -399,8 +393,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         '''   project's current state.  This can be important to access if the face of undo/redo
         '''   and other issues, but it's not what we public expose via DTE.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property CustomSubMainRaw() As Boolean Implements IMyApplicationPropertiesInternal.CustomSubMainRaw
             Get
                 Return Not _myAppData.MySubMain
@@ -431,7 +423,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Retrieves the MainForm property, including the root namespace
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' If this property is not currently set to a meaningful value, we return empty string.
         ''' </remarks>
@@ -453,7 +444,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         '''   serialized and stored, so this specifically does not do the step of adding/removing the
         '''   root namespace of the project)
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' If this property is not currently set to a meaningful value, we return empty string.
         ''' </remarks>
@@ -578,7 +568,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Retrieves the MainForm property, including the root namespace
         ''' </summary>
-        ''' <value></value>
         ''' If this property is not currently set to a meaningful value, we return empty string.
         Public Property SplashScreen() As String Implements IVsMyApplicationProperties.SplashScreen
             Get
@@ -598,7 +587,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         '''   serialized and stored, so this specifically does not do the step of adding/removing the
         '''   root namespace of the project)
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' If this property is not currently set to a meaningful value, we return empty string.
         ''' </remarks>
@@ -629,7 +617,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Makes sure the .MyApp file exists, creates a doc data for it, etc.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub PrepareMyAppDocData()
             If Not File.Exists(MyAppFileNameWithPath) Then
                 Dim FullPath As String = MyAppFileNameWithPath()
@@ -691,8 +678,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Returns the full path/filename of the .myapp file
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MyAppFileNameWithPath() As String
             Return Path.Combine(ProjectDesignerProjectItem.FileNames(1), _myAppFileName)
         End Function
@@ -701,8 +686,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Returns the DTE ProjectItem for the .myapp file
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property MyAppProjectItem() As ProjectItem
             Get
                 'First see if it is already in the project
@@ -726,8 +709,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Returns the docdata after initializing for the .myapp file
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property MyAppDocData() As DocData
             Get
                 Return _myAppDocData
@@ -737,8 +718,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' DocDataService provides SCC checkin/out interaction with VS
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property DocDataService() As DesignerDocDataService
             Get
                 Return _docDataService
@@ -748,8 +727,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Provides the TextReader for reading the .myapp file
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetMyAppTextReader() As TextReader
             Return New DocDataTextReader(DocDataService.PrimaryDocData, False)
         End Function
@@ -757,8 +734,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Provides the TextWriter for writing the .myapp file
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetMyAppTextWriter() As TextWriter
             Return New MyAppTextWriter(DocDataService.PrimaryDocData, False)
         End Function
@@ -767,8 +742,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' Retrieves the given project item's property, if it exists, else Nothing
         ''' </summary>
         ''' <param name="PropertyName">The name of the property to retrieve.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GetProjectItemProperty(ProjectItem As ProjectItem, PropertyName As String) As [Property]
             If ProjectItem.Properties Is Nothing Then
                 Return Nothing
@@ -823,8 +796,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <param name="MyEventsFileName">The name of the file to create</param>
         ''' <param name="MyEventsNamespaceName">The name of the namespace to use</param>
         ''' <param name="MyEventsClassName">The name of the partial class to use</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function CreateNewMyEventsFile(DestinationProjectItems As ProjectItems, MyEventsFileName As String, MyEventsNamespaceName As String, MyEventsClassName As String) As ProjectItem
             Debug.Assert(Path.GetExtension(MyEventsFileName) = ".vb", "Extension of MyEvents.vb file doesn't end in .vb?")
 
@@ -1011,8 +982,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' Returns the project item for the My Project node
         ''' </summary>
         ''' <param name="ProjectHierarchy"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function GetProjectItemForProjectDesigner(ProjectHierarchy As IVsHierarchy) As ProjectItem
             Dim SpecialFiles As IVsProjectSpecialFiles = CType(ProjectHierarchy, IVsProjectSpecialFiles)
             Dim ProjectDesignerItemId As UInteger
@@ -1037,7 +1006,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Called by the project system upon closing a project.  Any unpersisted data at this point is discarded
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Sub Close()
             If _myAppDocData IsNot Nothing Then
                 _myAppDocData = Nothing
@@ -1051,7 +1019,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' Called by the project system when we need to save all the MyApplication files.  Saves directly to disk.  Does not save
         '''   if not dirty.
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Sub Save()
             If _myAppDocData IsNot Nothing Then
                 'Make sure the doc data is up to date (in reality in our current model, we shouldn't ever be in a dirty state
@@ -1103,8 +1070,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Gets the root namespace for a given IVsHierarchy
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetRootNamespace() As String
             If _projectHierarchy IsNot Nothing Then
                 Dim ObjNamespace As Object = Nothing
@@ -1120,8 +1085,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Returns the set of files that need to be checked out to change the given property
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function FilesToCheckOut(CreateIfNotExist As Boolean) As String()
             If CreateIfNotExist Then
                 PrepareMyAppDocData()
@@ -1143,7 +1106,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MyAppDocDataChanged(sender As Object, e As EventArgs) Handles _myAppDocData.DataChanged
             'Now read the data 
             Using Reader As TextReader = GetMyAppTextReader()
@@ -1167,7 +1129,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' </summary>
         ''' <param name="OldValues"></param>
         ''' <param name="NewValues"></param>
-        ''' <remarks></remarks>
         Private Sub FireChangeNotificationsForNewValues(OldValues As MyApplicationData, NewValues As MyApplicationData)
             'AuthenticationMode
             If OldValues.AuthenticationMode <> NewValues.AuthenticationMode Then
@@ -1216,8 +1177,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' </summary>
         ''' <param name="String1"></param>
         ''' <param name="String2"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function StringPropertyValuesEqual(String1 As String, String2 As String) As Boolean
             Return NothingToEmptyString(String1).Equals(NothingToEmptyString(String2), StringComparison.Ordinal)
         End Function
@@ -1227,7 +1186,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' Fires the PropertyChanged event
         ''' </summary>
         ''' <param name="PropertyName">The name of the property whose value has changed</param>
-        ''' <remarks></remarks>
         Private Sub OnPropertyChanged(PropertyName As String)
             RaiseEvent PropertyChanged(Me, New PropertyChangedEventArgs(PropertyName))
         End Sub
@@ -1239,7 +1197,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' A text writer for the DocData behind the .myapp file
         ''' </summary>
-        ''' <remarks></remarks>
         Private Class MyAppTextWriter
             Inherits DocDataTextWriter
 
@@ -1291,8 +1248,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' </summary>
         ''' <param name="OutputType">Output type</param>
         ''' <param name="MyType">Current value of MyType in the project</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function ApplicationTypeFromOutputType(OutputType As UInteger, MyType As String) As ApplicationTypes
             Select Case OutputType
 
@@ -1358,8 +1313,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' Given an Application Type (a VB-only concept), return the Output Type for it (the project system's concept)
         ''' </summary>
         ''' <param name="AppType"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function OutputTypeFromApplicationType(AppType As ApplicationTypes) As UInteger
             Select Case AppType
 
@@ -1382,8 +1335,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Do we support the My SubMain?
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function IsMySubMainSupported(Hierarchy As IVsHierarchy) As Boolean
             Try
                 ' Query the MyType and OutputType properties from the project properties

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationSerializer.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.IO
 Imports System.Xml.Serialization
@@ -10,14 +10,12 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
     ''' Utility class to (de)serialize the contents of a DesignTimeSetting object 
     ''' given a stream reader/writer
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class MyApplicationSerializer
 
         ''' <summary>
         '''  Deserialize XML stream of MyApplication data
         ''' </summary>
         ''' <param name="Reader">Text reader on stream containing object info</param>
-        ''' <remarks></remarks>
         Public Shared Function Deserialize(Reader As TextReader) As MyApplicationData
             Dim serializer As XmlSerializer = New MyApplicationDataSerializer()
             'XmlSerializer(GetType(MyApplicationData))
@@ -30,7 +28,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' </summary>
         ''' <param name="data">Instance to serialize</param>
         ''' <param name="Writer">Text writer on stream to serialize MyApplicationData to</param>
-        ''' <remarks></remarks>
         Public Shared Sub Serialize(data As MyApplicationData, Writer As TextWriter)
             Dim serializer As XmlSerializer = New MyApplicationDataSerializer()
             'New XmlSerializer(GetType(MyApplicationData))

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectSettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectSettings.vb
@@ -276,7 +276,6 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' <summary>
         ''' Find MyExtensions folder, if it exists and is empty, remove it from the project.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub RemoveMyExtensionsFolderIfEmpty()
             If _extensionFolderProjectItem IsNot Nothing AndAlso _extensionFolderProjectItem.ProjectItems.Count <= 0 Then
                 _extensionFolderProjectItem.Delete()

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySettings.vb
@@ -329,7 +329,6 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' <summary>
         ''' Save the settings for triggering assemblies.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub SaveAssemblySettings()
             Dim fileStream As FileStream = Nothing
             Dim xmlWriter As XmlTextWriter = Nothing

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySolutionService.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySolutionService.vb
@@ -298,7 +298,6 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' <summary>
         ''' Handle solution's AfterClosing events and clear our collection of project services.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub SolutionEvents_AfterClosing()
             Switches.TraceMyExtensibility(TraceLevel.Verbose, "MyExtensibilitySolutionService.SolutionEvents_AfterClosing: Entry. Clear project services dictionary.")
             _projectServices.Clear()
@@ -335,7 +334,6 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' <summary>
         ''' Handle DTE OnBeginShutDown event to remove our event handlers.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub DTEEvents_OnBeginShutDown()
             Switches.TraceMyExtensibility(TraceLevel.Verbose, "MyExtensibilitySolutionService.DTEEvents_OnBeginShutDown: Entry. Call AfterClosing.")
             SolutionEvents_AfterClosing() ' Dispose all project services.

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityUtil.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityUtil.vb
@@ -14,7 +14,6 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
     ''' <summary>
     ''' Common utility methods for MyExtensibility.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class MyExtensibilityUtil
 
         ''' ;StringEquals

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.vb
@@ -12,11 +12,6 @@ Imports VSLangProj80
 Imports VBStrings = Microsoft.VisualBasic.Strings
 
 Namespace Microsoft.VisualStudio.Editors.PropertyPages
-
-    ''' <summary>
-    ''' 
-    ''' </summary>
-    ''' <remarks></remarks>
     Partial Friend Class AdvBuildSettingsPropPage
         Inherits PropPageUserControlBase
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
@@ -66,12 +66,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private Sub AssemblyInfoButton_Click(sender As Object, e As EventArgs) Handles AssemblyInfoButton.Click
             ShowChildPage(My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_AssemblyInfo_Title, GetType(AssemblyInfoPropPage), HelpKeywords.VBProjPropAssemblyInfo)
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
             Get
                 If m_ControlData Is Nothing Then
@@ -127,12 +121,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Return _controlGroup
             End Get
         End Property
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="OutputType"></param>
-        ''' <remarks></remarks>
         Private Sub PopulateControlSet(OutputType As UInteger)
             Debug.Assert(m_Objects.Length <= 1, "Multiple project updates not supported")
             PopulateStartupObject(StartUpObjectSupported(OutputType), False)
@@ -143,7 +132,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="StartUpObjectSupported">If false, (None) will be the only entry in the list.</param>
         ''' <param name="PopulateDropdown">If false, only the current text in the combobox is set.  If true, the entire dropdown list is populated.  For performance reasons, False should be used until the user actually drops down the list.</param>
-        ''' <remarks></remarks>
         Protected Overridable Sub PopulateStartupObject(StartUpObjectSupported As Boolean, PopulateDropdown As Boolean)
             'overridable to support the csharpapplication page (Sub Main isn't used by C#)
 
@@ -209,23 +197,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 m_fInsideInit = InsideInitSave
             End Try
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
-        ''' <remarks></remarks>
         Private Sub EnableControlSet()
             UpdateIconImage(False)
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function OutputTypeGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
 
             If OutputType.SelectedIndex = -1 Then
@@ -243,15 +220,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return True
 
         End Function
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function OutputTypeSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
 
             Dim didSelectItem As Boolean = False
@@ -405,15 +376,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return True
 
         End Function
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Shadows Function ApplicationIconGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
             If (IconRadioButton.Checked = True) Then
                 If (ApplicationIcon.Text.Equals(My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_Application_DefaultIconText, StringComparison.OrdinalIgnoreCase)) Then
@@ -429,27 +394,15 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Return False
             End If
         End Function
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function ApplicationIconSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
             Return SetIconAndWin32ResourceFile()
         End Function
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Shadows Function ApplicationManifestGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
             If (IconRadioButton.Checked = True) Then
                 If (ApplicationManifest.Text.Equals(My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_Application_DefaultManifestText, StringComparison.CurrentCultureIgnoreCase)) Then
@@ -468,27 +421,15 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Return False
             End If
         End Function
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function ApplicationManifestSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
             Return SetIconAndWin32ResourceFile()
         End Function
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function Win32ResourceGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
             If (Win32ResourceRadioButton.Checked = True) Then
                 value = Win32ResourceFile.Text
@@ -500,25 +441,14 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Return False
             End If
         End Function
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function Win32ResourceSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
             Return SetIconAndWin32ResourceFile()
         End Function
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub IconResourceFile_CheckedChanged(sender As Object, e As EventArgs) Handles IconRadioButton.CheckedChanged, Win32ResourceRadioButton.CheckedChanged
             If (IconRadioButton.Checked = True) Then
                 ManifestExplanationLabel.Enabled = True
@@ -574,8 +504,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="controlData"></param>
         ''' <param name="message"></param>
         ''' <param name="returnControl"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overrides Function ValidateProperty(controlData As PropertyControlData, ByRef message As String, ByRef returnControl As Control) As ValidationResult
             Select Case controlData.DispId
                 Case VsProjPropId.VBPROJPROPID_ApplicationIcon
@@ -623,16 +551,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Select
             Return ValidationResult.Succeeded
         End Function
-
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function StartupObjectGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
             'overridable to support the csharpapplication page (C# doesn't use root namespace)
             If Not StartUpObjectSupported() Then
@@ -730,13 +651,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Protected Overrides Sub TargetFrameworkMonikerChanged()
             ShowAutoGeneratedBindingRedirectsCheckBox(TargetFramework, AutoGenerateBindingRedirects)
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function RemoveRootNamespace(value As String) As String
             Dim root As String
             Dim RootLength As Integer
@@ -765,13 +680,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
             Return value
         End Function
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub OutputType_SelectionChangeCommitted(sender As Object, e As EventArgs) Handles OutputType.SelectionChangeCommitted
             If m_fInsideInit Then
                 Return
@@ -799,13 +709,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Debug.Assert(IsCSProject, "Unknown project type")
             Return HelpKeywords.CSProjPropApplication
         End Function
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub Win32ResourceFileBrowse_Click(sender As Object, e As EventArgs) Handles Win32ResourceFileBrowse.Click
 
             SkipValidating(Win32ResourceFile)   ' skip this because we will pop up dialog to edit it...
@@ -860,7 +765,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ComboBoxes_DropDown(sender As Object, e As EventArgs) Handles OutputType.DropDown
             SetComboBoxDropdownWidth(DirectCast(sender, ComboBox))
         End Sub
@@ -873,7 +777,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="FindIconsInProject">If False, only the standard items are added (this is faster
         '''   and so may be appropriate for page initialization).</param>
-        ''' <remarks></remarks>
         Private Overloads Sub PopulateIconList(FindIconsInProject As Boolean)
             PopulateIconList(FindIconsInProject, ApplicationIcon, CType(GetControlValueNative(Const_ApplicationIcon), String))
         End Sub
@@ -882,7 +785,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Update the image displayed for the currently-selected application icon
         ''' </summary>
-        ''' <remarks></remarks>
         Private Overloads Sub UpdateIconImage(AddToProject As Boolean)
             UpdateIconImage(ApplicationIcon, AppIconImage, AddToProject)
         End Sub
@@ -898,13 +800,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             PopulateIconList(True)
             SetComboBoxDropdownWidth(ApplicationIcon)
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ApplicationIcon_LostFocus(sender As Object, e As EventArgs) Handles ApplicationIcon.LostFocus
             If m_fInsideInit Then
                 Return
@@ -932,14 +829,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             SetDirty(VsProjPropId.VBPROJPROPID_ApplicationIcon, False)
         End Sub
-
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub AppIconBrowse_Click(sender As Object, e As EventArgs) Handles AppIconBrowse.Click
             BrowseForAppIcon(ApplicationIcon, AppIconImage)
         End Sub
@@ -953,7 +844,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="FindManifestInProject">If False, only the standard items are added (this is faster
         '''   and so may be appropriate for page initialization).</param>
-        ''' <remarks></remarks>
         Private Overloads Sub PopulateManifestList(FindManifestInProject As Boolean)
             PopulateManifestList(FindManifestInProject, ApplicationManifest, CType(GetControlValueNative(Const_ApplicationManifest), String))
         End Sub
@@ -967,13 +857,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             PopulateManifestList(True)
             SetComboBoxDropdownWidth(ApplicationManifest)
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ApplicationManifest_LostFocus(sender As Object, e As EventArgs) Handles ApplicationManifest.LostFocus
             If m_fInsideInit Then
                 Return

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageBase.vb
@@ -19,7 +19,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' Contains functionality common to the application prop pages of VB and C#
     '''   See comments in proppage.vb: "Application property pages (VB and C#)"
     ''' </summary>
-    ''' <remarks></remarks>
     Partial Public Class ApplicationPropPageBase
         Inherits PropPageUserControlBase
 
@@ -47,8 +46,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Retrieves the last set value for the Icon (as a path)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Protected ReadOnly Property LastIconImage() As String
             Get
                 Return _lastIconImage
@@ -62,8 +59,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function ApplicationIconGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
             Dim ApplicationIconCombobox As ComboBox = DirectCast(control, ComboBox)
             Dim ApplicationIconText As String = Trim(CStr(ApplicationIconCombobox.SelectedItem))
@@ -136,7 +131,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Adds an icon entry to the application icon combobox in its correct place
         ''' </summary>
         ''' <param name="ApplicationIconCombobox"></param>
-        ''' <remarks></remarks>
         Protected Overridable Sub AddIconEntryToCombobox(ApplicationIconCombobox As ComboBox, IconRelativePath As String)
             'By default, add the icon to the end of the combobox's dropdown list
             ApplicationIconCombobox.Items.Add(IconRelativePath)
@@ -147,7 +141,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Adds the given filename to the project.
         ''' </summary>
         ''' <param name="IconFileName"></param>
-        ''' <remarks></remarks>
         Private Function AddIconFileToProject(IconFileName As String) As ProjectItem
             'Note: we allow the project to set the Build Action property for the icon to the default (content),
             '  which causes it to get deployed.  That is the desired behavior.
@@ -161,7 +154,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="ApplicationIconCombobox">The combobox that displays the list of icons to choose from.</param>
         ''' <param name="ApplicationIconPictureBox">The picturebox that displays the image of the currently selected icon.</param>
-        ''' <remarks></remarks>
         Protected Sub BrowseForAppIcon(ApplicationIconCombobox As ComboBox, ApplicationIconPictureBox As PictureBox)
             Dim sInitialDirectory As String
             Dim sFileName As String
@@ -248,7 +240,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="ApplicationIconCombobox">The combobox that displays the list of icons to choose from.</param>
         ''' <param name="ApplicationIconPictureBox">The picturebox that displays the image of the currently selected icon.</param>
-        ''' <remarks></remarks>
         Protected Sub UpdateIconImage(ApplicationIconCombobox As ComboBox, ApplicationIconPictureBox As PictureBox, AddToProject As Boolean)
             If ApplicationIconCombobox.Enabled Then
                 Dim ApplicationIconText As String = Trim(CStr(ApplicationIconCombobox.SelectedItem))
@@ -372,8 +363,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="Icon">The icon to convert</param>
         ''' <param name="PictureBoxSize">The size into which the image needs to fit</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function IconToImage(Icon As Icon, PictureBoxSize As Size) As Image
             ' We want to fit the icon into the picture box, but we'll keep it square
             ' so as not to distort it.
@@ -411,7 +400,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   adds any .ico files underneath it recursively.
         ''' </summary>
         ''' <param name="ProjectItem"></param>
-        ''' <remarks></remarks>
         Protected Sub AddIconsFromProjectItem(ProjectItem As ProjectItem, ApplicationIconCombobox As ComboBox)
             For Index As Short = 1 To ProjectItem.FileCount
                 Dim FileName As String = ProjectItem.FileNames(Index)
@@ -433,8 +421,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns true if the text is the special "Browse" text for the icon combobox
         ''' </summary>
         ''' <param name="EntryText"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function IconEntryIsBrowse(EntryText As String) As Boolean
             Return False
         End Function
@@ -443,8 +429,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns true if the text is the special "(Default Icon)" text for the icon combobox
         ''' </summary>
         ''' <param name="EntryText"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function IconEntryIsDefault(EntryText As String) As Boolean
             Return EntryText IsNot Nothing AndAlso EntryText.Equals(m_DefaultIconText, StringComparison.OrdinalIgnoreCase)
         End Function
@@ -453,8 +437,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns true if the text is a special value (like Browse or Default)
         ''' </summary>
         ''' <param name="EntryText"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function IconEntryIsSpecial(EntryText As String) As Boolean
             Return IconEntryIsBrowse(EntryText) OrElse IconEntryIsDefault(EntryText)
         End Function
@@ -525,7 +507,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   adds any .manifest files underneath it recursively.
         ''' </summary>
         ''' <param name="ProjectItem"></param>
-        ''' <remarks></remarks>
         Protected Sub AddManifestsFromProjectItem(ProjectItem As ProjectItem, ApplicationManifestCombobox As ComboBox)
             For Index As Short = 1 To ProjectItem.FileCount
                 Dim FileName As String = ProjectItem.FileNames(Index)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
@@ -117,7 +117,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Fill up the allowed values in the target framework combo box
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Sub PopulateTargetFrameworkComboBox(targetFrameworkComboBox As ComboBox)
             Dim targetFrameworkSupported As Boolean = False
             targetFrameworkComboBox.Items.Clear()
@@ -174,8 +173,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function SetTargetFrameworkMoniker(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
             Dim combobox As ComboBox = CType(control, ComboBox)
             Dim previouslySelectedIndex = combobox.SelectedIndex
@@ -210,8 +207,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function GetTargetFrameworkMoniker(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
             Dim currentTarget As TargetFrameworkMoniker = CType(CType(control, ComboBox).SelectedItem, TargetFrameworkMoniker)
             If currentTarget IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBBase.vb
@@ -17,7 +17,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     '''   both WinForms and WPF projects
     '''   See comments in proppage.vb: "Application property pages (VB and C#)"
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class ApplicationPropPageVBBase
         Inherits ApplicationPropPageInternalBase
 
@@ -68,7 +67,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="FindIconsInProject">If False, only the standard items are added (this is faster
         '''   and so may be appropriate for page initialization).</param>
-        ''' <remarks></remarks>
         Protected Overloads Sub PopulateIconList(FindIconsInProject As Boolean)
             PopulateIconList(FindIconsInProject, CommonControls.IconCombobox, CType(GetControlValueNative(Const_ApplicationIcon), String))
         End Sub
@@ -98,7 +96,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Enables the Icon combobox (if Enable=True), but only if the associated property is supported
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overridable Sub EnableIconComboBox(Enable As Boolean)
             EnableControl(CommonControls.IconCombobox, Enable)
             UpdateIconImage(False)
@@ -108,7 +105,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Adds an icon entry to the application icon combobox in its correct place
         ''' </summary>
         ''' <param name="ApplicationIconCombobox"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub AddIconEntryToCombobox(ApplicationIconCombobox As ComboBox, IconRelativePath As String)
             'In VB, the last entry in the combobox is the <browse> entry, so we add it in the
             '  next-to-last position
@@ -120,7 +116,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Update the image displayed for the currently-selected application icon
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overloads Sub UpdateIconImage(AddToProject As Boolean)
             UpdateIconImage(CommonControls.IconCombobox, CommonControls.IconPicturebox, AddToProject)
         End Sub
@@ -343,7 +338,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             ''' <param name="ApplicationType"></param>
             ''' <param name="DisplayName"></param>
             ''' <param name="SupportedInExpress"></param>
-            ''' <remarks></remarks>
             Public Sub New(ApplicationType As ApplicationTypes, DisplayName As String, SupportedInExpress As Boolean)
                 _applicationType = ApplicationType
                 _displayName = DisplayName
@@ -381,9 +375,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             ''' <summary>
             ''' Get the references required for each project type...
             ''' </summary>
-            ''' <value></value>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public ReadOnly Property References() As String()
                 Get
                     Select Case ApplicationType
@@ -407,7 +398,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             ''' <summary>
             ''' Override ToString to get the "right" look in the ApplicationType combobox
             ''' </summary>
-            ''' <returns></returns>
             ''' <remarks>The current (localized) display name for the application type</remarks>
             Public Overrides Function ToString() As String
                 Return DisplayName
@@ -452,7 +442,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 ''' </summary>
                 ''' <param name="SemicolonSeparatedNames"></param>
                 ''' <param name="MustBeSupportedInExpressSKUs">If true, only application types supported by express SKUs will be returned</param>
-                ''' <remarks></remarks>
                 Friend Sub New(SemicolonSeparatedNames As String, MustBeSupportedInExpressSKUs As Boolean)
                     _mustBeSupportedInExpressSKUs = MustBeSupportedInExpressSKUs
                     For Each AppType As String In SemicolonSeparatedNames.Split(";"c)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
@@ -23,7 +23,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' The application property page for VB WinForms apps
     ''' - see comments in proppage.vb: "Application property pages (VB and C#)"
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class ApplicationPropPageVBWinForms
         Inherits ApplicationPropPageVBBase
 
@@ -77,7 +76,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         '''  Set up shared state...
         ''' </summary>
-        ''' <remarks></remarks>
         Shared Sub New()
             ' Populate shared list of all known application types allowed on this page
             s_applicationTypes.Add(New ApplicationTypeInfo(ApplicationTypes.WindowsApp, My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_WindowsFormsApp, True))
@@ -115,17 +113,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Let the base class know which control instances correspond to shared controls
         '''   between this inherited class and the base vb application property page class.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub SetCommonControls()
             CommonControls = New CommonPageControls(
                 IconCombobox, IconLabel, IconPicturebox)
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
             Get
                 Dim ControlsThatDependOnStartupObjectProperty As Control() = {
@@ -207,7 +198,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Removes references to anything that was passed in to SetObjects
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub CleanupCOMReferences()
             MyBase.CleanupCOMReferences()
 
@@ -228,7 +218,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Gets the MyApplication.MyApplicationProperties object returned by the project system (which the project system creates by calling into us)
         ''' </summary>
         ''' <value>The value of the MyApplication property, or else Nothing if it is not supported.</value>
-        ''' <remarks></remarks>
         Private ReadOnly Property MyApplicationProperties() As IMyApplicationPropertiesInternal
             Get
                 Debug.Assert(Implies(_myApplicationPropertiesCache IsNot Nothing, _isMyApplicationPropertiesCached))
@@ -258,7 +247,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   is thrown, it is displayed to the user and swallowed.
         ''' </summary>
         ''' <returns>True on success.</returns>
-        ''' <remarks></remarks>
         Private Function TryRunCustomToolForMyApplication() As Boolean
             If MyApplicationProperties IsNot Nothing Then
                 Try
@@ -278,8 +266,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function MyApplicationGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
             value = MyApplicationProperties
             Return True
@@ -291,8 +277,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function MyApplicationSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
             'Nothing for us to do
             Return True
@@ -304,8 +288,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function MyTypeGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
             value = _myType
             Return True
@@ -317,8 +299,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function MyTypeSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
 
             Dim stValue As String = CType(value, String)
@@ -346,7 +326,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
         ''' <remarks>OutputType is obtained from the value in the Application Type field</remarks>
         Protected Function OutputTypeGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
 
@@ -396,7 +375,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Make sure the application type combobox is showing the appropriate 
         ''' value
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub UpdateApplicationTypeUI()
             If _settingApplicationType Then
                 Return
@@ -425,7 +403,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' The UI checkbox's logic is reversed from the property ("Enable application frameworks" = Not CustomSubMain).  However, because the property
         '''   is specified as CustomSubMain and I don't want to change it at this point, and the property change notification is based on the
@@ -447,7 +424,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' The UI checkbox's logic is reversed from the property ("Enable application frameworks" = Not CustomSubMain).  However, because the property
         '''   is specified as CustomSubMain and I don't want to change it at this point, and the property change notification is based on the
@@ -478,7 +454,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Enables the "Enable application framework" checkbox (if Enable=True), but only if it is supported in this project with current settings
         ''' </summary>
         ''' <param name="Enable"></param>
-        ''' <remarks></remarks>
         Private Sub EnableUseApplicationFrameworkCheckBox(Enable As Boolean)
             If Enable Then
                 Dim useApplicationFrameworkEnabled As Boolean = MyApplicationFrameworkSupported()
@@ -495,16 +470,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 WindowsAppGroupBox.Enabled = False
             End If
         End Sub
-
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function StartupObjectGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
 
             If Not StartUpObjectSupported() Then
@@ -592,8 +560,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function StartupObjectSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
             'This is handled by the ApplicationType set, so do nothing here
             'CONSIDER: The start-up object/MainForm-handling code needs to be reworked - it makes undo/redo/external property changes 
@@ -614,8 +580,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function MainFormNoRootNSSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
             If Not PropertyControlData.IsSpecialValue(value) Then
                 MainFormTextboxNoRootNS.Text = DirectCast(value, String)
@@ -630,12 +594,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             Return True
         End Function
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="OutputType"></param>
-        ''' <remarks></remarks>
         Private Sub PopulateControlSet(OutputType As UInteger)
             Debug.Assert(m_Objects.Length <= 1, "Multiple project updates not supported")
             PopulateStartupObject(StartUpObjectSupported(OutputType), False)
@@ -650,7 +609,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Populates the splash screen combobox's text and optionally dropdown entries
         ''' </summary>
         ''' <param name="PopulateDropdown">If false, only the current text in the combobox is set.  If true, the entire dropdown list is populated.  For performance reasons, False should be used until the user actually drops down the list.</param>
-        ''' <remarks></remarks>
         Protected Sub PopulateSplashScreenList(PopulateDropdown As Boolean)
             'Use the same list as StartupObject, but no sub main
 
@@ -707,8 +665,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   in this project.  It does not necessarily mean that it's turned on,
         '''   just that it can be supported.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MyApplicationFrameworkSupported() As Boolean
             If Not MyApplicationPropertiesSupported Then
                 Return False
@@ -736,8 +692,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' This means, among other things, that we have a list of start-up *forms*
         '''   instead of objects.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MyApplicationFrameworkEnabled() As Boolean
             If Not MyApplicationFrameworkSupported() Then
                 Return False
@@ -762,8 +716,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Retrieve the list of start-up forms (not start-up objects) from the VB compiler
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetFormEntryPoints(IncludeSplashScreen As Boolean) As String()
             Try
                 Dim EntryPointProvider As Interop.IVBEntryPointProvider = CType(ServiceProvider.GetService(Interop.NativeMethods.VBCompilerGuid), Interop.IVBEntryPointProvider)
@@ -819,7 +771,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="StartUpObjectSupported">If false, (None) will be the only entry in the list.</param>
         ''' <param name="PopulateDropdown">If false, only the current text in the combobox is set.  If true, the entire dropdown list is populated.  For performance reasons, False should be used until the user actually drops down the list.</param>
-        ''' <remarks></remarks>
         Protected Sub PopulateStartupObject(StartUpObjectSupported As Boolean, PopulateDropdown As Boolean)
             'overridable to support the csharpapplication page (Sub Main isn't used by C#)
             Dim InsideInitSave As Boolean = m_fInsideInit
@@ -940,12 +891,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             EnableMyApplicationControlSet()
             EnableControl(ViewUACSettingsButton, UACSettingsButtonSupported(AppType))
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="OutputType"></param>
-        ''' <remarks></remarks>
         Private Sub EnableControlSet(OutputType As VSLangProj.prjOutputType)
             EnableIconComboBox(OutputType <> VSLangProj.prjOutputType.prjOutputTypeLibrary)
             EnableMyApplicationControlSet()
@@ -955,7 +901,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Sets the visibility of the MyApplication-related properties
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub EnableMyApplicationControlSet()
             If Not MyApplicationPropertiesSupported Then
                 'If MyApplication property not supported at all, then this project system flavor has disabled it,
@@ -1094,8 +1039,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="PropertyName"></param>
         ''' <param name="Value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function ReadUserDefinedProperty(PropertyName As String, ByRef Value As Object) As Boolean
 
             If PropertyName = Const_MyApplication Then
@@ -1196,8 +1139,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="PropertyName"></param>
         ''' <param name="Value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function WriteUserDefinedProperty(PropertyName As String, Value As Object) As Boolean
             If PropertyName = Const_MyApplication Then
                 Dim x = MyApplicationProperties
@@ -1299,8 +1240,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Get the current value of MyType from the project properties
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetMyTypeFromProject() As String
             Dim MyTypeObject As Object = Nothing
             If GetProperty(VBProjPropId.VBPROJPROPID_MyType, MyTypeObject) Then
@@ -1317,8 +1256,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   nor should it change the MyType to any other value.  This allows programmers to
         '''   effectively turn off My and leave it off.  Returns true if My has been disabled.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MyTypeDisabled() As Boolean
             If Not _isMyTypeDisabledCached Then
                 _isMyTypeDisabledCached = True
@@ -1337,7 +1274,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Sets the current value of MyType based on the application type
         ''' </summary>
         ''' <param name="AppType"></param>
-        ''' <remarks></remarks>
         Private Sub SetMyType(AppType As ApplicationTypes, ReadyToApply As Boolean)
             Debug.Assert(UseApplicationFrameworkCheckBox.CheckState <> CheckState.Indeterminate OrElse Not MyApplicationFrameworkSupported() OrElse MyTypeDisabled(),
                 "UseApplicationFrameworkCheckbox shouldn't be indeterminate")
@@ -1379,7 +1315,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Sets the current value of MyType based on the application type
         ''' </summary>
         ''' <param name="AppType"></param>
-        ''' <remarks></remarks>
         Private Shared Function MyTypeFromApplicationType(AppType As ApplicationTypes, CustomSubMain As Boolean) As String
             Dim MyType As String
 
@@ -1416,7 +1351,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Sets the text on the start-up object label to be either "Startup object" or "Startup form" depending
         '''   on whether a custom sub main is being used or not.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub SetStartupObjectLabelText()
             If MyApplicationFrameworkEnabled() Then
                 StartupObjectLabel.Text = _startupFormLabelText
@@ -1434,7 +1368,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ComboBoxes_DropDown(sender As Object, e As EventArgs) Handles ApplicationTypeComboBox.DropDown
             SetComboBoxDropdownWidth(DirectCast(sender, ComboBox))
         End Sub
@@ -1442,8 +1375,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Retrieve the current application type set in the UI
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetAppTypeFromUI() As ApplicationTypes
             Dim appTypeInfo As ApplicationTypeInfo = TryCast(ApplicationTypeComboBox.SelectedItem, ApplicationTypeInfo)
             If appTypeInfo IsNot Nothing Then
@@ -1456,7 +1387,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Add required references for the current application type set in the UI
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub AddRequiredReferences()
             Dim appTypeInfo As ApplicationTypeInfo = TryCast(ApplicationTypeComboBox.SelectedItem, ApplicationTypeInfo)
             Dim requiredReferences As String()
@@ -1554,7 +1484,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ViewCodeButton_Click(sender As Object, e As EventArgs) Handles ViewCodeButton.Click
             Static IsInViewCodeButtonClick As Boolean
             If IsInViewCodeButtonClick Then
@@ -1587,7 +1516,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub SplashScreenComboBox_DropDown(sender As Object, e As EventArgs) Handles SplashScreenComboBox.DropDown
             PopulateSplashScreenList(True)
             SetComboBoxDropdownWidth(DirectCast(sender, ComboBox))
@@ -1600,7 +1528,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub StartupObjectComboBox_DropDown(sender As Object, e As EventArgs) Handles StartupObjectComboBox.DropDown
             PopulateStartupObject(StartUpObjectSupported(), True)
             SetComboBoxDropdownWidth(DirectCast(sender, ComboBox))
@@ -1609,8 +1536,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns true iff the current project supports the default settings file
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MySettingsSupported() As Boolean
             Debug.Assert(DTEProject IsNot Nothing)
             If DTEProject IsNot Nothing Then
@@ -1701,8 +1626,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns True iff the given string is the special value used for "(None)"
         ''' </summary>
         ''' <param name="Value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function IsNoneText(Value As String) As Boolean
             'We use ordinal because a) we put the value into the combobox, it could not have magically
             '  changed case, and b) we don't want to use culture-aware because if the user changes cultures
@@ -1716,7 +1639,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MyApplicationProperties_PropertyChanged(sender As Object, e As PropertyChangedEventArgs) Handles _myApplicationPropertiesNotifyPropertyChanged.PropertyChanged
             Debug.Assert(e.PropertyName <> "")
             Switches.TracePDProperties(TraceLevel.Info, "MyApplicationProperties_PropertyChanged(""" & e.PropertyName & """)")
@@ -1748,7 +1670,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ViewUACSettingsButton_Click(sender As Object, e As EventArgs) Handles ViewUACSettingsButton.Click
             ViewUACSettings()
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoUtils.vb
@@ -152,7 +152,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Populate the neutral language combobox with cultures
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub PopulateNeutralLanguageComboBox(NeutralLanguageComboBox As Windows.Forms.ComboBox)
             'The list of cultures can't change on us, no reason to
             '  re-populate every time it's dropped down.

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPageBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPageBase.vb
@@ -13,7 +13,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' <summary>
     ''' Base class for the C# / VB build property pages
     ''' </summary>
-    ''' <remarks></remarks>
     <TypeDescriptionProvider(GetType(AbstractControlTypeDescriptionProvider(Of BuildPropPageBase, PropPageUserControlBase)))>
     Friend MustInherit Class BuildPropPageBase
         Inherits PropPageUserControlBase

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CSharpApplicationPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CSharpApplicationPropPage.vb
@@ -10,7 +10,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' <summary>
     ''' C# application property page - see comments in proppage.vb: "Application property pages (VB and C#)"
     ''' </summary>
-    ''' <remarks></remarks>
     Partial Friend Class CSharpApplicationPropPage
         Inherits ApplicationPropPage
 
@@ -27,7 +26,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Populates the start-up object combobox box dropdown
         ''' </summary>
         ''' <param name="PopulateDropdown">If false, only the current text in the combobox is set.  If true, the entire dropdown list is populated.  For performance reasons, False should be used until the user actually drops down the list.</param>
-        ''' <remarks></remarks>
         Protected Overrides Sub PopulateStartupObject(StartUpObjectSupported As Boolean, PopulateDropdown As Boolean)
             Dim InsideInitSave As Boolean = m_fInsideInit
             m_fInsideInit = True

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
@@ -93,7 +93,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' properties, we need to make sure that we have the right items/display text in
         ''' the option strict combobox
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub QueueUpdateOptionStrictComboBox()
             If _optionStrictComboBoxUpdateQueued Then
                 Return
@@ -109,7 +108,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' This method does *not* change the underlying property, it only updates the
         ''' UI.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub UpdateOptionStrictComboBox()
             Try
                 If IsOptionStrictOn() Then
@@ -296,8 +294,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function NoWarnGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
             If _noWarn IsNot Nothing Then
                 value = ConcatenateNumbers(_noWarn)
@@ -315,8 +311,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function NoWarnSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
             If value Is PropertyControlData.Indeterminate OrElse value Is PropertyControlData.MissingProperty Then
                 _noWarn = Nothing
@@ -344,8 +338,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function SpecWarnAsErrorGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
             Debug.Assert(_specWarnAsError IsNot Nothing)
             value = ConcatenateNumbers(_specWarnAsError)
@@ -360,8 +352,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function SpecWarnAsErrorSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
             If value Is PropertyControlData.Indeterminate OrElse value Is PropertyControlData.MissingProperty Then
                 _specWarnAsError = Nothing
@@ -387,8 +377,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function WarningLevelGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
             Select Case DisableAllWarningsCheckBox.CheckState
                 Case CheckState.Checked
@@ -408,8 +396,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function WarningLevelSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
             If value Is PropertyControlData.Indeterminate Then
                 DisableAllWarningsCheckBox.CheckState = CheckState.Indeterminate
@@ -483,7 +469,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' For some reason, AnyCPU includes as space when returned by the IVsConfigProvider.Get*PlatformNames
         ''' but should *not* include a space when passed to the compiler/set the property value
         ''' </summary>
-        ''' <remarks></remarks>
         Private Const AnyCPUPropertyValue As String = "AnyCPU"
         Private Const AnyCPUPlatformName As String = "Any CPU"
 
@@ -694,7 +679,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' We are in an indeterminate state if we have conflicting settings in
         ''' different configurations
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' We shouldn't be in this situation unless the user has messed around manually with
         ''' the project file...
@@ -824,7 +808,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Disables warnings which are not generated when Option Strict is on
         ''' (Option Strict On will generate error ids, not the warning ids)
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub UpdateWarningList()
             ' Depending on the order that we are populating the controls,
             ' we may get called to update the warnings list before we have
@@ -1305,7 +1288,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Check if the path is a trusted path or not
         ''' </summary>
         ''' <param name="path"></param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' This code was ported from langutil.cpp (function LuCheckSecurityLevel)
         ''' If that code ever changes, we've gotta update this as well...
@@ -1449,8 +1431,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 ''' Getter for the raw config objects. We override this to always return the properties for all
                 ''' configurations to make this property look like a config independent-ish property
                 ''' </summary>
-                ''' <value></value>
-                ''' <remarks></remarks>
                 Friend ReadOnly Property ConfigRawPropertiesObjects() As Object()
                     Get
                         Dim tmpRawObjects() As IVsCfg
@@ -1471,8 +1451,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 ''' Getter for the extended config objects. We override this to always return the properties for all
                 ''' configurations to make this property look like a config independent-ish property
                 ''' </summary>
-                ''' <value></value>
-                ''' <remarks></remarks>
                 Friend ReadOnly Property ConfigExtendedPropertiesObjects() As Object()
                     Get
                         If _extendedObjects Is Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePathsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePathsPropPage.vb
@@ -310,7 +310,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <returns>True iff the ENTER key is actually used.  False indicates it should be allowed
         '''   to be passed along and processed normally.</returns>
-        ''' <remarks></remarks>
         Private Function ProcessEnterKey() As Boolean
             'If the focus is on the Folder textbox, and the AddFolder button is enabled, then 
             '  we interpret ENTER as meaning, "Add this folder", i.e., click on the AddFolder button.
@@ -332,8 +331,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Gets the absolute path to the path currently in the Folder textbox.  If the path is invalid (contains bad
         '''   characters, etc.), returns simply the current text.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetCurrentFolderPathAbsolute() As String
             Dim FolderText As String = Trim(Folder.Text)
             If FolderText.Length > 0 Then

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
@@ -90,7 +90,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Removes references to anything that was passed in to SetObjects
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub CleanupCOMReferences()
 
             UnadviseReferencesEvents()
@@ -146,8 +145,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' not we are hiding the selection currently to work around the by-design CheckedListBox
         ''' behavior of visually looking like it has focus when it really doesn't.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property ImportListSelectedItem() As String
             Get
                 Debug.Assert(ImportList.SelectedItems.Count <= 1, "the ImportList is not set up to support multiple selection")
@@ -272,7 +269,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''  It is a workaround to use background thread to wait for the compiler to finish.
         ''' Note: it rarely happens. (It happens we have a post message when a third party start the compiler and wait for something.)
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub DelayPostingMessage(messageId As Object)
             If Not IsDisposed Then
                 NativeMethods.PostMessage(Handle, CInt(messageId), 0, 0)
@@ -284,7 +280,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Called when the page is activated or deactivated
         ''' </summary>
         ''' <param name="activated"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnPageActivated(activated As Boolean)
             MyBase.OnPageActivated(activated)
             If IsActivated Then
@@ -407,7 +402,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Refreshes the reference listviews (both regular and web references), based on the list of references ReferenceListData.
         ''' </summary>
         ''' <param name="ReferenceListData">reference object lists</param>
-        ''' <remarks></remarks>
         Private Sub RefreshReferenceList(ReferenceListData As ArrayList)
 
             ReferenceList.BeginUpdate()
@@ -449,7 +443,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Populates the Reference object of all references (regular and web) currently in the project, and also 
         '''   calls RefreshReferenceList() to update the listviews with those objects
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub PopulateReferenceList()
 
             Dim theVSProject As VSLangProj.VSProject
@@ -516,8 +509,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' check whether a project item is really a web reference
         ''' </summary>
         ''' <param name="webRef"></param>
-        ''' <return></return>
-        ''' <remarks></remarks>
         Private Shared Function IsWebReferenceItem(webRef As EnvDTE.ProjectItem) As Boolean
             Dim webRefProperty As EnvDTE.Property = Nothing
             Dim properties As EnvDTE.Properties = webRef.Properties
@@ -828,7 +819,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Take a snapshot of the user defined imports
         ''' </summary>
         ''' <returns>A dictionary with import name/is namespace pairs</returns>
-        ''' <remarks></remarks>
         Private Function GetUserDefinedImportsSnapshot() As IDictionary(Of String, Boolean)
             ' First, we get a collection of referenced namespaces that is fast to 
             ' search...
@@ -855,8 +845,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="ImportsSnapshot">
         ''' A snapshot of the project imports taken sometime before... 
         ''' </param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function TrimUserImports(ImportsSnapshot As IDictionary(Of String, Boolean)) As String()
             ' Let's give the compiler time to update the namespace list - it looks like we may
             ' have a race-condition here, but I can't find out why.... and o
@@ -1323,7 +1311,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Delegate for calling into RestoreImportListSelection.  Used by ImportPanel_Enter.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Delegate Sub RestoreImportListSelectionDelegate()
 
         ''' <summary>
@@ -1334,7 +1321,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ImportPanel_Enter(sender As Object, e As EventArgs) Handles addUserImportTableLayoutPanel.Enter
             ' We restore the selection through a message pump. 
             ' The reason is vswhidbey 496909.
@@ -1348,7 +1334,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' However, if ImportList has already got a selection. We will know the user actually clicks (mouse) one item of the list.
         ''' In that case, we shouldn't restore the old selection (wswhibey 496909)
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub RestoreImportListSelection()
             _hidingImportListSelectedItem = True
             Try
@@ -1370,7 +1355,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ImportPanel_Leave(sender As Object, e As EventArgs) Handles addUserImportTableLayoutPanel.Leave
             _hidingImportListSelectedItem = True
             Try
@@ -1547,7 +1531,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="owner">Control which owns the listview</param>
         ''' <param name="ReferenceList">The listview control to set column widths</param>
         ''' <param name="ColOffset">Offset to "Reference Name" column</param>
-        ''' <remarks></remarks>
         Friend Shared Sub SetReferenceListColumnWidths(ByRef owner As Control, ByRef ReferenceList As ListView, ColOffset As Integer)
             Dim _handle As IntPtr = ReferenceList.Handle
 
@@ -1596,7 +1579,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub AddUserImportButton_Click(sender As Object, e As EventArgs) Handles AddUserImportButton.Click
             Debug.Assert(UserImportTextBox.Text.Trim().Length > 0, "Why was the AddUserImportButton enabled when the UserImport text was empty?")
             ' Get the current list
@@ -1637,7 +1619,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ImportList_SelectedIndexChanged(sender As Object, e As EventArgs) Handles ImportList.SelectedIndexChanged
 
             If Not _hidingImportListSelectedItem Then
@@ -1653,7 +1634,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub UpdateUserImportButton_Click(sender As Object, e As EventArgs) Handles UpdateUserImportButton.Click
 
             Debug.Assert(ImportList.SelectedItems.Count <= 1 AndAlso
@@ -1704,7 +1684,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub UserImportTextBox_TextChanged(sender As Object, e As EventArgs) Handles UserImportTextBox.TextChanged
             EnableImportGroup()
         End Sub
@@ -1892,7 +1871,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Reference all service references in the list.
         ''' We actually compare the original list and new list to generate DelayUpdateItem and process them later.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub RefreshServiceReferences()
             If _referenceGroupManager IsNot Nothing Then
                 Dim collection As IVsWCFReferenceGroupCollection = _referenceGroupManager.GetReferenceGroupCollection()
@@ -2235,7 +2213,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Searches up the parent chain for an ApplicationDesignerView, if there is one.
         ''' </summary>
         ''' <returns>The PropPageUserControlBase which hosts this property page, if any, or else Nothing.</returns>
-        ''' <remarks></remarks>
         Private Function FindPropPageDesignerView() As PropPageDesigner.PropPageDesignerView
             Dim parentWindow As Control = Parent
             While parentWindow IsNot Nothing

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServiceReferenceComponent.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServiceReferenceComponent.vb
@@ -88,8 +88,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Service reference instance
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property ReferenceGroup() As IVsWCFReferenceGroup
             Get
                 Return _referenceGroup
@@ -99,8 +97,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Remove the service reference...
         ''' </summary>
-        ''' <return></return>
-        ''' <remarks></remarks>
         Private Sub Remove() Implements IReferenceComponent.Remove
             _collection.Remove(_referenceGroup)
         End Sub
@@ -161,8 +157,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''    - Makes the Metadata Location property readonly.
         ''' </summary>
         ''' <param name="orig">The original property list</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetModifiedPropertyList(orig As PropertyDescriptorCollection) As PropertyDescriptorCollection
             Dim modified As PropertyDescriptor() = New PropertyDescriptor(orig.Count - 1) {}
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/SingleConfigPropertyControlData.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/SingleConfigPropertyControlData.vb
@@ -27,7 +27,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     '''     (e.g., VB, C# Express, etc.).
     ''' 
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class SingleConfigPropertyControlData
         Inherits PropertyControlData
 
@@ -89,8 +88,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   passed in to the page through SetObjects.  However, it may be modified by subclasses to contain a superset
         '''   or subset for special purposes.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property RawPropertiesObjects() As Object()
             Get
                 Dim AllObjects As Object() = MyBase.RawPropertiesObjects
@@ -113,8 +110,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   based on the set of objects passed in to the page through SetObjects.  However, it may be modified by subclasses to 
         '''   contain a superset or subset for special purposes.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property ExtendedPropertiesObjects() As Object()
             Get
                 'We must pass the raw setobjects array to IndexOfSpecificConfig - it won't work with the extended objects
@@ -191,8 +186,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns true iff this project is in simplified configuration mode.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function SimplifiedConfigsMode() As Boolean
             Return ShellUtil.GetIsSimplifiedConfigMode(PropPage.ProjectHierarchy)
         End Function

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkAssemblies.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkAssemblies.vb
@@ -8,14 +8,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' Support for retrieving and working with the available target framework assemblies
     '''   for a project.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class TargetFrameworkAssemblies
 
         ''' <summary>
         ''' Represents a supported target framework assembly.  Can be placed directly into 
         '''   a listbox or combobox (it will show the Description text in the listbox)
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Class TargetFramework
             Private ReadOnly _version As UInteger
             Private ReadOnly _description As String
@@ -42,8 +40,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             ''' <summary>
             ''' Provides the text to show inside of a combobox/listbox
             ''' </summary>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Overrides Function ToString() As String
                 Return _description
             End Function
@@ -54,8 +50,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Retrieves the set of target framework assemblies that are supported
         ''' </summary>
         ''' <param name="vsTargetFrameworkAssemblies"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function GetSupportedTargetFrameworkAssemblies(vsTargetFrameworkAssemblies As IVsTargetFrameworkAssemblies) As IEnumerable(Of TargetFramework)
             Dim versions As UInteger() = GetSupportedTargetFrameworkAssemblyVersions(vsTargetFrameworkAssemblies)
             Dim targetFrameworks As New List(Of TargetFramework)
@@ -72,8 +66,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="vsTargetFrameworkAssemblies"></param>
         ''' <param name="version"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GetTargetFrameworkDescriptionFromVersion(vsTargetFrameworkAssemblies As IVsTargetFrameworkAssemblies, version As UInteger) As String
             Dim pszDescription As String = Nothing
             VSErrorHandler.ThrowOnFailure(vsTargetFrameworkAssemblies.GetTargetFrameworkDescription(version, pszDescription))
@@ -84,8 +76,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Retrieve the list of assemblies versions (as uint) that are supported
         ''' </summary>
         ''' <param name="vsTargetFrameworkAssemblies"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GetSupportedTargetFrameworkAssemblyVersions(vsTargetFrameworkAssemblies As IVsTargetFrameworkAssemblies) As UInteger()
             Dim targetFrameworkEnumerator As IEnumTargetFrameworks = Nothing
             VSErrorHandler.ThrowOnFailure(vsTargetFrameworkAssemblies.GetSupportedFrameworks(targetFrameworkEnumerator))

--- a/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
@@ -106,7 +106,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Initialize proppage for use on a PropPageHostDialog: 
         ''' Initialize proppage variables and install custom dialog event handlers.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub InitDialog()
             Try
                 ' Get our project hierarchy
@@ -131,7 +130,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' ;Abort
         ''' Abort requesting unused references from compiler.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub Abort()
 
             ' Stop polling
@@ -206,7 +204,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Sets the proppage appearance according to current operation
         ''' </summary>
         ''' <param name="Status">Current status of proppage (equivalent to status of GetUnusedRefsList call)</param>
-        ''' <remarks></remarks>
         Private Sub UpdateStatus(Status As ReferenceUsageResult)
 
             ' Only update status when necessary
@@ -331,7 +328,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Poll compiler for unused references list from compiler and update listview
         ''' when received.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub GetUnusedRefs()
 
             ' Request unused references from 
@@ -444,7 +440,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' ;RemoveCheckRefs
         ''' Remove all references the user checked from the project.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub RemoveCheckedRefs()
 
             Dim ref As VSLangProj.Reference

--- a/src/Microsoft.VisualStudio.Editors/PropPages/UserPropertyDescriptor.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/UserPropertyDescriptor.vb
@@ -11,7 +11,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' Should be returned by an overriden GetUserDefinedPropertyDescriptor.
     ''' This is used mainly in integrating with the Undo/Redo capabilities.
     ''' </summary>
-    ''' <remarks></remarks>
     Public Class UserPropertyDescriptor
         Inherits PropertyDescriptor
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlDocument.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlDocument.vb
@@ -17,7 +17,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
     '''   modify just the parts we need to directly in the text buffer.  This class
     '''   handles that surprisingly complex job.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class AppDotXamlDocument
         Implements IDebugLockCheck
         Implements IDisposable
@@ -33,7 +32,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' A simple interface to allow XamlProperty to ask the AppDotXamlDocument to 
         '''   make text replacements.
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Interface IReplaceText
 
             ''' <summary>
@@ -42,7 +40,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             ''' <param name="sourceStart"></param>
             ''' <param name="sourceEnd"></param>
             ''' <param name="newText"></param>
-            ''' <remarks></remarks>
             Sub ReplaceText(sourceStart As Location, sourceEnd As Location, newText As String)
 
         End Interface
@@ -54,7 +51,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         ''' Represents a position in a text buffer
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Class Location
             Public LineIndex As Integer 'Zero-based line #
             Public CharIndex As Integer 'Zero-based character on line
@@ -77,7 +73,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             ''' XmlReader
             ''' </summary>
             ''' <param name="reader"></param>
-            ''' <remarks></remarks>
             Public Sub New(reader As XmlReader)
                 Me.New(CType(reader, IXmlLineInfo).LineNumber - 1, CType(reader, IXmlLineInfo).LinePosition - 1)
             End Sub
@@ -95,7 +90,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         ''' Used by the document to verify BufferLock is used when it's needed
         ''' </summary>
-        ''' <remarks></remarks>
         Public Interface IDebugLockCheck
             Sub OnBufferLock()
             Sub OnBufferUnlock()
@@ -107,7 +101,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         '''  in the buffer.
         ''' This class keeps the buffer locked until it is disposed.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Class BufferLock
             Implements IDisposable
 
@@ -166,7 +159,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         ''' Represents a property value found in the XAML file.
         ''' </summary>
-        ''' <remarks></remarks>
         <DebuggerDisplay("{ActualDefinitionText}, Value={UnescapedValue}")>
         Friend MustInherit Class XamlProperty
             Protected VsTextLines As IVsTextLines
@@ -197,9 +189,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             '''   appears in the .xaml file.  If DefinitionIncludesQuotes=True, then this
             '''   includes the beginning/ending quote
             ''' </summary>
-            ''' <value></value>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Overridable ReadOnly Property ActualDefinitionText() As String
                 Get
                     Dim buffer As String = Nothing
@@ -231,7 +220,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             ''' </summary>
             ''' <param name="replaceTextInstance"></param>
             ''' <param name="value"></param>
-            ''' <remarks></remarks>
             Public Overridable Sub SetProperty(replaceTextInstance As IReplaceText, value As String)
                 If UnescapedValue.Equals(value, StringComparison.Ordinal) Then
                     'The property value is not changing.  Leave things alone.
@@ -255,7 +243,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         ''' Represents a property that was found in the XAML file in attribute syntax
         ''' </summary>
-        ''' <remarks></remarks>
         <DebuggerDisplay("{ActualDefinitionText}, Value={UnescapedValue}")>
         Friend Class XamlPropertyInAttributeSyntax
             Inherits XamlProperty
@@ -269,7 +256,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         ''' Represents a property that was found in property element syntax with a start and end tag.
         ''' </summary>
-        ''' <remarks></remarks>
         <DebuggerDisplay("{ActualDefinitionText}, Value={UnescapedValue}")>
         Friend Class XamlPropertyInPropertyElementSyntax
             Inherits XamlProperty
@@ -282,7 +268,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         ''' Represents a property that was found in property element syntax with an empty tag.
         ''' </summary>
-        ''' <remarks></remarks>
         <DebuggerDisplay("{ActualDefinitionText}, Value={UnescapedValue}")>
         Friend Class XamlPropertyInPropertyElementSyntaxWithEmptyTag
             Inherits XamlPropertyInPropertyElementSyntax
@@ -394,8 +379,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <param name="startIndex"></param>
         ''' <param name="endLine"></param>
         ''' <param name="endIndex"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetText(startLine As Integer, startIndex As Integer, endLine As Integer, endIndex As Integer) As String
             Dim text As String = Nothing
             ErrorHandler.ThrowOnFailure(_vsTextLines.GetLineText(startLine, startIndex, endLine, endIndex, text))
@@ -408,8 +391,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <param name="startLine"></param>
         ''' <param name="startIndex"></param>
         ''' <param name="count">Count of characters to return</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetText(startLine As Integer, startIndex As Integer, count As Integer) As String
             Return GetText(startLine, startIndex, startLine, startIndex + count)
         End Function
@@ -417,8 +398,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         ''' Retrieves the text between the given buffer line/char points
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetText(startLocation As Location, endLocation As Location) As String
             Return GetText(startLocation.LineIndex, startLocation.CharIndex, endLocation.LineIndex, endLocation.CharIndex)
         End Function
@@ -426,8 +405,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         ''' Retrieves the text starting at the given point and with the given length
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetText(startLocation As Location, count As Integer) As String
             Return GetText(startLocation.LineIndex, startLocation.CharIndex, count)
         End Function
@@ -435,8 +412,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         ''' Retrieves all of the text in the buffer
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetAllText() As String
             Dim lastLine, lastIndex As Integer
             ErrorHandler.ThrowOnFailure(_vsTextLines.GetLastLineIndex(lastLine, lastIndex))
@@ -451,8 +426,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Escape a string in XML format, including double and single quotes
         ''' </summary>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function EscapeXmlString(value As String) As String
             If value Is Nothing Then
                 value = String.Empty
@@ -475,8 +448,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Unescapes an element's content value from escaped XML format.
         ''' </summary>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function UnescapeXmlContent(value As String) As String
             If value Is Nothing Then
                 value = String.Empty
@@ -504,7 +475,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         '''   the single root node.
         ''' </summary>
         ''' <param name="reader"></param>
-        ''' <remarks></remarks>
         Public Shared Sub MoveToApplicationRootElement(reader As XmlTextReader)
             'XAML files must have only one root element.  For app.xaml, it must be "Application"
             If reader.MoveToContent() = XmlNodeType.Element And reader.Name = ELEMENT_APPLICATION Then
@@ -521,8 +491,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Creates an XmlTextReader for the text
         '''   in the buffer.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function CreateXmlTextReader() As XmlTextReader
             Debug.Assert(_debugBufferLockCount > 0, "Should be using BufferLock!")
             Dim stringReader As New StringReader(GetAllText())
@@ -541,8 +509,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Finds the value of the given property inside the xaml file.  If
         '''   the property is not set in the xaml, an empty string is returned.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetApplicationPropertyValue(propertyName As String) As String
             Using lock As New BufferLock(_vsTextLines, Me)
                 Dim reader As XmlTextReader = CreateXmlTextReader()
@@ -561,7 +527,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' </summary>
         ''' <param name="line"></param>
         ''' <returns>The index on the line where the closing angle bracket is found, or -1 if not found.</returns>
-        ''' <remarks></remarks>
         Public Shared Function FindClosingAngleBracketHelper(line As String) As Integer
             Dim index As Integer = 0
 
@@ -657,8 +622,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         '''   element, if it exists.  If not, returns Nothing.
         ''' </summary>
         ''' <param name="reader"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function FindApplicationPropertyInXaml(reader As XmlTextReader, propertyName As String) As XamlProperty
             MoveToApplicationRootElement(reader)
             Dim prop As XamlProperty = FindPropertyAsAttributeInCurrentElement(reader, ELEMENT_APPLICATION, propertyName)
@@ -674,8 +637,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         '''   element, if it exists.  If not, returns Nothing.
         ''' </summary>
         ''' <param name="reader"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function FindPropertyAsAttributeInCurrentElement(reader As XmlTextReader, optionalPropertyQualifier As String, propertyName As String) As XamlPropertyInAttributeSyntax
             'Look for either simple attribute syntax (StartupUri=xxx) or
             '  fully-qualified attribute syntax (Application.StartupUri=xxx)
@@ -764,8 +725,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         '''   element, using property element syntax, if it exists.  If not, returns Nothing.
         ''' </summary>
         ''' <param name="reader"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function FindPropertyAsChildElementInCurrentElement(reader As XmlTextReader, propertyQualifier As String, propertyName As String) As XamlPropertyInPropertyElementSyntax
             'See http://windowssdk.msdn.microsoft.com/en-us/library/ms788723(VS.80).aspx#PESyntax
             '
@@ -851,7 +810,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         '''   Application root element.  Returns Nothing if can't find the
         '''   correct position.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Function FindLocationToAddNewApplicationAttribute() As Location
             Using lock As New BufferLock(_vsTextLines, Me)
                 Dim reader As XmlTextReader = CreateXmlTextReader()
@@ -864,7 +822,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Finds the value of the StartupUri property inside the xaml file.  If
         '''   the property is not set in the xaml, an empty string is returned.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub SetApplicationPropertyValue(propertyName As String, value As String)
             If value Is Nothing Then
                 value = ""
@@ -923,7 +880,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         ''' Replace the text at the given location in the buffer with new text.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ReplaceText(sourceStart As Location, sourceLength As Integer, newText As String)
             ReplaceText(sourceStart, New Location(sourceStart.LineIndex, sourceStart.CharIndex + sourceLength), newText)
         End Sub
@@ -934,7 +890,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <param name="sourceStart"></param>
         ''' <param name="sourceEnd"></param>
         ''' <param name="newText"></param>
-        ''' <remarks></remarks>
         Private Sub ReplaceText(sourceStart As Location, sourceEnd As Location, newText As String) Implements IReplaceText.ReplaceText
             If newText Is Nothing Then
                 newText = String.Empty
@@ -958,7 +913,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' </summary>
         ''' <param name="tagStartLocation"></param>
         ''' <param name="elementName">The name of the element at the given location</param>
-        ''' <remarks></remarks>
         Public Sub MakeSureElementHasStartAndEndTags(tagStartLocation As Location, elementName As String)
             If Not "<".Equals(GetText(tagStartLocation, 1), StringComparison.Ordinal) Then
                 Debug.Fail("MakeSureElementHasStartAndEndTags: The start location doesn't point to the start of an element tag")
@@ -996,8 +950,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Finds the value of the StartupUri property inside the xaml file.  If
         '''   the property is not set in the xaml, an empty string is returned.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetStartupUri() As String
             Return GetApplicationPropertyValue(PROPERTY_STARTUPURI)
         End Function
@@ -1006,7 +958,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Finds the value of the StartupUri property inside the xaml file.  If
         '''   the property is not set in the xaml, an empty string is returned.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub SetStartupUri(value As String)
             SetApplicationPropertyValue(PROPERTY_STARTUPURI, value)
         End Sub
@@ -1019,8 +970,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Finds the value of the ShutdownMode property inside the xaml file.  If
         '''   the property is not set in the xaml, an empty string is returned.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetShutdownMode() As String
             Return GetApplicationPropertyValue(PROPERTY_SHUTDOWNMODE)
         End Function
@@ -1029,7 +978,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Finds the value of the StartupUri property inside the xaml file.  If
         '''   the property is not set in the xaml, an empty string is returned.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub SetShutdownMode(value As String)
             SetApplicationPropertyValue(PROPERTY_SHUTDOWNMODE, value)
         End Sub
@@ -1042,7 +990,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Throw an exception for an unexpected format, with line/col information
         ''' </summary>
         ''' <param name="location"></param>
-        ''' <remarks></remarks>
         Private Shared Sub ThrowUnexpectedFormatException(location As Location)
             Throw New XamlReadWriteException(
                 My.Resources.Microsoft_VisualStudio_Editors_Designer.GetString(My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_WPFApp_Xaml_UnexpectedFormat_2Args,
@@ -1057,7 +1004,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Verify the validity of the Application.xaml file, and throw an exception if
         '''   problems are found.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub VerifyAppXamlIsValidAndThrowIfNot()
             Using lock As New BufferLock(_vsTextLines, Me)
                 Dim reader As XmlTextReader = CreateXmlTextReader()

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlErrorControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlErrorControl.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 
@@ -7,7 +7,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
     ''' <summary>
     ''' Display an error control with an error icon, a text message, and an Edit Xaml button
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class AppDotXamlErrorControl
 
         Public Event EditXamlClicked()

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
@@ -87,7 +87,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         ''' Removes references to anything that was passed in to SetObjects
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub CleanupCOMReferences()
             TrySaveDocDataIfLastEditor()
             _docDataHasChanged = False
@@ -100,7 +99,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Closes our copy of the Application.xaml doc data.  If we're the last editor on it,
         '''   then we save it first.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub CleanUpApplicationXamlDocData()
             TrySaveDocDataIfLastEditor()
             If _applicationXamlDocData IsNot Nothing Then
@@ -117,7 +115,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         '''  Set up shared state...
         ''' </summary>
-        ''' <remarks></remarks>
         Shared Sub New()
             InitializeApplicationTypes()
             InitializeShutdownModeValues()
@@ -149,12 +146,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 #End Region
 
 #Region "PropertyControlData"
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
             Get
                 Dim ControlsThatDependOnStartupObjectOrUriProperty As Control() = {
@@ -266,7 +257,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Let the base class know which control instances correspond to shared controls
         '''   between this inherited class and the base vb application property page class.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub SetCommonControls()
             CommonControls = New CommonPageControls(
                 IconCombobox, IconLabel, IconPicturebox)
@@ -386,7 +376,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         ''' Initialize the application types applicable to this page (logic is in the base class)
         ''' </summary>
-        ''' <remarks></remarks>
         Private Shared Sub InitializeApplicationTypes()
             '   Note: WPF application page does not support NT service or Web control application types
             s_applicationTypes.Add(New ApplicationTypeInfo(ApplicationTypes.WindowsApp, My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_WindowsApp_WPF, True))
@@ -417,7 +406,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         ''' Enables the Icon combobox (if Enable=True), but only if the associated property is supported
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub EnableIconComboBox(Enable As Boolean)
             'Icon combobox shouldn't be enabled for XBAP projects
             EnableControl(CommonControls.IconCombobox, Enable AndAlso Not IsXBAP())
@@ -433,7 +421,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub AssemblyInfoButton_Click(sender As Object, e As EventArgs) Handles AssemblyInfoButton.Click
             ShowChildPage(My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_AssemblyInfo_Title, GetType(AssemblyInfoPropPage), HelpKeywords.VBProjPropAssemblyInfo)
         End Sub
@@ -448,7 +435,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
         ''' <remarks>OutputType is obtained from the value in the Application Type field</remarks>
         Private Function GetOutputTypeFromUI(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
             Dim AppType As ApplicationTypes
@@ -470,8 +456,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function SetOutputTypeIntoUI(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
             If value IsNot Nothing AndAlso Not PropertyControlData.IsSpecialValue(value) Then
                 Dim AppType As ApplicationTypes = ApplicationTypeFromOutputType(CType(value, VSLangProj.prjOutputType))
@@ -491,7 +475,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Enables/Disables some controls based on the current application type
         ''' </summary>
         ''' <param name="AppType"></param>
-        ''' <remarks></remarks>
         Private Sub EnableApplicationIconAccordingToApplicationType(AppType As ApplicationTypes)
             Select Case AppType
                 Case ApplicationTypes.CommandLineApp
@@ -524,8 +507,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Given an OutputType, returns the Application Type for it, differentiating if necessary based on the value of MyType
         ''' </summary>
         ''' <param name="OutputType">Output type</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function ApplicationTypeFromOutputType(OutputType As VSLangProj.prjOutputType) As ApplicationTypes
             Select Case OutputType
 
@@ -547,8 +528,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Given an Application Type (a VB-only concept), return the Output Type for it (the project system's concept)
         ''' </summary>
         ''' <param name="AppType"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function OutputTypeFromApplicationType(AppType As ApplicationTypes) As VSLangProj.prjOutputType
             Select Case AppType
 
@@ -572,7 +551,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Enables the "Enable application framework" checkbox (if Enable=True), but only if it is supported in this project with current settings
         ''' </summary>
         ''' <param name="Enable"></param>
-        ''' <remarks></remarks>
         Private Sub EnableUseApplicationFrameworkCheckBox(Enable As Boolean)
             GetPropertyControlData(PROPID_UseApplicationFramework).EnableControls(Enable)
         End Sub
@@ -710,8 +688,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         ''' Returns true iff the project contains an Application.xaml file
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function ApplicationXamlFileExistsInProject() As Boolean
             Return FindApplicationXamlProjectItem(False) IsNot Nothing
         End Function
@@ -719,7 +695,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         ''' Finds the Application.xaml file in the application, if one exists.
         ''' </summary>
-        ''' <returns></returns>
         ''' <remarks>
         ''' Overridable for unit testing.
         ''' </remarks>
@@ -730,7 +705,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         ''' Finds the Application.xaml file in the application, if one exists.
         ''' </summary>
-        ''' <returns></returns>
         ''' <remarks>
         ''' Overridable for unit testing.
         ''' </remarks>
@@ -798,8 +772,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' </summary>
         ''' <param name="createAppXamlIfDoesNotExist">If True, will attempt to create the file if it does not exist.  In this case, 
         ''' the function will never return Nothing, but rather will throw an exception if there's a problem.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetApplicationXamlDocData(createAppXamlIfDoesNotExist As Boolean) As DocData
             If _applicationXamlDocData Is Nothing Then
                 Dim applicationXamlProjectItem As ProjectItem = FindApplicationXamlProjectItem(createAppXamlIfDoesNotExist)
@@ -830,7 +802,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' </summary>
         ''' <param name="createAppXamlIfDoesNotExist"></param>
         ''' <returns>The AppDotXamlDocument</returns>
-        ''' <remarks></remarks>
         Protected Overridable Function CreateAppDotXamlDocumentForApplicationDefinitionFile(createAppXamlIfDoesNotExist As Boolean) As AppDotXamlDocument
             Dim docData As DocData = GetApplicationXamlDocData(createAppXamlIfDoesNotExist)
             If docData IsNot Nothing Then
@@ -883,7 +854,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         '''   (depending on the setting of the Enable Application Framework
         '''   checkbox)
         ''' </summary>
-        ''' <remarks></remarks>
         <Serializable()>
         Friend MustInherit Class StartupObjectOrUri
             Private ReadOnly _value As String
@@ -904,8 +874,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             ''' <summary>
             ''' The value displayed to the user in the combobox
             ''' </summary>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Overrides Function ToString() As String
                 Return Description
             End Function
@@ -1011,7 +979,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub StartupObjectOrUriComboBox_DropDown(sender As Object, e As EventArgs) Handles StartupObjectOrUriComboBox.DropDown
             PopulateStartupObjectOrUriComboboxAndKeepCurrentEntry()
             SetComboBoxDropdownWidth(DirectCast(sender, ComboBox))
@@ -1021,7 +988,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Populates the startup object/URI combobox with the available choices, depending on whether
         '''   it should be showing startup URI or startup object.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub PopulateStartupObjectOrUriComboboxAndKeepCurrentEntry()
             Dim populateWithStartupUriInsteadOfStartupObject As Boolean = ShouldStartupUriBeDisplayedInsteadOfStartupObject()
 #If DEBUG Then
@@ -1100,8 +1066,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetStartupObjectOrUriFromUI(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
             value = CType(StartupObjectOrUriComboBox.SelectedItem, StartupObjectOrUri)
             Debug.Assert(value IsNot Nothing, "GetStartupObjectOrUriFromUI(): Shouldn't get null value")
@@ -1134,8 +1098,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function SetStartupObjectOrUriIntoUI(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
             If PropertyControlData.IsSpecialValue(value) Then
                 StartupObjectOrUriComboBox.SelectedIndex = -1
@@ -1167,8 +1129,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' True if, according to the current, persisted state, the StartupObject/URI label should be
         '''   "Startup URI".  If it should be "Startup Object", it returns False.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function ShouldStartupUriBeDisplayedInsteadOfStartupObject() As Boolean
             Dim tristateUseApplicationFramework As TriState = GetUseApplicationFrameworkFromStorage()
             If tristateUseApplicationFramework = TriState.True Then
@@ -1183,8 +1143,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Retrieves the value of the Startup Object or Startup Uri from
         '''   its persisted storage (project file or Application.xaml)
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetStartupObjectOrUriValueFromStorage() As StartupObjectOrUri
             If ShouldStartupUriBeDisplayedInsteadOfStartupObject() Then
                 Return New StartupUri(GetStartupUriFromStorage())
@@ -1211,7 +1169,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Stores the value of the Startup Object or Startup Uri into
         '''   its persisted storage (project file or Application.xaml)
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub SetStartupObjectOrUriValueIntoStorage(value As StartupObjectOrUri)
             If TypeOf value Is StartupObject Then
                 SetStartupObjectIntoStorage(value.Value)
@@ -1287,8 +1244,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Returns true if the given file path is relative to the project directory
         ''' </summary>
         ''' <param name="fullPath"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function IsFileRelativeToProjectPath(fullPath As String) As Boolean
             Dim relativePath As String = GetProjectRelativeFilePath(fullPath)
             Return Not IO.Path.IsPathRooted(relativePath)
@@ -1299,7 +1254,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' </summary>
         ''' <param name="projectItems"></param>
         ''' <param name="list"></param>
-        ''' <remarks></remarks>
         Private Sub FindXamlPageFiles(projectItems As ProjectItems, list As List(Of ProjectItem))
             For Each projectItem As ProjectItem In projectItems
                 If IO.Path.GetExtension(projectItem.FileNames(1)).Equals(".xaml", StringComparison.OrdinalIgnoreCase) Then
@@ -1327,7 +1281,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Gets all the files (as a list of StartupUri objects) in the project which are appropriate for the 
         '''   StartupUri property.
         ''' </summary>
-        ''' <returns></returns>
         ''' <remarks>
         ''' Note: it's currently returning a List of Object only because I'm having trouble getting the VSTS
         '''   code accessors to work properly with List(Of StartupUri).
@@ -1363,7 +1316,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Nested class that represents a shutdown mode value, and can be placed
         '''   directly into a combobox as an entry.
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Class ShutdownMode
             Private ReadOnly _value As String
             Private ReadOnly _description As String
@@ -1430,8 +1382,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function GetShutdownModeFromUI(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
             Dim currentShutdownMode As ShutdownMode = CType(ShutdownModeComboBox.SelectedItem, ShutdownMode)
             If currentShutdownMode Is Nothing Then
@@ -1451,8 +1401,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Function SetShutdownModeIntoUI(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
             If PropertyControlData.IsSpecialValue(value) Then
                 ShutdownModeComboBox.SelectedIndex = -1
@@ -1494,7 +1442,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' Override this method to return a property descriptor for user-defined properties in a page.
         ''' </summary>
         ''' <param name="PropertyName">The property to return a property descriptor for.</param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' This method must be overridden to handle all user-defined properties defined in a page.  The easiest way to implement
         '''   this is to return a new instance of the UserPropertyDescriptor class, which was created for that purpose.
@@ -1522,8 +1469,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' </summary>
         ''' <param name="PropertyName"></param>
         ''' <param name="Value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function ReadUserDefinedProperty(PropertyName As String, ByRef Value As Object) As Boolean
             '
             'NOTE: We do not want to throw any exceptions from this method for our properties, because if this happens 
@@ -1572,8 +1517,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' </summary>
         ''' <param name="PropertyName"></param>
         ''' <param name="Value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function WriteUserDefinedProperty(PropertyName As String, Value As Object) As Boolean
             Select Case PropertyName
                 Case PROPNAME_StartupObjectOrUri
@@ -1604,7 +1547,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub EditXamlButton_Click(sender As Object, e As EventArgs) Handles EditXamlButton.Click
             TryShowXamlEditor(True)
         End Sub
@@ -1614,7 +1556,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         '''   fails.
         ''' </summary>
         ''' <param name="createAppDotXamlIfItDoesntExist"></param>
-        ''' <remarks></remarks>
         Friend Sub TryShowXamlEditor(createAppDotXamlIfItDoesntExist As Boolean)
             EnterProjectCheckoutSection()
             Try
@@ -1648,8 +1589,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' </summary>
         ''' <param name="projectItem"></param>
         ''' <param name="extension"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function FindDependentFile(projectItem As ProjectItem, extension As String) As ProjectItem
             For Each dependentItem As ProjectItem In projectItem.ProjectItems
                 If dependentItem.FileNames(1) IsNot Nothing _
@@ -1689,7 +1628,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <summary>
         ''' Open the XAML editor on the application.xaml file.  If it doesn't exist, create one.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub TryShowApplicationEventsCode()
             EnterProjectCheckoutSection()
             Try
@@ -1875,7 +1813,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         '''   be disabled by the flavor mechanism (due to architectural limitations for user-defined
         '''   properties - we should change this in the future).
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub DisableControlsForXBAPProjects()
             'Note: Once a project is an XBAP, it's always an XBAP (can't change it except
             '  by editing the project file)
@@ -1895,7 +1832,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ComboBoxes_DropDown(sender As Object, e As EventArgs) Handles IconCombobox.DropDown
             SetComboBoxDropdownWidth(DirectCast(sender, ComboBox))
         End Sub
@@ -1909,7 +1845,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ViewUACSettingsButton_Click(sender As Object, e As EventArgs) Handles ViewUACSettingsButton.Click
             ViewUACSettings()
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/CSVEncoder.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/CSVEncoder.vb
@@ -15,7 +15,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' This class contains routines for reading and writing CSV format (for communicating
     '''   via the clipboard with Excel and other applications)
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class CsvEncoder
 
         Public Enum EncodingType
@@ -28,7 +27,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Text">The CSV text to encode</param>
         ''' <param name="EncodingType"></param>
-        ''' <remarks></remarks>
         Public Shared Function IsSimpleString(Text As String, EncodingType As EncodingType, ByRef SimpleString As String) As Boolean
             If Text Is Nothing Then
                 Text = String.Empty
@@ -73,7 +71,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Text">The CSV text to decode</param>
         ''' <param name="View">The ResourceEditorView.  This is used for displaying messageboxes and creating resources.</param>
         ''' <param name="EncodingType"></param>
-        ''' <remarks></remarks>
         Public Shared Function DecodeResources(Text As String, View As ResourceEditorView, EncodingType As EncodingType) As Resource()
             Dim ResourceList As New List(Of Resource)
 
@@ -222,7 +219,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Given a string, escape it for use as a field in a CSV line
         ''' </summary>
         ''' <param name="Field">The string field to encode.</param>
-        ''' <remarks></remarks>
         Private Shared Function EscapeField(Field As String, EncodingType As EncodingType) As String
             If Field Is Nothing Then
                 Field = ""

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Category.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Category.vb
@@ -14,7 +14,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     '''   allow the user to filter the currently-displayed resources by 
     '''   a single category at a time.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class Category
 
         ''' <summary>
@@ -22,7 +21,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Public Event ResourcesExistChanged(sender As Object, e As EventArgs)
 
 
@@ -30,7 +28,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Indicates whether this category displays its resources in a stringtable
         '''   or a listview.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Enum Display
             StringTable 'Resources in this category displayed in a string table
             ListView    'Resources in this category displayed in a listview
@@ -65,7 +62,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="LocalizedName">A localized name for the category.  This name is the one shown to the user.</param>
         ''' <param name="CategoryDisplay">Whether this category uses a stringtable or listview.</param>
         ''' <param name="AssociatedResourceTypeEditors">A list of all resource type editors which are shown in this category (a resource type editor can only be shown in a single category).</param>
-        ''' <remarks></remarks>
         Public Sub New(ProgrammaticName As String, LocalizedName As String, CategoryDisplay As Display, MenuCommand As MenuCommand, addCommand As EventHandler, ParamArray AssociatedResourceTypeEditors() As ResourceTypeEditor)
             Debug.Assert(ProgrammaticName <> "", "programmatic name must be non-empty")
             Debug.Assert(LocalizedName <> "", "localized name should be non-empty")
@@ -99,8 +95,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' All resource type editors that are displayed in this category.  A particular
         '''   resource type editor may only be displayed in a single category.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property AssociatedResourceTypeEditors() As ResourceTypeEditor()
             Get
                 Return _associatedResourceTypeEditors
@@ -112,8 +106,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Indicates whether this category displays its resources in a stringtable
         '''   or a listview.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property CategoryDisplay() As Display
             Get
                 Return _categoryDisplay
@@ -124,8 +116,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Command to execute if you want to show this category
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property CommandToShow() As MenuCommand
             Get
                 Return _menuCommand
@@ -136,8 +126,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' The command used to add a new resources of appropriate type
         ''' for the current category
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property AddCommand() As EventHandler
             Get
                 Return _addCommand
@@ -151,8 +139,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Returns the friendly (localized) category name, which is shown to the
         '''   user in the category buttons.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property LocalizedName() As String
             Get
                 Return _localizedName
@@ -164,8 +150,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Returns a programmatic name which is never localized and never shown to
         '''   the user.  Used when searching for a category by name key.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property ProgrammaticName() As String
             Get
                 Return _programmaticName
@@ -176,7 +160,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' The number of resources currently in this category.
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' The boldness of the category button associated with this category is automatically
         '''   updated with the resource count.  I.e., when the count is zero, the font on the
@@ -206,8 +189,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns true iff there are resources in this category (ResourceCount > 0)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property ResourcesExist() As Boolean
             Get
                 Return _resourceCount > 0
@@ -220,8 +201,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   a listview.  This is the "Details", "Icons", "List" option for
         '''   the display mode of the listview.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property ResourceView() As ResourceListView.ResourceView
             Get
                 Return _resourceView
@@ -236,8 +215,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' If this category uses a string table, indicates whether or not the "Type"
         '''   column is displayed (shows the type of resource, e.g. System.Drawing.Image)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property ShowTypeColumnInStringTable() As Boolean
             Get
                 Return _showTypeColumnInStringTable
@@ -251,8 +228,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         '''  how to sort the resource items in the category...
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property Sorter() As IComparer(Of Resource)
             Get
                 Return _sorter
@@ -267,8 +242,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   to add new entries in this string table, via an add/new row at the bottom of
         '''   the table.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property AllowNewEntriesInStringTable() As Boolean
             Get
                 Return _allowNewEntriesInStringTable

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/CategoryCollection.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/CategoryCollection.vb
@@ -25,7 +25,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Searches for a category by its index
         ''' </summary>
         ''' <param name="Index">The integer index to look up</param>
-        ''' <value></value>
         ''' <remarks>Throws an exception if out of bounds.</remarks>
         Default Public ReadOnly Property Item(Index As Integer) As Category
             Get
@@ -62,7 +61,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Adds a category to the collection.
         ''' </summary>
         ''' <param name="Category">The category to add.</param>
-        ''' <remarks></remarks>
         Public Sub Add(Category As Category)
             'Add to the inner list (indexable by integer index)
             InnerList.Add(Category)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/DialogQueryName.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/DialogQueryName.vb
@@ -14,7 +14,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' <summary>
     ''' Requests a new resource name from the user.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class DialogQueryName
         Inherits BaseDialog
         'Inherits System.Windows.Forms.Form
@@ -24,7 +23,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Constructor.
         ''' </summary>
         ''' <param name="ServiceProvider"></param>
-        ''' <remarks></remarks>
         Public Sub New(ServiceProvider As IServiceProvider)
             MyBase.New(ServiceProvider)
 
@@ -160,7 +158,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="SuggestedName">The default name to show in the dialog when it is first shown.</param>
         ''' <param name="UserCancel">[Out] True iff the user canceled the dialog.</param>
         ''' <returns>The Name selected by the user.</returns>
-        ''' <remarks></remarks>
         Public Shared Function QueryAddNewResourceName(RootDesigner As ResourceEditorRootDesigner, SuggestedName As String, ByRef UserCancel As Boolean) As String
             Dim Dialog As New DialogQueryName(RootDesigner)
             With Dialog
@@ -190,7 +187,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ButtonAdd_Click(sender As Object, e As EventArgs) Handles ButtonAdd.Click
             Dim ResourceView As ResourceEditorView = _rootDesigner.GetView()
             Debug.Assert(ResourceView IsNot Nothing, "Why there is no view?")
@@ -219,7 +215,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ButtonCancel_Click(sender As Object, e As EventArgs) Handles ButtonCancel.Click
             Close()
         End Sub
@@ -229,7 +224,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub DialogQueryName_HelpButtonClicked(sender As Object, e As System.ComponentModel.CancelEventArgs) Handles MyBase.HelpButtonClicked
             e.Cancel = True
             ShowHelp()

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
@@ -18,7 +18,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' Watches for changes on files, and notifies any listeners when those
     '''   changes happen.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class FileWatcher
         Implements IDisposable
 
@@ -37,7 +36,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   This is the most efficient manner of using the FileSystemWatcher, since it
         '''   is based on directories, and allocates system resources per directory.
         ''' </summary>
-        ''' <remarks></remarks>
         Private ReadOnly _directoryWatchers As New Dictionary(Of String, DirectoryWatcher)(StringComparers.Paths)
 
         'Any Windows Forms control on the primary thread.  This is used for invoking 
@@ -52,7 +50,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Constructor.
         ''' </summary>
         ''' <param name="ControlForSynchronizingThreads">Any Windows Forms control on the primary thread.  This is used for invoking the system filewatch events (called on a secondary thread) back to the main thread.</param>
-        ''' <remarks></remarks>
         Public Sub New(ControlForSynchronizingThreads As Control)
             Debug.Assert(ControlForSynchronizingThreads IsNot Nothing)
             _controlForSynchronizingThreads = ControlForSynchronizingThreads
@@ -62,7 +59,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Dispose
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub Dispose() Implements IDisposable.Dispose
             For Each Watcher In _directoryWatchers.Values
                 Watcher.Dispose()
@@ -78,8 +74,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns the number of directories being watched.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property DirectoryWatchersCount() As Integer
             Get
                 Return _directoryWatchers.Count
@@ -158,8 +152,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="DirectoryPath">Directory path to watch.</param>
         ''' <param name="CreateIfNotFound">If True, will create a new DirectoryWatcher if none is found matching the file.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         ''' CONSIDER: be tolerant of 8.3 paths
         Private Function GetWatcherForDirectory(DirectoryPath As String, CreateIfNotFound As Boolean) As DirectoryWatcher
             DirectoryPath = NormalizeDirectoryPath(DirectoryPath)
@@ -181,8 +173,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Normalizes a directory path so we can use it as a key.
         ''' </summary>
         ''' <param name="DirectoryPath">The directory path to normalize</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function NormalizeDirectoryPath(DirectoryPath As String) As String
             Debug.Assert(DirectoryPath <> "")
             DirectoryPath = GetFullPathTolerant(DirectoryPath)
@@ -197,7 +187,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   call is marshalled to the thread on which m_ControlForSynchronizingThreads exists.
         ''' </summary>
         ''' <param name="Entry">The file watcher entry to invoke.</param>
-        ''' <remarks></remarks>
         Private Sub MarshallFileChangedEvent(Entry As FileWatcherEntry)
             _controlForSynchronizingThreads.BeginInvoke(New MethodInvoker(AddressOf Entry.OnFileChanged))
         End Sub
@@ -211,7 +200,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' A private class that watches a single directory and manages a list of single
         '''   file watchers (each with multiple listeners).
         ''' </summary>
-        ''' <remarks></remarks>
         Private NotInheritable Class DirectoryWatcher
             Implements IDisposable
 
@@ -266,7 +254,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Dispose
             ''' </summary>
-            ''' <remarks></remarks>
             Public Sub Dispose() Implements IDisposable.Dispose
                 If Not _fileSystemWatcher Is Nothing Then
                     _fileSystemWatcher.Dispose()
@@ -279,8 +266,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' The directory path being watched.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property DirectoryPath() As String
                 Get
                     Return _directoryPath
@@ -291,8 +276,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Returns the number of files being watched in this directory
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property FileCount() As Integer
                 Get
                     Return _fileWatcherEntries.Count
@@ -305,7 +288,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' </summary>
             ''' <param name="FileNameOnly">The FileName (no path) to watch</param>
             ''' <param name="Listener">The listener to add for this file</param>
-            ''' <remarks></remarks>
             Public Sub AddFileListener(FileNameOnly As String, Listener As IFileWatcherListener)
                 FileNameOnly = NormalizeFileName(FileNameOnly)
 
@@ -362,8 +344,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' Normalizes a filename so we can make comparisons between files
             ''' </summary>
             ''' <param name="FileNameOnly">The file (no path) to normalize</param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Private Shared Function NormalizeFileName(FileNameOnly As String) As String
                 Debug.Assert(Path.GetDirectoryName(FileNameOnly) = "" AndAlso Not Path.IsPathRooted(FileNameOnly),
                     "DirectoryWatcher does not accept paths with the filename - should be relative to the directory path in DirectoryWatcher")
@@ -378,7 +358,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' </summary>
             ''' <param name="FullDirectoryPath">Full path of the directory where the file was (should be our directory)</param>
             ''' <param name="FileName">The file name (no path) of the file in this directory that has changed.</param>
-            ''' <remarks></remarks>
             Private Sub OnFileChanged(FullDirectoryPath As String, FileName As String)
                 Debug.Assert(Not String.IsNullOrEmpty(FileName))
                 Debug.Assert(String.Equals(Path.GetDirectoryName(FullDirectoryPath), _directoryPath, StringComparison.OrdinalIgnoreCase))
@@ -408,7 +387,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' </summary>
             ''' <param name="sender"></param>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Private Sub FileSystemWatcher_Changed(sender As Object, e As FileSystemEventArgs) Handles _fileSystemWatcher.Changed
                 Debug.WriteLineIf(Switches.RSEFileWatcher.TraceVerbose, "DirectoryWatcher: Raw changed event: " & e.ChangeType & ", " & e.FullPath & ": " & e.Name & ", Thread = " & Hex(System.Threading.Thread.CurrentThread.GetHashCode))
                 OnFileChanged(e.FullPath, e.Name)
@@ -420,7 +398,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' </summary>
             ''' <param name="sender"></param>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Private Sub FileSystemWatcher_Renamed(sender As Object, e As RenamedEventArgs) Handles _fileSystemWatcher.Renamed
                 Debug.WriteLineIf(Switches.RSEFileWatcher.TraceVerbose, "DirectoryWatcher: Raw renamed event: " & e.ChangeType & ", " & e.FullPath & ": " & e.Name & ", Thread = " & Hex(System.Threading.Thread.CurrentThread.GetHashCode))
 
@@ -445,7 +422,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' </summary>
             ''' <param name="sender"></param>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Private Sub FileSystemWatcher_Created(sender As Object, e As FileSystemEventArgs) Handles _fileSystemWatcher.Created
                 OnFileChanged(e.FullPath, e.Name)
             End Sub
@@ -456,7 +432,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' </summary>
             ''' <param name="sender"></param>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Private Sub FileSystemWatcher_Deleted(sender As Object, e As FileSystemEventArgs) Handles _fileSystemWatcher.Deleted
                 OnFileChanged(e.FullPath, e.Name)
             End Sub
@@ -472,7 +447,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Private class that represents a single file being watched.  It can
         '''   handle multiple listeners.
         ''' </summary>
-        ''' <remarks></remarks>
         Private NotInheritable Class FileWatcherEntry
             Implements IDisposable
 
@@ -506,7 +480,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' </summary>
             ''' <param name="Directory">The DirectoryWatcher for the directory that this file is in.</param>
             ''' <param name="FileNameOnly">The filename (no path) of the file to watch.</param>
-            ''' <remarks></remarks>
             Friend Sub New(Directory As DirectoryWatcher, FileNameOnly As String)
                 Debug.Assert(Directory IsNot Nothing)
                 Debug.Assert(FileNameOnly <> "")
@@ -518,7 +491,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Dispose.
             ''' </summary>
-            ''' <remarks></remarks>
             Public Sub Dispose() Implements IDisposable.Dispose
                 If Not _timer Is Nothing Then
                     _timer.Dispose()
@@ -531,8 +503,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Gets the path and filename of the file.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property PathAndFileName() As String
                 Get
                     Return Path.Combine(_directoryWatcher.DirectoryPath, _fileNameOnly)
@@ -543,8 +513,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Retrieves the current number of listeners.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property ListenerCount() As Integer
                 Get
                     Return _listeners.Count
@@ -556,7 +524,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' Adds a new listener for this file.
             ''' </summary>
             ''' <param name="Listener">The listener to add.</param>
-            ''' <remarks></remarks>
             Public Sub AddListener(Listener As IFileWatcherListener)
                 If _listeners.Contains(Listener) Then
                     Debug.WriteLineIf(Switches.RSEFileWatcher.TraceInfo, "FileWatcher: There's already an entry for this listener on this file - Ignoring")
@@ -586,8 +553,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' ToString() override for debugging purposes.
             ''' </summary>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Overrides Function ToString() As String
                 Return "FileWatcherEntry: PathAndFileName = """ & PathAndFileName & """, " & ListenerCount & " listeners"
             End Function
@@ -597,7 +562,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' Called when the file referred to by this entry is changed.  This
             '''   method must be called on the synchronizing control's thread.
             ''' </summary>
-            ''' <remarks></remarks>
             Friend Sub OnFileChanged()
                 Debug.WriteLineIf(Switches.RSEFileWatcher.TraceVerbose, "    FileWatcherEntry: Received file change on main thread: " & ToString() & ", Thread = " & Hex(System.Threading.Thread.CurrentThread.GetHashCode) & ", Milliseconds = " & Now.Millisecond)
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
@@ -16,7 +16,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         '''  The fields of the resource we're going to find the pattern in.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Enum Field
             Name
             Value
@@ -68,7 +67,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Constructor
         ''' </summary>
         ''' <param name="RootDesigner">Pointer to the root designer</param>
-        ''' <remarks></remarks>
         Public Sub New(RootDesigner As ResourceEditorRootDesigner)
             Requires.NotNull(RootDesigner, NameOf(RootDesigner))
             _rootDesigner = RootDesigner
@@ -79,7 +77,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Does debug-only tracing for this class.
         ''' </summary>
         ''' <param name="Message"></param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub Trace(Message As String)
             Debug.WriteLineIf(Switches.RSEFindReplace.TraceVerbose, "RSE Find/Replace: " & Message)
@@ -114,7 +111,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="pfImage">Set to True if supporting GetSearchImage - seaching in a text image.</param>
         ''' <param name="pgrfOptions">Specifies supported options, syntax and options, taken from __VSFINDOPTIONS.</param>
-        ''' <remarks></remarks>
         Public Sub GetCapabilities(pfImage() As Boolean, pgrfOptions() As UInteger)
             Trace("GetCapabilities called.")
 
@@ -214,7 +210,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Sets the find state object that we hold for the find engine.
         ''' </summary>
         ''' <param name="pUnk">The find state object to hold.</param>
-        ''' <remarks></remarks>
         Public Sub SetFindState(pUnk As Object)
             _findState = pUnk
         End Sub
@@ -410,7 +405,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="grfOptions">The options passed in from the shell.</param>
         ''' <param name="Flag">The option we want to know.</param>
         ''' <returns>Value of the option, TRUE or FALSE.</returns>
-        ''' <remarks></remarks>
         Private Shared Function CheckFindOption(grfOptions As UInteger, Flag As __VSFINDOPTIONS) As Boolean
             Return (CType(grfOptions, __VSFINDOPTIONS) And Flag) <> 0
         End Function
@@ -422,7 +416,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   fields in the same resource.
         ''' </summary>
         ''' <param name="Resource">The resource to check</param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' This returns True for resources which are displayed in a listview, because there is no easy way to 
         '''   highlight separate parts of the resource.
@@ -436,7 +429,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Increments the current index pointer to the next resource
         ''' </summary>
         ''' <param name="FindBackwards">True if we're searching backwards</param>
-        ''' <remarks></remarks>
         Private Sub IncrementCurrentIndex(FindBackwards As Boolean)
             If FindBackwards Then
                 _currentIndex -= 1
@@ -456,7 +448,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Calculate the next index and field to search based on the current index/field and the direction of find
         ''' </summary>
         ''' <param name="FindBackwards">TRUE indicates finding backwards; otherwise, FALSE.</param>
-        ''' <remarks></remarks>
         Private Sub IncrementCurrentIndexAndField(FindBackwards As Boolean)
             Dim NextFieldIndex As Integer
 
@@ -488,7 +479,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="SearchText">The text to search in.</param>
         ''' <param name="Helper">The IVsFindHelper from VisualStudio</param>
         ''' <returns>TRUE if a match was found; otherwise, FALSE.</returns>
-        ''' <remarks></remarks>
         Private Shared Function IsMatch(SearchPattern As String, SearchText As String,
                                     Helper As IVsFindHelper, grfFindOptions As UInteger) As Boolean
             If String.IsNullOrEmpty(SearchText) Then
@@ -514,7 +504,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="FindInSelection">Whether or not to search only in the current selection</param>
         ''' <value>An ArrayList containing Resource instances ordered by category and names.</value>
-        ''' <remarks></remarks>
         Private ReadOnly Property GetResourcesToSearch(FindInSelection As Boolean) As Resource()
             Get
                 Dim ResourcesToSearch = New List(Of Resource)(View.ResourceFile.Resources.Count)
@@ -642,8 +631,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns the resource editor view associated with this designer.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property View() As ResourceEditorView
             Get
                 Return _rootDesigner.GetView()
@@ -654,8 +641,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns True iff there a View has already been created.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property HasView() As Boolean
             Get
                 Return _rootDesigner.HasView()

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/OpenFileWarningDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/OpenFileWarningDialog.vb
@@ -14,7 +14,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Constructor.
         ''' </summary>
         ''' <param name="ServiceProvider"></param>
-        ''' <remarks></remarks>
         Public Sub New(ServiceProvider As IServiceProvider, fileName As String)
             MyBase.New(ServiceProvider)
 
@@ -59,7 +58,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ButtonOk_Click(sender As Object, e As EventArgs) Handles buttonOK.Click
             Close()
         End Sub
@@ -70,7 +68,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub DialogQueryName_HelpButtonClicked(sender As Object, e As ComponentModel.CancelEventArgs) Handles MyBase.HelpButtonClicked
             e.Cancel = True
             ShowHelp()

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -47,7 +47,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   pointer to a Resource so that it can correctly hook up to either the project's
         '''   resources.
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Interface ITypeResolutionContextProvider
 
             ''' <summary>
@@ -55,7 +54,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '''   opened in.
             ''' </summary>
             ''' <returns>The ITypeResolutionService for the project the .resx file was opened in, or else Nothing if it was opened outside the context of a project.</returns>
-            ''' <remarks></remarks>
             Function GetTypeResolutionService() As ITypeResolutionService
 
         End Interface
@@ -68,7 +66,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         '''  The persistence mode of the resource to show in PropertyWindow.
         ''' </summary>
-        ''' <remarks></remarks>
         <TypeConverter(GetType(ResourcePersistenceModeEnumConverter))>
         Public Enum ResourcePersistenceMode
             'The resource is a link to a file on disk which is read and compiled into the manifest resources at compile time.
@@ -81,15 +78,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         '''  A Enum Converter class to covert ResourcePersistenceMode to localizable strings
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Class ResourcePersistenceModeEnumConverter
             Inherits EnumConverter
 
             Private ReadOnly _linkedDisplayValue As String = My.Resources.Microsoft_VisualStudio_Editors_Designer.RES_PersistenceMode_Linked
             Private ReadOnly _embeddedDisplayValue As String = My.Resources.Microsoft_VisualStudio_Editors_Designer.RES_PersistenceMode_Embeded
-
-            ''' <summary>
-            ''' </summary>
             Public Sub New(enumType As Type)
                 MyBase.New(enumType)
             End Sub
@@ -173,7 +166,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Indicates the possible types for a file-based resource in the resource editor.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Enum FileTypes
             Text
             Binary
@@ -189,7 +181,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   because retrieving their values requires having the current value of the Resource, which 
         '''   which don't want to keep longer than necessary (e.g., it might be a large bitmap)
         ''' </summary>
-        ''' <remarks></remarks>
         Private Class ImagePropertiesCache
             'Cached return value from ResourceTypeEditor.GetResourceFriendlyTypeDescription()
             Public FriendlyTypeDescription As String
@@ -473,7 +464,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ResXDataNode">The ResXDataNode which will hold the important information about the resource.</param>
         ''' <param name="TypeResolutionContextProvider">An interface from which this resource can query for an ITypeResolutionService for resolving types inside the .resx file.
         '''   May be Nothing, but then it must be provided as soon as possible via SetTypeResolutionContext().</param>
-        ''' <remarks></remarks>
         Private Sub Init(ResXDataNode As ResXDataNode, Optional Order As Integer = Integer.MaxValue, Optional TypeResolutionContextProvider As ITypeResolutionContextProvider = Nothing)
             _resXDataNode = ResXDataNode
             _orderID = Order
@@ -539,8 +529,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' The parent resource file in which this Resource is contained.  Will be Nothing until the resource is
         '''  actually added to a ResourceFile.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property ParentResourceFile() As ResourceFile
             Get
                 Return _parentResourceFile
@@ -563,8 +551,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns whether this object has been disposed
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property IsDisposed() As Boolean
             Get
                 Return _isDisposed
@@ -575,8 +561,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves the ResXDataNode associated with this resource
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property ResXDataNode() As ResXDataNode
             Get
                 Return _resXDataNode
@@ -593,8 +577,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   used normally (including changing the Name in response to user manipulation), since it
         '''   enables the undo engine to undo this change.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property Name() As String
             Get
                 Return _resXDataNode.Name
@@ -625,8 +607,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Sets/Gets the Name property of the Resource component, without undo support, and without causing the 
         '''  designer to be dirtied (because ComponentChangeService notifications won't get sent)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public WriteOnly Property NameWithoutUndo() As String
             Set(Value As String)
                 If Value = "" Then
@@ -663,7 +643,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   by any other code.  Other code should go through the Name property or
         '''   the NameWithoutUndo property.
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>Can't be private because ResourceFile needs access to it.</remarks>
         <EditorBrowsable(EditorBrowsableState.Never)>
         Friend Property NameRawWithoutUndo() As String
@@ -686,8 +665,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   used normally (including changing the property in response to user manipulation), since it
         '''   enables the undo engine to undo this change.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property Comment() As String
             Get
                 Return _resXDataNode.Comment
@@ -703,8 +680,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Sets/Gets the Comment property of the Resource component, without undo support, and without causing the 
         '''  designer to be dirtied (because ComponentChangeService notifications won't get sent)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private WriteOnly Property CommentWithoutUndo() As String
             Set(Value As String)
                 _resXDataNode.Comment = Value
@@ -717,8 +692,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         '''  Returns the ResourcePersistenceMode property.  (This property is shown in the properties window.)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property PersistenceMode() As ResourcePersistenceMode
             Get
                 If IsLink Then
@@ -737,8 +710,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Sets/Gets the persistence mode for this resource, without undo support, and without causing the 
         '''  designer to be dirtied (because ComponentChangeService notifications won't get sent)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private WriteOnly Property PersistenceWithoutUndo() As ResourcePersistenceMode
             Set(Value As ResourcePersistenceMode)
                 If PersistenceMode = Value Then
@@ -859,9 +830,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   property and not lose the original filename that the link was pointing to when changing
         '''   to a non-linked resource.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks>
-        ''' </remarks>
         Public Property FileName() As String
             Get
                 If IsLink Then
@@ -883,9 +851,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   property and not lose the original filename that the link was pointing to when changing
         '''   to a non-linked resource.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks>
-        ''' </remarks>
         Private WriteOnly Property FileNameWithoutUndo() As String
             Set(Value As String)
                 Dim PersistenceChanged As Boolean
@@ -931,7 +896,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets or retrieves the Encoding used for text file resources.
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' Meaningless for all resources other than those using ResourceTypeEditorTextFile.
         '''   This is the member which should be used normally (including changing the property 
@@ -955,8 +919,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Sets/Gets the Encoding used for text file resources, without undo support, and without causing the 
         '''  designer to be dirtied (because ComponentChangeService notifications won't get sent)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private WriteOnly Property EncodingWithoutUndo() As Encoding
             Set(Value As Encoding)
                 Debug.Assert(IsLink AndAlso ResourceTypeEditor.Equals(ResourceTypeEditors.TextFile))
@@ -972,7 +934,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   property browser).  In this case, that means re-automatically 
         '''   guessing the encoding from the file's contents.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ResetEncoding()
             Encoding = Nothing 'Note that we will get Undo/redo on this operation, which is what we want.
             TryGuessFileEncoding()
@@ -984,8 +945,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   This is the member which should be used normally (including changing the property 
         '''   in response to user manipulation), since it enables the undo engine to undo this change.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property FileType() As FileTypes
             Get
                 If TypeOf ResourceTypeEditor Is ResourceTypeEditorFileBase Then
@@ -1011,8 +970,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets/sets the file type of a binary or text file resource, without undo support, and without causing the 
         '''  designer to be dirtied (because ComponentChangeService notifications won't get sent)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private WriteOnly Property FileTypeWithoutUndo() As FileTypes
             Set(Value As FileTypes)
                 If Not IsLink OrElse Not TypeOf ResourceTypeEditor Is ResourceTypeEditorFileBase OrElse _resXDataNode.FileRef Is Nothing Then
@@ -1084,8 +1041,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Returns True iff the resource is contained in a separate file which we have a link to.  If False,
         '''   the resource is stored as a binary blob encoded directly inside the .resx file.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property IsLink() As Boolean Implements ResourceTypeEditor.IResource.IsLink
             Get
                 Return _resXDataNode.FileRef IsNot Nothing
@@ -1096,7 +1051,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves the path to the linked file (if any), relative to the resx file's path
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' Note: if you need to change the link, use SetLink()
         ''' </remarks>
@@ -1125,7 +1079,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves the absolute path to the linked file (if any)
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>Note: if you need to change the link, use SetLink()</remarks>
         Public ReadOnly Property AbsoluteLinkPathAndFileName() As String Implements ResourceTypeEditor.IResource.LinkedFilePath
             Get
@@ -1145,7 +1098,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves the string representation of the value type of the Resource.  E.g., for strings, this would be "System.String, blah blah".
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' For NullResX values (i.e., a resource value of Nothing), returns Nothing.  In all other cases, this returns a non-empty string.
         ''' No exceptions should be thrown from this property
@@ -1206,8 +1158,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns True iff this resource is a ResXNullRef (a Nothing value encoded into the resx).
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property IsResXNullRef() As Boolean
             Get
                 Return IsResXNullRef(ValueTypeName)
@@ -1218,8 +1168,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns True iff the type name given is the one used to mark a ResXDataNode as a ResXNullRef (a Nothing value encoded into the resx).
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Shared ReadOnly Property IsResXNullRef(ValueTypeName As String) As Boolean
             Get
                 Dim Match As Boolean = ValueTypeName.Equals(s_resXNullRefValueTypeName, StringComparison.Ordinal)
@@ -1250,7 +1198,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         '''  We keep the original order of the resource item, so we can keep the order when we save the file.
         ''' </summary>
-        ''' <value></value>
         Friend ReadOnly Property OrderID() As Integer
             Get
                 Return _orderID
@@ -1290,8 +1237,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   fully-qualified type name *without* the assembly information.  E.g., "System.Drawing.Bitmap".
         '''   This is used in the "Type" column of the resource string table.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property FriendlyValueTypeName() As String
             Get
                 Return ValueTypeNameWithoutAssemblyInfo
@@ -1301,8 +1246,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns the fully-qualified type name *without* the assembly information.  E.g., "System.Drawing.Bitmap".
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property ValueTypeNameWithoutAssemblyInfo() As String
             Get
                 Dim TypeName As String = ValueTypeName
@@ -1329,8 +1272,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Retrieves a friendly description of the type of resource for the user (e.g., "Icon", "Windows Metafile").
         ''' Used in the type column of the resource listview.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property FriendlyTypeDescription() As String
             Get
                 CacheFriendlyTypeAndSize()
@@ -1346,8 +1287,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves a string representing the "size" of the resource, e.g. "240 x 128"
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property FriendlySize() As String
             Get
                 CacheFriendlyTypeAndSize()
@@ -1373,8 +1312,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Returns Nothing on failure, or if a ResXNullRef (catches and ignores
         '''   all exceptions).
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function TryGetValue() As Object
             Try
                 Return GetValue()
@@ -1393,8 +1330,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   to load the value from the linked file.
         ''' Throws exceptions on failure.  Returns Nothing if a ResXNullRef.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetValue() As Object Implements ResourceTypeEditor.IResource.GetValue
             Debug.Assert(ValueTypeName <> "")
 
@@ -1460,7 +1395,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="ExceptionFromGetValue">The exception to create the task list entry from.</param>
         ''' <param name="ExceptionToRethrow">The exception to rethrow, if any.  May be the same exception as ExceptionFromGetValue or different.</param>
-        ''' <remarks></remarks>
         Friend Sub SetTaskFromGetValueException(ExceptionFromGetValue As Exception, ByRef ExceptionToRethrow As Exception)
             'We hit an exception.  Add a task list item for resource instantiation (if it doesn't already exist)
 
@@ -1527,7 +1461,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   only sets the current *cached* value for the resource.
         ''' </summary>
         ''' <param name="NewResourceValue">The new value to set the Value property to.</param>
-        ''' <remarks></remarks>
         Private Sub SetValueWithoutUndo(NewResourceValue As Object)
             If IsResXNullRef Then
                 Debug.Assert(NewResourceValue Is Nothing, "Can't set a non-Nothing value to a ResXNullRef resource")
@@ -1700,7 +1633,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Invalidates any currently stored cached thumbnail and image properties, as well as any
         '''   UI view, so that the resource may be fully updated, including thumbnail.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub InvalidateCachedInfoAndThumbnail()
             If ParentResourceFile IsNot Nothing Then
                 _cachedValue = Nothing
@@ -1715,7 +1647,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   has not yet been parented, this is a NOOP.
         ''' Does *not* update the current thumbnail or image properties (for that, use InvalidateCachedInfoAndThumbnail)
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub InvalidateUI()
             If _parentResourceFile IsNot Nothing Then
                 _parentResourceFile.InvalidateResourceInView(Me, InvalidateThumbnail:=False)
@@ -1842,7 +1773,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Sets the filename for a linked resource.  Also automatically adds a filewatcher entry.
         ''' </summary>
         ''' <param name="PathAndFileName">File and path to the linked file</param>
-        ''' <remarks></remarks>
         Public Sub SetLink(PathAndFileName As String)
             RemoveFileWatcherEntry()
 
@@ -1899,7 +1829,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Removes the file watcher entry for the linked filename, if this resource is a link.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub RemoveFileWatcherEntry()
             If AbsoluteLinkPathAndFileName <> "" Then
                 If _parentResourceFile IsNot Nothing Then
@@ -1915,7 +1844,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   currently cached value of the resource, and to update the thumbnail and other UI.
         ''' </summary>
         ''' <param name="FileNameAndPath">The file name and path of the file that was changed.</param>
-        ''' <remarks></remarks>
         Private Sub IFileWatcherListener_OnFileChanged(FileNameAndPath As String) Implements FileWatcher.IFileWatcherListener.OnFileChanged
             If Not IsLink Then
                 Debug.Fail("FileWatcherEntry.FileChanged fired on a Resource, but the resource is not a link")
@@ -1952,7 +1880,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Clears a particular type of task list entry from this resource, if it exists.
         ''' </summary>
         ''' <param name="TaskType">The type of task list entry/error to clear.</param>
-        ''' <remarks></remarks>
         Public Sub ClearTask(TaskType As ResourceFile.ResourceTaskType)
             If _parentResourceFile IsNot Nothing Then
                 _parentResourceFile.ClearResourceTask(Me, TaskType)
@@ -1969,7 +1896,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Priority">The priority.</param>
         ''' <param name="HelpLink">The help link of the new task list entry.</param>
         ''' <param name="ErrorCategory">The ErrorCategory of the new task list entry. It is an Error or Warning.</param>
-        ''' <remarks></remarks>
         Public Sub SetTask(TaskType As ResourceFile.ResourceTaskType, Text As String, Priority As TaskPriority, HelpLink As String, Optional ErrorCategory As TaskErrorCategory = TaskErrorCategory.Error)
             If _parentResourceFile IsNot Nothing Then
                 _parentResourceFile.SetResourceTask(Me, TaskType, Text, Priority, HelpLink, ErrorCategory)
@@ -1981,8 +1907,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Lazy-initializes and gets a list of names which are not recommended for use by 
         '''  the end user (because they cause compiler errors or other problems).
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private Shared ReadOnly Property UnrecommendedResourceNames() As HashSet(Of String)
             Get
                 If s_unrecommendedResourceNames Is Nothing Then
@@ -2008,7 +1932,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   part of a ResourceFile), then they are automatically added to the task list.
         ''' </summary>
         ''' <param name="FastChecksOnly">If true, then we'll only do quick checks (i.e., we're loading, etc.).</param>
-        ''' <remarks></remarks>
         Public Sub CheckForErrors(FastChecksOnly As Boolean)
             If _parentResourceFile Is Nothing Then
                 Exit Sub
@@ -2025,7 +1948,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   part of a ResourceFile), then they are automatically added to the task list.
         ''' <param name="FastChecksOnly">If true, then we'll only do quick checks (i.e., we're loading, etc.).</param>
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub CheckNameForErrors(FastChecksOnly As Boolean)
             If _parentResourceFile Is Nothing Then
                 'If there's no parent resource file, we can't set any tasks, so don't bother
@@ -2059,7 +1981,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   part of a ResourceFile), then they are automatically added to the task list.
         ''' </summary>
         ''' <param name="DelayValueInstantiation">If true, then we won't check for anything but obvious errors (otherwise it can be expensive)</param>
-        ''' <remarks></remarks>
         Private Sub CheckValueForErrors(DelayValueInstantiation As Boolean)
             If _parentResourceFile Is Nothing Then
                 'If there's no parent resource file, we can't set any tasks, so don't bother
@@ -2107,7 +2028,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Checks this resource's Comment property for any errors.  If any are found (and we're currently
         '''   part of a ResourceFile), then they are automatically added to the task list.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub CheckCommentForErrors()
             If _parentResourceFile Is Nothing Then
                 'If there's no parent resource file, we can't set any tasks, so don't bother
@@ -2132,7 +2052,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ValueTypeName">The type name of the value handled by this resource.  May be empty only for ResXNullRef's.</param>
         ''' <param name="IsResXNullRef">True iff the resource is a ResXNullRef reference.</param>
         ''' <returns>The property type converter for this type of resource.  If none is found, returns Nothing.</returns>
-        ''' <remarks></remarks>
         Private Shared Function GetTypeConverter(ValueTypeName As String, IsResXNullRef As Boolean) As TypeConverter
             If IsResXNullRef Then
                 Return Nothing
@@ -2155,7 +2074,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ValueTypeName">The type name of the value handled by this resource.  May be empty only for ResXNullRef's.</param>
         ''' <param name="IsResXNullRef">True iff the resource is a ResXNullRef reference.</param>
         ''' <returns>The property type converter for this type of resource.  If none is found, returns Nothing.</returns>
-        ''' <remarks></remarks>
         Private Shared Function GetTypeConverter(Value As Object, ValueTypeName As String, IsResXNullRef As Boolean) As TypeConverter
             If Value Is Nothing Then
                 Return GetTypeConverter(ValueTypeName, IsResXNullRef)
@@ -2168,8 +2086,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets a type converter that handles the type of values stored in this resource.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetTypeConverter() As TypeConverter
             Return GetTypeConverter(CachedValue, ValueTypeName, IsResXNullRef)
         End Function
@@ -2181,7 +2097,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ValueTypeName">The type name of the value handled by this resource.  May be empty only for ResXNullRef's.</param>
         ''' <param name="IsResXNullRef">True iff the resource is a ResXNullRef reference.</param>
         ''' <returns>True if it is convertible both to and from string values.</returns>
-        ''' <remarks></remarks>
         Private Shared Function IsConvertibleFromToString(ValueTypeName As String, IsResXNullRef As Boolean) As Boolean
             Return IsConvertibleFromToString(Nothing, ValueTypeName, IsResXNullRef)
         End Function
@@ -2194,7 +2109,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ValueTypeName">The type name of the value handled by this resource.  May be empty only for ResXNullRef's.</param>
         ''' <param name="IsResXNullRef">True iff the resource is a ResXNullRef reference.</param>
         ''' <returns>True if it is convertible both to and from string values.</returns>
-        ''' <remarks></remarks>
         Private Shared Function IsConvertibleFromToString(Value As Object, ValueTypeName As String, IsResXNullRef As Boolean) As Boolean
             Dim TC As TypeConverter = GetTypeConverter(Value, ValueTypeName, IsResXNullRef)
             If TC IsNot Nothing Then
@@ -2216,7 +2130,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Determines if this resource is convertible both to and from string values.
         ''' </summary>
         ''' <returns>True if it is convertible both to and from string values.</returns>
-        ''' <remarks></remarks>
         Public Function IsConvertibleFromToString() As Boolean
             Return IsConvertibleFromToString(CachedValue, ValueTypeName, IsResXNullRef)
         End Function
@@ -2332,8 +2245,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="PropertyName">A property name that we registered.</param>
         ''' <param name="Value">The value to set that property to.</param>
-        ''' <remarks>
-        ''' </remarks>
         Friend Sub SetPropertyValue(PropertyName As String, Value As Object)
             Select Case PropertyName
                 Case ResourcePropertyDescriptor.PROPERTY_COMMENT
@@ -2477,7 +2388,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="NewFormattedName">The name that should be used instead (stripped of spaces)</param>
         ''' <param name="Exception">The exception to use if there's a problem with the validation.</param>
         ''' <returns>True if the name is okay.</returns>
-        ''' <remarks></remarks>
         Public Function ValidateName(NewName As String, OldName As String, Optional ByRef NewFormattedName As String = Nothing, Optional ByRef Exception As Exception = Nothing) As Boolean
             Return ValidateName(ParentResourceFile, NewName, OldName, NewFormattedName, Exception)
         End Function
@@ -2494,7 +2404,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="FixInvalidIDs">If true, then NewFormattedName will contain the name fixed up to be a legal identifier the way StronglyTypedResourceGenerator would do it (but only if the resx file is set up for strongly-typed code generation.</param>
         ''' <param name="CheckForDuplicateNames">If true, then the new names are checked to make sure they don't duplicate anything currently in the ResourceFile</param>
         ''' <returns>True if the name is okay.</returns>
-        ''' <remarks></remarks>
         Public Shared Function ValidateName(ResourceFile As ResourceFile, NewName As String, Optional OldName As String = Nothing, Optional ByRef NewFormattedName As String = Nothing, Optional ByRef Exception As Exception = Nothing, Optional FixInvalidIDs As Boolean = False, Optional CheckForDuplicateNames As Boolean = True) As Boolean
             Dim NewNames(0), OldNames(0), NewFormattedNames(0) As String
             NewNames(0) = NewName
@@ -2516,7 +2425,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="FixInvalidIDs">If true, then NewFormattedNames will contain names fixed up to be legal identifiers the way StronglyTypedResourceGenerator would do it (but only if the resx file is set up for strongly-typed code generation.</param>
         ''' <param name="CheckForDuplicateNames">If true, then the new names are checked to make sure they don't duplicate anything currently in the ResourceFile</param>
         ''' <returns>True if the name is okay.</returns>
-        ''' <remarks></remarks>
         Private Shared Function ValidateNames(ResourceFile As ResourceFile, NewNames() As String, Optional OldNames() As String = Nothing, Optional ByRef NewFormattedNames() As String = Nothing, Optional ByRef Exception As Exception = Nothing, Optional FixInvalidIDs As Boolean = False, Optional CheckForDuplicateNames As Boolean = True) As Boolean
             Dim CodeDomProvider As CodeDomProvider = Nothing
             Dim CheckForInvalidIdentifiers As Boolean = True
@@ -2570,7 +2478,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Resources">The list of resources whose names should be validated</param>
         ''' <param name="Fix">If true, the resource names are fixed to be legal identifiers (if not possible, will throw)</param>
         ''' <param name="CheckForDuplicateNames">If true, then the new names are checked to make sure they don't duplicate anything currently in the ResourceFile</param>
-        ''' <remarks></remarks>
         Public Shared Sub CheckResourceIdentifiers(ResourceFile As ResourceFile, Resources As ICollection(Of Resource), Fix As Boolean, CheckForDuplicateNames As Boolean)
             Dim NewNames(Resources.Count - 1), NewFormattedNames(Resources.Count - 1) As String
             Dim i As Integer = 0
@@ -2609,7 +2516,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Exception">[Out] The exception to use if there's a problem with the validation.</param>
         ''' <param name="CheckForDuplicateNames">If true, then the new names are checked to make sure they don't duplicate anything currently in the ResourceFile</param>
         ''' <returns>True if the name is okay.</returns>
-        ''' <remarks></remarks>
         Private Shared Function ValidateNameHelper(ResourceFile As ResourceFile,
                 NewName As String, OldName As String,
                 ByRef NewFormattedName As String,
@@ -2690,7 +2596,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Name">The resource name</param>
         ''' <param name="CodeDomProvider"></param>
         ''' <returns>Returns a string of invalid characters</returns>
-        ''' <remarks></remarks>
         Private Shared Function FindInvalidCharactersInIdentifier(Name As String, CodeDomProvider As CodeDomProvider) As String
             Dim unsupportedChars As String = String.Empty
 
@@ -2740,7 +2645,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="NewParsedValue">[Out] The actual value that was parsed from the string.</param>
         ''' <param name="Exception">[Out] The exception to use if the return was false.</param>
         ''' <returns>True if the validation succeeds, otherwise false.</returns>
-        ''' <remarks></remarks>
         Public Function ValidateValueAsString(NewFormattedValue As String, Optional ByRef NewParsedValue As Object = Nothing, Optional ByRef Exception As Exception = Nothing) As Boolean
             'Use the Resource Type Editor (specifically, the methods derived inherited from ResourceTypeEditorStringBase)
             '  to try and get the formatted value for the cell.
@@ -2798,7 +2702,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Comment">The comment for the ResXDataNode</param>
         ''' <param name="Value">The non-linked value for the ResXDataNode</param>
         ''' <returns>The new ResXDataNode instance</returns>
-        ''' <remarks></remarks>
         Private Function NewResXDataNode(Name As String, Comment As String, Value As Object) As ResXDataNode
             Dim Node As ResXDataNode
             If Value IsNot Nothing AndAlso Value.GetType().Equals(GetType(ResXFileRef)) Then
@@ -2821,7 +2724,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ValueTypeName">The expected type of the resource in the file.</param>
         ''' <param name="TextFileEncoding">The encoding to be used if this is a text file resource.  May be Nothing.  Irrelevant for any other type of resource.</param>
         ''' <returns>The new ResXDataNode instance.</returns>
-        ''' <remarks></remarks>
         Private Function NewResXDataNode(Name As String, Comment As String, FileName As String, ValueTypeName As String, TextFileEncoding As Encoding) As ResXDataNode
             Dim FileRef As New ResXFileRef(FileName, ValueTypeName, TextFileEncoding)
             Return NewResXDataNode(Name, Comment, FileRef)
@@ -2864,7 +2766,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  ResXDataNode has some properties which require one or the other.  This stores the value we 
         '''  use for calling those properties.
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' This value is set either at construction time or upon the first call to SetTypeResolutionContext
         ''' </remarks>
@@ -2888,8 +2789,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   calculate, and it needs to be reasonably fast.
         ''' </summary>
         ''' <param name="Categories">The list of categories used by the ResourceEditorView</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         ''' CONSIDER: consider performance tuning with a hash table type editor -> category hash
         Public Function GetCategory(Categories As CategoryCollection) As Category
             Debug.Assert(Categories IsNot Nothing)
@@ -2911,8 +2810,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Debug override for ToString
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function ToString() As String
 #If DEBUG Then
             Dim Message As New StringBuilder("[Resource """ & Name & """")
@@ -2966,7 +2863,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' If this is a text file, and the user hasn't already specified an encoding, then guess it by analyzing the file
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub TryGuessFileEncoding()
             If IsLink AndAlso _resXDataNode.FileRef.TextFileEncoding Is Nothing AndAlso ResourceTypeEditor.Equals(ResourceTypeEditors.TextFile) Then
                 Try

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparer.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparer.vb
@@ -11,7 +11,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' This is an Icomparer implementation used to sort Resources for UI purposes (ResourceListView and
     '''    ResourceStringTable).
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ResourceComparer
         Implements IComparer
 
@@ -19,7 +18,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Sorts an ArrayList of Resources for UI purposes
         ''' </summary>
         ''' <param name="Resources">ArrayList of Resources to source (will be sorted in place)</param>
-        ''' <remarks></remarks>
         Public Shared Sub SortResources(Resources As ArrayList)
             Resources.Sort(New ResourceComparer)
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparerForFind.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparerForFind.vb
@@ -10,7 +10,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' This is an Icomparer implementation used to sort Resources for Find/Replace purposes.  It sorts according
     '''   to both category (in a given order) and resource name.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ResourceComparerForFind
         Implements IComparer(Of Resource)
 
@@ -26,7 +25,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Constructor.
         ''' </summary>
         ''' <param name="OrderedCategories">List of all categories, in order of desired search order</param>
-        ''' <remarks></remarks>
         Public Sub New(OrderedCategories As CategoryCollection)
             Debug.Assert(OrderedCategories IsNot Nothing)
             _categories = OrderedCategories
@@ -47,7 +45,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Sorts a <see cref="List(Of Resource)"/> for UI purposes
         ''' </summary>
         ''' <param name="Resources"><see cref="List(Of Resource)"/> to sort (will be sorted in place)</param>
-        ''' <remarks></remarks>
         Public Sub SortResources(Resources As List(Of Resource))
             Resources.Sort(Me)
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorDesignerLoader.vb
@@ -19,7 +19,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' <summary>
     ''' Designer loader for the Resource Editor.  Handles serialization and services.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class ResourceEditorDesignerLoader
         Inherits DesignerFramework.BaseDesignerLoader
 
@@ -69,8 +68,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' This must be overloaded to return the assembly-qualified name of the base component that is 
         '''   being designed by this editor.  This information is required by the managed VSIP classes.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overrides Function GetBaseComponentClassName() As String
             Return GetType(ResourceEditorRootComponent).AssemblyQualifiedName
         End Function
@@ -165,7 +162,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' OnDesignerLoadCompleted will be called when we finish loading the designer
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnDesignerLoadCompleted()
             If _rootComponent IsNot Nothing Then
                 _rootComponent.RootDesigner.OnDesignerLoadCompleted()
@@ -177,7 +173,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="ResXFile"></param>
         ''' <returns>The ResX in a string.</returns>
-        ''' <remarks></remarks>
         Private Function SerializeResourcesToText(ResXFile As ResourceFile) As String
             If _rootComponent IsNot Nothing Then
                 ' Make sure the ResourceFile is up to date with any pending user changes
@@ -215,7 +210,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   remove any custom services you add here by overriding
         '''   Dispose.
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub Initialize()
             MyBase.Initialize()
 
@@ -239,7 +233,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Overrides base Dispose.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overrides Sub Dispose()
             'Remove any services we proffered.
             '
@@ -256,7 +249,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Called when the document's window is activated or deactivated
         ''' </summary>
         ''' <param name="Activated"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnDesignerWindowActivated(Activated As Boolean)
             MyBase.OnDesignerWindowActivated(Activated)
             If _rootComponent IsNot Nothing AndAlso _rootComponent.RootDesigner IsNot Nothing Then
@@ -276,7 +268,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' ManualCheckOut without the ProjectReloaded flag because it is not needed in
         '''   the resource editor.
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Overloads Sub ManualCheckOut()
             Dim ProjectReloaded As Boolean
             ManualCheckOut(ProjectReloaded)
@@ -334,8 +325,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  The function in the baseclass checks whether the file has been checked out. For the resource designer, we should check whether
         '''  it is a dependent file (for example: a resx file of a winForm). We shouldn't enter the edit mode until the user said 'yes'.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Overrides Function OkToEdit() As Boolean
             If Not _allowToUpdateDependentFile Then
                 If _rootComponent IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorFactory.vb
@@ -18,7 +18,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     '''   simply to create a new resource editor designer when requested by the
     '''   shell.
     ''' </summary>
-    ''' <remarks></remarks>
     <CLSCompliant(False),
     Guid("ff4d6aca-9352-4a5f-821e-f4d6ebdcab11")>
     Friend NotInheritable Class ResourceEditorFactory
@@ -37,7 +36,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   by the DesignerPackage when it gets sited.
         ''' We pass in our designer loader type to the base.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub New()
             MyBase.New(GetType(ResourceEditorDesignerLoader))
         End Sub
@@ -46,7 +44,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Provides the (constant) GUID for the subclassed editor factory.
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' Must overridde the base.  Be sure to use the same GUID on the GUID attribute
         '''    attached to the inheriting class.
@@ -61,8 +58,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Provides the (constant) GUID for the command UI.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Protected Overrides ReadOnly Property CommandUIGuid() As Guid
             Get
                 'This is required for key bindings hook-up to work properly.

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRefactorNotify.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRefactorNotify.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -17,7 +17,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     '''   simply to create a new resource editor designer when requested by the
     '''   shell.
     ''' </summary>
-    ''' <remarks></remarks>
     <CLSCompliant(False),
     Guid("0407F754-C199-403e-B89B-1D8E1FF3DC79")>
     Friend NotInheritable Class ResourceEditorRefactorNotify
@@ -39,7 +38,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' nothing to do since we don't really store any state...
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Sub New()
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootComponent.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootComponent.vb
@@ -24,7 +24,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     '''    manages the state of the edited object.  Persistence is handled in the code loader, and the
     '''    UI is handled by the ResourceEditorRootDesigner.
     ''' </summary>
-    ''' <remarks></remarks>
     <Designer(GetType(ResourceEditorRootDesigner), GetType(IRootDesigner))>
     Friend NotInheritable Class ResourceEditorRootComponent
         Inherits Component
@@ -67,7 +66,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Override Dispose().
         ''' </summary>
         ''' <param name="Disposing"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub Dispose(Disposing As Boolean)
             _tearingDown = True
 
@@ -107,8 +105,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' True iff the root component is being torn down or is already torn down.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property IsTearingDown() As Boolean
             Get
                 Return _tearingDown
@@ -119,8 +115,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the ResXResourceFile that is currently being edited.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property ResourceFile() As ResourceFile
             Get
                 Debug.Assert(Not _resourceFile Is Nothing, "m_ResourceFile should have already been created!  SetResXResourceFile not called?")
@@ -131,8 +125,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the ResXResourceFileName that is currently being edited.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend Property ResourceFileName() As String
             Get
                 Return _resourceFileName
@@ -147,8 +139,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   designer which is showing the UI to the user which allows this component's
         '''   resx file to be edited by the user.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property RootDesigner() As ResourceEditorRootDesigner
             Get
                 If _rootDesigner Is Nothing Then
@@ -199,7 +189,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''    component.  This effectively sets the .resx file which is being edited by the user.
         ''' </summary>
         ''' <param name="NewResourceFile"></param>
-        ''' <remarks></remarks>
         Friend Sub LoadResXResourceFile(NewResourceFile As ResourceFile)
             Debug.Assert(NewResourceFile.RootComponent Is Me)
             Debug.Assert(Not NewResourceFile Is Nothing)
@@ -221,7 +210,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Checks to see whether the RESX file belongs to another file item (like form, usercontrol...)
         ''' </summary>
-        ''' <remarks></remarks>
         Private Function IsDependentItem() As Boolean
             Dim ProjectItem As ProjectItem = TryCast(RootDesigner.GetService(GetType(ProjectItem)), ProjectItem)
             Debug.Assert(ProjectItem IsNot Nothing, "ProjectItem not found!")
@@ -248,7 +236,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Checks to see whether the RESX file is inside a device project...
         '''  We got a lot of limitation for this kind of projects
         ''' </summary>
-        ''' <remarks></remarks>
         Private Function IsInDeviceProject() As Boolean
             Dim hierarchy As IVsHierarchy = DirectCast(RootDesigner.GetService(GetType(IVsHierarchy)), IVsHierarchy)
             If hierarchy IsNot Nothing Then
@@ -260,7 +247,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Checks to see whether the RESX file is under "App_GlobalResources" in an ASP project
         ''' </summary>
-        ''' <remarks></remarks>
         Private Function IsInGlobalResourceFolderInASP() As Boolean
             Try
                 Dim projectItem As ProjectItem = RootDesigner.DesignerLoader.ProjectItem

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
@@ -23,7 +23,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     '''   is the top-level designer.  In spite of the fancy term, it doesn't really do much except to dish out
     '''   the actual design surface for the resource editor - ResourceEditorView.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ResourceEditorRootDesigner
         Inherits DesignerFramework.BaseRootDesigner
         Implements IRootDesigner, IVsFindTarget, OLE.Interop.IOleCommandTarget, IVsDebuggerEvents
@@ -77,7 +76,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Overrides base Dispose()
         ''' </summary>
         ''' <param name="Disposing"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub Dispose(Disposing As Boolean)
             If Disposing Then
                 'We might be being disposed in order to perform a reload on the DocData.  If
@@ -107,8 +105,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Shadows MyBase.Component, just so we can hide it from Intellisense and
         '''   encourage the use of the strongly-typed RootComponent instead.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         <EditorBrowsable(EditorBrowsableState.Never)>
         Friend Shadows ReadOnly Property Component() As ResourceEditorRootComponent
             Get
@@ -120,8 +116,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns the ResourceEditorRoot component that is being edited by this designer.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property RootComponent() As ResourceEditorRootComponent
             Get
                 Dim Root As ResourceEditorRootComponent = CType(MyBase.Component, ResourceEditorRootComponent)
@@ -135,8 +129,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Returns the IDesignerHost from the RootDesigner.
         ''' </summary>
         ''' <value>An instance of IDesignerHost.</value>
-        ''' <remarks> 
-        ''' </remarks>
         Friend ReadOnly Property DesignerHost() As IDesignerHost
             Get
                 Debug.Assert(_designerHost IsNot Nothing, "Cannot get IDesignerHost!!!")
@@ -149,8 +141,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Returns the DesignerLoader associated with this RootDesigner.
         ''' </summary>
         ''' <value>The ResourceEditorDesignerLoader instance.</value>
-        ''' <remarks> 
-        ''' </remarks>
         Friend ReadOnly Property DesignerLoader() As ResourceEditorDesignerLoader
             Get
                 Dim DesignerLoaderService As Object = GetService(GetType(IDesignerLoaderService))
@@ -169,8 +159,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  The designer will be destroyed, and a new designer will be created later, so we will never set it back.
         ''' </summary>
         ''' <value>Whether we are in reloading mode</value>
-        ''' <remarks> 
-        ''' </remarks>
         Friend Property IsInReloading() As Boolean
             Get
                 Return _isInReloading
@@ -190,8 +178,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   user sees and associates as being the resource editor).  If one doesn't exist, a new
         '''   one will be created.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetView() As ResourceEditorView
             Return CType(IRootDesigner_GetView(ViewTechnology.Default), ResourceEditorView)
         End Function
@@ -200,8 +186,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns True iff there a View has already been created.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public ReadOnly Property HasView() As Boolean
             Get
                 Return _view IsNot Nothing
@@ -214,8 +198,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   We currently support only "Default" (i.e., our designer view, ResourceEditorView,
         '''   inherits from System.Windows.Forms.Control).
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property IRootDesigner_SupportedTechnologies() As ViewTechnology() Implements IRootDesigner.SupportedTechnologies
             Get
                 Return New ViewTechnology() {ViewTechnology.Default}
@@ -228,8 +210,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   our resource editor's designer surface.  In this case, we return an instance of ResourceEditorView.
         ''' </summary>
         ''' <param name="Technology"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function IRootDesigner_GetView(Technology As ViewTechnology) As Object Implements IRootDesigner.GetView
             If Technology <> ViewTechnology.Default Then
                 Throw New ArgumentException("Not a supported view technology", NameOf(Technology))
@@ -278,7 +258,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         '''  We need create a ErrorListProvider to support the error list
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Function GetErrorListProvider() As ErrorListProvider
             If _errorListProvider Is Nothing Then
                 _errorListProvider = New ErrorListProvider(DesignerHost)
@@ -319,7 +298,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Used to set the ResourceFile which should be displayed in the designer view.
         ''' </summary>
         ''' <param name="ResXResourceFile"></param>
-        ''' <remarks></remarks>
         Friend Sub SetResourceFile(ResXResourceFile As ResourceFile)
             GetView().SetResourceFile(ResXResourceFile)
         End Sub
@@ -328,8 +306,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Attempts to retrieve the filename and path of the .resx file being edited.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetResXFileNameAndPath() As String
             Try
                 Dim ProjectItem As EnvDTE.ProjectItem = TryCast(GetService(GetType(EnvDTE.ProjectItem)), EnvDTE.ProjectItem)
@@ -367,8 +343,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns whether the designer is editing a resw file
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function IsEditingResWFile() As Boolean
             Return HasResWExtension(GetResXFileNameAndPath())
         End Function
@@ -455,7 +429,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Register this root designer as a view helper with the current frame so the shell will can find our
         '''   implementations of IVsFindTarget, IOleCommandTarget, etc.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub RegisterViewHelper()
             Try
                 Dim VsWindowFrame As IVsWindowFrame = CType(GetService(GetType(IVsWindowFrame)), IVsWindowFrame)
@@ -493,7 +466,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         '''  Unregister our IVsFindTarget with the current frame so the shell will call us to find / replace.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub UnRegisterViewHelper()
             Try
                 Dim VsWindowFrame As IVsWindowFrame = CType(GetService(GetType(IVsWindowFrame)), IVsWindowFrame)
@@ -524,7 +496,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="pfImage">Set to True if supporting GetSearchImage - searching in a text image.</param>
         ''' <param name="pgrfOptions">Specifies supported options, syntax and options, taken from __VSFINDOPTIONS.</param>
-        ''' <remarks></remarks>
         Private Function GetCapabilities(pfImage() As Boolean, pgrfOptions() As UInteger) As Integer Implements IVsFindTarget.GetCapabilities
             _findReplace.GetCapabilities(pfImage, pgrfOptions)
             Return NativeMethods.S_OK
@@ -537,7 +508,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="propid">Property identifier of the requested property, taken from VSFTPROPID enum.</param>
         ''' <param name="pvar">Property value.</param>
         ''' <returns>S_OK if success, otherwise an error code.</returns>
-        ''' <remarks></remarks>
         Private Function GetProperty(propid As UInteger, ByRef pvar As Object) As Integer Implements IVsFindTarget.GetProperty
             Return _findReplace.GetProperty(propid, pvar)
         End Function
@@ -558,7 +528,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Sets the find state object that we hold for the find engine.
         ''' </summary>
         ''' <param name="pUnk">The find state object to hold.</param>
-        ''' <remarks></remarks>
         Private Function SetFindState(pUnk As Object) As Integer Implements IVsFindTarget.SetFindState
             _findReplace.SetFindState(pUnk)
             Return NativeMethods.S_OK
@@ -679,8 +648,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="cCmds">The number of commands in the prgCmds array. </param>
         ''' <param name="prgCmds">[in,out] A caller-allocated array of OLECMD structures that indicate the commands for which the caller needs status information. This method fills the cmdf member of each structure with values taken from the OLECMDF enumeration. </param>
         ''' <param name="pCmdText">[unique][in,out] Pointer to an OLECMDTEXT structure in which to return name and/or status information of a single command. Can be NULL to indicate that the caller does not need this information. </param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function IOleCommandTarget_QueryStatus(ByRef pguidCmdGroup As Guid, cCmds As UInteger, prgCmds As OLE.Interop.OLECMD(), pCmdText As IntPtr) As Integer _
         Implements OLE.Interop.IOleCommandTarget.QueryStatus
             'We don't implement this.
@@ -690,7 +657,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' OnDesignerLoadCompleted will be called when we finish loading the designer
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Sub OnDesignerLoadCompleted()
             ConnectDebuggerEvents()
             ' BUGFIX: Dev11#45255 
@@ -711,7 +677,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' We need get undoEngine to monitor undo state. But it is not available when the designer is just loaded. We do this on the first transaction (change) happens in the designer.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub DesignerHost_TransactionOpening(sender As Object, e As EventArgs) Handles _designerHost.TransactionOpening
             If _undoEngine Is Nothing Then
                 _undoEngine = DirectCast(GetService(GetType(UndoEngine)), UndoEngine)
@@ -743,7 +708,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="scope"></param>
         ''' <param name="action"></param>
-        ''' <remarks></remarks>
         Private Sub BuildBegin(scope As EnvDTE.vsBuildScope, action As EnvDTE.vsBuildAction) Handles _buildEvents.OnBuildBegin
             Dim DesignerLoaderService As Object = GetService(GetType(IDesignerLoaderService))
             If DesignerLoaderService IsNot Nothing Then
@@ -757,7 +721,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="scope"></param>
         ''' <param name="action"></param>
-        ''' <remarks></remarks>
         Private Sub BuildDone(scope As EnvDTE.vsBuildScope, action As EnvDTE.vsBuildAction) Handles _buildEvents.OnBuildDone
             Dim DesignerLoaderService As Object = GetService(GetType(IDesignerLoaderService))
             If DesignerLoaderService IsNot Nothing Then
@@ -769,7 +732,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Hook up with the debugger event mechanism to determine current debug mode
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ConnectDebuggerEvents()
             If _vsDebuggerEventsCookie = 0 Then
                 _vsDebugger = CType(GetService(GetType(IVsDebugger)), IVsDebugger)
@@ -790,7 +752,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Unhook event notification for debugger 
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub DisconnectDebuggerEvents()
             If _vsDebugger IsNot Nothing AndAlso _vsDebuggerEventsCookie <> 0 Then
                 VSErrorHandler.ThrowOnFailure(_vsDebugger.UnadviseDebuggerEvents(_vsDebuggerEventsCookie))
@@ -832,7 +793,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub UndoEngine_Undoing(sender As Object, e As EventArgs) Handles _undoEngine.Undoing
             If _view IsNot Nothing Then
                 _view.OnUndoing()
@@ -844,7 +804,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub UndoEngine_Undone(sender As Object, e As EventArgs) Handles _undoEngine.Undone
             If _view IsNot Nothing Then
                 _view.OnUndone()

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -34,7 +34,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' This class contains the actual top-level UI surface for the resource
     '''   editor.  It is created by ResourceEditorRootDesigner.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class ResourceEditorView
         Inherits BaseDesignerView
         Implements Resource.ITypeResolutionContextProvider
@@ -186,7 +185,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Constructor needed for form designer (should use the constructor with a service provider)
         ''' </summary>
-        ''' <remarks></remarks>
         <System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>
         Public Sub New()
             Me.New(Nothing)
@@ -197,7 +195,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Constructor
         ''' </summary>
         ''' <param name="ServiceProvider"></param>
-        ''' <remarks></remarks>
         Public Sub New(ServiceProvider As IServiceProvider)
             MyBase.New()
 
@@ -215,7 +212,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Overrides Dispose()
         ''' </summary>
         ''' <param name="Disposing"></param>
-        ''' <remarks></remarks>
         Protected Overloads Overrides Sub Dispose(Disposing As Boolean)
             If Disposing Then
                 'Turn off listening to virtual notifications immediately.
@@ -350,8 +346,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves the set of categories handled by this instance of the resource editor.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property Categories() As CategoryCollection
             Get
                 Return _categories
@@ -362,8 +356,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves the file watcher for this instance of the resource editor.  Creates one if necessary.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property FileWatcher() As FileWatcher
             Get
                 If _fileWatcher Is Nothing Then
@@ -380,8 +372,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Return true when we are editing a name label
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property IsInEditing() As Boolean
             Get
                 Return _inEditingItem
@@ -391,8 +381,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Return true when we are undoing/redoing
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property IsUndoing() As Boolean
             Get
                 Return _inUndoing
@@ -403,8 +391,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' ReadOnly Mode
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend Property ReadOnlyMode() As Boolean
             Get
                 Return _readOnlyMode
@@ -420,8 +406,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the RootDesigner associated with this resource editor instance.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property RootDesigner() As ResourceEditorRootDesigner
             Get
                 Debug.Assert(Not _rootDesigner Is Nothing, "Can't call RootDesigner before SetRootDesigner() - we don't have a root designer cached yet")
@@ -433,8 +417,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the ResourceFile that is being viewed/edited in this view.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property ResourceFile() As ResourceFile
             Get
                 Return _resourceFile
@@ -445,8 +427,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' The component being edited - ResourceEditorRootComponent
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property RootComponent() As ResourceEditorRootComponent
             Get
                 If _rootDesigner IsNot Nothing AndAlso _rootDesigner.Component IsNot Nothing Then
@@ -469,7 +449,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Return the root Registry key of the Resource Editor
         ''' </summary>
-        ''' <remarks></remarks>
         Private ReadOnly Property RegistryRoot() As String
             Get
                 If _registryRoot Is Nothing Then
@@ -488,7 +467,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  We save a list of file extensions in the registry. All extensions were approved by the customer that they don't want to see
         '''  a warning dialog when they double-click the item to open it.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Property SafeExtensions() As String
             Get
                 Dim registryPath As String = RegistryRoot
@@ -594,7 +572,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Initializes all UI elements.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub InitializeUI()
             AllowDrop = True
             StringTable.RowHeadersWidth = DpiAwareness.LogicalToDeviceUnits(Handle, 35)
@@ -604,8 +581,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the environment font for the shell.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GetEnvironmentFont(ServiceProvider As IServiceProvider) As Font
             Dim UIService As IUIService = DirectCast(ServiceProvider.GetService(GetType(IUIService)), IUIService)
             If UIService IsNot Nothing Then
@@ -623,7 +598,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Initialize the fonts in the resource editor from the environment (or from the resx file,
         '''   if hard-coded there).
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub SetFonts(ServiceProvider As IServiceProvider)
             Dim MainFont, StringTableFont, ListViewFont As Font
             'First try to get the environment font
@@ -658,7 +632,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   that can cause problems with reentrant code.
         ''' </summary>
         ''' <param name="RootDesigner"></param>
-        ''' <remarks></remarks>
         Public Sub SetRootDesigner(RootDesigner As ResourceEditorRootDesigner)
             'Cache off the pointer to our root designer (our parent)
             _rootDesigner = RootDesigner
@@ -698,7 +671,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Tells the view to starting displaying resources from a ResourceFile.  Can only be called once.
         ''' </summary>
         ''' <param name="ResourceFile">The ResourceFile to load.</param>
-        ''' <remarks></remarks>
         Public Sub SetResourceFile(ResourceFile As ResourceFile)
             Debug.Assert(Not (ResourceFile Is Nothing))
             If Not _resourceFile Is Nothing Then
@@ -858,7 +830,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Create instances of all the categories
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub InitializeResourceCategories()
             _categoryStrings = New Category(
                 _categoryNameStrings, My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Cat_Strings,
@@ -944,7 +915,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Received when the resource editor view window is resized.  Cause a layout.
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnResize(e As EventArgs)
             MyBase.OnResize(e)
 
@@ -956,7 +926,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Lays out the resource editor's controls.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub LayOutResourceEditor()
             Static InLayout As Boolean = False
             If InLayout Then
@@ -983,7 +952,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="msg"></param>
         ''' <param name="wParam"></param>
         ''' <param name="lParam"></param>
-        ''' <remarks></remarks>
         Public Function OnBroadcastMessage(msg As UInteger, wParam As IntPtr, lParam As IntPtr) As Integer Implements IVsBroadcastMessageEvents.OnBroadcastMessage
             If msg = Editors.Interop.Win32Constant.WM_SETTINGCHANGE Then
                 If RootDesigner IsNot Nothing Then
@@ -1091,7 +1059,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Changes the ResourceView for the current category.  Updates the display.
         ''' </summary>
         ''' <param name="View"></param>
-        ''' <remarks></remarks>
         Private Sub ChangeResourceView(View As ResourceListView.ResourceView)
             If _currentCategory Is Nothing Then
                 Debug.Fail("m_CurrentCategory Is Nothing")
@@ -1111,7 +1078,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Category">The category to change.</param>
         ''' <param name="View">The ResourceView to change to for that category.</param>
-        ''' <remarks></remarks>
         Private Sub ChangeResourceViewForCategory(Category As Category, View As ResourceListView.ResourceView)
             Debug.Assert(_currentCategory IsNot Nothing)
             If Category Is _currentCategory Then
@@ -1126,7 +1092,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="CategoryUpdated">The category to change.</param>
         ''' <param name="Sorter"></param>
-        ''' <remarks></remarks>
         Private Sub ChangeSorterForCategory(CategoryUpdated As Category, Sorter As IComparer(Of Resource))
             Debug.Assert(_currentCategory IsNot Nothing)
             If CategoryUpdated Is _currentCategory Then
@@ -1146,7 +1111,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Commits all pending changes in the string table or listview.
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Sub CommitPendingChanges()
             If _currentCategory Is Nothing Then
                 'Ignore if this is fired before categories are set up (InitializeComponent)
@@ -1167,7 +1131,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Ping the toolbar panel so that it gets included in the search for
         ''' toolbars when translating accelerators/pressing shift-alt
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub UpdateToolbarFocus()
             If _toolbarPanel IsNot Nothing Then
                 _toolbarPanel.Activate(Handle)
@@ -1186,8 +1149,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves the window that should be used as the owner of all dialogs and messageboxes.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetDialogOwnerWindow() As IWin32Window
             Dim UIService As IUIService = DirectCast(RootDesigner.GetService(GetType(IUIService)), IUIService)
             If UIService IsNot Nothing Then
@@ -1204,7 +1165,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The resource to invalidate</param>
         ''' <param name="InvalidateThumbnail">If True, the resource's thumbnail and other info is also invalidated.</param>
-        ''' <remarks></remarks>
         Public Sub InvalidateResource(Resource As Resource, InvalidateThumbnail As Boolean)
             If _currentCategory IsNot Nothing Then
                 Select Case _currentCategory.CategoryDisplay
@@ -1228,7 +1188,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="DefaultButton">Which button should be default?</param>
         ''' <param name="HelpLink">The help link</param>
         ''' <returns>One of the DialogResult values</returns>
-        ''' <remarks></remarks>
         Public Overridable Function DsMsgBox(Message As String,
                 Buttons As MessageBoxButtons,
                 Icon As MessageBoxIcon,
@@ -1243,7 +1202,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Displays a message box for an exception using the Visual Studio-approved manner.
         ''' </summary>
         ''' <param name="ex">The exception whose message we want to display.</param>
-        ''' <remarks></remarks>
         Public Overridable Sub DsMsgBox(ex As Exception)
             DesignerMessageBox.Show(DirectCast(RootDesigner, IServiceProvider), ex, s_messageBoxCaption)
         End Sub
@@ -1253,7 +1211,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Switch to the specified category, if it's not already the current category.
         ''' </summary>
         ''' <param name="Category"></param>
-        ''' <remarks></remarks>
         Private Sub SwitchToCategory(Category As Category)
             If _currentCategory IsNot Nothing AndAlso _currentCategory IsNot Category Then
                 PopulateResources(Category)
@@ -1270,8 +1227,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   editor close, etc.
         ''' </summary>
         ''' <param name="pfCommitFailed"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function IVsWindowPaneCommit_CommitPendingEdit(ByRef pfCommitFailed As Integer) As Integer Implements IVsWindowPaneCommit.CommitPendingEdit
             CommitPendingChanges()
             pfCommitFailed = 0
@@ -1308,7 +1263,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Unselects all resources in the current view.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub UnselectAllResources()
             CommitPendingChanges()
 
@@ -1330,7 +1284,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resources">Resources to highlight</param>
         ''' <param name="SelectInPropertyGrid">If true, the property grid is updated with the new selection.</param>
-        ''' <remarks></remarks>
         Public Sub HighlightResources(Resources As ICollection(Of Resource), SelectInPropertyGrid As Boolean)
             HighlightResourceHelper(Resources, 0, True, HighlightEntireResource:=True)
         End Sub
@@ -1346,7 +1299,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Resource">The Resource to highlight</param>
         ''' <param name="Field">The field in the resource's row to highlight.</param>
         ''' <param name="SelectInPropertyGrid">If true, update the property grid with the new selection</param>
-        ''' <remarks></remarks>
         Public Sub HighlightResource(Resource As Resource, Field As FindReplace.Field, SelectInPropertyGrid As Boolean)
             If Resource IsNot Nothing Then
                 HighlightResourceHelper(New Resource() {Resource}, Field, SelectInPropertyGrid, HighlightEntireResource:=False)
@@ -1361,7 +1313,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The Resource to highlight</param>
         ''' <param name="SelectInPropertyGrid">If true, update the property grid with the new selection</param>
-        ''' <remarks></remarks>
         Friend Sub HighlightResource(Resource As Resource, SelectInPropertyGrid As Boolean)
             If Resource IsNot Nothing Then
                 HighlightResourceHelper(New Resource() {Resource}, 0, SelectInPropertyGrid, HighlightEntireResource:=True)
@@ -1376,7 +1327,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Field">The field in the resource's row to highlight, if not HighlightEntireResource and if it's a stringtable.</param>
         ''' <param name="SelectInPropertyGrid">If true, update the property grid with the new selection</param>
         ''' <param name="HighlightEntireResource">If true, Field is ignored and the entire resource is highlighted.</param>
-        ''' <remarks></remarks>
         Private Sub HighlightResourceHelper(Resources As ICollection(Of Resource), Field As FindReplace.Field, SelectInPropertyGrid As Boolean, HighlightEntireResource As Boolean)
             Dim NewCategory As Category = Nothing
             Dim ResourceCollection As New List(Of Resource)
@@ -1435,7 +1385,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   when the user double-clicks on an error in the task list.
         ''' </summary>
         ''' <param name="Resource">The resource to navigate to</param>
-        ''' <remarks></remarks>
         Public Sub NavigateToResource(Resource As Resource)
             If ResourceFile.Contains(Resource) Then
                 'First, make sure our resx file has focus
@@ -1475,7 +1424,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Set the selection in the properties window to the currently-selected set of resources.
         '''  It is the real code to do updating when we receive the message posted by us.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub OnWmUpdatePropertyGrid()
             If _propertyGridNeedUpdate Then
                 Try
@@ -1492,8 +1440,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''    be unselected.
         ''' </summary>
         ''' <param name="Resources">An array of Resource to be selected.</param>
-        ''' <remarks>
-        ''' </remarks>
         Private Sub PropertyGridSelect(Resources() As Resource)
             'CONSIDER: Perf optimization: do delay-adding of resources to the component list.  Currently we just add all of them all the time.  This would
             '  probably involve some changes to the undo code as well.
@@ -1531,7 +1477,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Unselects all resources from the property grid.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub PropertyGridUnselectAll()
             PropertyGridSelect(Array.Empty(Of Resource))
         End Sub
@@ -1541,7 +1486,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ResourceListView_SelectedIndexChanged(sender As Object, e As EventArgs) Handles _resourceListView.SelectedIndexChanged
             Try
                 PropertyGridUpdate()
@@ -1575,7 +1519,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub StringTable_CellEnter(sender As Object, e As DataGridViewCellEventArgs) Handles StringTable.CellEnter
             Try
                 PropertyGridUpdate()
@@ -1590,7 +1533,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resources"></param>
         ''' <param name="SelectInPropertyGrid"></param>
-        ''' <remarks></remarks>
         Private Delegate Sub HighlightResourcesDelegate(Resources As ICollection(Of Resource), SelectInPropertyGrid As Boolean)
 
 
@@ -1600,7 +1542,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   being shown for a set of resources and simply doing PropertyGridUpdate() doesn't give Visual Studio enough
         '''   incentive, er, time, to notice the changes.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub DelayedPropertyGridUpdate()
             Dim SelectedResources() As Resource = GetSelectedResources()
 
@@ -1619,7 +1560,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub StringTable_CellBeginEdit(sender As Object, e As DataGridViewCellCancelEventArgs) Handles StringTable.CellBeginEdit
             Try
                 RootDesigner.DesignerLoader.ManualCheckOut()
@@ -1914,7 +1854,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   in our view yet, add them to our view.
         ''' </summary>
         ''' <param name="NewResources">The resources to add to our display.</param>
-        ''' <remarks></remarks>
         Private Sub AddAndHighlightResourcesInView(NewResources As IList(Of Resource))
             If NewResources Is Nothing OrElse NewResources.Count = 0 Then
                 Exit Sub
@@ -1984,7 +1923,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Removes a set of resources from the ResourceFile.
         ''' </summary>
         ''' <param name="Resources">The resources to remove.</param>
-        ''' <remarks></remarks>
         Public Sub RemoveResources(Resources As ICollection(Of Resource))
             CommitPendingChanges()
 
@@ -2029,7 +1967,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   in it.  Does not remove them from the ResourceFile.
         ''' </summary>
         ''' <param name="Resources"></param>
-        ''' <remarks></remarks>
         Private Sub RemoveResourcesFromView(Resources As IList)
             CommitPendingChanges()
 
@@ -2052,7 +1989,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   to our view, since they're in the ResourceFile but not yet displayed.
         ''' </summary>
         ''' <param name="Resource">The resource which has been added.</param>
-        ''' <remarks></remarks>
         Public Sub OnResourceAddedExternally(Resource As Resource)
             AddAndHighlightResourcesInView(New Resource() {Resource})
             OnResourceTouched(Resource)
@@ -2065,7 +2001,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   which is currently in our view.
         ''' </summary>
         ''' <param name="Resource">The resource which has been removed.</param>
-        ''' <remarks></remarks>
         Public Sub OnResourceRemovedExternally(Resource As Resource)
             If _inUndoing Then
                 Dim resourceCategory As Category = Resource.GetCategory(_categories)
@@ -2087,7 +2022,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' This is called when resources have been updated
         ''' </summary>
         ''' <param name="Resource">The resource which has been renamed.</param>
-        ''' <remarks></remarks>
         Friend Sub OnResourceTouched(Resource As Resource)
             If _inUndoing Then
                 Dim resourceCategory As Category = Resource.GetCategory(_categories)
@@ -2111,8 +2045,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   ResourceFile, and do not add the file to the project.
         ''' </summary>
         ''' <param name="ResourceSourceFilePath"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function CreateNewResourceFromFile(ResourceSourceFilePath As String) As Resource
             'We don't bother trying to make the name unique among those in ResourceFile, because we'll do that in AddResources.
             Dim ResourceName As String = GetResourceNameFromFileName(ResourceSourceFilePath)
@@ -2138,8 +2070,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Given a filename, returns an ID based on that name
         ''' </summary>
         ''' <param name="FileName">The filename to base the resource name on.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GetResourceNameFromFileName(FileName As String) As String
             Return Path.GetFileNameWithoutExtension(GetFileNameInActualCase(FileName))
         End Function
@@ -2153,7 +2083,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Extension">The filename extension (including the period prefix, e.g. ".txt") to check</param>
         ''' <returns>The ResourceTypeEditor found, or Nothing if none found</returns>
-        ''' <remarks></remarks>
         Private Function GetResourceTypeEditorForFileExtension(Extension As String) As ResourceTypeEditor
             Debug.Assert(Extension = "" OrElse Extension.Chars(0) = "."c)
 
@@ -2184,7 +2113,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Checks to see whether we can add a resource to this file
         ''' </summary>
-        ''' <remarks></remarks>
         Private Function IsValidResourceItem(NewResource As Resource, ByRef Message As String, ByRef HelpID As String) As Boolean
             Return NewResource.ResourceTypeEditor.IsResourceItemValid(NewResource, _resourceFile, Message, HelpID)
         End Function
@@ -2198,8 +2126,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Enabled handler for the Paste menu.  Determines if the menu item should be enabled or not.
         ''' </summary>
         ''' <param name="MenuCommand">The Paste menu.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuPasteEnabledHandler(MenuCommand As DesignerMenuCommand) As Boolean
             If ReadOnlyMode OrElse IsInEditing Then
                 Return False        ' if one editBox is activated, let it handle this...
@@ -2229,8 +2155,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' The remove row command should only be enabled if we are currently
         ''' showing the string table, and there is 1 or more cells selected
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuRemoveRowEnabledHandler(command As DesignerMenuCommand) As Boolean
             If ReadOnlyMode Then
                 Return False
@@ -2253,8 +2177,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns true iff the copy commands should be enabled
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuCopyShouldBeEnabled() As Boolean
             If IsInEditing Then
                 ' we should let the textBox to handle everything....
@@ -2290,8 +2212,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns true iff the delete commands should be enabled
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuDeleteShouldBeEnabled() As Boolean
             If ReadOnlyMode OrElse IsInEditing Then
                 ' we should let the textBox to handle everything....
@@ -2326,8 +2246,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Enabled handler for the cmdidDelete command
         ''' </summary>
         ''' <param name="menucommand"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuDeleteEnabledHandler(MenuCommand As DesignerMenuCommand) As Boolean
             Return Not ReadOnlyMode AndAlso MenuDeleteShouldBeEnabled()
         End Function
@@ -2336,8 +2254,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Visible handler for the cmdidRemove command
         ''' </summary>
         ''' <param name="menucommand"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuDeleteVisibleHandler(MenuCommand As DesignerMenuCommand) As Boolean
             Return _currentCategory IsNot Nothing AndAlso _currentCategory.CategoryDisplay = Category.Display.StringTable
         End Function
@@ -2346,8 +2262,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Enabled handler for the cmdidRemove command
         ''' </summary>
         ''' <param name="menucommand"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuRemoveEnabledHandler(MenuCommand As DesignerMenuCommand) As Boolean
             ' we should let the textBox to handle everything when IsInEditing = True
             Return Not IsInEditing AndAlso RemoveButtonShouldBeEnabled()
@@ -2357,8 +2271,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Visible handler for the cmdidRemove command
         ''' </summary>
         ''' <param name="menucommand"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuRemoveVisibleHandler(MenuCommand As DesignerMenuCommand) As Boolean
             Return _currentCategory IsNot Nothing AndAlso _currentCategory.CategoryDisplay <> Category.Display.StringTable
         End Function
@@ -2367,8 +2279,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Enabled handler for the Cut menus.  Determines if the menu items should be enabled or not.
         ''' </summary>
         ''' <param name="MenuCommand">The menu item to check</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuCutEnabledHandler(MenuCommand As DesignerMenuCommand) As Boolean
             Return Not ReadOnlyMode AndAlso MenuCopyShouldBeEnabled() AndAlso MenuDeleteShouldBeEnabled()
         End Function
@@ -2377,8 +2287,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Enabled handler for the Copy menus.  Determines if the menu items should be enabled or not.
         ''' </summary>
         ''' <param name="MenuCommand">The menu item to check</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuCopyEnabledHandler(MenuCommand As DesignerMenuCommand) As Boolean
             Return MenuCopyShouldBeEnabled()
         End Function
@@ -2413,7 +2321,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Enables or disables buttons as appropriate according to the current
         '''   selection state
         ''' </summary>
-        ''' <remarks></remarks>
         Private Function RemoveButtonShouldBeEnabled() As Boolean
             If ReadOnlyMode Then
                 ' we should let the textBox to handle everything....
@@ -2429,8 +2336,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Enabled handler for the Rename menus.  Determines if the menu items should be enabled or not.
         ''' </summary>
         ''' <param name="MenuCommand">The menu item to check</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuRenameEnabledHandler(MenuCommand As DesignerMenuCommand) As Boolean
             If _currentCategory IsNot Nothing AndAlso _currentCategory.CategoryDisplay = Category.Display.ListView Then
                 MenuCommand.Visible = True
@@ -2452,7 +2357,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Handles the Remove menu command
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub MenuRemove(sender As Object, e As EventArgs)
             If CurrentCategory.CategoryDisplay = Category.Display.StringTable AndAlso Not StringTable.InLineSelectionMode Then
                 ClearCells()
@@ -2464,7 +2368,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Clear cells in StringTable
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ClearCells()
             If CurrentCategory.CategoryDisplay <> Category.Display.StringTable Then
                 Return
@@ -2493,7 +2396,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuRemoveRow(sender As Object, e As EventArgs)
             RemoveResources(GetSelectedResources())
         End Sub
@@ -2504,7 +2406,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuRename(sender As Object, e As EventArgs)
             Dim SelectedResources() As Resource = GetSelectedResources()
             If SelectedResources.Length = 1 Then
@@ -2518,7 +2419,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuCut(sender As Object, e As EventArgs)
             MenuCopy(sender, e)
             MenuRemove(sender, e)
@@ -2530,7 +2430,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuCopy(sender As Object, e As EventArgs)
             If CurrentCategory.CategoryDisplay = Category.Display.StringTable AndAlso Not StringTable.InLineSelectionMode Then
                 Dim cells As DataGridViewSelectedCellCollection = StringTable.SelectedCells
@@ -2547,7 +2446,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Handles the Paste menu command
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub MenuPaste(sender As Object, e As EventArgs)
             Dim ActualEffect As DragDropEffects
             Dim ActualFormat As ResourceEditorDataFormats
@@ -2576,7 +2474,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' An enum for the clipboard formats supported by the resource editor.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Enum ResourceEditorDataFormats
             Resources 'Our own internal format, used between instances of the resource editor and intra-editor
             SolutionExplorer 'Visual Studio solution explorer
@@ -2627,7 +2524,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Clipboard format for intra-editor and between resource editor instances.  Essentially just a list of
         '''   serialized Resources.
         ''' </summary>
-        ''' <remarks></remarks>
         <Serializable()>
         Private NotInheritable Class ResourcesDataFormat
             'List of resources
@@ -2637,7 +2533,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' Constructor
             ''' </summary>
             ''' <param name="Resources"></param>
-            ''' <remarks></remarks>
             Public Sub New(Resources() As Resource)
                 _resources = Resources
             End Sub
@@ -2645,8 +2540,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Retrives the list of resources stored in this format.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property Resources() As Resource()
                 Get
                     Return _resources
@@ -2665,7 +2558,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resources">The set of resources</param>
         ''' <returns>A data object with our supported source formats.</returns>
-        ''' <remarks></remarks>
         Private Function CreateDataObjectFromResources(Resources() As Resource) As IDataObject
             Dim Data As New DataObject
 
@@ -2790,7 +2682,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Copies a set of resources to the clipboard in all formats sourced by us.
         ''' </summary>
         ''' <param name="Resources">The resources to copy</param>
-        ''' <remarks></remarks>
         Private Sub CopyResourcesToClipboard(Resources() As Resource)
             'The old temporary files from the last clipboard or drag/drop operation should no longer be needed - delete them now
             DeleteTemporaryFiles(_deleteFilesOnClipboardFlush)
@@ -2806,7 +2697,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Copies a single string to the clipboard in text format
         ''' </summary>
         ''' <param name="value">The value to copy</param>
-        ''' <remarks></remarks>
         Private Sub CopyValueToClipboard(value As Object)
             'The old temporary files from the last clipboard or drag/drop operation should no longer be needed - delete them now
             DeleteTemporaryFiles(_deleteFilesOnClipboardFlush)
@@ -2830,8 +2720,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="CopyAllowed">Whether a copy is currently allowed.</param>
         ''' <param name="MoveAllowed">Whether a move is currently allowed.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function DetermineCopyOrMove(CopyAllowed As Boolean, MoveAllowed As Boolean) As DragDropEffects
             'Shift pressed - want to move
             If (ModifierKeys And Keys.Shift) <> 0 AndAlso MoveAllowed Then
@@ -2865,7 +2753,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ActualEffect">[Out] The copy/move effect that we choose</param>
         ''' <param name="ActualFormat">[Out] The format that we choose.</param>
         ''' <returns>True if we were able to select a format to copy or move</returns>
-        ''' <remarks></remarks>
         Private Function DataFormatSupported(Data As IDataObject, AllowedEffects As DragDropEffects, ByRef ActualEffect As DragDropEffects, ByRef ActualFormat As ResourceEditorDataFormats) As Boolean
             Dim CopyAllowed As Boolean = (AllowedEffects And DragDropEffects.Copy) <> 0
             Dim MoveAllowed As Boolean = (AllowedEffects And DragDropEffects.Move) <> 0
@@ -2926,7 +2813,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Handles setting the drag/drop effect for drag/drop events
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub SetDragDropEffect(e As DragEventArgs)
             Dim ActualFormat As ResourceEditorDataFormats
             Call DataFormatSupported(e.Data, e.AllowedEffect, e.Effect, ActualFormat)
@@ -2937,7 +2823,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Called when the mouse is moved over our view during a drag/drop operation
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnDragOver(e As DragEventArgs)
             MyBase.OnDragOver(e)
             SetDragDropEffect(e)
@@ -2948,7 +2833,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Called when the mouse is moved into our view during a drag/drop operation
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnDragEnter(e As DragEventArgs)
             MyBase.OnDragEnter(e)
             RootDesigner.DesignerHost.Activate()
@@ -2987,7 +2871,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ResourceListView_ItemDrag(sender As Object, e As ItemDragEventArgs) Handles _resourceListView.ItemDrag
             Dim ResourcesToDrag() As Resource = GetSelectedResources()
             Dim Data As IDataObject = CreateDataObjectFromResources(ResourcesToDrag)
@@ -3164,8 +3047,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Decodes text data from an IDataObject
         ''' </summary>
         ''' <param name="Data"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GetTextFromIDataObject(Data As IDataObject, ClipboardFormat As String) As String
             Dim RawData As Object = Data.GetData(ClipboardFormat)
             Dim Text As String = ""
@@ -3214,7 +3095,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Represents a single file drop info from a drag/drop initiated from the Visual Studio solution explorer
         ''' </summary>
-        ''' <remarks></remarks>
         Private Structure DraggedFileInfo
             Public FilePath As String
             Public Guid As String
@@ -3227,8 +3107,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   parses the information from the drop and returns it.
         ''' </summary>
         ''' <param name="HDropStream"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GetFileListFromVsHDropHandle(HDropStream As Stream) As DraggedFileInfo()
             Dim Files() As DraggedFileInfo
             Const MAX_PATH As Integer = 260
@@ -3301,8 +3179,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Enabled handler for the Play menu command.  Determines if the menu item should be enabled/visible.
         ''' </summary>
         ''' <param name="MenuCommand">The menu item for Play.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuPlayEnabledHandler(MenuCommand As DesignerMenuCommand) As Boolean
             'Play should be only be visible in the Audio category
             If _currentCategory IsNot Nothing AndAlso _currentCategory.ProgrammaticName.Equals(_categoryNameAudio, StringComparison.OrdinalIgnoreCase) Then
@@ -3320,8 +3196,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Given a set of resources, determines if they can be played as audio.
         ''' </summary>
         ''' <param name="Resources"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function CanPlayResources(Resources() As Resource) As Boolean
             'The must be exactly one resource selected
             If Resources Is Nothing OrElse Resources.Length <> 1 Then
@@ -3340,7 +3214,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Handler for the "Play" menu command
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub MenuPlay(sender As Object, e As EventArgs)
             Dim SelectedResources As Resource() = GetSelectedResources()
             If Not CanPlayResources(SelectedResources) Then
@@ -3395,7 +3268,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ResourceListView_ItemActivate(sender As Object, e As EventArgs) Handles _resourceListView.ItemActivate
             If CanPlayResources(GetSelectedResources()) Then
                 MenuPlay(sender, e)
@@ -3408,7 +3280,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Handler for the "Open" menu command
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub MenuOpen(sender As Object, e As EventArgs)
             Try
                 For Each Resource As Resource In GetSelectedResources()
@@ -3424,7 +3295,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Handler for the "Open With..." menu command
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub MenuOpenWith(sender As Object, e As EventArgs)
             Try
                 For Each Resource As Resource In GetSelectedResources()
@@ -3441,8 +3311,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Enabled handler for the Open/Open With menu commands.  Determines if the menu item should be enabled.
         ''' </summary>
         ''' <param name="MenuCommand">The menu item for Open or Open/With.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuOpenOpenWithEnabledHandler(MenuCommand As DesignerMenuCommand) As Boolean
             'Open/Open With should be shown only in the listview mode
             If _currentCategory IsNot Nothing AndAlso _currentCategory.CategoryDisplay <> Category.Display.ListView Then
@@ -3605,7 +3473,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuExport(sender As Object, e As EventArgs)
             'CONSIDER: persist per resource editor instance
             Static StickyExportPath As String 'Remember where the used last exported, so we'll bring up the dialog there by default
@@ -3659,7 +3526,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuImport(sender As Object, e As EventArgs)
             Dim SelectedResources() As Resource = GetSelectedResources()
 
@@ -3725,7 +3591,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resources">The set of resources.</param>
         ''' <returns>True iff all resources in the set can be imported or exported.</returns>
-        ''' <remarks></remarks>
         Private Function CanImportOrExportResources(Resources() As Resource) As Boolean
             For Each Resource As Resource In Resources
                 'We can import or export non-string, non-resxref, non-linked resources.  Can't import
@@ -3753,8 +3618,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Menu handler for the Import command.  Determines whether it's enabled and/or visible
         ''' </summary>
         ''' <param name="MenuCommand">The import DesignerMenuCommand</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuImportEnabledHandler(MenuCommand As DesignerMenuCommand) As Boolean
             'Only visible if we're in the listview
             If _currentCategory IsNot Nothing AndAlso _currentCategory.CategoryDisplay <> Category.Display.ListView Then
@@ -3780,8 +3643,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Menu handler for the Export command.  Determines whether it's enabled and/or visible
         ''' </summary>
         ''' <param name="MenuCommand">The import DesignerMenuCommand</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuExportEnabledHandler(MenuCommand As DesignerMenuCommand) As Boolean
             'Only visible if we're in the listview
             If _currentCategory IsNot Nothing AndAlso _currentCategory.CategoryDisplay <> Category.Display.ListView Then
@@ -3803,7 +3664,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Given a Resource, get a filename to suggest to the user for saving that resource, based on its name.
         ''' </summary>
         ''' <param name="Resource">The Resource to get the name from.</param>
-        ''' <returns></returns>
         ''' <remarks>Only suggests only legal filenames.</remarks>
         Public Shared Function GetSuggestedFileNameForResource(Resource As Resource) As String
             Debug.Assert(Resource IsNot Nothing)
@@ -3829,7 +3689,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="FileNames"></param>
         ''' <returns>True if the user says Yes, otherwise False.</returns>
-        ''' <remarks></remarks>
         Public Function QueryUserToReplaceFiles(FileNames As IList) As Boolean
             If FileNames.Count = 0 Then
                 Debug.Fail("QueryUserToReplaceFiles: there weren't any files passed in")
@@ -3855,7 +3714,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="FolderPath">The directory to export all resources to.</param>
         ''' <param name="SingleFileName">If specified, and if there is only a single resource in the list, then this filename will be used to export to (in FolderPath).
         '''   Otherwise, the individual filenames will be derived automatically from the resource names.</param>
-        ''' <remarks></remarks>
         Private Sub ExportResources(Resources() As Resource, FolderPath As String, Optional SingleFileName As String = Nothing)
             Debug.Assert(SingleFileName = "" OrElse UBound(Resources) = 0, "ExportResources: SingleFileName is only allowed if exporting a single resource")
             If Resources Is Nothing OrElse Resources.Length = 0 Then
@@ -3944,7 +3802,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Handler for the "Select All" menu command
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub MenuSelectAll(sender As Object, e As EventArgs)
             If IsInEditing Then
                 CommitPendingChanges()
@@ -3966,8 +3823,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Enabled handler for the Cut and Copy menus.  Determines if the menu items should be enabled or not.
         ''' </summary>
         ''' <param name="MenuCommand">The menu item to check</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuSelectAllEnableHandler(MenuCommand As DesignerMenuCommand) As Boolean
             Select Case CurrentCategory.CategoryDisplay
                 Case Category.Display.ListView
@@ -3988,7 +3843,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' The function was called by child-page when an editBox is activated
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Sub OnItemBeginEdit()
             _inEditingItem = True
             RefreshCommandStatus()
@@ -3997,7 +3851,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' The function was called by child-page when an editBox is dismissed
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Sub OnItemEndEdit()
             _inEditingItem = False
             RefreshCommandStatus()
@@ -4007,7 +3860,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' The function forces to refresh the status of all commonds...
         '''  The reason is that the selection isn't updated when we activate an editBox to edit the name label in the listView, so the status of the menu items won't be updated as well
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub RefreshCommandStatus()
             If _menuCommands IsNot Nothing Then
                 For Each command As DesignerMenuCommand In _menuCommands
@@ -4026,7 +3878,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuEditLabel(sender As Object, e As EventArgs)
             If CurrentCategory.CategoryDisplay = Category.Display.StringTable Then
                 StringTable.BeginEdit(False)
@@ -4045,8 +3896,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  the menu item is usually invisible, we use this to handle F2
         ''' </summary>
         ''' <param name="MenuCommand">The menu item to check</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuEditLabelEnabledHandler(MenuCommand As DesignerMenuCommand) As Boolean
             If _currentCategory IsNot Nothing Then
                 If _currentCategory.CategoryDisplay = Category.Display.ListView Then
@@ -4072,7 +3921,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub Category_XXX_ResourcesExistChanged(sender As Object, e As EventArgs) _
         Handles _
             _categoryAudio.ResourcesExistChanged,
@@ -4089,7 +3937,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuResourceTypeStrings(sender As Object, e As EventArgs)
             SwitchToCategory(_categoryStrings)
         End Sub
@@ -4100,7 +3947,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuResourceTypeImages(sender As Object, e As EventArgs)
             SwitchToCategory(_categoryImages)
         End Sub
@@ -4111,7 +3957,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuResourceTypeIcons(sender As Object, e As EventArgs)
             SwitchToCategory(_categoryIcons)
         End Sub
@@ -4122,7 +3967,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuResourceTypeAudio(sender As Object, e As EventArgs)
             SwitchToCategory(_categoryAudio)
         End Sub
@@ -4133,7 +3977,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuResourceTypeFiles(sender As Object, e As EventArgs)
             SwitchToCategory(_categoryFiles)
         End Sub
@@ -4144,7 +3987,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuResourceTypeOther(sender As Object, e As EventArgs)
             SwitchToCategory(_categoryOther)
         End Sub
@@ -4159,7 +4001,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ButtonAdd_ExistingFile_Click(sender As Object, e As EventArgs)
             Dim Title As String = My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_DlgTitle_AddExisting
             Dim FilterIndex As Integer = 0
@@ -4216,8 +4057,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Check whether "add item" menu should be enabled
         ''' </summary>
         ''' <param name="MenuCommand">The menu item to check</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuAddEnabledHandler(MenuCommand As DesignerMenuCommand) As Boolean
             Return Not ReadOnlyMode
         End Function
@@ -4228,7 +4067,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ButtonFixedAdd_Click(sender As Object, e As EventArgs)
             If CurrentCategory.AddCommand IsNot Nothing Then
                 CurrentCategory.AddCommand.Invoke(sender, e)
@@ -4239,8 +4077,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Check whether "add TIFF" menu should be enabled
         ''' </summary>
         ''' <param name="MenuCommand">The menu item to check</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuAddTiffEnabledHandler(MenuCommand As DesignerMenuCommand) As Boolean
             Return Not ReadOnlyMode AndAlso Not RootComponent.IsInsideDeviceProject
         End Function
@@ -4248,7 +4084,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Handles the "Add.New String" ToolStripMenuItem
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ButtonAdd_NewString_Click(sender As Object, e As EventArgs)
             CommitPendingChanges()
 
@@ -4261,7 +4096,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Handles the "Add.New Image.BMP Image" ToolStripMenuItem
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ButtonAdd_NewImage_BMP_Click(sender As Object, e As EventArgs)
             QueryAddNewLinkedResource(ResourceTypeEditors.Bitmap, ResourceTypeEditorImageBase.EXT_BMP)
 
@@ -4273,7 +4107,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Handles the "Add.New Image.GIF Image" ToolStripMenuItem
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ButtonAdd_NewImage_GIF_Click(sender As Object, e As EventArgs)
             QueryAddNewLinkedResource(ResourceTypeEditors.Bitmap, ResourceTypeEditorImageBase.EXT_GIF)
 
@@ -4285,7 +4118,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Handles the "Add.New Image.JPEG Image" ToolStripMenuItem
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ButtonAdd_NewImage_JPEG_Click(sender As Object, e As EventArgs)
             QueryAddNewLinkedResource(ResourceTypeEditors.Bitmap, ResourceTypeEditorImageBase.EXT_JPG)
 
@@ -4297,7 +4129,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Handles the "Add.New Image.PNG" ToolStripMenuItem
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ButtonAdd_NewImage_PNG_Click(sender As Object, e As EventArgs)
             QueryAddNewLinkedResource(ResourceTypeEditors.Bitmap, ResourceTypeEditorImageBase.EXT_PNG)
 
@@ -4309,7 +4140,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Handles the "Add.New Image.TIFF Image" ToolStripMenuItem
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ButtonAdd_NewImage_TIFF_Click(sender As Object, e As EventArgs)
             QueryAddNewLinkedResource(ResourceTypeEditors.Bitmap, ResourceTypeEditorImageBase.EXT_TIF)
 
@@ -4321,7 +4151,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Handles the "Add.New Icon" ToolStripMenuItem
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ButtonAdd_NewIcon_Click(sender As Object, e As EventArgs)
             QueryAddNewLinkedResource(ResourceTypeEditors.Icon, ResourceTypeEditorIcon.EXT_ICO)
         End Sub
@@ -4330,7 +4159,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Handles the "Add.New Text File" ToolStripMenuItem
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ButtonAdd_NewTextFile_Click(sender As Object, e As EventArgs)
             QueryAddNewLinkedResource(ResourceTypeEditors.TextFile, ResourceTypeEditorTextFile.EXT_TXT)
         End Sub
@@ -4385,7 +4213,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   where to place the new resource.
         ''' </summary>
         ''' <param name="TypeEditor">The resource type editor for the type(s) of file being created.</param>
-        ''' <remarks></remarks>
         Private Sub QueryAddNewLinkedResource(TypeEditor As ResourceTypeEditor, ResourceFileExtension As String)
             Try
                 ' If we can't check out the resource file, do not pop up any dialog...
@@ -4492,7 +4319,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ButtonFixedView_Click(sender As Object, e As EventArgs)
         End Sub
 
@@ -4501,7 +4327,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ButtonViews_List_Click(sender As Object, e As EventArgs)
             ChangeResourceView(ResourceListView.ResourceView.List)
         End Sub
@@ -4512,7 +4337,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ButtonViews_Details_Click(sender As Object, e As EventArgs)
             ChangeResourceView(ResourceListView.ResourceView.Details)
         End Sub
@@ -4523,7 +4347,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ButtonViews_Thumbnail_Click(sender As Object, e As EventArgs)
             ChangeResourceView(ResourceListView.ResourceView.Thumbnail)
         End Sub
@@ -4532,8 +4355,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Enabled handler for the Open/Open With menu commands.  Determines if the menu item should be enabled.
         ''' </summary>
         ''' <param name="MenuCommand">The menu item for Open or Open/With.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function ViewsMenuItemsEnabledHandler(MenuCommand As DesignerMenuCommand) As Boolean
             'Only visible/enabled if we're in a listview
             If _currentCategory IsNot Nothing AndAlso _currentCategory.CategoryDisplay = Category.Display.ListView Then
@@ -4554,7 +4375,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Shows a context menu, given mouse event args.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ShowContextMenu(sender As Object, e As MouseEventArgs)
             If e.Button = System.Windows.Forms.MouseButtons.Right Then
                 Try
@@ -4570,7 +4390,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Called when the listview should show a context menu.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ResourceListView_ContextMenuShow(sender As Object, e As MouseEventArgs) Handles _resourceListView.ContextMenuShow
             ShowContextMenu(sender, e)
         End Sub
@@ -4581,7 +4400,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub StringTable_ContextMenuShow(sender As Object, e As MouseEventArgs) Handles StringTable.ContextMenuShow
             ShowContextMenu(sender, e)
         End Sub
@@ -4600,7 +4418,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ShowNewFolderButton">Whether to show the "New Folder" button</param>
         ''' <param name="DefaultPath">The path to start out with.</param>
         ''' <returns>The selected folder, or Nothing if the user canceled.</returns>
-        ''' <remarks></remarks>
         Public Function ShowFolderBrowserDialog(ByRef UserCanceled As Boolean, Title As String, ShowNewFolderButton As Boolean, Optional DefaultPath As String = Nothing) As String
             Using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware))
                 UserCanceled = False
@@ -4634,7 +4451,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="MultiSelect">Whether the user can select multiple files.</param>
         ''' <param name="DefaultPath">The initial path for the dialog to open</param>
         ''' <returns>The selected file/path, or Nothing if the user canceled.</returns>
-        ''' <remarks></remarks>
         Public Function ShowOpenFileDialog(ByRef UserCanceled As Boolean, Title As String, Filter As String, FilterIndex As Integer, MultiSelect As Boolean, Optional DefaultPath As String = Nothing) As String()
             Try
                 ' BUGFIX: Dev11#35824: Initialize Open File Dialog on the DefaultPath.  Nothing means devenv location.
@@ -4690,8 +4506,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="DefaultCategory">(Optional).  If present and non-Nothing, indicates which category should be the default.  This is done by checking the ByRef FilterIndexForDefaultCategory value on return.</param>
         ''' <param name="FilterIndexForDefaultCategory">[Out] (Optional) Returns the filter index which corresponds to the filter for DefaultCategory, or to the
         '''    *.* filter if there was no filter for the default category.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetFileDialogFilterForCategories(Categories As CategoryCollection, Optional DefaultCategory As Category = Nothing, Optional ByRef FilterIndexForDefaultCategory As Integer = 0) As String
             Dim Filter As New StringBuilder
             FilterIndexForDefaultCategory = -1
@@ -4777,8 +4591,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Create a subdirectory in the user's temporary folder and returns it.  It will
         '''   will automatically be deleted when the editor exits.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetTemporarySubfolder() As String
             'We want to start with a fairly unique name, so we'll call GetTempFileName().  But
             '  Windows actually creates this for us as a file.  So we'll try deleting it and
@@ -4805,7 +4617,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ParentDirectory">The parent folder to create the file in.  If not specified, it's created in the user's temporary folder.</param>
         ''' <param name="PreferredFileName">If specified, tries to use this filename for the file.  Must contain only valid characters.</param>
         ''' <returns>The path to the created temporary file.</returns>
-        ''' <remarks></remarks>
         Private Function GetTemporaryFile(AutoDelete As AutoDelete, Optional ParentDirectory As String = "", Optional PreferredFileName As String = "") As String
             Dim TempFileName As String
 
@@ -4859,7 +4670,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Constructor
             ''' </summary>
-            ''' <remarks></remarks>
             Public Sub New(background As Color)
                 _errorGlyphLarge = GetImageFromImageService(KnownMonikers.Blank, 96, 96, background)
                 _errorGlyphSmall = GetImageFromImageService(KnownMonikers.Blank, 16, 16, background)
@@ -4871,8 +4681,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' The error glyph used in a large thumbnail
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property ErrorGlyphLarge() As Image
                 Get
                     Return _errorGlyphLarge
@@ -4882,8 +4690,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' The error glyph used in a small thumbnail (details or list view)
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property ErrorGlyphSmall() As Image
                 Get
                     Return _errorGlyphSmall
@@ -4893,8 +4699,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' The error glyph used next to a thumbnail as a state image
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property ErrorGlyphState() As Image
                 Get
                     Return _errorGlyphState
@@ -4904,8 +4708,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' The arrow glyph used in the ListView to show that it is column being sorted
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property SortUpGlyph() As Image
                 Get
                     Return _sortUpGlyph
@@ -4915,8 +4717,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' The arrow glyph used in the ListView to show that it is column being sorted
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property SortDownGlyph() As Image
                 Get
                     Return _sortDownGlyph
@@ -4929,8 +4729,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves the set of internal resources that we cache for this instance of the resource editor
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property CachedResources() As CachedResourcesForView
             Get
                 Return _cachedResources
@@ -4945,7 +4743,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the DTE ProjectItem corresponding to the ResX file being edited.
         ''' </summary>
-        ''' <returns></returns>
         ''' <remarks>There's always a ProjectItem, even if you're not opened in a project, 'cause then you're really opened in the Miscellaneous Files project.</remarks>
         Public Function GetResXProjectItem() As ProjectItem
             'Retrieve the ProjectItem service that we proffered in our designer loader.
@@ -4962,7 +4759,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns the DTE Project associated with the ResX file being edited.
         ''' </summary>
-        ''' <returns></returns>
         ''' <remarks>If the ResX file isn't opened in the context of a project, this will return the
         '''   Miscellaneous Files project (so in reality it is always opened in the context of
         '''   a project).</remarks>
@@ -4985,8 +4781,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves the IVsHierarchy interface for the project the resx file is in
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function GetVsHierarchy() As IVsHierarchy
             Dim Hierarchy As IVsHierarchy = DirectCast(RootComponent.RootDesigner.GetService(GetType(IVsHierarchy)), IVsHierarchy)
             Debug.Assert(Hierarchy IsNot Nothing, "Couldn't find IVsHierarchy as a service from our root designer - should have been added from our designerloader")
@@ -5019,8 +4813,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves the itemid for the resx file
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function GetVsItemId() As UInteger
             Dim DesignerLoader As ResourceEditorDesignerLoader = GetDesignerLoader()
             If DesignerLoader IsNot Nothing Then
@@ -5042,7 +4834,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   will no longer be fully qualified in Whidbey) according to the project references.
         ''' </summary>
         ''' <returns>The ITypeResolutionService for the project the .resx file was opened in, or else Nothing if it was opened outside the context of a project.</returns>
-        ''' <remarks></remarks>
         Public Function GetTypeResolutionService() As ITypeResolutionService Implements Resource.ITypeResolutionContextProvider.GetTypeResolutionService
             If _typeResolutionServiceIsCached Then
                 Return _typeResolutionServiceCache
@@ -5080,8 +4871,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   a .resx file is opened outside the context of a project.  This is a list of
         '''   assemblies commonly found in .resx files.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function GetDefaultAssemblyReferences() As AssemblyName()
             Return s_defaultAssemblyReferences
         End Function
@@ -5161,8 +4950,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns true iff the resx file being edited is the default resx file
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function IsDefaultResXFile() As Boolean
             Dim VsSpecialFiles As IVsProjectSpecialFiles = TryCast(GetVsHierarchy(), IVsProjectSpecialFiles)
             If VsSpecialFiles Is Nothing Then
@@ -5209,8 +4996,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' An example is Form1.en-US.resx  [en-US is a valid CultureInfo]
         ''' </summary>
         ''' <param name="fileName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function IsLocalizedResXFile(fileName As String) As Boolean
 
             Dim isLocalizedFileName As Boolean = False
@@ -5238,8 +5023,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Returns true if the given project is a VB project (or a VB for smart devices project)
         ''' </summary>
         ''' <param name="Project"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function IsVBProject(Project As Project) As Boolean
             Return Project IsNot Nothing AndAlso (New Guid(Project.Kind).Equals(_projectGuid_VB))
         End Function
@@ -5247,8 +5030,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns true iff this the default resx file for a VB project
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function ShouldUseVbMyResXCodeGenerator() As Boolean
             Return IsVBProject(GetProject()) AndAlso IsDefaultResXFile()
         End Function
@@ -5259,7 +5040,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets the current value of the Custom Tool property for this resx file.  If the project
         '''   does not support a Custom Tool property, returns Nothing.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Function GetCustomToolCurrentValue() As String
             Dim ProjectItem As ProjectItem = GetResXProjectItem()
 
@@ -5288,7 +5068,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="OldName">The old name of the resource that was renamed</param>
         ''' <param name="NewName">The new name of the resource</param>
-        ''' <remarks></remarks>
         Friend Sub CallGlobalRename(OldName As String, NewName As String)
             Dim ProjItem As ProjectItem = GetResXProjectItem()
 
@@ -5375,7 +5154,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   generator is our own.  Otherwise returns empty.
         ''' </summary>
         ''' <returns>The name of the strongly-typed generated class, if any, otherwise String.Empty.</returns>
-        ''' <remarks></remarks>
         Friend Function GetStronglyGeneratedClassName() As String
 
             If RootComponent.RootDesigner.IsEditingResWFile() Then
@@ -5480,8 +5258,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Given a filename, determines what the generated class name would be
         ''' </summary>
         ''' <param name="FileName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function GetGeneratedClassNameFromFileName(FileName As String) As String
             Return DesignUtil.GenerateValidLanguageIndependentIdentifier(Path.GetFileNameWithoutExtension(FileName))
         End Function
@@ -5494,7 +5270,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' handle Undo Event, it will be called when undo is started
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Sub OnUndoing()
             _inUndoing = True
             _categoryAffected = Nothing
@@ -5506,7 +5281,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' handle Undo Event, it will be called when undo is done
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Sub OnUndone()
             _inUndoing = False
 
@@ -5532,7 +5306,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Handle custom window messages...
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub WndProc(ByRef m As Message)
             Select Case m.Msg
                 Case WmUserConstants.WM_UPDATE_PROPERTY_GRID

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView_EditorState.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView_EditorState.vb
@@ -47,7 +47,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Public constructor.  Sets it to an empty state.
             ''' </summary>
-            ''' <remarks></remarks>
             Public Sub New()
                 _statePersisted = False
             End Sub
@@ -55,8 +54,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Returns whether or not state has actually been persisted into this object.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property StatePersisted() As Boolean
                 Get
                     Return _statePersisted
@@ -66,7 +63,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Clears all the editor state into a non-persisted state.
             ''' </summary>
-            ''' <remarks></remarks>
             Private Sub Clear()
                 _statePersisted = False
                 _currentCategoryName = Nothing
@@ -81,7 +77,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' Persists state from a given resource editor view into this object.
             ''' </summary>
             ''' <param name="View">Resource editor view object to save state from.</param>
-            ''' <remarks></remarks>
             Public Sub PersistStateFrom(View As ResourceEditorView)
                 Debug.Assert(View IsNot Nothing, "View can't be Nothing in EditorState")
 
@@ -135,7 +130,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '''   this object.
             ''' </summary>
             ''' <param name="View">The resource editor view instance to depersist the old state into</param>
-            ''' <remarks></remarks>
             Public Sub DepersistStateInto(View As ResourceEditorView)
                 If _statePersisted Then
                     Try

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
@@ -24,8 +24,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     '''   reading and writing of the file, plus the management of the resources
     '''   (instances of the Resource class) within it.
     ''' </summary>
-    ''' <remarks>
-    ''' </remarks>
     Friend Class ResourceFile
         Implements IDisposable
         Implements ResourceTypeEditor.IResourceContentFile
@@ -107,7 +105,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="RootComponent">The root component for this ResourceFile</param>
         ''' <param name="ServiceProvider">The service provider provided by the designer host</param>
         ''' <param name="BasePath">The base path to use for resolving relative paths in the resx file.</param>
-        ''' <remarks></remarks>
         Public Sub New(mtsrv As MultiTargetService, RootComponent As ResourceEditorRootComponent, ServiceProvider As IServiceProvider, BasePath As String)
             Debug.Assert(Not RootComponent Is Nothing)
             Debug.Assert(ServiceProvider IsNot Nothing)
@@ -161,7 +158,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' IDisposable.Dispose()
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub Dispose() Implements IDisposable.Dispose
             Dispose(True)
         End Sub
@@ -171,7 +167,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Dispose.
         ''' </summary>
         ''' <param name="Disposing">If True, we're disposing.  If false, we're finalizing.</param>
-        ''' <remarks></remarks>
         Protected Sub Dispose(Disposing As Boolean)
             If Disposing Then
                 'Stop listening to component removing events - we want to just tear down in peace.
@@ -215,8 +210,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' The service provider provided by the designer host
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property ServiceProvider() As IServiceProvider
             Get
                 Return _serviceProvider
@@ -229,8 +222,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   change events, set this property to Nothing.  It does not need to be set up initially - it gets it
         '''   automatically from the service provider passed in.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property ComponentChangeService() As IComponentChangeService
             Get
                 Return _componentChangeService
@@ -244,7 +235,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the ResourceEditorView associated with this ResourceFile.
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>Overridable for unit testing.</remarks>
         Public Overridable ReadOnly Property View() As ResourceEditorView
             Get
@@ -256,8 +246,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the root component associated with this resource file.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property RootComponent() As ResourceEditorRootComponent
             Get
                 Return _rootComponent
@@ -268,8 +256,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves the designer host for the resource editor
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property DesignerHost() As IDesignerHost
             Get
                 If RootComponent.RootDesigner Is Nothing Then
@@ -287,8 +273,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns the resources from this resource file
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property Resources() As Dictionary(Of String, Resource)
             Get
                 Return _resources
@@ -300,8 +284,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' The base path to use for resolving relative paths in the resx file.  This should be the
         '''   directory where the resx file lives.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property BasePath() As String
             Get
                 Return _basePath
@@ -313,8 +295,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Get the taskProvider
         '''   directory where the resx file lives.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property ErrorListProvider() As ErrorListProvider
             Get
                 If _errorListProvider Is Nothing Then
@@ -330,8 +310,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         '''  Whether the resource item belongs to a device project
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property IsInsideDeviceProject() As Boolean Implements ResourceTypeEditor.IResourceContentFile.IsInsideDeviceProject
             Get
                 Return RootComponent IsNot Nothing AndAlso RootComponent.IsInsideDeviceProject()
@@ -365,8 +343,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets a suggested name for a new Resource which is not used by any resource currently in this ResourceFile.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetUniqueName(TypeEditor As ResourceTypeEditor) As String
             Dim UniqueNamePrefix As String
 
@@ -394,8 +370,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets a suggested name for a new Resource which is not used by any resource currently in this ResourceFile.
         ''' </summary>
         ''' <param name="NameFormat">A format to use for String.Format which indicates how to format the integer portion of the name.  Must contain a single {0} parameter.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetUniqueName(NameFormat As String) As String
             Debug.Assert(NameFormat.IndexOf("{") >= 0 AndAlso NameFormat.IndexOf("}") >= 2,
                 "NameFormat must contain a replacement arg")
@@ -416,8 +390,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Determines if a resource with a given name (case-insensitive) exists in this ResourceFile.
         ''' </summary>
         ''' <param name="Name">The resource name to look for (case insensitive)</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function Contains(Name As String) As Boolean
             Return Not FindResource(Name) Is Nothing
         End Function
@@ -427,8 +399,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Determines if a particular resource is in this ResourceFile (by reference)
         ''' </summary>
         ''' <param name="Resource"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function Contains(Resource As Resource) As Boolean
             Return _resources.ContainsValue(Resource)
         End Function
@@ -439,7 +409,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Name">The resource name to look for (case insensitive)</param>
         ''' <returns>The found Resource, or Nothing if not found.</returns>
-        ''' <remarks></remarks>
         Public Function FindResource(Name As String) As Resource
             If Name = "" Then
                 Return Nothing
@@ -544,7 +513,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The Resource to remove.  Must exist in the ResourceFile</param>
         ''' <param name="DisposeResource">If True, the Resource is also disposed.</param>
-        ''' <remarks></remarks>
         Public Sub RemoveResource(Resource As Resource, DisposeResource As Boolean)
             Debug.Assert(Not Resource Is Nothing)
             Debug.Assert(FindResource(Resource.Name) Is Resource, "RemoveResource: not found by Name")
@@ -652,7 +620,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender">Event sender</param>
         ''' <param name="e">Event args</param>
-        ''' <remarks></remarks>
         Private Sub ComponentChangeService_ComponentRemoved(sender As Object, e As ComponentEventArgs) Handles _componentChangeService.ComponentRemoved
             Dim ResourceObject As Object = e.Component
             If Not TypeOf ResourceObject Is Resource Then
@@ -771,7 +738,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender">Event sender</param>
         ''' <param name="e">Event args</param>
-        ''' <remarks></remarks>
         Private Sub ComponentChangeService_ComponentRename(sender As Object, e As ComponentRenameEventArgs) Handles _componentChangeService.ComponentRename
             If Not TypeOf e.Component Is Resource Then
                 Debug.Fail("Got component rename event for a component that isn't a resource")
@@ -833,7 +799,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender">Event sender</param>
         ''' <param name="e">Event args</param>
-        ''' <remarks></remarks>
         Private Sub ComponentChangeService_ComponentChanged(sender As Object, e As ComponentChangedEventArgs) Handles _componentChangeService.ComponentChanged
             If Not TypeOf e.Component Is Resource Then
                 Debug.Fail("Got component rename event for a component that isn't a resource")
@@ -854,7 +819,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Reads resources from a string (contents of a resx file).
         ''' </summary>
         ''' <param name="allBufferText">The TextReader to read from</param>
-        ''' <remarks></remarks>
         Public Sub ReadResources(resourceFileName As String, allBufferText As String)
 
             If IsDangerous(resourceFileName, allBufferText) Then
@@ -891,7 +855,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Writes all resources into a TextWriter in resx format.
         ''' </summary>
         ''' <param name="TextWriter">TextWriter to write to</param>
-        ''' <remarks></remarks>
         Public Sub WriteResources(TextWriter As TextWriter)
             Dim ResXWriter As IResourceWriter
 
@@ -916,7 +879,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Reads all resources into this ResourceFile from a ResXReader
         ''' </summary>
         ''' <param name="ResXReader">The ResXReader to read from</param>
-        ''' <remarks></remarks>
         Private Sub ReadResources(ResXReader As ResXResourceReader)
             Debug.Assert(ResXReader IsNot Nothing, "ResXReader must exist!")
 
@@ -977,7 +939,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Writes all resources into a ResXResourceWriter
         ''' </summary>
         ''' <param name="ResXWriter">The ResXResourceWriter instance to use</param>
-        ''' <remarks></remarks>
         Private Sub WriteResources(ResXWriter As IResourceWriter)
             Debug.Assert(Not ResXWriter Is Nothing, "ResXWriter must exist.")
 
@@ -1051,7 +1012,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The resource to invalidate</param>
         ''' <param name="InvalidateThumbnail">If True, then the Resource's thumbnail is also invalidated so it will be regenerated on the next paint.</param>
-        ''' <remarks></remarks>
         Public Sub InvalidateResourceInView(Resource As Resource, Optional InvalidateThumbnail As Boolean = False)
             If RootComponent.RootDesigner IsNot Nothing AndAlso RootComponent.RootDesigner.GetView() IsNot Nothing Then
                 RootComponent.RootDesigner.GetView().InvalidateResource(Resource, InvalidateThumbnail)
@@ -1072,7 +1032,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   can have a task list item for bad link (CantInstantiateResource) and for
         '''   a bad Name, and both task items will show up in the task list.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Enum ResourceTaskType
             'ID is bad or otherwise not a good idea
             BadName
@@ -1096,7 +1055,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   kind.  A resource can have a single task list entry for each slot, and thus for
         '''   each distinct kind of task list entry or error/warning.
         ''' </summary>
-        ''' <remarks></remarks>
         Private NotInheritable Class ResourceTaskSet
             'The number of error types that we have.  Calculated from the ResourceTaskType enum.
             Private Shared ReadOnly s_errorTypeCount As Integer
@@ -1112,7 +1070,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '''   enum types start with zero and are contiguous.  This is necessary in order
             '''   to use them as an index into a simple array.
             ''' </summary>
-            ''' <remarks></remarks>
             Shared Sub New()
                 s_errorTypeCount = [Enum].GetValues(GetType(ResourceTaskType)).Length
 
@@ -1129,7 +1086,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Constructor.
             ''' </summary>
-            ''' <remarks></remarks>
             Public Sub New()
                 ReDim _tasks(s_errorTypeCount - 1)
             End Sub
@@ -1140,8 +1096,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Gets the array (indexed by ResourceTaskType) of tasks in this set
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property Tasks() As ResourceTask()
                 Get
                     Return _tasks
@@ -1160,7 +1114,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   that is associated with it, for handling navigation (when the user double-clicks
         '''   on a task list entry).
         ''' </summary>
-        ''' <remarks></remarks>
         Friend NotInheritable Class ResourceTask
             Inherits ErrorTask
 
@@ -1172,7 +1125,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' Constructor.
             ''' </summary>
             ''' <param name="Resource"></param>
-            ''' <remarks></remarks>
             Public Sub New(Resource As Resource)
                 _resource = Resource
             End Sub
@@ -1181,8 +1133,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' The resource associated with this task list entry.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property Resource() As Resource
                 Get
                     Return _resource
@@ -1199,8 +1149,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Returns True iff the specified Resource has any task list items.
         ''' </summary>
         ''' <param name="resource">The resource to look for task entries for.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function ResourceHasTasks(Resource As Resource) As Boolean
             Dim TaskSet As ResourceTaskSet = Nothing
             If Not _resourceTaskSets.TryGetValue(Resource, TaskSet) Then
@@ -1225,8 +1173,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The task to get the text for.</param>
         ''' <param name="TaskType">The type of task list entry to retrieve for this Resource.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetResourceTaskMessage(Resource As Resource, TaskType As ResourceTaskType) As String
             Dim TaskSet As ResourceTaskSet = Nothing
             If Not _resourceTaskSets.TryGetValue(Resource, TaskSet) Then
@@ -1248,8 +1194,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   CR/LF.
         ''' </summary>
         ''' <param name="Resource">The resource to look up task list entries for.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetResourceTaskMessages(Resource As Resource) As String
             Dim TaskSet As ResourceTaskSet = Nothing
             If Not _resourceTaskSets.TryGetValue(Resource, TaskSet) Then
@@ -1276,7 +1220,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender">The task that was double-clicked.</param>
         ''' <param name="e">Event args</param>
-        ''' <remarks></remarks>
         Private Sub OnTaskNavigate(sender As Object, e As EventArgs)
             Dim Task As ResourceTask = TryCast(sender, ResourceTask)
             If Task Is Nothing Then
@@ -1302,7 +1245,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Priority">The priority of the new task list entry.</param>
         ''' <param name="HelpLink">The help link of the new task list entry.</param>
         ''' <param name="ErrorCategory">The ErrorCategory of the new task list entry. It is an Error or Warning.</param>
-        ''' <remarks></remarks>
         Public Sub SetResourceTask(Resource As Resource, TaskType As ResourceTaskType, Text As String, Priority As TaskPriority, HelpLink As String, ErrorCategory As TaskErrorCategory)
             Debug.Assert(Resource IsNot Nothing)
             Dim taskProvider As ErrorListProvider = ErrorListProvider
@@ -1380,7 +1322,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The resource from which the task list entry will be cleared.</param>
         ''' <param name="TaskType">The type of task list entry to clear, if it exists.</param>
-        ''' <remarks></remarks>
         Public Sub ClearResourceTask(Resource As Resource, TaskType As ResourceTaskType)
             Dim TaskSet As ResourceTaskSet = Nothing
             If Not _resourceTaskSets.TryGetValue(Resource, TaskSet) Then
@@ -1425,7 +1366,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Clears all task list entries for the given resource.
         ''' </summary>
         ''' <param name="Resource">The resource to clear.</param>
-        ''' <remarks></remarks>
         Public Sub ClearResourceTasks(Resource As Resource)
             Dim TaskSet As ResourceTaskSet = Nothing
             If _resourceTaskSets.TryGetValue(Resource, TaskSet) Then
@@ -1488,7 +1428,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   list during component add.  This is only needed if something has changed that
         '''   might change the validation of some resources.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub DelayCheckAllResourcesForErrors()
             StopDelayingCheckingForErrors()
             If _resources IsNot Nothing Then
@@ -1505,7 +1444,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   is that it is being deleted and so is no longer valid.
         ''' </summary>
         ''' <param name="Resource">The resource to add.  If it doesn't exist, this call is a NOOP.</param>
-        ''' <remarks></remarks>
         Private Sub RemoveResourceToDelayCheckForErrors(Resource As Resource)
             If _resourcesToDelayCheckForErrors.Contains(Resource) Then
                 Debug.WriteLineIf(Switches.RSEDelayCheckErrors.TraceVerbose, "Delay-check errors: Removing resource from list: " & Resource.Name)
@@ -1566,7 +1504,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Stops delay-checking for errors, and removes ourselves from idle-time processing.  The list
         '''   of resources to delay-check for errors will be cleared.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub StopDelayingCheckingForErrors()
             While _resourcesToDelayCheckForErrors.Count > 0
                 RemoveResourceToDelayCheckForErrors(_resourcesToDelayCheckForErrors(0))
@@ -1718,8 +1655,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Returns true iff this resource file is set up for strongly-typed code generation (i.e., a [resxname].vb file
         '''   is created from it).
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function IsGeneratedToCode() As Boolean
 
             ' Code gen is not supported currently for resw files
@@ -1749,8 +1684,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the CodeDomProvider for this ResX file, or Nothing if none found.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetCodeDomProvider() As CodeDomProvider
             If RootComponent IsNot Nothing AndAlso RootComponent.IsGlobalResourceInASP() Then
                 ' Venus project always use C# CodeDomProvider to generate StrongType code for the resource file.
@@ -1775,7 +1708,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Post a flush and run custom tool request it request not already posted
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub DelayFlushAndRunCustomTool()
             If Not _delayFlushAndRunCustomToolQueued Then
                 If View IsNot Nothing AndAlso View.IsHandleCreated Then
@@ -1788,7 +1720,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Flush and run the single file generator 
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub DelayFlushAndRunCustomToolImpl()
             _delayFlushAndRunCustomToolQueued = False
             If View IsNot Nothing AndAlso View.GetDesignerLoader() IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
@@ -15,7 +15,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' <summary>
     ''' This is a virtualized listview capable of displaying Resource items as thumbnails.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ResourceListView
         Inherits DesignerFramework.DesignerListView
 
@@ -135,7 +134,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' The view mode for the listview.  (Starting at non-zero helps find possible bugs in
         '''    case this enum is mixed up with the base's View enum.)
         ''' </summary>
-        ''' <remarks></remarks>
         Public Enum ResourceView
             Thumbnail = 1000
             List = 1001
@@ -167,7 +165,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Constructor.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub New()
             MyBase.New()
 
@@ -191,7 +188,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Overrides Dispose to do clean-up of managed resources
         ''' </summary>
         ''' <param name="Disposing"></param>
-        ''' <remarks></remarks>
         Protected Overloads Overrides Sub Dispose(Disposing As Boolean)
             StopIdleMessage()
 
@@ -230,8 +226,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' The current view of the listview (in ResourceView terms - shadows the
         '''   base ListView's View property)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Shadows Property View() As ResourceView
             Get
                 Select Case MyBase.View
@@ -265,8 +259,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' If this is turned on, attempted retrieval of listview items will simply return
         '''   a blank entry.  This is useful when the resource editor is being disposed of.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property DisableItemRetrieval() As Boolean
             Get
                 Return _disableItemRetrieval
@@ -279,8 +271,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the Parent of this ResourceListView control, which must be an instance of ResourceEditorView.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property ParentView() As ResourceEditorView
             Get
                 If TypeOf Parent Is ResourceEditorView Then
@@ -296,7 +286,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the ResourceFile that was used to populate this listview.
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>Can be called only after population</remarks>
         Private ReadOnly Property ResourceFile() As ResourceFile
             Get
@@ -349,7 +338,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Clear all entries from the listview.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overloads Sub Clear()
             StopIdleMessage()
 
@@ -375,7 +363,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="ResourceFile">The resources from which the displayed resources will be pulled.</param>
         ''' <param name="CategoryToFilterOn">The category of resources to display.</param>
-        ''' <remarks></remarks>
         Public Sub Populate(ResourceFile As ResourceFile, CategoryToFilterOn As Category)
             VirtualListSize = 0
             _resourceFile = ResourceFile
@@ -475,7 +462,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Resource">The Resource which should be repainted.</param>
         ''' <param name="InvalidateThumbnail">If True, also invalidates the Resource's thumbnail image and other cached
         '''   info so that it is re-created on the next redraw.</param>
-        ''' <remarks></remarks>
         Public Sub InvalidateResource(Resource As Resource, Optional InvalidateThumbnail As Boolean = False)
             Debug.Assert(Resource IsNot Nothing)
             If Not _virtualResourceList.Contains(Resource) Then
@@ -500,7 +486,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Occurs when the user tries to go into label edit mode to change the resource name
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnBeforeLabelEdit(e As LabelEditEventArgs)
             If ParentView.ReadOnlyMode Then
                 e.CancelEdit = True
@@ -563,7 +548,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Causes the listview to go into label edit mode
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub BeginLabelEdit(Resource As Resource)
             If LabelEdit AndAlso Resource IsNot Nothing Then
                 Dim Index As Integer = IndexOf(Resource)
@@ -582,7 +566,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Commits all pending changes that the user has made in the grid.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub CommitPendingChanges()
             If ParentView.IsInEditing Then
                 ' Don't do this if we are not in edit mode. The function will refresh the window...
@@ -606,7 +589,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   We need sort the whole list
         ''' </summary>
         ''' <param name="e">Event args</param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnColumnClick(e As ColumnClickEventArgs)
             If e.Column <> _sorter.ColumnIndex Then
                 SortOnColumn(e.Column, False)
@@ -621,7 +603,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Restore Sorter -- used when we need restore view state
         ''' </summary>
         ''' <param name="originalSorter"></param>
-        ''' <remarks></remarks>
         Friend Sub RestoreSorter(originalSorter As IComparer(Of Resource))
             Dim listViewSorter As DetailViewSorter = TryCast(originalSorter, DetailViewSorter)
             If listViewSorter IsNot Nothing Then
@@ -636,7 +617,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="columnIndex"></param>
         ''' <param name="inReverseOrder"></param>
-        ''' <remarks></remarks>
         Private Sub SortOnColumn(columnIndex As Integer, inReverseOrder As Boolean)
             Dim currentResource As Resource = Nothing
             Dim selectedResources() As Resource
@@ -693,7 +673,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="columnIndex"></param>
         ''' <param name="inReverseOrder"></param>
-        ''' <remarks></remarks>
         Private Sub SetColumnSortImage(columnIndex As Integer, inReverseOrder As Boolean)
             Dim headerHandle As IntPtr
             headerHandle = Interop.NativeMethods.SendMessage(Handle, Interop.Win32Constant.LVM_GETHEADER, IntPtr.Zero, IntPtr.Zero)
@@ -725,7 +704,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Remove the column header image
         ''' </summary>
         ''' <param name="columnIndex"></param>
-        ''' <remarks></remarks>
         Private Sub ClearColumnSortImage(columnIndex As Integer)
             Dim headerHandle As IntPtr
             headerHandle = Interop.NativeMethods.SendMessage(Handle, Interop.Win32Constant.LVM_GETHEADER, IntPtr.Zero, IntPtr.Zero)
@@ -751,7 +729,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Update the column header image when the system color is changed
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnSystemColorsChanged(e As EventArgs)
             MyBase.OnSystemColorsChanged(e)
 
@@ -784,7 +761,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   displayed, so it's likely to be our page size.
         ''' </summary>
         ''' <param name="e">Event args</param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnCacheVirtualItems(e As CacheVirtualItemsEventArgs)
             MyBase.OnCacheVirtualItems(e)
 
@@ -830,7 +806,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="StartIndex"></param>
         ''' <param name="EndIndex"></param>
-        ''' <remarks></remarks>
         Private Sub RequireCacheImage(StartIndex As Integer, EndIndex As Integer)
             If Not _onIdleEnabled Then
                 _imageStartIndex = StartIndex
@@ -878,7 +853,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         '''  Turn off OnIdle Message
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub StopIdleMessage()
             If _onIdleEnabled Then
                 _cacheRequirementStack = Nothing
@@ -895,7 +869,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e">Event arguments</param>
-        ''' <remarks></remarks>
         Private Sub OnDelayLoadImages(sender As Object, e As EventArgs)
             Debug.Assert(_thumbnailCache IsNot Nothing)
             _needLoadVisibleItem = False
@@ -967,7 +940,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   be displayed, etc.
         ''' </summary>
         ''' <param name="e">Retrieval arguments</param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnRetrieveVirtualItem(e As RetrieveVirtualItemEventArgs)
             MyBase.OnRetrieveVirtualItem(e)
 
@@ -1106,7 +1078,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Resource">The Resource to look up/create a thumbnail for</param>
         ''' <param name="AllowDelayLoading">If it is true, we won't load image, and leave it to the idle time</param>
         ''' <returns>The index into the imagelist for the resource's thumbnail</returns>
-        ''' <remarks></remarks>
         Private Function GetThumbnailIndex(Resource As Resource, AllowDelayLoading As Boolean) As Integer
             'Verify that the error glyphs aren't too big (we don't expand them, so being too small
             '  is okay)
@@ -1253,7 +1224,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Highlights a given resource (selects it and scrolls the listview so that it's visible)
         ''' </summary>
         ''' <param name="Resources">The Resources to highlight</param>
-        ''' <remarks></remarks>
         Friend Sub HighlightResources(Resources As ICollection)
             Dim firstOne As Boolean = True
             For Each Resource As Resource In Resources
@@ -1340,7 +1310,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Unselect all resources in this listview.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub SelectAll()
             For i As Integer = 0 To VirtualListSize - 1
                 SelectedIndices.Add(i)
@@ -1408,7 +1377,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   otherwise do anything to the resources.
         ''' </summary>
         ''' <param name="Resources">The set of Resources to remove from view.</param>
-        ''' <remarks></remarks>
         Public Sub RemoveResources(Resources As IList)
             UnselectAll()
             Debug.Assert(_virtualResourceList.Count = VirtualListSize)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcePropertyDescriptor.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcePropertyDescriptor.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -11,7 +11,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' <summary>
     ''' Provides information about a specific property of a Resource instance.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ResourcePropertyDescriptor
         Inherits PropertyDescriptor
 
@@ -81,7 +80,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Returns the type of the instance this property is bound to, which is Resource.
         ''' </summary>
         ''' <value>The Resource type.</value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property ComponentType() As Type
             Get
                 Return GetType(Resource)
@@ -93,7 +91,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Returns a value indicating whether this property is read-only.
         ''' </summary>
         ''' <value>True if the property is read-only, False otherwise.</value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property IsReadOnly() As Boolean
             Get
                 Return _isReadOnly
@@ -105,7 +102,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Returns the type of the property.
         ''' </summary>
         ''' <value>A Type that represents the type of the property.</value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property PropertyType() As Type
             Get
                 Return _propertyType

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService.vb
@@ -40,7 +40,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     '''     format best suited for them.
     '''
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ResourceSerializationService
         Inherits ComponentSerializationService
 
@@ -66,7 +65,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Message">The message to displaying, including optional formatting parameters "{0}" etc.</param>
         ''' <param name="FormatArguments">Arguments for "{0}", "{1}", etc.</param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Public Shared Sub Trace(Message As String, ParamArray FormatArguments() As Object)
             Debug.WriteLineIf(Switches.RSEResourceSerializationService.TraceVerbose, "ResourceSerializationService: " & String.Format(Message, FormatArguments))
@@ -79,7 +77,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  state for a group of objects.
         ''' </summary>
         ''' <returns>An instance of a new serialization store for resources</returns>
-        ''' <remarks></remarks>
         Public Overrides Function CreateStore() As SerializationStore
             Return New ResourceSerializationStore()
         End Function
@@ -92,7 +89,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Stream">The stream to load from.</param>
         ''' <returns>The loaded store for resources.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function LoadStore(Stream As Stream) As SerializationStore
             Requires.NotNull(Stream, NameOf(Stream))
 
@@ -107,7 +103,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="Value">The object (must be a Resource instance) to serialize into the store.</param>
-        ''' <remarks></remarks>
         Public Overrides Sub Serialize(Store As SerializationStore, Value As Object)
             Requires.NotNull(Store, NameOf(Store))
             Requires.NotNull(Value, NameOf(Value))
@@ -173,7 +168,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="OwningObject">The object (must be a Resource instance) whose property (member) you are trying to serialize into the store.</param>
         ''' <param name="Member">The property whose value needs to be serialized into the store.</param>
-        ''' <remarks></remarks>
         Public Overrides Sub SerializeMemberAbsolute(Store As SerializationStore, OwningObject As Object, Member As MemberDescriptor)
             'This method is intended for properties such as collections which might have had only some of their
             '  members changed.
@@ -191,7 +185,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Store">The store to serialize into.</param>
         ''' <returns>The set of components that were deserialized.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function Deserialize(Store As SerializationStore) As ICollection
             Requires.NotNull(Store, NameOf(Store))
 
@@ -212,7 +205,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
         ''' <returns>The list of objects that were deserialized.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function Deserialize(Store As SerializationStore, Container As IContainer) As ICollection
             Requires.NotNull(Store, NameOf(Store))
             Requires.NotNull(Container, NameOf(Container))
@@ -240,7 +232,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
-        ''' <remarks></remarks>
         Public Overrides Sub DeserializeTo(Store As SerializationStore, Container As IContainer, ValidateRecycledTypes As Boolean, applyDefault As Boolean)
             Requires.NotNull(Store, NameOf(Store))
             Requires.NotNull(Container, NameOf(Container))

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService_Store.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService_Store.vb
@@ -57,7 +57,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   instances that no longer exist, or of re-applying old property values to
         '''   an existing Resource instance.
         ''' </summary>
-        ''' <remarks></remarks>
         <Serializable()>
         Private NotInheritable Class ResourceSerializationStore
             Inherits Design.Serialization.SerializationStore
@@ -90,7 +89,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Constructor.
             ''' </summary>
-            ''' <remarks></remarks>
             Public Sub New()
                 _resourcesToSerialize = New Dictionary(Of Resource, ResourceDataToSerialize)
 
@@ -105,7 +103,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '''   from being serialized into it.  Once closed, the serialization store 
             '''   may be saved (or deserialized).
             ''' </summary>
-            ''' <remarks></remarks>
             Public Overrides Sub Close()
                 If _serializedState Is Nothing Then
                     Dim SerializedState As New ArrayList(_resourcesToSerialize.Count)
@@ -152,7 +149,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' </summary>
             ''' <param name="info">Serialization info</param>
             ''' <param name="context">Serialization context</param>
-            ''' <remarks></remarks>
             Private Sub GetObjectData(info As SerializationInfo, context As StreamingContext) Implements ISerializable.GetObjectData
                 info.AddValue(KEY_STATE, _serializedState)
 
@@ -166,7 +162,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' </summary>
             ''' <param name="Info">Serialization info</param>
             ''' <param name="Context">Serialization context</param>
-            ''' <remarks></remarks>
             Private Sub New(Info As SerializationInfo, Context As StreamingContext)
                 _serializedState = DirectCast(Info.GetValue(KEY_STATE, GetType(ArrayList)), ArrayList)
 
@@ -182,8 +177,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' Loads our state from a stream.
             ''' </summary>
             ''' <param name="Stream">The stream to load from</param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Shared Function Load(Stream As Stream) As ResourceSerializationStore
                 Dim f As New BinaryFormatter
                 Return DirectCast(f.Deserialize(Stream), ResourceSerializationStore)
@@ -196,7 +189,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '''     to different streams.
             ''' </summary>
             ''' <param name="stream">The stream to save to</param>
-            ''' <remarks></remarks>
             Public Overrides Sub Save(Stream As Stream)
                 Close()
 
@@ -265,7 +257,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' </summary>
             ''' <param name="Resource">The Resource from which we want to serialize something.</param>
             ''' <returns>The ResourceDataToSerialize object associated with this Resource.</returns>
-            ''' <remarks></remarks>
             Private Function GetResourceSerializationData(Resource As Resource) As ResourceDataToSerialize
                 Dim ResourceData As ResourceDataToSerialize = Nothing
                 If Not _resourcesToSerialize.TryGetValue(Resource, ResourceData) Then
@@ -300,7 +291,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '''     object to be used.
             ''' </summary>
             ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
-            ''' <remarks></remarks>
             Friend Sub DeserializeTo(Container As IContainer)
                 DeserializeHelper(Container, True)
             End Sub
@@ -313,7 +303,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '''     that are created that implement IComponent will be added to the container. 
             ''' </summary>
             ''' <returns>The set of components that were deserialized.</returns>
-            ''' <remarks></remarks>
             Friend Function Deserialize() As ICollection
                 Return DeserializeHelper(Nothing, False)
             End Function
@@ -327,7 +316,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' </summary>
             ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
             ''' <returns>The list of objects that were deserialized.</returns>
-            ''' <remarks></remarks>
             Friend Function Deserialize(Container As IContainer) As ICollection
                 Return DeserializeHelper(Container, False)
             End Function
@@ -341,7 +329,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <param name="RecycleInstances">If True, we are applying property changes to existing
             '''   instances of Resource components (this is always the case for Undo/Redo).</param>
             ''' <returns>The objects which have been serialized.</returns>
-            ''' <remarks></remarks>
             Private Function DeserializeHelper(Container As IContainer, RecycleInstances As Boolean) As ICollection
 
                 Trace("Deserializing store (Container Exists={0}, RecycleInstances={1}): {2} objects", Container IsNot Nothing, RecycleInstances, _serializedState.Count)
@@ -433,7 +420,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '''   Resource instance (either the entire Resource itself, or a set of
             '''   its properties)
             ''' </summary>
-            ''' <remarks></remarks>
             Private Class ResourceDataToSerialize
 
                 'Backing for public properties
@@ -447,7 +433,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' Constructor
                 ''' </summary>
                 ''' <param name="Resource">The Resource from which we want to serialize stuff.</param>
-                ''' <remarks></remarks>
                 Public Sub New(Resource As Resource)
                     If Resource Is Nothing Then
                         Throw Common.CreateArgumentException(NameOf(Resource))
@@ -461,8 +446,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' <summary>
                 ''' The Resource from which we want to serialize stuff.
                 ''' </summary>
-                ''' <value></value>
-                ''' <remarks></remarks>
                 Public ReadOnly Property Resource() As Resource
                     Get
                         Return _resource
@@ -474,8 +457,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' If True, the entire Resource instance should be serialized.  If false,
                 '''   then only the properties in PropertiesToSerialize should be serialized.
                 ''' </summary>
-                ''' <value></value>
-                ''' <remarks></remarks>
                 Public Property EntireObject() As Boolean
                     Get
                         Return _entireObject
@@ -493,8 +474,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' A list of PropertyDescriptors representing the properties on
                 '''   the Resource which should be serialized.
                 ''' </summary>
-                ''' <value></value>
-                ''' <remarks></remarks>
                 Public ReadOnly Property PropertiesToSerialize() As IList
                     Get
                         If _propertiesToSerialize Is Nothing Then
@@ -509,7 +488,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' Adds a property to be serialized to the list.
                 ''' </summary>
                 ''' <param name="Member">The property (must be a PropertyDescriptor) to be serialized.</param>
-                ''' <remarks></remarks>
                 Public Sub AddPropertyToSerialize(Member As MemberDescriptor)
                     Requires.NotNull(Member, NameOf(Member))
 
@@ -532,7 +510,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Stores a single binary serialized Resource instance or Resource property value
             ''' </summary>
-            ''' <remarks></remarks>
             <Serializable()>
             Private NotInheritable Class SerializedResourceOrProperty
 
@@ -595,8 +572,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' <summary>
                 ''' Gets the name of the resource from which this was serialized.
                 ''' </summary>
-                ''' <value></value>
-                ''' <remarks></remarks>
                 Public ReadOnly Property ResourceName() As String
                     Get
                         Return _resourceName
@@ -608,8 +583,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' Gets the name of the property which was serialized (or Nothing if
                 '''   not a property serialization).
                 ''' </summary>
-                ''' <value></value>
-                ''' <remarks></remarks>
                 Public ReadOnly Property PropertyName() As String
                     Get
                         Return _propertyName
@@ -621,8 +594,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' The name of the value type for this resource (needed to create a
                 '''   new resource if necessary)
                 ''' </summary>
-                ''' <value></value>
-                ''' <remarks></remarks>
                 Public ReadOnly Property ResourceValueTypeName() As String
                     Get
                         Return _resourceValueTypeName
@@ -634,8 +605,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' Returns True iff an entire Resource object has been serialized, as opposed
                 '''   to just a property from it.
                 ''' </summary>
-                ''' <returns></returns>
-                ''' <remarks></remarks>
                 Public ReadOnly Property IsEntireResourceObject() As Boolean
                     Get
                         Return (PropertyName = "")
@@ -648,7 +617,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' </summary>
                 ''' <param name="Object">The object to serialize</param>
                 ''' <returns>The binary serialized object.</returns>
-                ''' <remarks></remarks>
                 Private Shared Function SerializeObject([Object] As Object) As Byte()
                     Dim MemoryStream As New MemoryStream
                     Call (New BinaryFormatter).Serialize(MemoryStream, [Object])
@@ -659,7 +627,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' <summary>
                 ''' Deserializes an entire Resource instance which has been serialized.
                 ''' </summary>
-                ''' <returns></returns>
                 ''' <remarks>Can only be called if IsEntireResourceObject = True</remarks>
                 Public Function GetEntireResourceObject() As Resource
                     If Not IsEntireResourceObject() Then
@@ -674,7 +641,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' <summary>
                 ''' Deserializes a property value which has been serialized.
                 ''' </summary>
-                ''' <returns></returns>
                 ''' <remarks>Can only be called if IsEntireResourceObject = False</remarks>
                 Public Function GetPropertyValue() As Object
                     If IsEntireResourceObject() Then

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
@@ -15,7 +15,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' <summary>
     ''' This is a virtualized grid capable of displaying Resource items as strings.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ResourceStringTable
         Inherits DesignerFramework.DesignerDataGridView
 
@@ -77,7 +76,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Constructor
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub New()
             InitializeColumns()
 
@@ -105,8 +103,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         '''  Return true if the user selected whole lines in the DataGridView...
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property InLineSelectionMode() As Boolean
             Get
                 If MyBase.SelectionMode = DataGridViewSelectionMode.FullRowSelect Then
@@ -147,8 +143,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Indicates whether or not the "Type" column is visible to the user.  This
         '''   column is always present, but its visibility can be turned on/off.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property TypeColumnVisible() As Boolean
             Get
                 Debug.Assert(ColumnCount >= COLUMN_TYPE, "Columns not set up properly?")
@@ -166,8 +160,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Return the ResourceEditorView which is the parent of this
         '''   control.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property ParentView() As ResourceEditorView
             Get
                 If TypeOf Parent Is ResourceEditorView Then
@@ -183,7 +175,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the ResourceFile that was used to populate this grid.
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>Can be called only after population</remarks>
         Private ReadOnly Property ResourceFile() As ResourceFile
             Get
@@ -203,7 +194,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Sets up all the columns properly
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub InitializeColumns()
             'There are four columns in the string table:
             '
@@ -294,7 +284,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="ResourceFile">The source of the Resources</param>
         ''' <param name="CategoryToFilterOn">Which category of resources to show.</param>
-        ''' <remarks></remarks>
         Public Sub Populate(ResourceFile As ResourceFile, CategoryToFilterOn As Category)
             _resourceFile = ResourceFile
             Rows.Clear()
@@ -347,7 +336,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Clear all entries
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub Clear()
             Rows.Clear()
             _virtualResourceList.Clear()
@@ -358,8 +346,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Creates a new row with blank values
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function CreateNewResourceRow() As DataGridViewRow
             'The error glyphs don't show up if the row height is below the glyph size.  We don't want that
             '  to happen, so restrict the minimum height.
@@ -405,8 +391,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Icon"></param>
         ''' <param name="DefaultButton"></param>
         ''' <param name="HelpLink"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function DsMsgBox(Message As String,
                     Buttons As MessageBoxButtons,
                     Icon As MessageBoxIcon,
@@ -421,7 +405,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Commits all pending changes that the user has made in the grid.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub CommitPendingChanges()
             If IsCurrentCellDirty Then
                 'We have a cell dirty.  We should commit it.  However, we need to verify that it's okay to commit
@@ -448,7 +431,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   new data at the next paint.
         ''' </summary>
         ''' <param name="Resource">The Resource whose row should be invalidated.</param>
-        ''' <remarks></remarks>
         Public Sub InvalidateResource(Resource As Resource)
             Dim RowIndex As Integer = GetRowIndexFromResource(Resource)
             If RowIndex >= 0 Then
@@ -460,7 +442,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' When the font has changed, adjust the height of rows, so it could show at least one line of text
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnFontChanged(e As EventArgs)
             MyBase.OnFontChanged(e)
 
@@ -477,7 +458,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   to assert in case.
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnDataError(displayErrorDialogIfNoHandler As Boolean, e As DataGridViewDataErrorEventArgs)
             MyBase.OnDataError(displayErrorDialogIfNoHandler, e)
 
@@ -497,7 +477,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="FormattedValue">The string value which the user has typed</param>
         ''' <param name="Exception">The exception to show if the validation fails</param>
         ''' <returns>True if the cell validates, or False if it fails.</returns>
-        ''' <remarks></remarks>
         Protected Function ValidateCell(RowIndex As Integer, ColumnIndex As Integer, FormattedValue As String, Optional ByRef Exception As Exception = Nothing) As Boolean
             If Rows(RowIndex).ReadOnly OrElse Rows.SharedRow(RowIndex).Cells(ColumnIndex).ReadOnly Then
                 'No reason to do any checking for cells that we don't allow the user to change
@@ -532,7 +511,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  validate it, and if the validation fails, we show a messagebox.
         ''' </summary>
         ''' <param name="e">Event args</param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnCellValidating(e As DataGridViewCellValidatingEventArgs)
             MyBase.OnCellValidating(e)
 
@@ -561,7 +539,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Before we rush into edit mode on a single cell click, we make sure that everything is checked out OK...
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Friend Overrides Sub OnCellClickBeginEdit(e As System.ComponentModel.CancelEventArgs)
             MyBase.OnCellClickBeginEdit(e)
             If Not e.Cancel Then
@@ -577,7 +554,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Occurs when the user starts to edit values in the grid.
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnCellBeginEdit(e As DataGridViewCellCancelEventArgs)
             ' First of all, we should never enter edit mode if we are in read-only mode...
             If ParentView.ReadOnlyMode Then
@@ -613,7 +589,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Expands the height of the row to show all its text
         ''' </summary>
         ''' <param name="rowIndex"></param>
-        ''' <remarks></remarks>
         Private Sub ExpandRowHeightIfNeeded(rowIndex As Integer)
             Dim preferredHeight As Integer = Rows(rowIndex).GetPreferredHeight(rowIndex, DataGridViewAutoSizeRowMode.AllCells, True)
             Dim currentHeight As Integer = Rows(rowIndex).Height
@@ -635,7 +610,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Occurs when the user end to edit values in the grid.
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnCellEndEdit(e As DataGridViewCellEventArgs)
             ParentView.OnItemEndEdit()
             MyBase.OnCellEndEdit(e)
@@ -704,7 +678,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Adds a set of Resources to the grid (i.e., resources that were added since calling Populate).
         ''' </summary>
         ''' <param name="Resources">The Resources to add.  They must already be present in the ResourceFile.</param>
-        ''' <remarks></remarks>
         Public Sub AddResources(Resources As IList)
             UnselectAll()
             Debug.Assert(_virtualResourceList.Count = RowCountVirtual)
@@ -823,7 +796,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Does *not* remove the resource from the resource file, just from this control's view.
         ''' </summary>
         ''' <param name="Resources">The set of Resources to remove.  Must already be present in this grid.</param>
-        ''' <remarks></remarks>
         Public Sub RemoveResources(Resources As IList)
             UnselectAll()
 
@@ -858,8 +830,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the number of Resource rows in this grid.  Does not include the "addnew" row at the bottom.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property RowCountVirtual() As Integer
             Get
                 Return _virtualResourceList.Count
@@ -873,7 +843,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   the bottom, then use MyBase.RowCount.  But note that that includes the add/new row
         '''   and is therefore *not* a correct count of the resources in the grid
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>Marked invisible so it's less likely to be accidentally used.</remarks>
         <System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>
         Public Shadows ReadOnly Property RowCount() As Integer
@@ -889,7 +858,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="SearchResource">The Resource to find.</param>
         ''' <returns>The row index of that Resource, or -1 if not found.</returns>
-        ''' <remarks></remarks>
         Public Function GetRowIndexFromResource(SearchResource As Resource) As Integer
             Debug.Assert(SearchResource IsNot Nothing)
             Dim IndexFound As Integer = _virtualResourceList.IndexOf(SearchResource)
@@ -919,7 +887,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="RowIndex">The index of the row to get the resource from.</param>
         ''' <param name="AllowUncommittedRow">If True, then RowIndex is allowed to be past the rows which actually contain a valid resource.  In this case, it is assumed that the uncommitted resource (the one created for the add/new row but not yet added to the ResourceFile) is intended, and is returned.</param>
         ''' <returns>The Resource for that row, or possibly the uncommitted Resource (if AllowUncommittedRow = True).  Returns Nothing if there's a problem (and asserts).</returns>
-        ''' <remarks></remarks>
         Public Function GetResourceFromRowIndex(RowIndex As Integer, AllowUncommittedRow As Boolean) As Resource
             If RowIndex >= 0 AndAlso RowIndex < RowCountVirtual Then
                 Return DirectCast(_virtualResourceList(RowIndex), Resource)
@@ -939,8 +906,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Retrieves the Resource associated with a particular grid row.
         ''' </summary>
         ''' <param name="Row"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetResourceFromRow(Row As DataGridViewRow) As Resource
             Debug.Assert(Not Row Is Nothing, "Row is Nothing")
             Debug.Assert(Row.Index >= 0 AndAlso Row.Index < Rows.Count, "Huh?")
@@ -952,7 +917,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Called by the grid when its need data for a particular grid cell.
         ''' </summary>
         ''' <param name="e">Event args.</param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnCellValueNeeded(e As DataGridViewCellValueEventArgs)
             MyBase.OnCellValueNeeded(e)
             e.Value = GetCellStringValue(e.RowIndex, e.ColumnIndex)
@@ -964,7 +928,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="RowIndex"></param>
         ''' <param name="ColumnIndex"></param>
-        ''' <remarks></remarks>
         Private Function GetCellStringValue(RowIndex As Integer, ColumnIndex As Integer) As String
             Dim Resource As Resource = GetResourceFromRowIndex(RowIndex, True)
             If Resource Is Nothing Then
@@ -978,7 +941,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource"></param>
         ''' <param name="ColumnIndex"></param>
-        ''' <remarks></remarks>
         Friend Shared Function GetResourceCellStringValue(Resource As Resource, ColumnIndex As Integer) As String
             Dim Value As String = String.Empty
 
@@ -1017,7 +979,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Called by the grid when it needs the error text for a particular grid cell.
         ''' </summary>
         ''' <param name="e">Event args.</param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnCellErrorTextNeeded(e As DataGridViewCellErrorTextNeededEventArgs)
             MyBase.OnCellErrorTextNeeded(e)
 
@@ -1070,7 +1031,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   needs to be pushed to the virtualized store.
         ''' </summary>
         ''' <param name="e">Event args</param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnCellValuePushed(e As DataGridViewCellValueEventArgs)
             MyBase.OnCellValuePushed(e)
 
@@ -1156,7 +1116,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   is committed).
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnNewRowNeeded(e As DataGridViewRowEventArgs)
             MyBase.OnNewRowNeeded(e)
 
@@ -1187,7 +1146,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  we would need to remove this and handle RowEnter and CancelRowEdit.
         ''' </summary>
         ''' <param name="e">Event args</param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnRowDirtyStateNeeded(e As QuestionEventArgs)
             MyBase.OnRowDirtyStateNeeded(e)
 
@@ -1203,7 +1161,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Commit the uncommitted row by adding it to the ResourceFile.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub CommitTheUncommittedRow()
             If _uncommittedResource IsNot Nothing Then
                 Debug.Assert(Not ResourceFile.Contains(_uncommittedResource), "The uncommitted resource is already in the resource list!")
@@ -1243,7 +1200,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   the uncommitted resource.
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnUserAddedRow(e As DataGridViewRowEventArgs)
             MyBase.OnUserAddedRow(e)
 
@@ -1267,7 +1223,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   user pressing ESC.
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnUserDeletingRow(e As DataGridViewRowCancelEventArgs)
             MyBase.OnUserDeletingRow(e)
 
@@ -1299,7 +1254,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Places the cursor on the bottom row of the string table, ready for the user to enter a new string.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub NewString()
             If AllowUserToAddRows Then
                 UnselectAll()
@@ -1320,7 +1274,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The Resource to highlight</param>
         ''' <param name="Field">The field in the resource's row to highlight.</param>
-        ''' <remarks></remarks>
         Friend Sub HighlightResource(Resource As Resource, Field As FindReplace.Field)
             Dim Row As DataGridViewRow = GetRowFromResource(Resource)
             If Row IsNot Nothing Then
@@ -1351,7 +1304,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Highlights (selects) the specified resource and scrolls it into view.
         ''' </summary>
         ''' <param name="Resources">The Resources to highlight</param>
-        ''' <remarks></remarks>
         Friend Sub HighlightResources(Resources As ICollection)
             Dim firstOne As Boolean = True
             For Each Resource As Resource In Resources
@@ -1373,7 +1325,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Unselect all resources in this grid.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub UnselectAll()
             For Each Row As DataGridViewRow In SelectedRows
                 Row.Selected = False
@@ -1388,7 +1339,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets all resources currently selected in this grid.
         ''' </summary>
         ''' <returns>An array of selected Resources (returns an empty array instead of Nothing)</returns>
-        ''' <remarks></remarks>
         Public Function GetSelectedResources() As Resource()
             Dim indexArray As Integer() = Nothing
             Dim rowCount As Integer = 0
@@ -1457,8 +1407,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets the find/replace field for the current cell.  Returns Name if there's no current cell or
         '''   if it isn't a column that has a FindReplace.Field match.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetCurrentCellFindField() As FindReplace.Field
             If CurrentCell IsNot Nothing Then
                 Select Case CurrentCell.ColumnIndex
@@ -1472,11 +1420,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             End If
             Return FindReplace.Field.Name
         End Function
-
-        ''' <summary>
-        ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnMouseDown(e As MouseEventArgs)
             MyBase.OnMouseDown(e)
 
@@ -1500,7 +1444,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   We need sort the whole list
         ''' </summary>
         ''' <param name="e">Event args</param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnColumnHeaderMouseClick(e As DataGridViewCellMouseEventArgs)
             MyBase.OnColumnHeaderMouseClick(e)
 
@@ -1515,7 +1458,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Restore Sorter -- used when we need restore view state
         ''' </summary>
         ''' <param name="originalSorter"></param>
-        ''' <remarks></remarks>
         Friend Sub RestoreSorter(originalSorter As IComparer(Of Resource))
             Dim stringSorter As StringTableSorter = TryCast(originalSorter, StringTableSorter)
             If stringSorter IsNot Nothing Then
@@ -1530,7 +1472,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="columnIndex"></param>
         ''' <param name="inReverseOrder"></param>
-        ''' <remarks></remarks>
         Private Sub SortOnColumn(columnIndex As Integer, inReverseOrder As Boolean)
             Using (New WaitCursor)
                 Dim currentCellColumnIndex As Integer = -1
@@ -1669,7 +1610,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Delete values from selected cells
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Sub ClearSelectedCells()
             Dim cells As DataGridViewSelectedCellCollection = SelectedCells
             If cells.Count = 0 Then
@@ -1757,9 +1697,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Process windows message to handle special keys...
         ''' </summary>
-        ''' <returns></returns>
         ''' <param name="m"></param>
-        ''' <remarks></remarks>
         Public Overrides Function PreProcessMessage(ByRef m As Message) As Boolean
             If m.Msg = Interop.Win32Constant.WM_KEYDOWN AndAlso CInt(m.WParam) = Keys.F2 Then
                 Return ProcessF2Key(Keys.F2 Or ModifierKeys)
@@ -1800,8 +1738,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' </summary>
             ''' <param name="keyData"></param>
             ''' <param name="dataGridViewWantsInputKey"></param>
-            ''' <return></return>
-            ''' <remarks></remarks>
             Public Overrides Function EditingControlWantsInputKey(keyData As Keys, dataGridViewWantsInputKey As Boolean) As Boolean
                 ' The following code is added to fix devdiv bug 874
                 ' we want to let the multiline editbox to handle up/down key, when the current position is not the first/last line in the control
@@ -1818,11 +1754,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                 Return MyBase.EditingControlWantsInputKey(keyData, dataGridViewWantsInputKey)
             End Function
-
-            ''' <summary>
-            ''' </summary>
             ''' <param name="m"></param>
-            ''' <remarks></remarks>
             <SecurityPermission(SecurityAction.LinkDemand, Flags:=SecurityPermissionFlag.UnmanagedCode)>
             Protected Overrides Sub WndProc(ByRef m As Message)
                 ' CONSIDER: should we take care of other events?

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeDescriptionProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeDescriptionProvider.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -26,7 +26,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ObjectType">The type of the class to return the type descriptor for. In our case, Resource.</param>
         ''' <param name="Instance">Instance of the class. In our case, a Resource instance.</param>
         ''' <returns>A new ResourceTypeDescriptor for the specified Resource instance.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetTypeDescriptor(ObjectType As Type, Instance As Object) As ICustomTypeDescriptor
             If Instance Is Nothing Then
                 Return MyBase.GetTypeDescriptor(ObjectType, Instance)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeDescriptor.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeDescriptor.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -35,7 +35,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Constructs a new instance of ResourceTypeDescriptor with the specified Resource.
         ''' </summary>
         ''' <param name="Instance">An instance of Resource class.</param>
-        ''' <remarks></remarks>
         Public Sub New(Instance As Resource)
             MyBase.New()
 
@@ -76,7 +75,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' The GetComponentName method returns the name of the component instance 
         '''     this type descriptor is describing.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overrides Function GetComponentName() As String
             Debug.Assert(_instance.Name <> "")
             Return _instance.Name
@@ -86,7 +84,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' The GetClassName method returns the name of the resource type
         '''     this type descriptor is describing.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overrides Function GetClassName() As String
             ' CONSIDER: We should return Category here...
             If _instance IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditor.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditor.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+ï»¿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -16,7 +16,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     '''   class as Public), the architecture was designed to handle this easily if we decided to publicly
     '''   expose it in a future version.
     ''' </summary>
-    ''' <remarks></remarks>
     <Security.Permissions.PermissionSet(Security.Permissions.SecurityAction.InheritanceDemand, Name:="FullTrust"),
     Security.Permissions.PermissionSet(Security.Permissions.SecurityAction.LinkDemand, Name:="FullTrust")>
     Friend MustInherit Class ResourceTypeEditor
@@ -36,7 +35,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '   future flexibility (perhaps we want the resource editor to be hostable from Loc Studio, for example), 
         '   and also so that assemblies which contain custom editors only have to reference the DLL with 
         '   ResourceTypeEditor, and not the larger and more arbitrary Microsoft.VisualStudio.Editors.dll.  
-        '   (Note that only the custom editor assembly actually has to reference ResourceTypeEditor – the 
+        '   (Note that only the custom editor assembly actually has to reference ResourceTypeEditor â€“ the 
         '   class which the editor edits can specify type names rather than actual types and thus does not 
         '   need a reference either to the ResourceTypeEditor assembly or to the assembly with its custom 
         '   editor.)  We could either create a new DLL or look for an existing DLL with a similar function of 
@@ -50,7 +49,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '       <Editor(GetType(MyFunkyResourceCustomResourceEditor), GetType(ResourceTypeEditor)), _
         '         Serializable()> _
         '       Public Class MyFunkyResource
-        '   	…
+        '   	â€¦
         '       End Class
         '   
         '   This associates the MyFunkyResourceCustomResourceEditor custom editor with the .resx-persistable 
@@ -59,9 +58,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '   
         '   To ensure our pluggable architecture is working, the native types that are supported in the 
         '   resource editor (bitmap, icon, etc.) are all implemented using this same architecture.  We use 
-        '   TypeDescriptor.AddEditorTable in ResourceTypeEditor’s Shared Sub New to associate our intrinsic 
+        '   TypeDescriptor.AddEditorTable in ResourceTypeEditorâ€™s Shared Sub New to associate our intrinsic 
         '   type editors with their corresponding types in the frameworks classes (since we own editors for 
-        '   classes that we do not own, such as Bitmap and therefore can’t place an attribute directly on 
+        '   classes that we do not own, such as Bitmap and therefore canâ€™t place an attribute directly on 
         '   the class).  Note that it is not possible for 3rd parties to use TypeDescriptor.AddEditorTable.  
         '   Since a custom type editor is associated with that resource class that it edits by placing an 
         '   attribute on the resource class, in general a custom resource type editor must be created by the 
@@ -75,13 +74,13 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '   there is no actual instance of that type in the .resx file, we would not know to add them to 
         '   the categories list.  To make it possible for programmers to create new resources of such 
         '   custom types, we would need to allow the user to specify new types to add to the categories 
-        '   list.  BrianPe has suggested we create a dialog which searches through the installed SDK’s 
+        '   list.  BrianPe has suggested we create a dialog which searches through the installed SDKâ€™s 
         '   searching for public types with custom resource type editors.  (Note: He says we can steal 
         '   similar code from the toolbox code and modify it for our use probably within a couple of 
         '   days.)  Once a type has been added to the category list, it would persist through multiple 
         '   sessions of using the VS shell until it is explicitly removed.  Once the new type is installed 
         '   in the category list, it would be possible to create a new instance of that resource type in 
-        '   the .resx file using the editor.  The advantage of the dialog is that 3rd parties aren’t 
+        '   the .resx file using the editor.  The advantage of the dialog is that 3rd parties arenâ€™t 
         '   required to register themselves somehow.
 
 
@@ -93,7 +92,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Pre-defined values for use with GetExtensionPriority
         ''' </summary>
-        ''' <remarks></remarks>
         Public Enum ExtensionPriorities
             NotHandled = 0 'Extension is not handled by this resource type editor
             Lowest = 1     'Lowest priority (used by binary files for *.*)
@@ -110,35 +108,26 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   it's a link (and to what file), etc.  If the type editor doesn't need to know the current value for
         '''   an operation, that's a performance gain.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Interface IResource
 
             ''' <summary>
             ''' Attempts to get the type of the given resource.
             ''' </summary>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Function GetValueType() As Type
 
             ''' <summary>
             ''' Attempts to get the current value of the resource.
             ''' </summary>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Function GetValue() As Object
 
             ''' <summary>
             ''' Returns whether or not the resource is a link to a file (True) or a non-linked value (False).
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             ReadOnly Property IsLink() As Boolean
 
             ''' <summary>
             ''' If IsLinked = True, returns the absolute path and filename to the linked file.  Otherwise, returns Nothing.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             ReadOnly Property LinkedFilePath() As String
 
         End Interface
@@ -147,14 +136,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' This gives a very simple view of a resource file containing resources. 
         ''' </summary>
-        ''' <remarks></remarks>
         Public Interface IResourceContentFile
 
             ''' <summary>
             ''' Returns whether the resource file is inside a device project
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             ReadOnly Property IsInsideDeviceProject() As Boolean
 
             ''' <summary>
@@ -174,7 +160,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Constructor.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub New()
         End Sub
 
@@ -188,7 +173,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   resource editor handles resource types that it does not own (e.g. Bitmap), this method
         '''   is not possible.
         ''' </summary>
-        ''' <remarks></remarks>
         Shared Sub New()
             Dim IntrinsicEditors As New Hashtable
 
@@ -214,7 +198,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <value>True if this resources handled by this ResourceTypeEditor should be displayed
         '''   in a string table, and False if they should be displayed in a listview.</value>
-        ''' <remarks></remarks>
         Public Overridable ReadOnly Property DisplayInStringTable() As Boolean
             Get
                 Return False
@@ -286,7 +269,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Returns a hash code for this resource type editor.  The algorithm is such that 
         '''   if A.Equals(B), then A and B will return the same hash code.
         ''' </summary>
-        ''' <returns></returns>
         ''' <remarks>This is overridden from Object's version of GetHashCode(), which is based on
         '''   referential equality, to equality based simply on the objects being of the same type.
         '''   This override is necessary in order to get proper behavior when using ResourceTypeEditor
@@ -307,7 +289,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="FilePath"></param>
         ''' <param name="ResourceContentFile">The resource file contains the resource item. </param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' Default implementation uses a ResXFileRef to automatically load the resource from the file.  Can be
         '''   overriden if this behavior is insufficient.
@@ -355,7 +336,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The IResource instance.  May not be Nothing.  The value of the resource to save.  Must be of the type handled by this ResourceTypeEditor.</param>
         ''' <returns>True iff the resource type editor supports saving the specific resource value to a file.</returns>
-        ''' <remarks></remarks>
         Public Overridable Function CanSaveResourceToFile(Resource As IResource) As Boolean
             Return False
         End Function
@@ -488,7 +468,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The IResource instance.  May not be Nothing.  The value of the resource to save.  Must be of the type handled by this ResourceTypeEditor.</param>
         ''' <returns>The friendly description of the resource's type.</returns>
-        ''' <remarks></remarks>
         Public Overridable Function GetResourceFriendlyTypeDescription(Resource As IResource) As String
             Return ""
         End Function
@@ -499,7 +478,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The IResource instance.  May not be Nothing.  The value of the resource to save.  Must be of the type handled by this ResourceTypeEditor.</param>
         ''' <returns>The friendly size string.</returns>
-        ''' <remarks></remarks>
         Public Overridable Function GetResourceFriendlySize(Resource As IResource) As String
             Return ""
         End Function
@@ -527,8 +505,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   handled by this resource type editor, the suggested names could take the form 
         '''   of "id01", "id02", etc.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overridable Function GetSuggestedNamePrefix() As String
             'By default, this is simply "id"
             Return "id"
@@ -539,8 +515,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Attempts to call CanSaveResourceToFile, and returns False if there are any exceptions.
         ''' </summary>
         ''' <param name="Resource">The IResource instance.  May not be Nothing.  The value of the resource.  Must be of the type handled by this ResourceTypeEditor.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function TryCanSaveResourceToFile(Resource As IResource) As Boolean
             Try
                 Return CanSaveResourceToFile(Resource)
@@ -556,8 +530,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   Persistence property changed.
         ''' </summary>
         ''' <param name="ResourceContentFile">The resource file that contains the resource</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Overridable ReadOnly Property CanChangePersistenceProperty(ResourceContentFile As IResourceContentFile) As Boolean
             Get
                 Return True

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorAudio.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorAudio.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -100,7 +100,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The IResource instance.  May not be Nothing.  The value of the resource to save.  Must be of the type handled by this ResourceTypeEditor.</param>
         ''' <returns>The friendly description of the resource's type.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetResourceFriendlyTypeDescription(Resource As IResource) As String
             ValidateResourceValue(Resource, GetType(Byte()), GetType(MemoryStream))
             Return My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Type_Wave
@@ -112,7 +111,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The IResource instance.  May not be Nothing.  The value of the resource to save.  Must be of the type handled by this ResourceTypeEditor.</param>
         ''' <returns>The friendly size string.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetResourceFriendlySize(Resource As IResource) As String
             ValidateResourceValue(Resource, GetType(Byte()), GetType(MemoryStream))
 
@@ -157,7 +155,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The IResource instance.  May not be Nothing.  The value of the resource to save.  Must be of the type handled by this ResourceTypeEditor.</param>
         ''' <returns>True iff the resource type editor supports saving the specific resource value to a file.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function CanSaveResourceToFile(Resource As IResource) As Boolean
             ValidateResourceValue(Resource, GetType(Byte()), GetType(MemoryStream))
             Return True
@@ -271,8 +268,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   handled by this resource type editor, the suggested names could take the form 
         '''   of "id01", "id02", etc.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetSuggestedNamePrefix() As String
             Return "Sound"
         End Function

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorBinaryFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorBinaryFile.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -98,7 +98,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The IResource instance.  May not be Nothing.  The value of the resource to save.  Must be of the type handled by this ResourceTypeEditor.</param>
         ''' <returns>The friendly description of the resource's type.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetResourceFriendlyTypeDescription(Resource As IResource) As String
             ValidateResourceValue(Resource, BinaryFileValueType)
             Debug.Assert(Resource.IsLink)
@@ -111,7 +110,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The IResource instance.  May not be Nothing.  The value of the resource to save.  Must be of the type handled by this ResourceTypeEditor.</param>
         ''' <returns>The friendly size string.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetResourceFriendlySize(Resource As IResource) As String
             ValidateResourceValue(Resource, BinaryFileValueType)
             Debug.Assert(Resource.GetValueType().Equals(BinaryFileValueType))

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorBitmap.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorBitmap.vb
@@ -12,7 +12,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' <summary>
     ''' A resource type editor that handles Bitmaps (GIF, JPG, BMP, etc).
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ResourceTypeEditorBitmap
         Inherits ResourceTypeEditorImageBase
 
@@ -71,7 +70,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="FilePath"></param>
         ''' <param name="ResourceContentFile">The resource file contains the resource item. </param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' Default implementation uses a ResXFileRef to automatically load the resource from the file.  Can be
         '''   overriden if this behavior is insufficient.
@@ -121,8 +119,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Create extension -> resource ID mapping table
         ''' </summary>
-        ''' <return></return>
-        ''' <remarks></remarks>
         Private Shared Function GetManifestResourceList() As ListDictionary
             If s_manifestResourceList Is Nothing Then
                 s_manifestResourceList = New ListDictionary(StringComparer.OrdinalIgnoreCase) From {
@@ -248,8 +244,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   Persistence property changed.
         ''' </summary>
         ''' <param name="ResourceContentFile">The resource file that contains the resource</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Overrides ReadOnly Property CanChangePersistenceProperty(ResourceContentFile As IResourceContentFile) As Boolean
             Get
                 ' We don't support changing the persistence type unless Bitmap is supported because embedding

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorFileBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorFileBase.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -42,8 +42,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   Persistence property changed.
         ''' </summary>
         ''' <param name="ResourceContentFile">The resource file that contains the resource</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Overrides ReadOnly Property CanChangePersistenceProperty(ResourceContentFile As IResourceContentFile) As Boolean
             Get
                 Return False

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorIcon.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorIcon.vb
@@ -11,7 +11,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' <summary>
     ''' A resource type editor that handles icons.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ResourceTypeEditorIcon
         Inherits ResourceTypeEditorInternalBase
 
@@ -57,7 +56,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The IResource instance.  May not be Nothing.  The value of the resource to save.  Must be of the type handled by this ResourceTypeEditor.</param>
         ''' <returns>True iff the resource type editor supports saving the specific resource value to a file.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function CanSaveResourceToFile(Resource As IResource) As Boolean
             ValidateResourceValue(Resource)
             Return True
@@ -213,7 +211,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The IResource instance.  May not be Nothing.  The value of the resource to save.  Must be of the type handled by this ResourceTypeEditor.</param>
         ''' <returns>The friendly description of the resource's type.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetResourceFriendlyTypeDescription(Resource As IResource) As String
             ValidateResourceValue(Resource)
             Return My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Type_Icon
@@ -225,7 +222,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The IResource instance.  May not be Nothing.  The value of the resource to save.  Must be of the type handled by this ResourceTypeEditor.</param>
         ''' <returns>The friendly size string.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetResourceFriendlySize(Resource As IResource) As String
             ValidateResourceValue(Resource)
             Dim Icon As Icon = DirectCast(Resource.GetValue(), Icon)
@@ -239,8 +235,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   handled by this resource type editor, the suggested names could take the form 
         '''   of "id01", "id02", etc.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetSuggestedNamePrefix() As String
             Return "Icon"
         End Function
@@ -250,8 +244,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   Persistence property changed.
         ''' </summary>
         ''' <param name="ResourceContentFile">The resource file that contains the resource</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Overrides ReadOnly Property CanChangePersistenceProperty(ResourceContentFile As IResourceContentFile) As Boolean
             Get
                 ' We don't support changing the persistence type unless Icon is supported because embedding

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorImageBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorImageBase.vb
@@ -165,8 +165,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   handled by this resource type editor, the suggested names could take the form 
         '''   of "id01", "id02", etc.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetSuggestedNamePrefix() As String
             Return "Image"
         End Function

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorInternalBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorInternalBase.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -14,7 +14,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' This is a base class used by all resource type editors internal to the resource editor.
     '''   It simply provides a few helpful functions.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend MustInherit Class ResourceTypeEditorInternalBase
         Inherits ResourceTypeEditor
 
@@ -26,7 +25,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Extensions">The list of extensions to match against.</param>
         ''' <param name="MatchedIndex">[out optional] Set to the index of the extension which matched, or -1 if none.</param>
         ''' <returns>True if the extension is found in the list.</returns>
-        ''' <remarks></remarks>
         Protected Shared Function MatchAgainstListOfExtensions(Extension As String, Extensions() As String, Optional ByRef MatchedIndex As Integer = -1) As Boolean
             Debug.Assert(Extension = "" OrElse Extension.Chars(0) = "."c, "HandlesExtension: must start extension with dot")
             MatchedIndex = -1
@@ -50,8 +48,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="FilterText">The text for that filter entry, e.g. "Metafiles"</param>
         ''' <param name="Extensions">An array of extensions supported, e.g. {".wmf", ".emf")</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Shared Function CreateSingleDialogFilter(FilterText As String, Extensions() As String) As String
             Return Common.CreateDialogFilter(FilterText, Extensions)
         End Function
@@ -89,7 +85,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The IResource instance.  May not be Nothing.  The value of the resource to save.  Must be of the type handled by this ResourceTypeEditor.</param>
         ''' <returns>The friendly file size as string.</returns>
-        ''' <remarks></remarks>
         Protected Shared Function GetLinkedResourceFriendlySize(Resource As IResource) As String
             If Resource.IsLink Then
                 Dim SizeInBytes As Long = New FileInfo(Resource.LinkedFilePath).Length

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorNonStringConvertible.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorNonStringConvertible.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -12,7 +12,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     '''   to show the type of the resource, and to display a message telling the user that the value cannot
     '''   be edited.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ResourceTypeEditorNonStringConvertible
         Inherits ResourceTypeEditorStringBase
 
@@ -30,7 +29,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <value>True if this resources handled by this ResourceTypeEditor should be displayed
         '''   in a string table, and False if they should be displayed in a listview.</value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property StringValueCanBeEdited() As Boolean
             Get
                 'We don't understand this resource value, so we don't know how to let the user edit it.

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorNothing.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorNothing.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -31,7 +31,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <value>True if this resources handled by this ResourceTypeEditor should be displayed
         '''   in a string table, and False if they should be displayed in a listview.</value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property StringValueCanBeEdited() As Boolean
             Get
                 'Can't change a Nothing/null value to anything else.

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorString.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorString.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -12,7 +12,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' A resource type editor for strings (displayed in a string table).  Does not handle
     '''   linked text files.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ResourceTypeEditorString
         Inherits ResourceTypeEditorStringBase
 
@@ -28,8 +27,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets whether or not the strings handled by this resource type editor
         '''   are allowed to be edited by the user.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property StringValueCanBeEdited() As Boolean
             Get
                 Return True
@@ -99,8 +96,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   handled by this resource type editor, the suggested names could take the form 
         '''   of "id01", "id02", etc.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetSuggestedNamePrefix() As String
             Return "String"
         End Function

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorStringBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorStringBase.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -10,7 +10,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' A base class for resource type editors that support strings, or more specifically,
     '''   which should have their resources displayed in a string table.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend MustInherit Class ResourceTypeEditorStringBase
         Inherits ResourceTypeEditorInternalBase
 
@@ -27,7 +26,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <value>True if this resources handled by this ResourceTypeEditor should be displayed
         '''   in a string table, and False if they should be displayed in a listview.</value>
-        ''' <remarks></remarks>
         Public NotOverridable Overrides ReadOnly Property DisplayInStringTable() As Boolean
             Get
                 Return True
@@ -39,8 +37,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets whether or not the strings handled by this resource type editor
         '''   are allowed to be edited by the user.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public MustOverride ReadOnly Property StringValueCanBeEdited() As Boolean
 
 
@@ -50,8 +46,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   Persistence property changed.
         ''' </summary>
         ''' <param name="ResourceContentFile">The resource file that contains the resource</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Overrides ReadOnly Property CanChangePersistenceProperty(ResourceContentFile As IResourceContentFile) As Boolean
             Get
                 Return False

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorStringConvertible.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorStringConvertible.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -15,7 +15,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     '''   by another resource type editor, but that is convertible from/to a string.  It allows the
     '''   user to edit the resource value as a string.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ResourceTypeEditorStringConvertible
         Inherits ResourceTypeEditorStringBase
 
@@ -30,8 +29,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets whether or not the strings handled by this resource type editor
         '''   are allowed to be edited by the user.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property StringValueCanBeEdited() As Boolean
             Get
                 Return True

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorTextFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorTextFile.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -225,7 +225,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The IResource instance.  May not be Nothing.  The value of the resource to save.  Must be of the type handled by this ResourceTypeEditor.</param>
         ''' <returns>The friendly description of the resource's type.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetResourceFriendlyTypeDescription(Resource As IResource) As String
             ValidateResourceValue(Resource, TextFileValueType)
             Debug.Assert(Resource.IsLink)
@@ -238,7 +237,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Resource">The IResource instance.  May not be Nothing.  The value of the resource to save.  Must be of the type handled by this ResourceTypeEditor.</param>
         ''' <returns>The friendly size string.</returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetResourceFriendlySize(Resource As IResource) As String
             ValidateResourceValue(Resource, TextFileValueType)
             Debug.Assert(Resource.IsLink)
@@ -337,8 +335,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   handled by this resource type editor, the suggested names could take the form 
         '''   of "id01", "id02", etc.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetSuggestedNamePrefix() As String
             Return "TextFile"
         End Function

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditors.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditors.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -20,61 +20,51 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     '''   be necessary anyway), then use ResourceTypeEditor.Equals().  It will do the
     '''   right thing.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ResourceTypeEditors
         ''' <summary>
         ''' A instance of a ResourceTypeEditor that handles audio data (wav files)
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared Audio As New ResourceTypeEditorAudio
 
         ''' <summary>
         ''' A instance of a ResourceTypeEditor that handles binary files
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared BinaryFile As New ResourceTypeEditorBinaryFile
 
         ''' <summary>
         ''' A instance of a ResourceTypeEditor that handles bitmaps (BMP, JPG, GIF)
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared Bitmap As New ResourceTypeEditorBitmap
 
         ''' <summary>
         ''' A instance of a ResourceTypeEditor that handles icons
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared Icon As New ResourceTypeEditorIcon
 
         ''' <summary>
         ''' An instance of a ResourceTypeEditor that handles resources which are not convertible to/from string,
         '''   and which otherwise are not treated specially by the resource editor.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared NonStringConvertible As New ResourceTypeEditorNonStringConvertible
 
         ''' <summary>
         ''' An instance of a ResourceTypeEditor that handles ResXNullRef (a value of Nothing)
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared [Nothing] As New ResourceTypeEditorNothing
 
         ''' <summary>
         ''' An instance of a ResourceTypeEditor that handles strings
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared [String] As New ResourceTypeEditorString
 
         ''' <summary>
         ''' An instance of a ResourceTypeEditor that handles values which are convertible to/from strings.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared StringConvertible As New ResourceTypeEditorStringConvertible
 
         ''' <summary>
         ''' A instance of a ResourceTypeEditor that handles text files
         ''' </summary>
-        ''' <remarks></remarks>
         Public Shared TextFile As New ResourceTypeEditorTextFile
 
     End Class

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcesFolderService.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcesFolderService.vb
@@ -17,7 +17,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' <summary>
     ''' An interface for adding files to a project.  Used by both the Resource Editor and Resource Picker.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ResourcesFolderService
 
 #Region "Fields and Enums"
@@ -29,7 +28,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '''   behavior as when the resource editor is opened on a resx that�s not in a project in 
             '''   the current solution.
             ''' </summary>
-            ''' <remarks></remarks>
             AddNone = 0
 
             ''' <summary>
@@ -133,7 +131,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Message">The message to displaying, including optional formatting parameters "{0}" etc.</param>
         ''' <param name="FormatArguments">Arguments for "{0}", "{1}", etc.</param>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Friend Shared Sub Trace(Message As String, ParamArray FormatArguments() As Object)
             If FormatArguments.Length > 0 Then
@@ -283,8 +280,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Retrieves the given Project item's property, if it exists, else Nothing
         ''' </summary>
         ''' <param name="PropertyName">The name of the property to retrieve.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GetProjectItemProperty(Item As ProjectItem, PropertyName As String) As [Property]
             If Item.Properties Is Nothing Then
                 Return Nothing
@@ -305,7 +300,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   have that property, this call is a NOP.
         ''' </summary>
         ''' <param name="Item">The ProjectItem on which to set the property</param>
-        ''' <remarks></remarks>
         Private Shared Sub SetBuildAction(Item As ProjectItem)
             Const BuildActionPropertyName As String = "BuildAction"
             Const BuildActionNone As Integer = 0
@@ -324,7 +318,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Project">The project that the file is in.</param>
         ''' <param name="SourceFilePath">The path of the source file.</param>
         ''' <param name="DestinationFolder">The destination folder (ProjectItems) where the file should be copied.</param>
-        ''' <returns></returns>
         ''' <remarks>Either DestinationFolder or DestinationFolderPath must be passed in.</remarks>
         Private Shared Function CopyFileWithinProject(Project As Project, SourceFilePath As String, DestinationFolder As ProjectItems) As String
             'Need to determine the destination disk path
@@ -349,7 +342,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Project">The project that the file is in.</param>
         ''' <param name="SourceFilePath">The path of the source file.</param>
         ''' <param name="DestinationFolderPath">The path of the destination folder where this item should be copied.</param>
-        ''' <returns></returns>
         ''' <remarks>Either DestinationFolder or DestinationFolderPath must be passed in.</remarks>
         Private Shared Function CopyFileWithinProject(Project As Project, SourceFilePath As String, DestinationFolderPath As String) As String
             Debug.Assert(DestinationFolderPath IsNot Nothing AndAlso DestinationFolderPath <> "", "DestinationFolderPath was empty")
@@ -373,7 +365,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="SourceFilePath">The path of the source file.</param>
         ''' <param name="DestinationFolder">The destination folder (ProjectItems) where the file should be copied.  Can be Nothing</param>
         ''' <param name="DestinationFolderPath">The path of the destination folder where this item should be copied.  Must not be empty.</param>
-        ''' <returns></returns>
         ''' <remarks>Either DestinationFolder or DestinationFolderPath must be passed in.</remarks>
         Private Shared Function CopyFileWithinProjectHelper(Project As Project, SourceFilePath As String, DestinationFolder As ProjectItems, DestinationFolderPath As String) As String
             If DestinationFolderPath Is Nothing OrElse DestinationFolderPath = "" OrElse Project Is Nothing OrElse SourceFilePath Is Nothing OrElse SourceFilePath = "" Then
@@ -524,7 +515,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ResourcesFolderName">The name of the Resources folder (usually this is "Resources")</param>
         ''' <param name="ResourcesFolderProjectItems">[Out] Returns the ProjectItem collection that represents the Resources folder in the project</param>
         ''' <param name="ResourcesFolderPath">[Out] Returns the path on disk of the Resources folder.</param>
-        ''' <remarks></remarks>
         Private Shared Sub GetOrCreateResourcesFolder(Project As Project, ResourcesFolderName As String, ByRef ResourcesFolderProjectItems As ProjectItems, ByRef ResourcesFolderPath As String)
             Dim AddToProjectRoot As Boolean = False
 
@@ -616,7 +606,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Project">The project to check the behavior for.</param>
         ''' <param name="Behavior">[Out] Returns the add-to-project behavior to use for this project.</param>
         ''' <param name="ResourcesFolderName">[Out] Returns the name of the Resources folder to use for this project (only relevant if the behavior is to copy to the Resources folder)</param>
-        ''' <remarks></remarks>
         Private Shared Sub GetProjectBehavior(Project As Project, ByRef Behavior As ResourcesFolderBehavior, ByRef ResourcesFolderName As String)
             'If we can't find evidence in the registry to say otherwise, our behavior will be to not do any
             '  copying of files into the project
@@ -762,7 +751,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ProjectItems">The collection of ProjectItem to check</param>
         ''' <param name="Name">The key to check for.</param>
         ''' <returns>The ProjectItem for the given key, if found, else Nothing.  Throws exceptions only in unexpected cases.</returns>
-        ''' <remarks></remarks>
         Friend Shared Function QueryProjectItems(ProjectItems As ProjectItems, Name As String) As ProjectItem
             Try
                 Return ProjectItems.Item(Name)
@@ -815,7 +803,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="ProjectItem">The project item to check.</param>
         ''' <returns>The filename and path of the project item.</returns>
-        ''' <remarks></remarks>
         Private Shared Function GetFileNameFromProjectItem(ProjectItem As ProjectItem, ExpectedExtension As String) As String
             'Look for a FileName with the expected extension.  It's unclear whether we can assume it will always be the
             '  first one.  (There can be multiple files for a ProjectItem for such cases as code behind, etc.)
@@ -836,7 +823,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="ProjectItem">The project item to check.</param>
         ''' <returns>The filename and path of the project item.</returns>
-        ''' <remarks></remarks>
         Private Shared Function GetFileNameFromFolderProjectItem(ProjectItem As ProjectItem) As String
             If s_guid_vsProjectItemKindPhysicalFolder.Equals(New Guid(ProjectItem.Kind)) Then
                 'The FileNames property represents the actual full path of the directory if the folder
@@ -855,7 +841,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="ProjectItems">The ProjectItems collection to check.  Must refer to a physical folder on disk.</param>
         ''' <returns>The directory name of the collection on disk.</returns>
-        ''' <remarks></remarks>
         Friend Shared Function GetFolderNameFromProjectItems(ProjectItems As ProjectItems) As String
             If s_guid_vsProjectItemKindPhysicalFolder.Equals(New Guid(ProjectItems.Kind)) Then
                 If TypeOf ProjectItems.Parent Is Project Then
@@ -877,8 +862,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Given a project, determine if it is the Miscellaneous Files project
         ''' </summary>
         ''' <param name="Project"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function IsMiscellaneousProject(Project As Project) As Boolean
             If vsMiscFilesProjectUniqueName.Equals(Project.UniqueName, StringComparison.OrdinalIgnoreCase) Then
                 Return True
@@ -897,8 +880,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Given a project, returns the project's directory on disk.
         ''' </summary>
         ''' <param name="Project">The project to query.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GetProjectDirectory(Project As Project) As String
             'Some special cases.  In particular, note that the Miscellaneous Files project
             '  has a FullName value of the empty string.
@@ -959,7 +940,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Project">The project in which to search</param>
         ''' <param name="FolderPathToFind">The folder path to search for</param>
         ''' <returns>The parent ProjectItem collection.</returns>
-        ''' <remarks></remarks>
         Private Shared Function FindProjectItemsForFolderPath(Project As Project, FolderPathToFind As String) As ProjectItems
             Return FindProjectItemsForFolderPathHelper(Project.ProjectItems, EnsureBackslash(Path.GetFullPath(FolderPathToFind)))
         End Function
@@ -971,7 +951,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ProjectItemsTree">The ProjectItems subtree to search in.</param>
         ''' <param name="FullFolderPathToFind">The folder path to look for.  Must have had Path.GetFullPath() and EnsureBackslash() called on it.</param>
         ''' <returns>The parent ProjectItem collection, or Nothing if not found.</returns>
-        ''' <remarks></remarks>
         Private Shared Function FindProjectItemsForFolderPathHelper(ProjectItemsTree As ProjectItems, FullFolderPathToFind As String) As ProjectItems
             Debug.Assert(FullFolderPathToFind.Equals(Path.GetFullPath(FullFolderPathToFind), StringComparison.OrdinalIgnoreCase),
                 "FullFolderPathToFind should have already had Path.GetFullPath() called on it")
@@ -1000,8 +979,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Given a file directory path, ensures that it ends with a backslash
         ''' </summary>
         ''' <param name="FilePath"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function EnsureBackslash(FilePath As String) As String
             If FilePath IsNot Nothing AndAlso Not FilePath.EndsWith(Path.DirectorySeparatorChar) Then
                 Return FilePath & Path.DirectorySeparatorChar

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcesFolderService_ResourceEditor.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcesFolderService_ResourceEditor.vb
@@ -39,7 +39,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Project">The Project to get the destination path for.  If this is Nothing or the Miscellaneous Files project, returns Nothing.</param>
         ''' <returns>The default destination path for this project, or Nothing if the Project is Nothing or the Miscellaneous Files project.</returns>
-        ''' <remarks></remarks>
         Friend Shared Function GetAddFileDestinationPath(Project As Project, ResXProjectItem As ProjectItem, CreateDirectoryIfDoesntExist As Boolean) As String
             If Project Is Nothing OrElse IsMiscellaneousProject(Project) OrElse Project.FullName = "" Then
                 Return Nothing
@@ -67,8 +66,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Project">The Project to query.  Returns False if Project = Nothing or the project is the Miscellaneous Files project.</param>
         ''' <param name="FilePath">The file path to check to see if it's in the project's subdirectories.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function IsFileInProjectSubdirectories(Project As Project, FilePath As String) As Boolean
             If Project Is Nothing OrElse IsMiscellaneousProject(Project) OrElse Project.FullName = "" Then
                 Return False

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResxItemWizard.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResxItemWizard.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Strict On
 Option Explicit On
@@ -17,7 +17,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' file-name. If it is a localized .resx file (e.g. foo.en.resx), this class will skip setting
     ''' any CustomTool-related properties [CustomTool is the project-property name for a generator]
     ''' </summary>
-    ''' <remarks></remarks>
     Public Class ResxItemWizard
         Implements IWizard
 
@@ -27,7 +26,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Do nothing
         ''' </summary>
         ''' <param name="projectItem"></param>
-        ''' <remarks></remarks>
         Public Sub BeforeOpeningFile(projectItem As ProjectItem) Implements IWizard.BeforeOpeningFile
         End Sub
 
@@ -35,7 +33,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Do nothing
         ''' </summary>
         ''' <param name="project"></param>
-        ''' <remarks></remarks>
         Public Sub ProjectFinishedGenerating(project As Project) Implements IWizard.ProjectFinishedGenerating
         End Sub
 
@@ -45,7 +42,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' CultureInfo string).
         ''' </summary>
         ''' <param name="projectItem"></param>
-        ''' <remarks></remarks>
         Public Sub ProjectItemFinishedGenerating(projectItem As ProjectItem) Implements IWizard.ProjectItemFinishedGenerating
 
             Debug.Assert(projectItem IsNot Nothing, "Null projectItem?")
@@ -102,7 +98,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Do nothing
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub RunFinished() Implements IWizard.RunFinished
         End Sub
 
@@ -114,7 +109,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="replacementsDictionary"></param>
         ''' <param name="runKind"></param>
         ''' <param name="customParams"></param>
-        ''' <remarks></remarks>
         Public Sub RunStarted(automationObject As Object, replacementsDictionary As Dictionary(Of String, String), runKind As WizardRunKind, customParams() As Object) Implements IWizard.RunStarted
 
             ' we can't do any work if the dictionary is nothing...
@@ -156,8 +150,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Do nothing and simply return true
         ''' </summary>
         ''' <param name="filePath"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function ShouldAddProjectItem(filePath As String) As Boolean Implements IWizard.ShouldAddProjectItem
             Return True
         End Function

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/SerializableEncoding.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/SerializableEncoding.vb
@@ -15,7 +15,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     '''   property on Resource for text files.  The Undo engine requires all the properties to be serializable, and 
     '''   System.Text.Encoding is not.
     ''' </summary>
-    ''' <remarks></remarks>
     <Serializable()>
     Friend NotInheritable Class SerializableEncoding
         Implements ISerializable
@@ -31,7 +30,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Constructor.
         ''' </summary>
         ''' <param name="Encoding">The encoding to wrap.  Nothing is acceptable (indicates a default value - won't be written out to the resx if Nothing).</param>
-        ''' <remarks></remarks>
         Public Sub New(Encoding As Encoding)
             _encoding = Encoding
         End Sub
@@ -42,7 +40,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="info"></param>
         ''' <param name="context"></param>
-        ''' <remarks></remarks>
         Private Sub New(info As SerializationInfo, context As StreamingContext)
             Dim EncodingName As String = info.GetString(KEY_NAME)
             If EncodingName <> "" Then
@@ -54,8 +51,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns/sets the encoding wrapped by this class.  Nothing is an okay value (indicates a default encoding).
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property Encoding() As Encoding
             Get
                 Return _encoding
@@ -69,8 +64,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the display name (localized) of the encoding.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function DisplayName() As String
             If _encoding IsNot Nothing Then
                 Return My.Resources.Microsoft_VisualStudio_Editors_Designer.GetString(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_EncodingDisplayName, _encoding.EncodingName, CStr(_encoding.CodePage))
@@ -86,7 +79,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="info"></param>
         ''' <param name="context"></param>
-        ''' <remarks></remarks>
         Private Sub GetObjectData(info As SerializationInfo, context As StreamingContext) Implements ISerializable.GetObjectData
             If _encoding IsNot Nothing Then
                 info.AddValue(KEY_NAME, _encoding.WebName)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/SerializableEncodingConverter.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/SerializableEncodingConverter.vb
@@ -14,7 +14,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     '''   on Resource allows the Encoding property to have a dropdown list that we control and fill with
     '''   suggested encoding values.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class SerializableEncodingConverter
         Inherits TypeConverter
 
@@ -26,7 +25,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets a value indicating whether this converter can convert an object in the given source 
         '''   type to a SerializableEncoding object using the specified context.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overrides Function CanConvertFrom(Context As ITypeDescriptorContext, SourceType As Type) As Boolean
             If SourceType.Equals(GetType(String)) Then
                 Return True
@@ -39,7 +37,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Converts the specified value object to a SerializableEncoding object.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overrides Function ConvertFrom(Context As ITypeDescriptorContext, Culture As CultureInfo, Value As Object) As Object
             If TypeOf Value Is String Then
                 Dim EncodingName As String = DirectCast(Value, String)
@@ -65,7 +62,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Converts the given value object to the specified destination type.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overrides Function ConvertTo(Context As ITypeDescriptorContext, Culture As CultureInfo, Value As Object, DestinationType As Type) As Object
             Requires.NotNull(DestinationType, NameOf(DestinationType))
 
@@ -85,7 +81,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets a value indicating whether this object supports a standard set of values that 
         '''   can be picked from a list using the specified context.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overrides Function GetStandardValuesSupported(Context As ITypeDescriptorContext) As Boolean
             Return True
         End Function
@@ -95,7 +90,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Indicates whether the standard values that we return are the only allowable values.
         ''' </summary>
         ''' <param name="Context"></param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' We return false so that the user is allows to type in a value manually (in particular,
         '''    a codepage value).
@@ -109,7 +103,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets a collection of standard values collection for a System.Globalization.CultureInfo
         '''   object using the specified context.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overrides Function GetStandardValues(Context As ITypeDescriptorContext) As StandardValuesCollection
             If _standardValuesCache Is Nothing Then
                 'We want to sort like the the Save As... dialog does.  In particular, we want this sorting:
@@ -172,8 +165,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Returns true if the encoding is a Unicode encoding variant
         ''' </summary>
         ''' <param name="Encoding"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function IsUnicodeEncoding(Encoding As Encoding) As Boolean
             Return Encoding.Equals(Encoding.BigEndianUnicode) _
                 OrElse Encoding.Equals(Encoding.Unicode) _
@@ -190,7 +181,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Encoding">The encoding to check for validity.</param>
         ''' <returns>True if the encoding is valid.</returns>
-        ''' <remarks></remarks>
         Private Shared Function IsValidEncoding(Encoding As Encoding) As Boolean
             If Interop.NativeMethods.IsValidCodePage(CUInt(Encoding.CodePage)) Then
                 Return True

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ThumbnailCache.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ThumbnailCache.vb
@@ -25,7 +25,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     '''   (esp. since we're using a virtualized listview and doing other work to delay load images from disk),
     '''   therefore we need to take the caching approach.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ThumbnailCache
 
         'The ImageList which contains the thumbnail images
@@ -98,7 +97,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   to ensure that there is no thrashing from displaying a single page.  If the cache cannot grow
         '''   but is less than this value, out of memory exceptions will be thrown.
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>Does not change the number of images in the cache, only affects future behavior.</remarks>
         Public Property MinimumSizeBeforeRecycling() As Integer
             Get
@@ -119,7 +117,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   MinimumSizeBeforeRecycling is greater than MaximumSuggestedCacheSize, then MinimumSizeBeforeRecycling is used
         '''   as the maximum cache size instead.
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>Method does not try to remove any images if you set this to a lower value than the current
         '''   number of images in the cache (because the caching hints from the ListView are not very accurate, no
         '''   need to get rid of items from the cache that we already had the memory to create).
@@ -138,8 +135,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the number of thumbnails currently in the cache (not including the number of reserved images)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property ThumbnailCount() As Integer
             Get
                 Debug.Assert(_imageList.Images.Count - _reservedImagesCount >= 0)
@@ -152,8 +147,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Retrieves the actual, effective maximum size to which the cache can grow.  This is equal to 
         '''   the largest of the MaximumSuggestedCacheSize and MinimumSizeBeforeRecycling properties.
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property EffectiveMaximumSuggestedCacheSize() As Integer
             Get
                 Return Math.Max(_minimumSizeBeforeRecycling, _maximumSuggestedCacheSize)
@@ -269,7 +262,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   key, it is removed.  If if is not found, nothing happens.
         ''' </summary>
         ''' <param name="Key">Key to remove if found.</param>
-        ''' <remarks></remarks>
         Public Sub InvalidateThumbnail(Key As Object)
             Dim Index As Integer
             If GetCachedImageListIndexInternal(Key, Index) Then
@@ -281,7 +273,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Check whether the object has already been cached.
         ''' </summary>
         ''' <param name="Key">Key to remove if found.</param>
-        ''' <remarks></remarks>
         Public Function IsThumbnailInCache(Key As Object) As Boolean
             Return _keys.ContainsKey(Key)
         End Function
@@ -293,7 +284,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Key">The key to search for in the cache.</param>
         ''' <param name="ThumbnailFound">Returns true iff the key was found in the cache.</param>
         ''' <param name="Index">The index of the found image.  If ThumbnailFail is False, this value is undefined.</param>
-        ''' <remarks></remarks>
         Public Sub GetCachedImageListIndex(Key As Object, ByRef ThumbnailFound As Boolean, ByRef Index As Integer)
             ThumbnailFound = GetCachedImageListIndexInternal(Key, Index)
             If ThumbnailFound AndAlso IsInMruList(Index) Then
@@ -310,7 +300,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Key">The key to search for in the cache.</param>
         ''' <param name="Index">The index of the found image.  If ThumbnailFail is False, this value is undefined.</param>
         ''' <returns>True if we found one</returns>
-        ''' <remarks></remarks>
         Private Function GetCachedImageListIndexInternal(Key As Object, ByRef Index As Integer) As Boolean
             Dim ThumbnailFound As Boolean
             Debug.Assert(Key IsNot Nothing)
@@ -383,7 +372,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Key">Key to be removed.</param>
         ''' <param name="Index">Index at which that key is currently found.</param>
-        ''' <remarks></remarks>
         Private Sub RemoveKey(Key As Object, Index As Integer)
             ' NOTE: It could be a reserved item (shared icon), in this case, it is not in the MRU list, and we shouldn't update the LIST.
             If IsInMruList(Index) Then
@@ -443,8 +431,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Check whether an item is in the MRU list
         ''' </summary>
         ''' <param name="Index">Index in the ImageList.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function IsInMruList(Index As Integer) As Boolean
             Dim MruIndex As Integer = Index + 1
             If MruIndex >= _mruList.Length Then
@@ -459,7 +445,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Debug code that checks the integrity of the cache's data structures.
         ''' </summary>
-        ''' <remarks></remarks>
         <Conditional("DEBUG")>
         Private Sub DebugCheckQueueInvariant()
             Dim count As Integer = 0

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Utility.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Utility.vb
@@ -17,7 +17,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' <summary>
     ''' Utility functions.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Module Utility
 
         ''' <summary>
@@ -32,7 +31,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="BorderWidth">The width of the border (ignored if DrawBorder=False)</param>
         ''' <param name="ImageListTransparentColor">The TransparentColor property of the ImageList that this will be used for.  This is required to get the selection border drawing to work properly.</param>
         ''' <returns>The drawn thumbnail image</returns>
-        ''' <remarks></remarks>
         Public Function CreateThumbnail(SourceImage As Image, ThumbnailSize As Size, DrawBorder As Boolean, BorderWidth As Integer, SelectionBorderWidth As Integer, ImageListTransparentColor As Color) As Bitmap
             If SourceImage Is Nothing Then
                 Debug.Fail("SourceImage can't be nothing")
@@ -117,8 +115,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="MaxScaledSize">Maximum size that is allowed</param>
         ''' <param name="OnlyScaleDownward">If true, image sizes which are smaller than maximum size will *not* be
         '''    scaled upward.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function ScaleSizeProportionally(OriginalSize As Size, MaxScaledSize As Size, OnlyScaleDownward As Boolean) As Size
             'Get the scale required to match the original width to the maximum scaled width
             Dim ScaleBasedOnWidth As Double = MaxScaledSize.Width / OriginalSize.Width
@@ -150,7 +146,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="SuggestedFileName">The suggested (desired) filename, with no path</param>
         ''' <returns>A valid path based on the suggested one.</returns>
-        ''' <remarks></remarks>
         Public Function CreateLegalFileName(SuggestedFileName As String) As String
             Debug.Assert(SuggestedFileName <> "")
             If SuggestedFileName = "" Then
@@ -205,7 +200,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="StringValue">The string value to check against Nothing.</param>
         ''' <returns>Empty string if the string is Nothing, or else the original string value.</returns>
-        ''' <remarks></remarks>
         Public Function NonNothingString(StringValue As String) As String
             If StringValue Is Nothing Then
                 Return ""
@@ -468,7 +462,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ch0">First byte</param>
         ''' <param name="ch1">Second byte</param>
         ''' <returns>The Int16combined from the bytes</returns>
-        ''' <remarks></remarks>
         Private Function BytesToInt16(ch0 As Byte, ch1 As Byte) As Short
             Return CShort(ch1) Or CShort(CInt(ch0) << 8)
         End Function
@@ -483,7 +476,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ch2">Third byte</param>
         ''' <param name="ch3">Fourth byte</param>
         ''' <returns>The Int32 combined from these four bytes in a way used by the mmio functions.</returns>
-        ''' <remarks></remarks>
         Private Function BytesToInt(ch0 As Byte, ch1 As Byte, ch2 As Byte, ch3 As Byte) As Integer
             Dim Result As Integer = ch3
             Result = Result Or (CInt(ch2) << 8)
@@ -499,7 +491,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="LengthInBytes">The length in bytes</param>
         ''' <returns>A friendly formatted string</returns>
-        ''' <remarks></remarks>
         Public Function GetKBDisplay(LengthInBytes As Long) As String
             Const BytesInKilobyte As Integer = 1024
 
@@ -518,8 +509,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Message">The message for the exception.</param>
         ''' <param name="HelpLink">The help link for the exception</param>
         ''' <param name="InnerException">The inner exception.</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function NewException(Message As String, Optional HelpLink As String = Nothing, Optional InnerException As Exception = Nothing) As Exception
             Dim ex As Exception
             If InnerException IsNot Nothing Then
@@ -543,7 +532,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="FilePath">The full path and filename of the file</param>
         ''' <returns>The filename only, as actually found in the file system.</returns>
-        ''' <remarks></remarks>
         Public Function GetFileNameInActualCase(FilePath As String) As String
             If File.Exists(FilePath) Then
                 'Strange, but there appears to be no way to do this from the CLR/NDP, other than searching for it.
@@ -563,8 +551,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   Nothing if the font was not set in the resx file (the strings are empty).
         ''' </summary>
         ''' <param name="FontResourceString">The font described as a string, just as if it were in a form's resx file.  Example: "Arial, 12pt"</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetFontFromResources(FontResourceString As String) As Font
             Dim FontAsString As String = FontResourceString
 
@@ -585,8 +571,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Determines if the provided file name has the .resw file extension
         ''' </summary>
         ''' <param name="fileName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function HasResWExtension(fileName As String) As Boolean
             Return Path.GetExtension(fileName).Equals(".resw", StringComparison.OrdinalIgnoreCase)
         End Function
@@ -595,8 +579,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Determines if the provided file name has any resource file extension (.resx or .resw)
         ''' </summary>
         ''' <param name="fileName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function HasResourceFileExtension(fileName As String) As Boolean
             Dim extension As String = Path.GetExtension(fileName)
             Return extension.Equals(".resx", StringComparison.OrdinalIgnoreCase) OrElse

--- a/src/Microsoft.VisualStudio.Editors/Resources/Resources.vb
+++ b/src/Microsoft.VisualStudio.Editors/Resources/Resources.vb
@@ -10,8 +10,6 @@ Namespace My.Resources
         ''' Just returns the input string unless there are arguments, in which case it calls String.Format.
         ''' </summary>
         ''' <param name="s"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         <ComponentModel.EditorBrowsable(ComponentModel.EditorBrowsableState.Never)>
         Friend Shared Function GetString(s As String, ParamArray Arguments() As Object) As String
             If Arguments Is Nothing OrElse Arguments.Length = 0 Then
@@ -26,7 +24,6 @@ Namespace My.Resources
         '''   actual string value).  These are not automatically kept up to date from
         '''   the .resx file, so they must be edited manually.
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Class ConstantResourceIDs
 
             'IMPORTANT: These must be kept manually up to date, they are not automatically

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/AppConfigSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/AppConfigSerializer.vb
@@ -14,14 +14,12 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' <summary>
     ''' Helper class for (de)serializing the contents app.config
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class AppConfigSerializer
 
         ''' <summary>
         ''' Indicate how we should handle conflicts between value in app.config file
         ''' and in settings object passed in
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Enum MergeValueMode
             UseSettingsFileValue    ' The value in the settings file wins
             UseAppConfigFileValue   ' The value in the app.config file wins
@@ -31,7 +29,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Indicate what changes were performed during deserialization
         ''' </summary>
-        ''' <remarks></remarks>
         <Flags()>
         Friend Enum DirtyState
             NoChange = 0            ' No changes made
@@ -49,7 +46,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' If one or more values have been added to the settings object, the user is notified after deserialization is complete.
         ''' </summary>
         ''' <returns>True if we made any changes to the object, false otherwise</returns>
-        ''' <remarks></remarks>
         Friend Shared Function Deserialize(Settings As DesignTimeSettings, typeCache As SettingsTypeCache, SectionName As String, AppConfigDocData As DocData, mergeMode As MergeValueMode, Optional UIService As IUIService = Nothing) As DirtyState
             Dim objectDirty As DirtyState = DirtyState.NoChange
 
@@ -175,8 +171,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' DocDataService will be checked out
         ''' </param>
         ''' <param name="DocDataService">If specified, the DesignerDocDataService to add/get this DocData to/from</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function GetAppConfigDocData(ServiceProvider As IServiceProvider, Hierarchy As IVsHierarchy, CreateIfNotExists As Boolean, Writable As Boolean, Optional DocDataService As DesignerDocDataService = Nothing) As DocData
             Dim ProjSpecialFiles As IVsProjectSpecialFiles = TryCast(Hierarchy, IVsProjectSpecialFiles)
             Dim AppConfigDocData As DocData = Nothing
@@ -243,7 +237,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="ClassName"></param>
         ''' <param name="NamespaceName"></param>
         ''' <param name="AppConfigDocData"></param>
-        ''' <remarks></remarks>
         Friend Shared Sub Serialize(Settings As DesignTimeSettings, typeCache As SettingsTypeCache, valueCache As SettingsValueCache, ClassName As String, NamespaceName As String, AppConfigDocData As DocData, Hierarchy As IVsHierarchy, SynchronizeUserConfig As Boolean)
             Common.Switches.TraceSDSerializeSettings(TraceLevel.Info, "Serializing {0} settings to App.Config", Settings.Count)
             Requires.NotNull(Settings, NameOf(Settings))
@@ -274,7 +267,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="AppConfigDocData"></param>
         ''' <param name="Hierarchy"></param>
         ''' <param name="ShouldSynchronizeUserConfig"></param>
-        ''' <remarks></remarks>
         Private Shared Sub Serialize(Settings As DesignTimeSettings, typeCache As SettingsTypeCache, valueCache As SettingsValueCache, SectionName As String, AppConfigDocData As DocData, Hierarchy As IVsHierarchy, ShouldSynchronizeUserConfig As Boolean)
             ' Populate settingspropertyvalue collections for user & application scoped settings respectively
             Dim ExistingUserScopedSettings As New SettingsPropertyValueCollection
@@ -346,7 +338,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="ConfigHelperService"></param>
         ''' <param name="Settings"></param>
         ''' <param name="AppConfigDocData"></param>
-        ''' <remarks></remarks>
         Private Shared Sub SynchronizeUserConfig(SectionName As String, Hierarchy As IVsHierarchy, ConfigHelperService As ConfigurationHelperService, Settings As DesignTimeSettings, AppConfigDocData As DocData)
             ' We list all the USER scoped settings that we know about and set the value to true or false depending
             ' on if the setting is roaming...
@@ -371,7 +362,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="ConfigHelperService"></param>
         ''' <param name="SettingsTheDesignerKnownsAbout"></param>
         ''' <param name="AppConfigDocData"></param>
-        ''' <remarks></remarks>
         Private Shared Sub SynchronizeUserConfig(SectionName As String, Hierarchy As IVsHierarchy, ConfigHelperService As ConfigurationHelperService, SettingsTheDesignerKnownsAbout As Dictionary(Of String, Boolean), AppConfigDocData As DocData)
             Dim hierSp As IServiceProvider = Common.ServiceProviderFromHierarchy(Hierarchy)
             Dim project As EnvDTE.Project = Common.DTEUtils.EnvDTEProject(Hierarchy)
@@ -453,7 +443,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="ExistingSettings"></param>
         ''' <param name="UIService"></param>
         ''' <returns>True if a new instance was added to the the root component</returns>
-        ''' <remarks></remarks>
         Private Shared Function MergeAndMaybeAddValue(Settings As DesignTimeSettings, DeserializedPropertyValue As SettingsPropertyValue, Scope As DesignTimeSettingInstance.SettingScope, ExistingSettings As Dictionary(Of String, DesignTimeSettingInstance), mergeMode As MergeValueMode, UIService As IUIService) As DirtyState
             If Not ExistingSettings.ContainsKey(DeserializedPropertyValue.Name) Then
                 If Settings.IsValidName(DeserializedPropertyValue.Name) Then
@@ -500,7 +489,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="SerializedAppConfigValue">The serialized representation of the value found in the app.config file</param>
         ''' <param name="AppConfigScope">The scope of the value found in the app.config file</param>
         ''' <param name="UIService">An option UI service to help us pop up a nice dialog</param>
-        ''' <remarks></remarks>
         Private Shared Function QueryReplaceValue(Settings As DesignTimeSettings, Instance As DesignTimeSettingInstance, SerializedAppConfigValue As String, AppConfigScope As DesignTimeSettingInstance.SettingScope, mergeMode As MergeValueMode, UIService As IUIService) As DirtyState
             Dim ReplaceValue As Boolean
             Select Case mergeMode

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ConnectionStringUITypeEditor.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ConnectionStringUITypeEditor.vb
@@ -16,7 +16,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' Simple UI type editor that launches a IVsDataConnectionDialog dialog to let 
     ''' the user create/edit connection strings
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class ConnectionStringUITypeEditor
         Inherits UITypeEditor
 
@@ -24,8 +23,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' This is a modal dialog...
         ''' </summary>
         ''' <param name="context">The context parameter is ignored...</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function GetEditStyle(context As ComponentModel.ITypeDescriptorContext) As UITypeEditorEditStyle
             Return UITypeEditorEditStyle.Modal
         End Function
@@ -42,7 +39,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         '''   IUIService (will work without it)
         ''' </param>
         ''' <param name="oValue"></param>
-        ''' <returns></returns>
         ''' <remarks>Does not use the IWindowsFormsEditorService service to show it's dialog...</remarks>
         Public Overrides Function EditValue(context As ComponentModel.ITypeDescriptorContext, ServiceProvider As IServiceProvider, oValue As Object) As Object
             Using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware))
@@ -179,8 +175,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="ProviderManager"></param>
         ''' <param name="DataProvider"></param>
         ''' <param name="ConnectionString"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function ContainsSensitiveData(ProviderManager As IVsDataProviderManager, DataProvider As Guid, ConnectionString As String) As Boolean
             If ConnectionString = "" Then
                 Return False
@@ -201,8 +195,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="ServiceProvider"></param>
         ''' <param name="DataProvider"></param>
         ''' <param name="ConnectionString"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function ContainsSensitiveData(ServiceProvider As IServiceProvider, DataProvider As Guid, ConnectionString As String) As Boolean
             Dim providerManager As IVsDataProviderManager = DirectCast(ServiceProvider.GetService(GetType(IVsDataProviderManager)), IVsDataProviderManager)
             If providerManager IsNot Nothing Then
@@ -223,7 +215,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Unencrypted ConnectionString with or without the user-entered password depending on if
         ''' there exists sensitive information in the string and whether the user chooses to persist it
         '''</returns>
-        ''' <remarks></remarks>
         Private Shared Function GetConnectionString(ServiceProvider As IServiceProvider, Dialog As IVsDataConnectionDialog, PromptIfContainsSensitiveData As Boolean) As String
             Requires.NotNull(Dialog, NameOf(Dialog))
             Requires.NotNull(ServiceProvider, NameOf(ServiceProvider))
@@ -258,8 +249,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="ProviderManager"></param>
         ''' <param name="ProviderGUID"></param>
         ''' <param name="ConnectionString"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GetConnectionStringProperties(ProviderManager As IVsDataProviderManager, ProviderGUID As Guid, ConnectionString As String) As IVsDataConnectionProperties
             Dim provider As IVsDataProvider = Nothing
             If ProviderManager.Providers.ContainsKey(ProviderGUID) Then
@@ -277,8 +266,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Does the given connection string contain sensitive data?
         ''' </summary>
         ''' <param name="ConnectionProperties"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function ContainsSensitiveData(ConnectionProperties As IVsDataConnectionProperties) As Boolean
             If ConnectionProperties Is Nothing Then
                 Debug.Fail("We can't tell if it contains sensitive data if we didn't get a bag of properties!")

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorCell.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorCell.vb
@@ -10,7 +10,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' <summary>
     ''' Cell type for displaying UI Type editors in DataGridView 
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class DataGridViewUITypeEditorCell
         Inherits DataGridViewCell
 
@@ -20,7 +19,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' For edit on keydown or mouse click we sometimes need to
         ''' ignore a mouse click...
         ''' </summary>
-        ''' <remarks></remarks>
         Private _ignoreNextMouseClick As Boolean
 
 #Region "DataGridViewCell overrides"
@@ -28,8 +26,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Return the custom editing control used by this type
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property EditType() As Type
             Get
                 Return GetType(DataGridViewUITypeEditorEditingControl)
@@ -44,8 +40,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="rowIndex"></param>
         ''' <param name="cellStyle"></param>
         ''' <param name="context"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overrides Function GetFormattedValue(value As Object, rowIndex As Integer, ByRef cellStyle As DataGridViewCellStyle, valueTypeConverter As TypeConverter, formattedValueTypeConverter As TypeConverter, context As DataGridViewDataErrorContexts) As Object
             If (context And DataGridViewDataErrorContexts.Display) <> 0 AndAlso
                 value IsNot Nothing AndAlso
@@ -60,8 +54,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Type of formatted value
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property FormattedValueType() As Type
             Get
                 Return GetType(String)
@@ -75,8 +67,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="CellStyle"></param>
         ''' <param name="valueTypeConverter"></param>
         ''' <param name="formattedTypeConverter"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function ParseFormattedValue(FormattedValue As Object,
                                                  CellStyle As DataGridViewCellStyle,
                                                  valueTypeConverter As TypeConverter,
@@ -115,8 +105,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="cellStyle"></param>
         ''' <param name="rowIndex"></param>
         ''' <param name="constraintSize"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overrides Function GetPreferredSize(g As Graphics, cellStyle As DataGridViewCellStyle, rowIndex As Integer, constraintSize As Size) As Size
             Dim FormattedValue As String = DirectCast(GetFormattedValue(GetValue(rowIndex), rowIndex, cellStyle, Nothing, Nothing, DataGridViewDataErrorContexts.Formatting Or DataGridViewDataErrorContexts.Display), String)
             Dim preferredStringSize As SizeF = g.MeasureString(FormattedValue, cellStyle.Font)
@@ -138,7 +126,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="cellStyle"></param>
         ''' <param name="advancedBorderStyle"></param>
         ''' <param name="paintParts"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub Paint(graphics As Graphics, clipBounds As Rectangle, cellBounds As Rectangle, rowIndex As Integer, cellState As DataGridViewElementStates, value As Object, formattedValue As Object, errorText As String, cellStyle As DataGridViewCellStyle, advancedBorderStyle As DataGridViewAdvancedBorderStyle, paintParts As DataGridViewPaintParts)
             MyBase.Paint(graphics, clipBounds, cellBounds, rowIndex, cellState, value, formattedValue, errorText, cellStyle, advancedBorderStyle, paintParts)
 
@@ -235,7 +222,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="InitialFormattedValue"></param>
         ''' <param name="CellStyle"></param>
-        ''' <remarks></remarks>
         Public Overrides Sub InitializeEditingControl(RowIndex As Integer, InitialFormattedValue As Object, CellStyle As DataGridViewCellStyle)
             Debug.Assert(DataGridView IsNot Nothing AndAlso DataGridView.EditingControl IsNot Nothing AndAlso TypeOf DataGridView.EditingControl Is DataGridViewUITypeEditorEditingControl)
             MyBase.InitializeEditingControl(RowIndex, InitialFormattedValue, CellStyle)
@@ -251,7 +237,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="rowIndex"></param>
         ''' <param name="throughMouseClick"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnEnter(rowIndex As Integer, throughMouseClick As Boolean)
             MyBase.OnEnter(rowIndex, throughMouseClick)
             If throughMouseClick Then
@@ -275,7 +260,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="rowIndex"></param>
         ''' <param name="throughMouseClick"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnLeave(rowIndex As Integer, throughMouseClick As Boolean)
             MyBase.OnLeave(rowIndex, throughMouseClick)
             _ignoreNextMouseClick = False

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorEditingControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorEditingControl.vb
@@ -10,7 +10,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' <summary>
     ''' Editing control for UI type editor in DataGridView
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class DataGridViewUITypeEditorEditingControl
         Inherits TypeEditorHostControl
         Implements IDataGridViewEditingControl
@@ -57,7 +56,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Stop listening for DataGridView events
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub DisconnectDataGridViewEventHandlers()
             If DataGridView IsNot Nothing Then
                 RemoveHandler DataGridView.CellValidating, AddressOf CellValidatingHandler
@@ -67,7 +65,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Start listening for DataGridView events
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ConnectDataGridViewEventHandlers()
             If DataGridView IsNot Nothing Then
                 AddHandler DataGridView.CellValidating, AddressOf CellValidatingHandler
@@ -80,8 +77,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Set the datagridview instance I'm showing in
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property DataGridView() As DataGridView Implements IDataGridViewEditingControl.EditingControlDataGridView
             Get
                 Return _dataGridView
@@ -96,7 +91,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Set the formatted representation of my current value
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>Will set my value to the deserialized value - nothing if deserialization fails</remarks>
         Public Property FormattedValue() As Object Implements IDataGridViewEditingControl.EditingControlFormattedValue
             Get
@@ -308,8 +302,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' ITypeDescriptorContext to pass into UITypeEditors providing services and access to the current instance
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Overrides ReadOnly Property Context() As System.ComponentModel.ITypeDescriptorContext
             Get
                 Return New EditContext(TryCast(DataGridView.CurrentRow.Tag, DesignTimeSettingInstance))
@@ -319,7 +311,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' ITypeDescriptorContext to pass into UITypeEditors providing services and access to the current instance
         ''' </summary>
-        ''' <remarks></remarks>
         Private Class EditContext
             Implements System.ComponentModel.ITypeDescriptorContext
 
@@ -332,8 +323,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' <summary>
             ''' The container (site) that the current instance is hosted in
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property Container() As System.ComponentModel.IContainer Implements System.ComponentModel.ITypeDescriptorContext.Container
                 Get
                     If _instance IsNot Nothing AndAlso _instance.Site IsNot Nothing Then
@@ -347,8 +336,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' <summary>
             ''' The instance this value is associated with
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property Instance() As Object Implements System.ComponentModel.ITypeDescriptorContext.Instance
                 Get
                     Return _instance
@@ -358,7 +345,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' <summary>
             ''' Let the IComponentChangeService handle component change notifications
             ''' </summary>
-            ''' <remarks></remarks>
             Public Sub OnComponentChanged() Implements System.ComponentModel.ITypeDescriptorContext.OnComponentChanged
 
             End Sub
@@ -366,7 +352,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' <summary>
             ''' We don't have any objections to things changing...
             ''' </summary>
-            ''' <remarks></remarks>
             Public Function OnComponentChanging() As Boolean Implements System.ComponentModel.ITypeDescriptorContext.OnComponentChanging
                 Return True
             End Function
@@ -374,8 +359,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' <summary>
             ''' Get the associated instance's value property descriptor
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public ReadOnly Property PropertyDescriptor() As System.ComponentModel.PropertyDescriptor Implements System.ComponentModel.ITypeDescriptorContext.PropertyDescriptor
                 Get
                     Return System.ComponentModel.TypeDescriptor.GetProperties(GetType(DesignTimeSettingInstance)).Item("Value")
@@ -386,8 +369,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' Provide services to the UITypeEditor...
             ''' </summary>
             ''' <param name="serviceType"></param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Function GetService(serviceType As Type) As Object Implements IServiceProvider.GetService
                 Return Nothing
             End Function

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettingInstance.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettingInstance.vb
@@ -12,7 +12,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' A DesignTimeSettingInstance wraps a single setting. Each setting will generate 
     ''' a property with the appropriate attributes in the generated file.
     ''' </summary>
-    ''' <remarks></remarks>
     <Serializable()>
     Friend Class DesignTimeSettingInstance
         Inherits Component
@@ -21,7 +20,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Application or user scoped setting?
         ''' </summary>
-        ''' <remarks></remarks>
         <TypeConverter(GetType(ScopeConverter))>
         Friend Enum SettingScope
             ' Don't use zero in the enum since that hides CType(NULL, SettingScope) 
@@ -33,43 +31,36 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The name of this setting instance
         ''' </summary>
-        ''' <remarks></remarks>
         Private _name As String
 
         ''' <summary>
         ''' The type name (as persisted in the .settings file) of this setting
         ''' </summary>
-        ''' <remarks></remarks>
         Private _settingTypeName As String = GetType(String).FullName
 
         ''' <summary>
         ''' The setting scope (application or user) for this setting
         ''' </summary>
-        ''' <remarks></remarks>
         Private _settingScope As SettingScope = SettingScope.User
 
         ''' <summary>
         ''' Is this setting a roaming setting?
         ''' </summary>
-        ''' <remarks></remarks>
         Private _roaming As Boolean = False
 
         ''' <summary>
         ''' The serialized representation of this setting
         ''' </summary>
-        ''' <remarks></remarks>
         Private _serializedValue As String = ""
 
         ''' <summary>
         ''' The setting provider if any
         ''' </summary>
-        ''' <remarks></remarks>
         Private _provider As String
 
         ''' <summary>
         ''' The description for this setting
         ''' </summary>
-        ''' <remarks></remarks>
         Private _description As String
 
         ''' <summary>
@@ -78,7 +69,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' contains sensitive information, the user can set this to false
         ''' through the property grid...
         ''' </summary>
-        ''' <remarks></remarks>
         Private _generateDefaultValueInCode As Boolean = True
 
 #Region "Cached property descriptors with this instance as the owner"
@@ -172,7 +162,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' behavior and overrides to make it more explicit what we expect from each
         ''' propertydescriptor.
         ''' </summary>
-        ''' <remarks></remarks>
         Private MustInherit Class DesignTimeSettingInstanceCustomPropertyDescriptorBase
             Inherits PropertyDescriptor
 
@@ -222,17 +211,12 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' Override to set the description (shown in the properties window) for this
             ''' property
             ''' </summary>
-            ''' <value></value>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Protected MustOverride ReadOnly Property DescriptionAttributeText() As String
 
             ''' <summary>
             ''' Override to get the value for the current component in a type-safe way
             ''' </summary>
             ''' <param name="component"></param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Protected MustOverride Overloads Function GetValue(component As DesignTimeSettingInstance) As Object
         End Class
 
@@ -240,7 +224,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Add Undo support (component change notifications and designer transactions w. descriptions)
         ''' whenever we change the value
         ''' </summary>
-        ''' <remarks></remarks>
         Private MustInherit Class DesignTimeSettingInstanceCustomPropertyDescriptor
             Inherits DesignTimeSettingInstanceCustomPropertyDescriptorBase
 
@@ -256,7 +239,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' </summary>
             ''' <param name="component"></param>
             ''' <param name="value"></param>
-            ''' <remarks></remarks>
             Public NotOverridable Overrides Sub SetValue(component As Object, value As Object)
                 Dim instance As DesignTimeSettingInstance = DirectCast(component, DesignTimeSettingInstance)
                 Dim ccsvc As Design.IComponentChangeService = Nothing
@@ -305,9 +287,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' <summary>
             ''' Override to provide the description showing up in the undo menu
             ''' </summary>
-            ''' <value></value>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Protected MustOverride ReadOnly Property UndoDescription() As String
 
             ''' <summary>
@@ -315,7 +294,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' </summary>
             ''' <param name="component"></param>
             ''' <param name="value"></param>
-            ''' <remarks></remarks>
             Protected MustOverride Overloads Sub SetValue(component As DesignTimeSettingInstance, value As Object)
 
 
@@ -673,7 +651,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Translate to/from localized string representation of User and Application
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Class ScopeConverter
             Inherits EnumConverter
 
@@ -774,9 +751,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The name of a setting
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public ReadOnly Property NameProperty() As PropertyDescriptor
             Get
                 Return _namePropertyDescriptor
@@ -819,9 +793,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The scope for a setting
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public ReadOnly Property ScopeProperty() As PropertyDescriptor
             Get
                 Return _scopePropertyDescriptor
@@ -844,9 +815,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The name of the type for a setting
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public ReadOnly Property TypeNameProperty() As PropertyDescriptor
             Get
                 Return _settingTypeNamePropertyDescriptor
@@ -869,9 +837,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The serialized (string) representation of the value of this setting
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public ReadOnly Property SerializedValueProperty() As PropertyDescriptor
             Get
                 Return _serializedValuePropertyDescriptor
@@ -895,9 +860,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Flag indicating if this is a roaming setting 
         ''' (value is stored in the roaming user.config by the runtime)
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public ReadOnly Property Roaming() As Boolean
             Get
                 Return _roaming
@@ -914,9 +876,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The description for this setting
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public ReadOnly Property Description() As String
             Get
                 Return _description
@@ -933,9 +892,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The settings provider for this setting
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public ReadOnly Property Provider() As String
             Get
                 Return _provider
@@ -956,9 +912,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Flag indicating if we should generate a defaultsettingsvalue attribute
         ''' on this setting
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public ReadOnly Property GenerateDefaultValueInCode() As Boolean
             Get
                 Return _generateDefaultValueInCode
@@ -1038,8 +991,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Does the current project system support user scoped settings?
         ''' </summary>
         ''' <param name="instance"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function ProjectSupportsUserScopedSettings(instance As DesignTimeSettingInstance) As Boolean
             If instance Is Nothing OrElse instance.Site Is Nothing Then
                 Return True
@@ -1052,8 +1003,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Does the current project system support user scoped settings?
         ''' </summary>
         ''' <param name="hierarchy"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function ProjectSupportsUserScopedSettings(hierarchy As IVsHierarchy) As Boolean
             If hierarchy Is Nothing Then
                 Return True

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettings.vb
@@ -9,7 +9,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' The DesignTimeSettings class is a list of all the settings that are currently
     ''' available in a .Settings file.
     ''' </summary>
-    ''' <remarks></remarks>
     <
     Designer(GetType(SettingsDesigner), GetType(Design.IRootDesigner)),
     DesignerCategory("Designer")
@@ -25,7 +24,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' We may want to special-case handling of the generated class name to avoid
         ''' name clashes with updated projects...
         ''' </summary>
-        ''' <remarks></remarks>
         Private _useSpecialClassName As Boolean
 
         Private ReadOnly _settings As New List(Of DesignTimeSettingInstance)(16)
@@ -50,9 +48,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Is the UseMySettingsClassName flag set in the underlying .settings file?
         ''' If so, we may want to special-case the class name...
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Property UseSpecialClassName() As Boolean
             Get
                 Return _useSpecialClassName
@@ -65,7 +60,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The namespace as persisted in the .settings file
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>May return NULL if no namespace was persisted!!!</remarks>
         Friend Property PersistedNamespace() As String
             Get
@@ -100,8 +94,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="Name">Name to test</param>
         ''' <param name="instanceToIgnore">If we want to rename an existing setting, we want to that particular it from the unique name check</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function IsValidName(Name As String, Optional checkForUniqueness As Boolean = False, Optional instanceToIgnore As DesignTimeSettingInstance = Nothing) As Boolean
             Return IsValidIdentifier(Name) AndAlso (Not checkForUniqueness OrElse IsUniqueName(Name, instanceToIgnore))
         End Function
@@ -111,8 +103,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="Name"></param>
         ''' <param name="IgnoreThisInstance"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function IsUniqueName(Name As String, Optional IgnoreThisInstance As DesignTimeSettingInstance = Nothing) As Boolean
             ' Empty name not considered unique!
             If Name = "" Then
@@ -143,8 +133,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Is this a valid identifier for us to use?
         ''' </summary>
         ''' <param name="Name"></param>
-        ''' <returns>
-        ''' </returns>
         ''' <remarks>
         ''' We are more strict than the language specific code provider (if any) since the language specific code provider
         ''' may allow escaped identifiers. 
@@ -174,8 +162,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="Id1"></param>
         ''' <param name="Id2"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function EqualIdentifiers(Id1 As String, Id2 As String) As Boolean
             Return StringComparers.SettingNames.Equals(Id1, Id2)
         End Function
@@ -223,8 +209,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="TypeName"></param>
         ''' <param name="SettingName"></param>
         ''' <param name="AllowMakeUnique">If true, we are allowed to change the name in order to make this setting unique</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function AddNew(TypeName As String, SettingName As String, AllowMakeUnique As Boolean) As DesignTimeSettingInstance
             Dim Instance As New DesignTimeSettingInstance
             Instance.SetSettingTypeName(TypeName)
@@ -251,7 +235,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="Instance"></param>
         ''' <param name="MakeNameUnique"></param>
-        ''' <remarks></remarks>
         Friend Sub Add(Instance As DesignTimeSettingInstance, Optional MakeNameUnique As Boolean = False)
             If Contains(Instance) Then
                 Return
@@ -285,7 +268,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Do we already contain this instance? 
         ''' </summary>
         ''' <param name="instance"></param>
-        ''' <returns></returns>
         ''' <remarks>
         ''' Useful to prevent adding the same setting multiple times
         ''' </remarks>
@@ -297,7 +279,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Remove a setting from our list of components...
         ''' </summary>
         ''' <param name="instance"></param>
-        ''' <remarks></remarks>
         Friend Sub Remove(instance As DesignTimeSettingInstance)
             ' If the instance is site:ed, and it's containers components contains the instance, we better remove it...
             ' ...but only if our m_settings collection contains this instance...

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/FakeCollectionEditor.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/FakeCollectionEditor.vb
@@ -9,7 +9,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' Since the stringcollection isn't associated with the stringcollectioneditor class, we
     ''' invent our own little editor that uses the stringarrayeditor instead.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class StringArrayEditorForStringCollections
         Inherits UITypeEditor
 
@@ -18,7 +17,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Create a new StringArrayEditorForStringCollections
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub New()
             _parent = DirectCast(ComponentModel.TypeDescriptor.GetEditor(GetType(String()), GetType(UITypeEditor)), UITypeEditor)
         End Sub
@@ -30,8 +28,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="context"></param>
         ''' <param name="provider"></param>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Overrides Function EditValue(context As ComponentModel.ITypeDescriptorContext, provider As IServiceProvider, value As Object) As Object
             Dim result As Object = _parent.EditValue(context, provider, ConvertToUITypeEditorSource(value))
             Return ConvertToOriginal(result)
@@ -60,8 +56,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Convert from StringCollection to string()
         ''' </summary>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function ConvertToUITypeEditorSource(value As Object) As Object
             If value Is Nothing Then
                 Return Nothing
@@ -80,8 +74,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Convert back from String() to StringCollection
         ''' </summary>
         ''' <param name="value"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function ConvertToOriginal(value As Object) As Object
             If value Is Nothing Then
                 Return Nothing

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
@@ -13,7 +13,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' Get the file name from a project item. 
         ''' </summary>
         ''' <param name="ProjectItem"></param>
-        ''' <returns></returns>
         ''' <remarks>If the item contains of multiple files, the first one is returned</remarks>
         Friend Function FileName(ProjectItem As EnvDTE.ProjectItem) As String
             If ProjectItem Is Nothing Then
@@ -35,8 +34,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' </summary>
         ''' <param name="Hierarchy"></param>
         ''' <param name="ProjectItem"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function ItemId(Hierarchy As IVsHierarchy, ProjectItem As EnvDTE.ProjectItem) As UInteger
             Dim FoundItemId As UInteger
             VSErrorHandler.ThrowOnFailure(Hierarchy.ParseCanonicalName(FileName(ProjectItem), FoundItemId))
@@ -48,8 +45,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' </summary>
         ''' <param name="project"></param>
         ''' <param name="FullFilePath"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function IsFileInProject(project As IVsProject, FullFilePath As String) As Boolean
             Dim found As Integer
             Dim prio(0) As VSDOCUMENTPRIORITY
@@ -77,8 +72,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' </summary>
         ''' <param name="Namespace"></param>
         ''' <param name="ClassName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function FullyQualifiedClassName([Namespace] As String, ClassName As String) As String
             Dim sectionName As String
 
@@ -97,8 +90,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' </summary>
         ''' <param name="Hierarchy"></param>
         ''' <param name="ItemId"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function GeneratedSettingsClassNamespace(Hierarchy As IVsHierarchy, ItemId As UInteger) As String
             Dim IncludeRootNamespace As Boolean = PersistedNamespaceIncludesRootNamespace(Hierarchy)
             Return GeneratedSettingsClassNamespace(Hierarchy, ItemId, IncludeRootNamespace)
@@ -110,8 +101,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' <param name="Hierarchy"></param>
         ''' <param name="ItemId"></param>
         ''' <param name="IncludeRootNamespace"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function GeneratedSettingsClassNamespace(Hierarchy As IVsHierarchy, ItemId As UInteger, IncludeRootNamespace As Boolean) As String
             Return Common.GeneratedCodeNamespace(Hierarchy, ItemId, IncludeRootNamespace, True)
         End Function
@@ -121,8 +110,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' </summary>
         ''' <param name="Hierarchy"></param>
         ''' <param name="Item"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function IsDefaultSettingsFile(Hierarchy As IVsHierarchy, Item As EnvDTE.ProjectItem) As Boolean
             If Hierarchy Is Nothing Then
                 Debug.Fail("Can't get the special files from a NULL Hierarchy!")
@@ -162,7 +149,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' <param name="Hierarchy"></param>
         ''' <param name="ProjectItem"></param>
         ''' <param name="CodeProvider"></param>
-        ''' <remarks></remarks>
         Friend Sub OpenAndMaybeAddExtendingFile(ClassName As String, SuggestedFileName As String, sp As IServiceProvider, Hierarchy As IVsHierarchy, ProjectItem As EnvDTE.ProjectItem, CodeProvider As CodeDomProvider, View As DesignerFramework.BaseDesignerView)
             Dim SettingClassElement As EnvDTE.CodeElement = FindElement(ProjectItem, False, True, New KnownClassName(ClassName))
 
@@ -279,8 +265,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' <param name="NewFilePath">Fully specified name and path for new file</param>
         ''' <param name="Generator">Code generator to use to generate the code</param>
         ''' <param name="CollectionToAddTo"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function AddNewProjectItemExtendingClass(cc2 As EnvDTE80.CodeClass2, NewFilePath As String, Generator As CodeDomProvider, supportsDeclarativeEventHandlers As Boolean, Optional CollectionToAddTo As EnvDTE.ProjectItems = Nothing) As EnvDTE.ProjectItem
             If cc2 Is Nothing Then
                 Debug.Fail("CodeClass2 isntance to extend can't be NULL!")
@@ -366,7 +350,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' <summary>
         ''' Indicates whether to search for a class or a module or either
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Enum ClassOrModule
             ClassOnly
             ModuleOnly
@@ -376,7 +359,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' <summary>
         ''' Look for a CodeClass with a known name in the project
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Class KnownClassName
             Implements IFindFilter
 
@@ -413,14 +395,12 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' <summary>
         ''' Filter that finds a class expanding a known class specified by a CodeClass2 instance
         ''' </summary>
-        ''' <remarks></remarks>
         Private Class ExpandsKnownClass
             Implements IFindFilter
 
             ''' <summary>
             ''' The class to expand
             ''' </summary>
-            ''' <remarks></remarks>
             Private ReadOnly _classToExpand As EnvDTE80.CodeClass2
 
             Friend Sub New(ClassToExpand As EnvDTE80.CodeClass2)
@@ -448,7 +428,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' <summary>
         ''' Find a CodeElement representing a property with a known name in a known class
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Class FindPropertyFilter
             Implements IFindFilter
 
@@ -506,7 +485,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' <summary>
         ''' Find a CodeElement representing a method with a known name in a known class
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Class FindFunctionFilter
             Implements IFindFilter
 
@@ -575,7 +553,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' <param name="ExpandChildItems">If we should recurse to ProjectItem children</param>
         ''' <param name="Filter">The IFilter to satisfy</param>
         ''' <returns>The found element, NULL if no matching element found</returns>
-        ''' <remarks></remarks>
         Friend Function FindElement(Project As EnvDTE.Project, ExpandChildElements As Boolean, ExpandChildItems As Boolean, Filter As IFindFilter) As EnvDTE.CodeElement
             For Each Item As EnvDTE.ProjectItem In Project.ProjectItems
                 Dim Result As EnvDTE.CodeElement = FindElement(Item, ExpandChildElements, ExpandChildItems, Filter)
@@ -595,7 +572,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' <param name="ExpandChildItems">If we should recurse to ProjectItem children</param>
         ''' <param name="Filter">The IFilter to satisfy</param>
         ''' <returns>The found element, NULL if no matching element found</returns>
-        ''' <remarks></remarks>
         Friend Function FindElement(ProjectItem As EnvDTE.ProjectItem, ExpandChildElements As Boolean, ExpandChildItems As Boolean, Filter As IFindFilter) As EnvDTE.CodeElement
             If ProjectItem.FileCodeModel IsNot Nothing Then
                 For Each Element As EnvDTE.CodeElement In ProjectItem.FileCodeModel.CodeElements
@@ -623,8 +599,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' <param name="Element">The element to check</param>
         ''' <param name="ExpandChildren">If we want to recurse through this elements children</param>
         ''' <param name="Filter">The filter to satisfy</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function FindElement(Element As EnvDTE.CodeElement, ExpandChildren As Boolean, Filter As IFindFilter) As EnvDTE.CodeElement
             If Filter.IsMatch(Element) Then
                 Return Element
@@ -663,7 +637,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' </summary>
         ''' <param name="ct"></param>
         ''' <param name="generator"></param>
-        ''' <remarks></remarks>
         Private Sub GenerateExtendingClassInstructions(ct As CodeTypeDeclaration, generator As CodeDomProvider)
             Const SettingChangingEventName As String = "SettingChanging"
             Const SettingsSavingEventName As String = "SettingsSaving"
@@ -721,8 +694,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' If "statement" is already a comment, we can choose to add another level of comments by
         ''' settings this guy to true
         ''' </param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function CommentStatement(statement As CodeStatement, generator As CodeDomProvider, doubleCommentComments As Boolean) As CodeCommentStatement
             ' If this is already a comment and we don't want to double comment it, just return the statement...
             If TypeOf statement Is CodeCommentStatement AndAlso Not doubleCommentComments Then
@@ -744,8 +715,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' </summary>
         ''' <param name="ProjectItem"></param>
         ''' <param name="VsHierarchy"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function AppConfigOrProjectFileNameForCheckout(ProjectItem As EnvDTE.ProjectItem, VsHierarchy As IVsHierarchy) As String
             ' We also want to check out the app.config and possibly the project file(s)...
             If ProjectItem IsNot Nothing Then
@@ -775,8 +744,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' to what CodeDom expects
         ''' </summary>
         ''' <param name="cc2"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Function CodeModelToCodeDomTypeAttributes(cc2 As EnvDTE80.CodeClass2) As TypeAttributes
             Requires.NotNull(cc2, NameOf(cc2))
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/PublicSettingsSingleFileGenerator.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/PublicSettingsSingleFileGenerator.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Reflection
 Imports System.Runtime.InteropServices
@@ -8,7 +8,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' <summary>
     ''' Generator for strongly typed settings wrapper class
     ''' </summary>
-    ''' <remarks></remarks>
     <Guid("940f36b5-a42e-435e-8ef4-20b9d4801d22")>
     Public Class PublicSettingsSingleFileGenerator
         Inherits SettingsSingleFileGeneratorBase

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingTypeNameResolutionService.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingTypeNameResolutionService.vb
@@ -13,7 +13,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     '''    types
     ''' 3) The .NET FX type name. This is what we present to the single file generator and the settings global object.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class SettingTypeNameResolutionService
 
         Private Enum Language
@@ -79,9 +78,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Is the current language case sensitive?
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public ReadOnly Property IsCaseSensitive() As Boolean
             Get
                 Return _caseSensitive
@@ -92,8 +88,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' show in the UI
         ''' </summary>
         ''' <param name="typeName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function PersistedSettingTypeNameToTypeDisplayName(typeName As String) As String
             Dim displayName As String = Nothing
             If String.Equals(typeName, SettingsSerializer.CultureInvariantVirtualTypeNameConnectionString, StringComparison.Ordinal) Then
@@ -111,8 +105,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' that we'll use when building the CodeDom tree
         ''' </summary>
         ''' <param name="typeName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function PersistedSettingTypeNameToFxTypeName(typeName As String) As String
             If String.Equals(typeName, SettingsSerializer.CultureInvariantVirtualTypeNameConnectionString, StringComparison.Ordinal) Then
                 Return GetType(String).FullName
@@ -128,8 +120,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' .settings file
         ''' </summary>
         ''' <param name="typeName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function TypeDisplayNameToPersistedSettingTypeName(typeName As String) As String
             Dim persistedTypeName As String = Nothing
             If String.Equals(typeName, DisplayTypeNameConnectionString, StringComparison.Ordinal) Then

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingTypeValidator.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingTypeValidator.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 Imports System.Reflection
@@ -8,15 +8,12 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' Manages the decisions on if a type is valid as a setting type and/or
     ''' is obsolete
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class SettingTypeValidator
 
         ''' <summary>
         ''' Indicate if the type has changed from the version that is currently loaded in this app domain
         ''' </summary>
         ''' <param name="type"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function IsTypeObsolete(type As Type) As Boolean
             Dim typeInLoadedAssembly As Type = Type.GetType(type.AssemblyQualifiedName)
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
@@ -10,7 +10,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' <summary>
     ''' The root designer for settings
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class SettingsDesigner
         Inherits DesignerFramework.BaseRootDesigner
         Implements IRootDesigner
@@ -28,8 +27,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Trace switch used by all SettingsDesigner components - should be moved to the common Switches file
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend Shared ReadOnly Property TraceSwitch() As TraceSwitch
             Get
                 Static MyTraceSwitch As New TraceSwitch("SettingsDesigner", "Tracing for settings designer")
@@ -40,8 +37,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Demand-crete our designer view 
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property View() As SettingsDesignerView
             Get
                 If _settingsDesignerViewProperty Is Nothing Then
@@ -56,8 +51,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Have we already created a view?
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property HasView() As Boolean
             Get
                 Return _settingsDesignerViewProperty IsNot Nothing
@@ -69,7 +62,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="technology"></param>
         ''' <returns>The view for this root designer</returns>
-        ''' <remarks></remarks>
         Public Function GetView(technology As ViewTechnology) As Object Implements IRootDesigner.GetView
             If technology <> ViewTechnology.Default Then
                 Debug.Fail("Unsupported view technology!")
@@ -83,8 +75,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Our supported technologies
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property SupportedTechnologies() As ViewTechnology() Implements IRootDesigner.SupportedTechnologies
             Get
                 Return New ViewTechnology() {ViewTechnology.Default}
@@ -94,8 +84,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get access to all our settings
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property Settings() As DesignTimeSettings
             Get
                 Return Component
@@ -105,7 +93,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Commit any pending changes
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub CommitPendingChanges(suppressValidationUI As Boolean, cancelOnValidationFailure As Boolean)
             If _settingsDesignerViewProperty IsNot Nothing Then
                 _settingsDesignerViewProperty.CommitPendingChanges(suppressValidationUI, cancelOnValidationFailure)
@@ -118,8 +105,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Make component property type safe if we want to access the component through
         ''' a SettingsDesigner instance
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Shadows ReadOnly Property Component() As DesignTimeSettings
             Get
                 Return CType(MyBase.Component, DesignTimeSettings)
@@ -133,7 +118,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Public Overloads Sub ShowContextMenu(sender As Object, e As Windows.Forms.MouseEventArgs)
             ShowContextMenu(Constants.MenuConstants.SettingsDesignerContextMenuID, e.X, e.Y)
         End Sub
@@ -156,8 +140,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         '''</summary>
         '''<param name="Hierarchy"></param>
         '''<param name="Item"></param>
-        '''<returns></returns>
-        '''<remarks></remarks>
         Friend Shared Function FullyQualifiedGeneratedTypedSettingsClassName(Hierarchy As IVsHierarchy, ItemId As UInteger, Settings As DesignTimeSettings, Item As EnvDTE.ProjectItem) As String
             Dim Ns As String
             Ns = ProjectUtils.GeneratedSettingsClassNamespace(Hierarchy, ProjectUtils.ItemId(Hierarchy, Item), True)
@@ -175,8 +157,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="itemId"></param>
         ''' <param name="Settings"></param>
         ''' <param name="FullPath"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function GeneratedClassName(Hierarchy As IVsHierarchy, itemId As UInteger, Optional Settings As DesignTimeSettings = Nothing, Optional FullPath As String = Nothing) As String
             Try
                 If itemId = VSITEMID.NIL AndAlso FullPath = "" Then
@@ -242,8 +222,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' The class name is basically the file name minus the file extension...
         ''' </summary>
         ''' <param name="PathName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GeneratedClassNameFromPath(PathName As String) As String
             If PathName Is Nothing Then
                 Debug.Fail("Can't get a class name from an empty path!")
@@ -257,8 +235,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="Hierarchy"></param>
         ''' <param name="itemId"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function IsDefaultSettingsFile(Hierarchy As IVsHierarchy, itemId As UInteger) As Boolean
             If itemId = VSITEMID.NIL OrElse itemId = VSITEMID.ROOT OrElse itemId = VSITEMID.SELECTION Then
                 Return False
@@ -285,8 +261,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Is this the "default" settings file
         ''' </summary>
         ''' <param name="FilePath">Fully qualified path of file to check</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function IsDefaultSettingsFile(Hierarchy As IVsHierarchy, FilePath As String) As Boolean
             If Hierarchy Is Nothing Then
                 Debug.Fail("Passed in a NULL hiearchy - can't figure out if this is the default settings file")
@@ -325,8 +299,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Find all user config files that are associated with this application
         ''' </summary>
         ''' <param name="DIrectories"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function FindUserConfigFiles(Directories As List(Of String)) As List(Of String)
             Dim result As New List(Of String)
             For Each directory As String In Directories
@@ -339,8 +311,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Find all directories that we are going to search through to find user.config files
         ''' </summary>
         ''' <param name="hierarchy"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function FindUserConfigDirectories(hierarchy As IVsHierarchy) As List(Of String)
             Dim result As New List(Of String)
             Dim ConfigHelper As New Shell.Design.Serialization.ConfigurationHelperService
@@ -393,7 +363,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="path"></param>
         ''' <param name="files"></param>
-        ''' <remarks></remarks>
         Friend Shared Sub AddUserConfigFiles(path As String, files As List(Of String))
             Debug.WriteLineIf(Common.Switches.SDSyncUserConfig.TraceInfo, String.Format("SettingsDesigner::DeleteUserConfig, path={0}", path))
 
@@ -426,7 +395,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="files">List of files to delete</param>
         ''' <param name="directories">List of directories to delete (if empty)</param>
-        ''' <remarks></remarks>
         Friend Shared Function DeleteFilesAndDirectories(files As List(Of String), directories As List(Of String)) As Boolean
             Dim completeSuccess As Boolean = True
             If files IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerEditorFactory.vb
@@ -11,7 +11,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' <summary>
     ''' The editor factory for the settings designer
     ''' </summary>
-    ''' <remarks></remarks>
     <Guid(SettingsDesignerEditorFactory.EditorGuidString)>
     Friend NotInheritable Class SettingsDesignerEditorFactory
         Inherits DesignerFramework.BaseEditorFactory
@@ -33,8 +32,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' My commandUI GUID
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Protected Overrides ReadOnly Property CommandUIGuid() As Guid
             Get
                 Return Constants.MenuConstants.GUID_SETTINGSDESIGNER_CommandUI
@@ -44,8 +41,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Return my editor GUID
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Protected Overrides ReadOnly Property EditorGuid() As Guid
             Get
                 Return New Guid(EditorGuidString)
@@ -66,7 +61,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="Caption"></param>
         ''' <param name="CmdUIGuid"></param>
         ''' <param name="Canceled"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub CreateEditorInstance(VsCreateEditorFlags As UInteger, FileName As String, PhysicalView As String, Hierarchy As Shell.Interop.IVsHierarchy, ItemId As UInteger, ExistingDocData As Object, ByRef DocView As Object, ByRef DocData As Object, ByRef Caption As String, ByRef CmdUIGuid As Guid, ByRef Canceled As Boolean)
             Static prjKindVenus As String = "{E24C65DC-7377-472b-9ABA-BC803B73C61A}"
             Dim proj As EnvDTE.Project = Common.DTEUtils.EnvDTEProject(Hierarchy)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerLoader.vb
@@ -16,7 +16,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' <summary>
     ''' Designer loader for settings files
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class SettingsDesignerLoader
         Inherits DesignerFramework.BaseDesignerLoader
         Implements INameCreationService, IVsDebuggerEvents
@@ -57,7 +56,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' NOTE: Remember to call RemoveService on any service object we don't own, when the Loader is disposed
         '''  Otherwise, the service container will dispose those objects.
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub Initialize()
             MyBase.Initialize()
 
@@ -110,7 +108,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="Hierarchy">Hierarchy (project) for item to load</param>
         ''' <param name="ItemId">ItemId in Hierarchy to load</param>
         ''' <param name="punkDocData">Document data to load</param>
-        ''' <remarks></remarks>
         Friend Overrides Sub InitializeEx(ServiceProvider As ServiceProvider, moniker As String, Hierarchy As IVsHierarchy, ItemId As UInteger, punkDocData As Object)
             MyBase.InitializeEx(ServiceProvider, moniker, Hierarchy, ItemId, punkDocData)
 
@@ -122,7 +119,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Overrides base Dispose.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Overrides Sub Dispose()
             'Remove services we proffered.
             '
@@ -141,7 +137,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Name of base component this loader (de)serializes
         ''' </summary>
         ''' <returns>Name of base component this loader (de)serializes</returns>
-        ''' <remarks></remarks>
         Protected Overrides Function GetBaseComponentClassName() As String
             Return GetType(DesignTimeSettings).Name
         End Function
@@ -150,7 +145,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Flush any changes to underlying docdata(s)
         ''' </summary>
         ''' <param name="SerializationManager"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub HandleFlush(SerializationManager As IDesignerSerializationManager)
             Try
                 _flushing = True
@@ -185,7 +179,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' the contents of "my" docdata.
         ''' </summary>
         ''' <param name="SerializationManager">My serialization manager</param>
-        ''' <remarks></remarks>
         Protected Overrides Sub HandleLoad(SerializationManager As IDesignerSerializationManager)
             Switches.TraceSDSerializeSettings(TraceLevel.Info, "SettingsDesignerLoader: Start loading settings")
             Debug.Assert(LoaderHost IsNot Nothing, "Asked to load settings designer without a LoaderHost!?")
@@ -236,8 +229,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get access to "our" root component
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property RootComponent() As DesignTimeSettings
             Get
                 Try
@@ -279,7 +270,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get a DocData for the App.Config file (if any)
         ''' </summary>
-        ''' <remarks></remarks>
         Private Function AttachAppConfigDocData(CreateIfNotExist As Boolean) As Boolean
             ' Now, Let's try and get to the app.config file
             If _appConfigDocData Is Nothing Then
@@ -295,7 +285,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Make sure that we have a custom tool associated with this file
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub SetSingleFileGenerator()
             Dim ProjectItem As EnvDTE.ProjectItem = DTEUtils.ProjectItemFromItemId(VsHierarchy, ProjectItemid)
             If ProjectItem IsNot Nothing AndAlso ProjectItem.Properties IsNot Nothing Then
@@ -324,7 +313,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ComponentAddedHandler(sender As Object, e As ComponentEventArgs)
             If TypeOf e.Component Is DesignTimeSettingInstance Then
                 ' Let's make sure our root component knows about this guy!
@@ -338,7 +326,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ComponentChangingHandler(sender As Object, e As ComponentChangingEventArgs)
             Dim instance As DesignTimeSettingInstance = TryCast(e.Component, DesignTimeSettingInstance)
             ' If this is a rename of a web reference, we have to check out the project file in order to update
@@ -367,7 +354,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ComponentChangedHandler(sender As Object, e As ComponentChangedEventArgs)
             ' If the name property of a designtimesetting instance (or derived class) has changed in a project item
             ' that has "our" custom tool associated with it, we want to invoke a global rename of the setting
@@ -448,7 +434,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ComponentRemovedHandler(sender As Object, e As ComponentEventArgs)
             If LoaderHost IsNot Nothing AndAlso LoaderHost.Loading Then
                 ' If we are currently (re)loading the design surface, we don't want to force-run the custom tool
@@ -477,7 +462,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ExternalChange(sender As Object, e As EventArgs)
             If Not _flushing Then
                 Debug.Assert(_appConfigDocData IsNot Nothing, "Why did we get a change notification for a NULL App.Config DocData?")
@@ -489,7 +473,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Load the contents of the app.config file
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub LoadAppConfig()
             Debug.Assert(_appConfigDocData IsNot Nothing, "Can't load a non-existing app.config file!")
             Try
@@ -523,7 +506,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="successful"></param>
         ''' <param name="errors"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnEndLoad(successful As Boolean, errors As ICollection)
             MyBase.OnEndLoad(successful, errors)
             ConnectDebuggerEvents()
@@ -550,7 +532,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Persist our values to the app.config file...
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub FlushAppConfig()
             If AttachAppConfigDocData(True) Then
                 Debug.Assert(_appConfigDocData IsNot Nothing, "Why did AttachAppConfigDocData return true when we don't have an app.config docdata!?")
@@ -575,7 +556,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Called when the document's window is activated or deactivated
         ''' </summary>
         ''' <param name="Activated"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnDesignerWindowActivated(Activated As Boolean)
             MyBase.OnDesignerWindowActivated(Activated)
 
@@ -596,7 +576,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         '''  Dispose any owned resources
         ''' </summary>
         ''' <param name="Disposing"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub Dispose(Disposing As Boolean)
             If Disposing Then
                 ' The LoaderHost will remove all services all by itself...
@@ -669,9 +648,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' We sometimes want to check out the project file (to add app.config) and sometimes we only want to 
         ''' check out the app.config file itself...
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overrides ReadOnly Property ManagingDynamicSetOfFiles() As Boolean
             Get
                 Return True
@@ -682,9 +658,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Overridden in order to provide the app.config file name or the project name when as well as the project item
         ''' and dependent file...
         ''' </summary>
-        ''' <value></value>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Overrides ReadOnly Property FilesToCheckOut() As List(Of String)
             Get
                 Dim result As List(Of String) = MyBase.FilesToCheckOut
@@ -751,7 +724,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Start listening to build events and set our initial build status
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ConnectBuildEvents()
             Dim dte As EnvDTE.DTE
             dte = CType(GetService(GetType(EnvDTE.DTE)), EnvDTE.DTE)
@@ -766,7 +738,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         '''     Returns a value indicating whether the designer is currently editable; that is, 
         '''     we're not debugging in any form and the solution is not currently building.
         ''' </summary>
-        ''' <returns></returns>
         Friend Function IsDesignerEditable() As Boolean
 
             Return InDesignMode() AndAlso Not _readOnly
@@ -787,7 +758,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="scope"></param>
         ''' <param name="action"></param>
-        ''' <remarks></remarks>
         Private Sub BuildDone(scope As EnvDTE.vsBuildScope, action As EnvDTE.vsBuildAction) Handles _buildEvents.OnBuildDone
             SetReadOnlyMode(False, String.Empty)
             _readOnly = False
@@ -797,7 +767,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Refresh the status of Settings view commands
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub RefreshView()
             Dim Designer As SettingsDesigner = DirectCast(LoaderHost.GetDesigner(RootComponent), SettingsDesigner)
             If Designer IsNot Nothing AndAlso Designer.HasView Then
@@ -809,7 +778,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Hook up with the debugger event mechanism to determine current debug mode
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub ConnectDebuggerEvents()
             If _vsDebuggerEventsCookie = 0 Then
                 _vsDebugger = CType(GetService(GetType(IVsDebugger)), IVsDebugger)
@@ -830,7 +798,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Unhook event notification for debugger 
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub DisconnectDebuggerEvents()
             Try
                 If _vsDebugger IsNot Nothing AndAlso _vsDebuggerEventsCookie <> 0 Then

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerUndoTransaction.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerUndoTransaction.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel.Design
 
@@ -9,14 +9,12 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' we can't assume that we can create a transaction. This class allows the use of a "Using" statement
     ''' regardless of if a designer host is available or not...
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class SettingsDesignerUndoTransaction
         Implements IDisposable
 
         ''' <summary>
         ''' Our wrapped transaction, or nothing if not designer host is available
         ''' </summary>
-        ''' <remarks></remarks>
         Private _transaction As DesignerTransaction
 
         ''' <summary>
@@ -24,7 +22,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="Provider"></param>
         ''' <param name="Description"></param>
-        ''' <remarks></remarks>
         Public Sub New(Provider As IServiceProvider, Description As String)
             If Provider IsNot Nothing Then
                 Initialize(DirectCast(Provider.GetService(GetType(IDesignerHost)), IDesignerHost), Description)
@@ -38,7 +35,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="DesignerHost"></param>
         ''' <param name="Description"></param>
-        ''' <remarks></remarks>
         Public Sub New(DesignerHost As IDesignerHost, Description As String)
             Initialize(DesignerHost, Description)
         End Sub
@@ -48,7 +44,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="DesignerHost"></param>
         ''' <param name="Description"></param>
-        ''' <remarks></remarks>
         Private Sub Initialize(DesignerHost As IDesignerHost, Description As String)
             If DesignerHost IsNot Nothing Then
                 _transaction = DesignerHost.CreateTransaction(Description)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -26,7 +26,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' For each row in the grid, the Tag property should be set to a corresponding 
     ''' DesignTimeSettingInstance
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class SettingsDesignerView
         Inherits BaseDesignerView
         Implements IVsWindowPaneCommit
@@ -78,7 +77,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' that it is a really bad time to change the current cell while already committing
         ''' changes...
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Class SettingsGridView
             Inherits DesignerDataGridView
 
@@ -131,19 +129,16 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Cached instance of the type name resolution service
         ''' </summary>
-        ''' <remarks></remarks>
         Private _typeNameResolver As SettingTypeNameResolutionService
 
         ''' <summary>
         ''' Cached instance of the setting type cache service
         ''' </summary>
-        ''' <remarks></remarks>
         Private _settingTypeCache As SettingsTypeCache
 
         ''' <summary>
         ''' Cached instance of the setting value cache
         ''' </summary>
-        ''' <remarks></remarks>
         Private _valueCache As SettingsValueCache
 
 
@@ -201,7 +196,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Dispose my resources
         ''' </summary>
         ''' <param name="disposing"></param>
-        ''' <remarks></remarks>
         Protected Overloads Overrides Sub Dispose(disposing As Boolean)
             If disposing Then
                 If _accessModifierCombobox IsNot Nothing Then
@@ -334,13 +328,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Reference to "our" root designer
         ''' </summary>
-        ''' <remarks></remarks>
         Private _rootDesigner As SettingsDesigner
 
         ''' <summary>
         ''' The settings we show in the grid
         ''' </summary>
-        ''' <remarks></remarks>
         Private _settingsProperty As DesignTimeSettings
 
         ' Private cached service
@@ -444,8 +436,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Gets the environment font for the shell.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetEnvironmentFont() As Drawing.Font
             If UIService IsNot Nothing Then
                 Dim Font As Drawing.Font = DirectCast(UIService.Styles("DialogFont"), Drawing.Font)
@@ -460,7 +450,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Set the localized text and link part of the link label
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub SetLinkLabelText()
             Dim fullText As String = My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_FullDescriptionText
             Dim linkText As String = My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_LinkPartOfDescriptionText
@@ -478,7 +467,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Pop up the appropriate help context when the user clicks on the description link
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub DescriptionLinkLabel_LinkClicked(sender As Object, e As LinkLabelLinkClickedEventArgs) Handles _descriptionLinkLabel.LinkClicked
             DesignUtil.DisplayTopicFromF1Keyword(_rootDesigner, HelpIDs.SettingsDesignerDescription)
         End Sub
@@ -488,7 +476,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Initialize the fonts in the resource editor from the environment (or from the resx file,
         '''   if hard-coded there).
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub SetFonts()
             Dim DialogFont As Drawing.Font = GetEnvironmentFont()
             If DialogFont IsNot Nothing Then
@@ -502,8 +489,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The settings we are currently displaying in the grid...
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private Property Settings() As DesignTimeSettings
             Get
                 Return _settingsProperty
@@ -529,7 +514,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Our cached component change service
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>
         ''' Will unhook event handlers from old component changed service and hook up handlers
         ''' to the new service
@@ -550,7 +534,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Hook up component changed/added/removed event handlers
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub SubscribeChangeServiceNotifications()
             If ChangeService IsNot Nothing Then
                 AddHandler ChangeService.ComponentChanged, AddressOf ComponentChangedHandler
@@ -562,7 +545,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Unhook component changed/added/removed event handlers
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub UnSubscribeChangeServiceNotifications()
             If ChangeService IsNot Nothing Then
                 RemoveHandler ChangeService.ComponentChanged, AddressOf ComponentChangedHandler
@@ -576,7 +558,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="Sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ComponentChangedHandler(Sender As Object, e As ComponentChangedEventArgs)
             ' There is a slight possibility that we'll be called after the designer has been disposed (a web reference
             ' rename can cause a project file checkout, which may cause a project reload, which will dispose us and
@@ -603,7 +584,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="Sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ComponentRemovedHandler(Sender As Object, e As ComponentEventArgs)
             If TypeOf e.Component Is DesignTimeSettingInstance Then
                 ' This was a setting instance - let's find the corresponding row and
@@ -634,7 +614,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="Sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ComponentAddedHandler(Sender As Object, e As ComponentEventArgs)
             If GetType(DesignTimeSettingInstance).IsAssignableFrom(CType(e.Component, Object).GetType()) Then
                 ' A component was added - let's get the corresponding row from the grid...
@@ -666,7 +645,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Get a row from a component
         ''' </summary>
         ''' <param name="Instance"></param>
-        ''' <returns></returns>
         ''' <remarks>O(n) running time</remarks>
         Private Function RowFromComponent(Instance As DesignTimeSettingInstance) As DataGridViewRow
             For Each Row As DataGridViewRow In _settingsGridView.Rows
@@ -681,8 +659,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Get the instance from the current row, creating one if necessary
         ''' </summary>
         ''' <param name="Row"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function ComponentFromRow(Row As DataGridViewRow) As DesignTimeSettingInstance
             If Row.Tag IsNot Nothing Then
                 Debug.Assert(TypeOf Row.Tag Is DesignTimeSettingInstance, "Unknown tag of this object!")
@@ -706,8 +682,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' 2. We are showing the type picker dialog
         ''' 3. We are showing a UI type editor
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property AllowCommitPendingChanges() As Boolean
             Get
                 If _isReportingError OrElse _isShowingTypePicker OrElse _inCellValidated OrElse _settingsGridView.CommittingChanges Then
@@ -725,7 +699,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The function forces to refresh the status of all commands.
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub RefreshCommandStatus()
             If _menuCommands IsNot Nothing Then
                 For Each command As DesignerMenuCommand In _menuCommands
@@ -737,7 +710,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Commit any pending changes
         ''' </summary>
-        ''' <remarks></remarks>
         Public Function CommitPendingChanges(suppressValidationUI As Boolean, cancelOnValidationFailure As Boolean) As Boolean
             Dim savedSuppressValidationUI As Boolean = _suppressValidationUI
             Dim succeeded As Boolean = False
@@ -791,8 +763,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Type safe accessor for the type column
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property TypeColumn() As DataGridViewComboBoxColumn
             Get
                 Return DirectCast(_settingsGridView.Columns(TypeColumnNo), DataGridViewComboBoxColumn)
@@ -802,8 +772,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Type safe accessor for the type column
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property ScopeColumn() As DataGridViewComboBoxColumn
             Get
                 Return DirectCast(_settingsGridView.Columns(ScopeColumnNo), DataGridViewComboBoxColumn)
@@ -819,7 +787,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Completely refresh grid (remove current rows and re-create them from settings
         ''' in associated designer
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub RefreshGrid()
             If _settingsGridView.RowCount() > 0 Then
                 _settingsGridView.Rows.Clear()
@@ -834,7 +801,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Add a row to the grid, associate it with the the setting instance and update the UI
         ''' </summary>
         ''' <param name="Instance"></param>
-        ''' <remarks></remarks>
         Private Sub AddRow(Instance As DesignTimeSettingInstance)
             If Not _settingsGridView.IsHandleCreated Then
                 _settingsGridView.CreateControl()
@@ -850,7 +816,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Make sure the user sees the properties as the are set in the setting instance
         ''' </summary>
         ''' <param name="Row"></param>
-        ''' <remarks></remarks>
         Private Sub SetUIRowValues(Row As DataGridViewRow, Instance As DesignTimeSettingInstance)
             Row.Cells(NameColumnNo).Value = Instance.Name
             Row.Cells(NameColumnNo).ReadOnly = DesignTimeSettingInstance.IsNameReadOnly(Instance)
@@ -878,7 +843,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Update the value column of the current row and set the correct visual style
         ''' </summary>
         ''' <param name="row"></param>
-        ''' <remarks></remarks>
         Private Sub UpdateUIValueColumn(row As DataGridViewRow)
             Dim Instance As DesignTimeSettingInstance = CType(row.Tag, DesignTimeSettingInstance)
             Dim Cell As DataGridViewUITypeEditorCell = CType(row.Cells(ValueColumnNo), DataGridViewUITypeEditorCell)
@@ -919,7 +883,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' If files under source control, prompt the user if (s)he wants to check them out.
         ''' </summary>
         ''' <returns>True if not under source control or if the check out succeeded, false otherwise</returns>
-        ''' <remarks></remarks>
         Private Function EnsureCheckedOut() As Boolean
             If DesignerLoader Is Nothing Then
                 Debug.Fail("Failed to get the IDesignerLoaderService from out settings site (or the IDesignerLoaderService wasn't a SettingsDesignerLoader :(")
@@ -994,7 +957,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub OnSettingsGridViewUserDeletingRow(sender As Object, e As DataGridViewRowCancelEventArgs) Handles _settingsGridView.UserDeletingRow
             If _settingsGridView.SelectedRows.Count = 0 AndAlso e.Row.IsNewRow Then
                 ' The user cancelled an edit of the new row - we should not prevent the 
@@ -1023,7 +985,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub OnSettingsGridViewUserDeletedRow(sender As Object, e As DataGridViewRowEventArgs) Handles _settingsGridView.UserDeletedRow
             Dim InstanceToDelete As DesignTimeSettingInstance = CType(e.Row.Tag, DesignTimeSettingInstance)
             If InstanceToDelete IsNot Nothing Then
@@ -1039,7 +1000,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="FormattedValue"></param>
         ''' <param name="RowIndex"></param>
         ''' <param name="ColumnIndex"></param>
-        ''' <remarks></remarks>
         Private Function ValidateCell(FormattedValue As Object, RowIndex As Integer, ColumnIndex As Integer) As Boolean
             Dim Instance As DesignTimeSettingInstance = TryCast(_settingsGridView.Rows(RowIndex).Tag, DesignTimeSettingInstance)
             Select Case ColumnIndex
@@ -1062,7 +1022,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub OnSettingsGridViewCellValidating(sender As Object, e As DataGridViewCellValidatingEventArgs) Handles _settingsGridView.CellValidating
             ' We can get into this when delay-disposing due to project reloads...
             If Disposing Then Return
@@ -1112,7 +1071,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub OnSettingsGridViewCellValidated(sender As Object, e As DataGridViewCellEventArgs) Handles _settingsGridView.CellValidated
             If Disposing Then
                 Return
@@ -1226,7 +1184,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub OnSettingsGridViewOnCellClickBeginEdit(sender As Object, e As CancelEventArgs) Handles _settingsGridView.CellClickBeginEdit
             If DesignerLoader IsNot Nothing Then
                 e.Cancel = Not DesignerLoader.OkToEdit()
@@ -1240,7 +1197,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub OnSettingsGridViewCellBeginEdit(sender As Object, e As DataGridViewCellCancelEventArgs) Handles _settingsGridView.CellBeginEdit
             ' Check out , but we can't check out if settings file is readonly
             If Not EnsureCheckedOut() Then
@@ -1298,8 +1254,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get access to a UI service - useful to pop up message boxes and getting fonts
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property UIService() As IUIService
             Get
                 Dim Result As IUIService
@@ -1325,7 +1279,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub OnSettingsGridViewDefaultValuesNeeded(sender As Object, e As DataGridViewRowEventArgs) Handles _settingsGridView.DefaultValuesNeeded
             Dim SampleInstance As New DesignTimeSettingInstance()
             If Not _projectSystemSupportsUserScope Then
@@ -1339,7 +1292,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Change the type of the setting on the current row
         ''' </summary>
         ''' <param name="Row"></param>
-        ''' <remarks></remarks>
         Private Sub ChangeSettingType(Row As DataGridViewRow, TypeDisplayName As String)
             Dim addingNewSetting As Boolean = (Row.Tag Is Nothing)
 
@@ -1467,8 +1419,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The user wants to view (and maybe add) code that extends the generated settings class
         ''' </summary>
-        ''' <remarks>
-        ''' </remarks>
         Private Sub ViewCode()
             Dim Hierarchy As IVsHierarchy = DirectCast(Settings.Site.GetService(GetType(IVsHierarchy)), IVsHierarchy)
             Dim ProjectItem As EnvDTE.ProjectItem = DirectCast(Settings.Site.GetService(GetType(EnvDTE.ProjectItem)), EnvDTE.ProjectItem)
@@ -1531,7 +1481,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Remove event handler for showing context menu
         ''' </summary>
         ''' <param name="Designer"></param>
-        ''' <remarks></remarks>
         Private Sub UnregisterMenuCommands(Designer As SettingsDesigner)
             RemoveHandler _settingsGridView.ContextMenuShow, AddressOf Designer.ShowContextMenu
         End Sub
@@ -1539,7 +1488,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Register the settings designer menu commands(context menus)
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub RegisterMenuCommands(Designer As SettingsDesigner)
             'Protect against recursively invoking this
             Static InThisMethod As Boolean
@@ -1597,7 +1545,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Tell the shell that our toolbar wants to be included in the translation of
         ''' accelerators/alt-shift navigation
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub UpdateToolbarFocus()
             If _toolbarPanel IsNot Nothing Then
                 _toolbarPanel.Activate(Handle)
@@ -1624,8 +1571,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Should the remove menu item be enabled?
         ''' </summary>
         ''' <param name="MenuCommand"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuRemoveEnableHandler(MenuCommand As DesignerMenuCommand) As Boolean
             ' If we are not editable we shouldn't allow removal of rows...
             If Not IsDesignerEditable() Then
@@ -1651,8 +1596,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Is the EditCell command enabled?
         ''' </summary>
         ''' <param name="MenuCommand"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuEditCellEnableHandler(MenuCommand As DesignerMenuCommand) As Boolean
             Return _settingsGridView.CurrentCell IsNot Nothing AndAlso Not _settingsGridView.IsCurrentCellInEditMode AndAlso IsDesignerEditable() AndAlso Not _settingsGridView.CurrentCell.ReadOnly
         End Function
@@ -1661,8 +1604,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Indicate if the view code button should be enabled?
         ''' </summary>
         ''' <param name="MenuCommand"></param>
-        ''' <remarks></remarks>
-        ''' <returns></returns>
         Private Function MenuViewCodeEnableHandler(MenuCommand As DesignerMenuCommand) As Boolean
             If Not IsDesignerEditable() Then
                 Return False
@@ -1696,7 +1637,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuViewCode(sender As Object, e As EventArgs)
             ViewCode()
         End Sub
@@ -1705,8 +1645,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Is the Synchronize command on the settings designer toolbar enabled?
         ''' </summary>
         ''' <param name="MenuCommand"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuSynchronizeUserConfigEnableHandler(MenuCommand As DesignerMenuCommand) As Boolean
             If Not IsDesignerEditable() Then
                 Return False
@@ -1724,8 +1662,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Is the Load Web Settings command on the settings designer toolbar enabled?
         ''' </summary>
         ''' <param name="MenuCommand"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuLoadWebSettingsFromAppConfigEnableHandler(MenuCommand As DesignerMenuCommand) As Boolean
             If Not IsDesignerEditable() Then
                 Return False
@@ -1763,7 +1699,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuSynchronizeUserConfig(sender As Object, e As EventArgs)
             Dim allDeletedFiles As New List(Of String)
             Dim allDeletedDirectories As New List(Of String)
@@ -1808,7 +1743,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuLoadWebSettingsFromAppConfig(sender As Object, e As EventArgs)
 
             If Not IsDesignerEditable() Then
@@ -1900,7 +1834,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Whether this SettingsProperty allows anonymous access
         ''' </summary>
         ''' <param name="settingsProp">The SettingsProperty to check for AllowsAnonymous attribute</param>
-        ''' <remarks></remarks>
         Private Shared Function AllowsAnonymous(settingsProp As SettingsProperty) As Boolean
             If settingsProp IsNot Nothing AndAlso settingsProp.Attributes IsNot Nothing AndAlso
             settingsProp.Attributes.ContainsKey("AllowAnonymous") Then
@@ -1915,7 +1848,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' If there are unreferenced types, display an error dialog
         ''' </summary>
         ''' <param name="badNames">List of the bad names</param>
-        ''' <remarks></remarks>
         Private Sub ShowErrorIfThereAreUnreferencedTypes(badNames As List(Of String))
             If badNames.Count > 0 Then
                 Dim displayString As String = String.Join(System.Threading.Thread.CurrentThread.CurrentCulture.TextInfo.ListSeparator, badNames.ToArray())
@@ -1927,7 +1859,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' If there are duplicate names, display an error dialog
         ''' </summary>
         ''' <param name="badNames">List of the bad names</param>
-        ''' <remarks></remarks>
         Private Sub ShowErrorIfThereAreDuplicateNames(badNames As List(Of String))
             If badNames.Count > 0 Then
                 Dim displayString As String = String.Join(System.Threading.Thread.CurrentThread.CurrentCulture.TextInfo.ListSeparator, badNames.ToArray())
@@ -1938,7 +1869,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Remove all the WebProvider settings
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub RemoveAllWebProviderSettings()
             Dim settingsToRemove As New List(Of DesignTimeSettingInstance)
             Dim setting As DesignTimeSettingInstance
@@ -1958,8 +1888,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Should the Add setting menu command be enabled?
         ''' </summary>
         ''' <param name="menucommand"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function MenuAddSettingEnableHandler(menucommand As DesignerMenuCommand) As Boolean
             Return IsDesignerEditable()
         End Function
@@ -1969,7 +1897,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuAddSetting(sender As Object, e As EventArgs)
             _settingsGridView.CurrentCell = _settingsGridView.Rows(_settingsGridView.Rows.Count - 1).Cells(NameColumnNo)
             Debug.Assert(_settingsGridView.CurrentRow.Tag Is Nothing, "Adding a new setting failed - there is already a setting associated with the new row!?")
@@ -1981,7 +1908,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuEditCell(sender As Object, e As EventArgs)
             If _settingsGridView.CurrentCell IsNot Nothing AndAlso Not _settingsGridView.IsCurrentCellInEditMode Then
                 If EnsureCheckedOut() Then
@@ -1989,13 +1915,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 End If
             End If
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="Sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub MenuRemove(Sender As Object, e As EventArgs)
             ' Gotta check out files before removing anything...
             If Not EnsureCheckedOut() Then
@@ -2048,7 +1969,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' When the "Browse" item in the types combobox is selected, we want to pop a 
         ''' the type picker dialog...
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub TypeComboBoxSelectedIndexChanged()
             Dim ptCurrent As Drawing.Point = _settingsGridView.CurrentCellAddress
 
@@ -2110,7 +2030,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="msg"></param>
         ''' <param name="wParam"></param>
         ''' <param name="lParam"></param>
-        ''' <remarks></remarks>
         Private Function OnBroadcastMessage(msg As UInteger, wParam As IntPtr, lParam As IntPtr) As Integer Implements IVsBroadcastMessageEvents.OnBroadcastMessage
             If msg = Interop.Win32Constant.WM_SETTINGCHANGE Then
                 SetFonts()
@@ -2121,7 +2040,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Helper method to get a service from either our settings object or from out root designer
         ''' </summary>
         ''' <param name="service"></param>
-        ''' <remarks></remarks>
         Protected Overrides Function GetService(service As Type) As Object
             Dim svc As Object = Nothing
             If Settings IsNot Nothing AndAlso Settings.Site IsNot Nothing Then
@@ -2144,7 +2062,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub OnRowAdded(sender As Object, e As DataGridViewRowsAddedEventArgs) Handles _settingsGridView.RowsAdded
             Dim newRow As DataGridViewRow = _settingsGridView.Rows(e.RowIndex)
             newRow.Height = newRow.GetPreferredHeight(e.RowIndex, DataGridViewAutoSizeRowMode.AllCells, True)
@@ -2154,7 +2071,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Whenever the font changes, we have to resize the row headers...
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnFontChanged(e As EventArgs)
             MyBase.OnFontChanged(e)
             _settingsGridView.AutoResizeRows(DataGridViewAutoSizeRowsMode.AllCells)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSerializer.vb
@@ -10,7 +10,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' Utility class to (de)serialize the contents of a DesignTimeSetting object 
     ''' given a stream reader/writer
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class SettingsSerializer
 
         Friend Class SettingsSerializerException
@@ -44,8 +43,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Demand create an XML Schema instance for .settings files
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private Shared ReadOnly Property Schema() As System.Xml.Schema.XmlSchema
             Get
                 Static schemaInstance As System.Xml.Schema.XmlSchema
@@ -63,7 +60,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Shared Sub SchemaValidationEventHandler(sender As Object, e As System.Xml.Schema.ValidationEventArgs)
             System.Diagnostics.Debug.Fail("Failed to load XML schema from manifest resource stream!")
             s_SchemaLoadFailed = True
@@ -72,7 +68,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Stores all validation errors from a ValidatingReader
         ''' </summary>
-        ''' <remarks></remarks>
         Private Class ValidationErrorBag
             Private m_ValidationErrors As New System.Collections.ArrayList
 
@@ -93,7 +88,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="Settings">Instance to populate</param>
         ''' <param name="Reader">Text reader on stream containing serialized settings</param>
-        ''' <remarks></remarks>
         Public Shared Sub Deserialize(Settings As DesignTimeSettings, Reader As TextReader, getRuntimeValue As Boolean)
             Dim XmlDoc As New XmlDocument With {
                 .XmlResolver = Nothing
@@ -244,7 +238,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="Settings">Instance to serialize</param>
         ''' <param name="Writer">Text writer on stream to serialize settings to</param>
-        ''' <remarks></remarks>
         Public Shared Sub Serialize(Settings As DesignTimeSettings, GeneratedClassNameSpace As String, ClassName As String, Writer As TextWriter, DeclareEncodingAs As System.Text.Encoding)
             Common.Switches.TraceSDSerializeSettings(TraceLevel.Info, "Serializing {0} settings", Settings.Count)
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGenerator.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGenerator.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Runtime.InteropServices
 
@@ -7,7 +7,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' <summary>
     ''' Generator for strongly typed settings wrapper class
     ''' </summary>
-    ''' <remarks></remarks>
     <Guid("3b4c204a-88a2-3af8-bcfd-cfcb16399541")>
     Public Class SettingsSingleFileGenerator
         Inherits SettingsSingleFileGeneratorBase

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
@@ -61,7 +61,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Returns the default visibility of this properties
         ''' </summary>
-        ''' <value></value>
         ''' <remarks>MemberAttributes indicating what visibility to make the generated properties.</remarks>
         Friend Shared ReadOnly Property SettingsPropertyVisibility() As MemberAttributes
             Get
@@ -84,7 +83,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="compileUnit">The full compile unit that we are to generate code from</param>
         ''' <param name="generatedClass">The generated settings class</param>
-        ''' <remarks></remarks>
         Protected Overridable Sub OnCompileUnitCreated(compileUnit As CodeCompileUnit, generatedClass As CodeTypeDeclaration)
             ' By default, we don't want to make any modifications...
         End Sub
@@ -94,7 +92,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Get the default extension for the generated class.
         ''' </summary>
         ''' <param name="pbstrDefaultExtension"></param>
-        ''' <remarks></remarks>
         Private Function DefaultExtension(ByRef pbstrDefaultExtension As String) As Integer Implements IVsSingleFileGenerator.DefaultExtension
             If CodeDomProvider IsNot Nothing Then
                 ' For some reason some the code providers seem to be inconsistent in the way that they 
@@ -119,7 +116,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="rgbOutputFileContents"></param>
         ''' <param name="pcbOutput"></param>
         ''' <param name="pGenerateProgress"></param>
-        ''' <remarks></remarks>
         Private Function Generate(wszInputFilePath As String, bstrInputFileContents As String, wszDefaultNamespace As String, rgbOutputFileContents() As IntPtr, ByRef pcbOutput As UInteger, pGenerateProgress As IVsGeneratorProgress) As Integer Implements IVsSingleFileGenerator.Generate
 
 
@@ -241,7 +237,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="GeneratedClassVisibility"></param>
         ''' <param name="GenerateVBMyAutoSave"></param>
         ''' <returns>CodeCompileUnit of the given DesignTimeSettings object</returns>
-        ''' <remarks></remarks>
         Friend Shared Function Create(Hierarchy As IVsHierarchy,
                                       Settings As DesignTimeSettings,
                                       DefaultNamespace As String,
@@ -321,8 +316,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="InputString"></param>
         ''' <param name="GenerateProgress"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function DeserializeSettings(InputString As String, GenerateProgress As IVsGeneratorProgress) As DesignTimeSettings
             Dim Settings As New DesignTimeSettings()
             If InputString <> "" Then
@@ -537,8 +530,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get the type of the class that our strongly typed wrapper class is supposed to inherit from
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend Shared ReadOnly Property SettingsBaseClass() As Type
             Get
                 Return GetType(Configuration.ApplicationSettingsBase)
@@ -549,8 +540,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Generate CodeDomStatements to get a setting from our base class
         ''' </summary>
         ''' <param name="Instance"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GenerateGetterStatements(Instance As DesignTimeSettingInstance, SettingType As CodeTypeReference) As CodeStatementCollection
             Dim Statements As New CodeStatementCollection
             Dim Parameters() As CodeExpression = {New CodePrimitiveExpression(Instance.Name)}
@@ -569,8 +558,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Generate statements to set a settings value
         ''' </summary>
         ''' <param name="Instance"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GenerateSetterStatements(Instance As DesignTimeSettingInstance) As CodeStatementCollection
             Dim Statements As New CodeStatementCollection
             Dim Parameters() As CodeExpression = {New CodePrimitiveExpression(Instance.Name)}
@@ -589,8 +576,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="projectRootNamespace">project's root namespace (may be String.Empty)</param>
         ''' <param name="defaultNamespace">namespace into which we are generating (may be String.Empty)</param>
         ''' <param name="typeName">the type of the settings-class we are generating</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GetFullTypeName(projectRootNamespace As String, defaultNamespace As String, typeName As String) As String
 
             Dim fullTypeName As String = String.Empty
@@ -614,7 +599,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Add required references to the project - currently only adding a reference to the settings base class assembly
         ''' </summary>
         ''' <param name="GenerateProgress"></param>
-        ''' <remarks></remarks>
         Protected Overridable Sub AddRequiredReferences(GenerateProgress As IVsGeneratorProgress)
             Dim CurrentProjectItem As EnvDTE.ProjectItem = CType(GetService(GetType(EnvDTE.ProjectItem)), EnvDTE.ProjectItem)
             If CurrentProjectItem Is Nothing Then
@@ -636,7 +620,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' My.Settings for easy access to typed-settings.
         ''' </summary>
         ''' <param name="Unit"></param>
-        ''' <remarks></remarks>
         Private Shared Sub AddMyModule(Unit As CodeCompileUnit, projectRootNamespace As String, defaultNamespace As String)
 
             Debug.Assert(Unit IsNot Nothing AndAlso Unit.Namespaces.Count = 1 AndAlso Unit.Namespaces(0).Types.Count = 1, "Expected a compile unit with a single namespace containing a single type!")
@@ -740,8 +723,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' we are currently generating. This will include the root-namespace for VB even though
         ''' we would not have been passed in that namespace in the call to Generate.
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overridable Function GetProjectRootNamespace() As String
 
             Dim rootNamespace As String = String.Empty
@@ -805,8 +786,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Is this the "default" settings file
         ''' </summary>
         ''' <param name="FilePath">Fully qualified path of file to check</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function IsDefaultSettingsFile(FilePath As String) As Boolean
             Dim Hierarchy As IVsHierarchy = DirectCast(GetService(GetType(IVsHierarchy)), IVsHierarchy)
             If Hierarchy Is Nothing Then
@@ -842,7 +821,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Demand-create a CodeDomProvider corresponding to my projects current language
         ''' </summary>
         ''' <value>A CodeDomProvider</value>
-        ''' <remarks></remarks>
         Private Property CodeDomProvider() As CodeDomProvider
             Get
                 If _codeDomProvider Is Nothing Then
@@ -865,8 +843,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Demand-create service provider from my site
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property ServiceProvider() As ServiceProvider
             Get
                 If _serviceProvider Is Nothing AndAlso _site IsNot Nothing Then
@@ -881,8 +857,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Create a CodeTypeReference instance with the GlobalReference option set.
         ''' </summary>
         ''' <param name="type"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function CreateGlobalCodeTypeReference(type As Type) As CodeTypeReference
             Dim ctr As New CodeTypeReference(type) With {
                 .Options = CodeTypeReferenceOptions.GlobalReference
@@ -1101,7 +1075,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="serviceType">The type of service requested</param>
         ''' <returns>An instance of the service, or nothing if service not found</returns>
-        ''' <remarks></remarks>
         Private Function GetService(serviceType As Type) As Object Implements System.IServiceProvider.GetService
             If ServiceProvider IsNot Nothing Then
                 Return ServiceProvider.GetService(serviceType)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsTypeCache.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsTypeCache.vb
@@ -8,7 +8,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' Wrapper class for the settings type resolver that caches previously resolved
     ''' type names.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class SettingsTypeCache
         Implements IDisposable
 
@@ -46,7 +45,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Given a "normal" ITypeResolutionService, create an instance of the settingstypecache
         ''' </summary>
         ''' <param name="typeResolutionService"></param>
-        ''' <remarks></remarks>
         Public Sub New(vsHierarchy As IVsHierarchy, ItemId As UInteger, typeResolutionService As ComponentModel.Design.ITypeResolutionService, caseSensitive As Boolean)
             If typeResolutionService Is Nothing OrElse vsHierarchy Is Nothing Then
                 Debug.Fail("We really need a type resolution service or IVsHierarchy in order to do anything interesting!")
@@ -80,8 +78,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' The cache is updated with the returned type to improve performance of subsequent resolves...
         ''' </summary>
         ''' <param name="typeName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetSettingType(typeName As String) As Type
             ' First, check our list of well known types...
             For Each wellKnownType As Type In GetWellKnownTypes()
@@ -97,8 +93,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Get the list of "well known" types (i.e. types that we don't need any type resolution service
         ''' in order to resolve...
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetWellKnownTypes() As Type()
             Return _multiTargetService.GetSupportedTypes(_wellKnownTypes)
         End Function
@@ -107,8 +101,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Is the given type a well known type?
         ''' </summary>
         ''' <param name="type"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function IsWellKnownType(type As Type) As Boolean
             For Each wellKnownType As Type In GetWellKnownTypes()
                 If wellKnownType Is type Then
@@ -124,8 +116,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="persistedSettingTypeName"></param>
         ''' <param name="caseSensitive"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function ResolveType(persistedSettingTypeName As String, caseSensitive As Boolean) As Type
             Dim t As Type
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsValueCache.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsValueCache.vb
@@ -4,7 +4,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' <summary>
     ''' Caching implementation for value serializations. 
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class SettingsValueCache
 
         ' We cache the values in a hashtable of hashtables:
@@ -23,8 +22,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="settingType"></param>
         ''' <param name="serializedValue"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Function GetValue(settingType As Type, serializedValue As String) As Object
             Dim valueDictionary As Dictionary(Of String, Object) = Nothing
             If Not _cachedSettingValues.TryGetValue(settingType, valueDictionary) Then

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsValueSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsValueSerializer.vb
@@ -10,7 +10,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' Serialize object in the same way that the runtime will serialize them, with the additional twist that you can pass
     ''' a culture info.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class SettingsValueSerializer
 
         Private Sub New()
@@ -142,8 +141,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="serializedValue"></param>
         ''' <param name="type"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function Normalize(serializedValue As String, type As Type) As String
             If SettingTypeValidator.IsTypeObsolete(type) Then
                 Return serializedValue

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorDataGridViewColumn.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorDataGridViewColumn.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Windows.Forms
 
@@ -6,7 +6,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' <summary>
     ''' UI Type editor column for DataGridView
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class DataGridViewUITypeEditorColumn
         Inherits DataGridViewColumn
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorHostControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorHostControl.vb
@@ -14,7 +14,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' <summary>
     ''' Control to host UI type editor. Set the value and value type of the value to edit
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class TypeEditorHostControl
         Inherits UserControl
         Implements IWindowsFormsEditorService, IServiceProvider
@@ -114,7 +113,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' that we need to re-parse it if the user wants to get the deserialized
         ''' value
         ''' </summary>
-        ''' <remarks></remarks>
         Private _textValueDirty As Boolean
 
         ' Indicating if we are currently showing a UI type editor
@@ -250,7 +248,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub PreviewPanel_Paint(sender As Object, e As PaintEventArgs) Handles _previewPanel.Paint
             If Not _typeEditor Is Nothing Then
                 If _typeEditor.GetPaintValueSupported Then
@@ -269,7 +266,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Layout contained controls
         ''' </summary>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnLayout(e As LayoutEventArgs)
             MyBase.OnLayout(e)
 
@@ -318,7 +314,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ShowEditorButton_Click(sender As Object, e As EventArgs) Handles _showEditorButton.Click
             Debug.Assert(Not _typeEditor Is Nothing)
             ShowUITypeEditor()
@@ -327,7 +322,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Display the associated type editor if not already showing
         ''' </summary>
-        ''' <remarks></remarks>
         <Security.SecurityCritical()>
         <System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions()>
         Private Sub ShowUITypeEditor()
@@ -386,7 +380,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub TextChangedHandler(sender As Object, e As EventArgs) Handles _valueTextBox.TextChanged, _valueComboBox.TextChanged
             If Not _ignoreTextChangeEvents Then
                 TextValueDirty = True
@@ -400,7 +393,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub KeyDownHandler(sender As Object, e As KeyEventArgs) Handles _valueTextBox.KeyDown
             If _typeEditor IsNot Nothing Then
                 If _typeEditor.GetEditStyle() = UITypeEditorEditStyle.DropDown Then
@@ -428,8 +420,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' and the current UI Type editor is a modal editor...
         ''' </summary>
         ''' <param name="keyData"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overrides Function IsInputKey(keyData As Keys) As Boolean
             If keyData = Keys.Enter Then
                 If _showEditorButton.Focused AndAlso _typeEditor IsNot Nothing AndAlso _typeEditor.GetEditStyle() = UITypeEditorEditStyle.Modal Then
@@ -526,8 +516,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Are we currently showing the UI type editor?
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public ReadOnly Property IsShowingUITypeEditor() As Boolean
             Get
                 Return _isShowingUITypeEditor
@@ -551,7 +539,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Host the UI type editor control given to use. 
         ''' </summary>
-        ''' <remarks></remarks>
         Private Class DropDownHolder
             Inherits Form
 
@@ -563,8 +550,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' <summary>
             ''' Override default create parameters for window
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Protected Overrides ReadOnly Property CreateParams() As CreateParams
                 Get
                     Dim BaseParams As CreateParams = MyBase.CreateParams
@@ -589,12 +574,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             Protected Sub HideForm()
                 Hide()
             End Sub
-
-            ''' <summary>
-            ''' 
-            ''' </summary>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Protected Overrides Sub OnDeactivate(e As EventArgs)
                 HideForm()
             End Sub
@@ -602,8 +582,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' <summary>
             ''' Get/set the UI type editor that I'm hosting...
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public Property Editor() As Control
                 Get
                     If Controls.Count = 1 Then
@@ -625,7 +603,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' Pressing the escape key should close the window
             ''' </summary>
             ''' <param name="m"></param>
-            ''' <remarks></remarks>
             Protected Overrides Function ProcessKeyPreview(ByRef m As Message) As Boolean
                 If m.Msg = Interop.NativeMethods.WM_KEYDOWN Then
                     If CType(m.WParam.ToInt32(), Keys) = Keys.Escape Then
@@ -642,7 +619,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub ValueComboBox_SelectedIndexChanged(sender As Object, e As EventArgs) Handles _valueComboBox.SelectedIndexChanged
             _innerValue = _valueComboBox.SelectedItem
             TextValueDirty = False
@@ -652,8 +628,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Is the text in the currently selected edit control dirty?
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private Property TextValueDirty() As Boolean
             Get
                 Return _textValueDirty
@@ -666,7 +640,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Map the SelectAll procedure to the currently selected edit control
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub SelectAll()
             If TypeOf EditControl Is ComboBox Then
                 DirectCast(EditControl, ComboBox).SelectAll()
@@ -679,8 +652,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Map the selection length property to the currently selected edit control
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property SelectionLength() As Integer
             Get
                 If _valueComboBox.Visible Then
@@ -703,8 +674,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Map the selection start property to the currently selected edit control
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property SelectionStart() As Integer
             Get
                 If _valueComboBox.Visible Then
@@ -727,8 +696,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Map the selected text to the currently selected edit control
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property SelectedText() As String
             Get
                 If _valueComboBox.Visible Then
@@ -751,8 +718,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get the text in the edit control
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Overrides Property Text() As String
             Get
                 Return EditControl.Text
@@ -771,8 +736,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get the currently active edit control (textbox or combobox)
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend Property EditControl() As Control
             Get
                 If _currentEditControl IsNot Nothing Then
@@ -796,8 +759,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get an instance of a ITypeDescriptorContext to pass into the UITypeEditor
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Overridable ReadOnly Property Context() As ITypeDescriptorContext
             Get
                 Return Nothing
@@ -807,7 +768,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' We want to special-handle a couple of keyboard messages from the textbox...
         ''' </summary>
-        ''' <remarks></remarks>
         Private Class TypeEditorHostControlTextBox
             Inherits TextBox
 
@@ -815,8 +775,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' This code was mainly ripped from DataGridViewTextBoxEditingControl...
             ''' </summary>
             ''' <param name="m"></param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             <Security.Permissions.SecurityPermission(Security.Permissions.SecurityAction.LinkDemand, Flags:=Security.Permissions.SecurityPermissionFlag.UnmanagedCode)>
             Protected Overrides Function ProcessKeyEventArgs(ByRef m As Message) As Boolean
                 Select Case CType(CInt(m.WParam), Keys)
@@ -847,7 +805,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Custom button that alternates between ... and combobox drop down
         ''' </summary>
-        ''' <remarks></remarks>
         Private Class ComboBoxDotDotDotButton
             Inherits Button
 
@@ -869,8 +826,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' Do we want to look like a browse button or like a 
             ''' combobox dropdown?
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Public Property PaintStyle() As PaintStyles
                 Get
                     Return _paintStyle
@@ -891,7 +846,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' Keep track on when the mouse is over us
             ''' </summary>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Protected Overrides Sub OnMouseEnter(e As EventArgs)
                 _drawHot = True
                 Invalidate()
@@ -902,7 +856,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' Keep track on when the mouse is over us
             ''' </summary>
             ''' <param name="e"></param>
-            ''' <remarks></remarks>
             Protected Overrides Sub OnMouseLeave(e As EventArgs)
                 _drawHot = False
                 Invalidate()
@@ -913,7 +866,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' Custom paint ... or combobox drop down...
             ''' </summary>
             ''' <param name="pevent"></param>
-            ''' <remarks></remarks>
             Protected Overrides Sub OnPaint(pevent As PaintEventArgs)
                 MyBase.OnPaint(pevent)
                 Select Case PaintStyle

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
@@ -15,7 +15,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' <summary>
     ''' Show a dialog allowing the user to pick a type
     ''' </summary>
-    ''' <remarks></remarks>
     Friend NotInheritable Class TypePickerDialog
         'Inherits System.Windows.Forms.Form
         Inherits BaseDialog
@@ -230,8 +229,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get whatever type name the user selected
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Public Property TypeName() As String
             Get
                 Return _typeTextBox.Text.Trim()
@@ -248,8 +245,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' A collection of available types
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private ReadOnly Property AvailableTypes() As AutoCompleteStringCollection
             Get
                 Return _typeTextBox.AutoCompleteCustomSource
@@ -303,7 +298,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub OnOkButtonClick(sender As Object, e As EventArgs) Handles _okButton.Click
             If QueryClose() Then
                 DialogResult = DialogResult.OK
@@ -317,7 +311,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <returns>
         ''' True if validation successful OR validation unsuccessful, but user chooses to save type anyway
         '''</returns>
-        ''' <remarks></remarks>
         Private Function QueryClose() As Boolean
             Dim ShouldClose As Boolean
 
@@ -374,8 +367,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' type names (i.e. int for System.Int32) as well as type names in imported namespaces
         ''' </summary>
         ''' <param name="displayName"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function NormalizeTypeName(displayName As String) As String
             Dim typeNameResolutionService As SettingTypeNameResolutionService =
                 DirectCast(GetService(GetType(SettingTypeNameResolutionService)), SettingTypeNameResolutionService)
@@ -421,8 +412,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get the project level imports
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function GetProjectImports() As List(Of String)
             Dim Result As New List(Of String)
             Dim vsProject As VSLangProj.VSProject
@@ -621,7 +610,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
-        ''' <remarks></remarks>
         Private Sub TypePickerDialog_FormClosed(sender As Object, e As FormClosedEventArgs) Handles Me.FormClosed
             s_previousSize = Size
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
@@ -60,20 +60,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         Private _ignoreAppConfigChanges As Boolean
 
         Private Shared s_globalSettings As TraceSwitch
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub Finalize()
             Dispose(False)
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend Shared ReadOnly Property GlobalSettings() As TraceSwitch
             Get
                 If (s_globalSettings Is Nothing) Then
@@ -88,7 +77,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' gets the running-doc-table for the instance of VS
         ''' </summary>
         ''' <value>running-doc-table</value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property RunningDocTable() As IVsRunningDocumentTable
             Get
                 If (_rdt Is Nothing) Then
@@ -336,7 +324,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' <param name="project">Project that we're searching</param>
         ''' <param name="baseType">type to which we should limit our search</param>
         ''' <returns>collection of global objects</returns>
-        ''' <remarks></remarks>
         Protected Overrides Function GetGlobalObjectsCore(project As Project, baseType As Type) As GlobalObjectCollection
 
 #If DEBUG Then
@@ -467,13 +454,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             End If
             Return result
         End Function 'GetGlobalObjectsCore
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="o"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function DebugGetId(o As Object) As String
 #If DEBUG Then
             If (o Is Nothing) Then
@@ -485,13 +466,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             Return ""
 #End If
         End Function
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="o"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Friend Shared Function DebugGetStr(o As Object) As String
 #If DEBUG Then
             If (o Is Nothing) Then
@@ -669,8 +644,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' </summary>
         ''' <param name="docCookie">Cookie corresponding to the file we are looking for</param>
         ''' <param name="hier">Nothing or the IVsHierarchy in which the document is the default app.config file</param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function IsDefaultAppConfigFile(docCookie As UInteger, ByRef hier As IVsHierarchy) As Boolean
             Dim itemid As UInteger = VSITEMID.NIL
 
@@ -712,8 +685,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' the settings objects... That will only affect that particular object, and it should raise
         ''' it's own change notifications!
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend Property IgnoreAppConfigChanges() As Boolean
             Get
                 Return _ignoreAppConfigChanges
@@ -1023,8 +994,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' <param name="rgpProjects"></param>
         ''' <param name="rgFirstIndices"></param>
         ''' <param name="cFiles"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Shared Function GetCorrespondingProjects(rgpProjects() As IVsProject, rgFirstIndices() As Integer, cFiles As Integer) As IVsHierarchy()
             ' We trust that someone has already checked these parameters, so we only ASSERT if something looks
             ' bogus....
@@ -1194,7 +1163,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' (the XML serializer may use the DynamicTypeService to resolve the type to
         ''' deserialize, which means that we may be called again - See VsWhidbey 444946)
         ''' </summary>
-        ''' <remarks></remarks>
         Private _loadingSettings As Boolean = False
 
         ''' <summary>
@@ -1225,8 +1193,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' <summary>
         ''' access to the DesignTimeSettings class this global-object represents
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Friend ReadOnly Property Settings() As DesignTimeSettings
             Get
                 Debug.Assert(_dtSettings IsNot Nothing, "missing the design-time settings collection?")
@@ -1247,8 +1213,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' gets/sets the DocData associated with this global object, appropriately adding
         ''' or removing event listeners
         ''' </summary>
-        ''' <value></value>
-        ''' <remarks></remarks>
         Private Property DocData() As DocData
             Get
                 Return _docData
@@ -1302,7 +1266,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' Builds a virtual type based on the data stored in this global object.  Also populates
         ''' all of the child global objects.
         ''' </summary>
-        ''' <returns></returns>
         Private Function BuildType() As Type
 
 #If DEBUG Then
@@ -1406,8 +1369,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' <summary>
         ''' Creates an instance of this global type
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Protected Overrides Function CreateInstance() As Object
 
             Dim value As Object = TypeDescriptor.CreateInstance(DirectCast(_provider, IServiceProvider), GetObjectType(), Array.Empty(Of Type), Array.Empty(Of Object))
@@ -1440,7 +1401,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' <summary>
         ''' ensures that this file is generating a typed-settings class
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Sub EnsureGeneratingSettingClass()
 
             Dim customTool As String
@@ -1464,15 +1424,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             End Try
 
         End Sub
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <param name="fileName">IN: name of the file to get the document info from</param>
         ''' <param name="readLocks">OUT: Number of read locks for the document</param>
         ''' <param name="editLocks">OUT: Number of edit locks on the document</param>
         ''' <param name="docCookie">OUT: A cookie for the doc, 0 if the doc isn't found in the RDT</param>
-        ''' <remarks></remarks>
         Private Sub GetDocumentInfo(fileName As String, ByRef readLocks As UInteger, ByRef editLocks As UInteger, ByRef itemid As UInteger, ByRef docCookie As UInteger)
             Dim rdt As IVsRunningDocumentTable = _provider.RunningDocTable
             Debug.Assert((rdt IsNot Nothing), "What?  No RDT?")
@@ -1504,7 +1459,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' <summary>
         ''' Whenever the schema of the object changes, we have to clear our cached type
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub PerformChange()
             MyBase.PerformChange()
             _virtualType = Nothing
@@ -1534,7 +1488,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' </summary>
         ''' <param name="fileName">path to a .settings file</param>
         ''' <returns>DesignTimeSettings that represents the given file</returns>
-        ''' <remarks></remarks>
         Private Function LoadSettings(fileName As String) As DesignTimeSettings
 
 #If DEBUG Then
@@ -1641,7 +1594,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' <summary>
         ''' Allow clients to force us to update our contents..
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub Refresh() Implements VSDesignerPackage.IRefreshSettingsObject.Refresh
             RaiseChange()
         End Sub
@@ -1685,7 +1637,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' <summary>
         ''' Called when the last lock is removed from this document.
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Sub OnLastUnlock()
 
             If (Not _ignoreDocLock) Then
@@ -1727,7 +1678,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' If the root namespace changes, we've gotta remove all old stuff from the 
         ''' app/web.config and re-serialize the .settings file
         ''' </summary>
-        ''' <remarks></remarks>
         Friend Sub OnRootNamespaceChanged(OldRootNamespace As String)
             ' If we don't have a persisted namespace, that means that we have a newly created
             ' instance, which doesn't exist in the app.config (yet)
@@ -1761,7 +1711,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' DesignTimeSettings class -- intended to be called after the forms
         ''' designer pokes in new settings
         ''' </summary>
-        ''' <remarks></remarks>
         Private Sub Save()
 
 #If DEBUG Then
@@ -2007,7 +1956,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' <summary>
         ''' This class is the code serializer for SettingsFile global object.
         ''' </summary>
-        ''' <remarks></remarks>
         <Serializable()>
         Private NotInheritable Class SettingsFileCodeDomSerializer
             Inherits CodeDomSerializer
@@ -2017,8 +1965,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             ''' <summary>
             ''' Provides a stock serializer instance.
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Friend Shared ReadOnly Property [Default]() As SettingsFileCodeDomSerializer
                 Get
                     If (s_default Is Nothing) Then
@@ -2033,8 +1979,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             ''' </summary>
             ''' <param name="manager"></param>
             ''' <param name="codeObject"></param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Overrides Function Deserialize(manager As IDesignerSerializationManager, codeObject As Object) As Object
 
                 Debug.Fail("Should never be called")
@@ -2047,8 +1991,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             ''' </summary>
             ''' <param name="manager"></param>
             ''' <param name="value">a SettingsGlobalObjectValueAttribute</param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Overrides Function Serialize(manager As IDesignerSerializationManager, value As Object) As Object
 
 #If DEBUG Then
@@ -2098,7 +2040,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' <summary>
         ''' The virtual type implementor for our global object.  This maps properties to setting names.
         ''' </summary>
-        ''' <remarks></remarks>
         Private NotInheritable Class SettingsFileTypeImplementor
             Inherits VirtualTypeImplementor
 
@@ -2108,7 +2049,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             ''' constructor for this implementor
             ''' </summary>
             ''' <param name="globalObject">object we implement in place of</param>
-            ''' <remarks></remarks>
             Friend Sub New(globalObject As SettingsFileGlobalObject)
 
 #If DEBUG Then
@@ -2124,8 +2064,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             ''' <param name="prop"></param>
             ''' <param name="instance"></param>
             ''' <param name="args"></param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Overrides Function GetPropertyValue(prop As PropertyInfo, instance As Object, args() As Object) As Object
 
                 Debug.Assert(prop IsNot Nothing, "bad property passed to GetPropertyValue")
@@ -2207,14 +2145,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
                 Debug.Fail(("Property " + prop.Name + " could not be located in our global object collection."))
                 Return Nothing
             End Function 'GetPropertyValue
-
-            ''' <summary>
-            ''' 
-            ''' </summary>
             ''' <param name="ctor"></param>
             ''' <param name="args"></param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Overrides Function InvokeConstructor(ctor As ConstructorInfo, args As Object()) As Object
 
 #If DEBUG Then
@@ -2227,15 +2159,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
                 Return constructedObject
 
             End Function 'InvokeConstructor
-
-            ''' <summary>
-            ''' 
-            ''' </summary>
             ''' <param name="prop"></param>
             ''' <param name="instance"></param>
             ''' <param name="value"></param>
             ''' <param name="args"></param>
-            ''' <remarks></remarks>
             Public Overrides Sub SetPropertyValue(prop As PropertyInfo, instance As Object, value As Object, args As Object())
 
                 Debug.Assert(prop IsNot Nothing, "bad property passed to SetPropertyValue")
@@ -2295,19 +2222,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             End Sub
 
         End Class 'SettingsFileTypeImplementor
-
-
-
-
-
-
-
-
-
-
-        ''' <summary>
-        ''' 
-        ''' </summary>
         ''' <remarks>
         ''' This type must be serializable to satisfy the VS shell.
         ''' https://devdiv.visualstudio.com/DevDiv/_workitems/edit/765098
@@ -2320,12 +2234,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             Private ReadOnly _globalObject As SettingsFileGlobalObject
             <NonSerialized>
             Private _properties As SettingsPropertyCollection
-
-            ''' <summary>
-            ''' 
-            ''' </summary>
             ''' <param name="globalObject"></param>
-            ''' <remarks></remarks>
             Friend Sub New(globalObject As SettingsFileGlobalObject)
 
 #If DEBUG Then
@@ -2344,7 +2253,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             ''' objects in general) we use our derived SettingsPropertyCollection that will happily pick up the settings from
             ''' the DesignTimeSettings object associated with this instance.
             ''' </summary>
-            ''' <value></value>
             ''' <remarks>
             ''' The properties collection is cached in this instance, so it will only reflect the settings that were
             ''' present at the time when the client called this property getter. Whenever someone adds/removes settings
@@ -2375,17 +2283,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' This collection should only be used to add/remove settings - you should not rely on the actual attributes that
         ''' are put on each property as they may not be correct...
         ''' </summary>
-        ''' <remarks></remarks>
         Private Class GlobalSettingsPropertyCollection
             Inherits SettingsPropertyCollection
 
             Private ReadOnly _globalObject As SettingsFileGlobalObject
-
-            ''' <summary>
-            ''' 
-            ''' </summary>
             ''' <param name="globalObject"></param>
-            ''' <remarks></remarks>
             Friend Sub New(globalObject As SettingsFileGlobalObject)
 
 #If DEBUG Then
@@ -2401,12 +2303,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
                 Debug.Assert(globalObject IsNot Nothing, "")
                 _globalObject = globalObject
             End Sub
-
-            ''' <summary>
-            ''' 
-            ''' </summary>
             ''' <param name="prop"></param>
-            ''' <remarks></remarks>
             Protected Overrides Sub OnAddComplete(prop As SettingsProperty)
                 If _globalObject Is Nothing Then Return
 #If DEBUG Then
@@ -2490,7 +2387,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             ''' Handle the remove of a setting
             ''' </summary>
             ''' <param name="property"></param>
-            ''' <remarks></remarks>
             Protected Overrides Sub OnRemoveComplete([property] As SettingsProperty)
                 If _globalObject Is Nothing Then Return
 #If DEBUG Then
@@ -2549,7 +2445,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' Attribute we tack on to values that we return from GetPropertyValue to identify which property
         ''' the value hails from.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Class SettingsGlobalObjectValueAttribute
             Inherits Attribute
 
@@ -2561,7 +2456,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             ''' </summary>
             ''' <param name="globalObject"></param>
             ''' <param name="propertyName"></param>
-            ''' <remarks></remarks>
             Friend Sub New(globalObject As SettingsFileGlobalObject, propertyName As String)
                 _globalObject = globalObject
                 _propertyName = propertyName
@@ -2570,8 +2464,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             ''' <summary>
             ''' gets the GlobalObject associated with this value
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Friend ReadOnly Property GlobalObject() As SettingsFileGlobalObject
                 Get
                     Return _globalObject
@@ -2581,8 +2473,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             ''' <summary>
             ''' Gets the property-name associated with this value
             ''' </summary>
-            ''' <value></value>
-            ''' <remarks></remarks>
             Friend ReadOnly Property PropertyName() As String
                 Get
                     Return _propertyName
@@ -2597,7 +2487,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
     ''' <summary>
     ''' Class that helps get an IVsHierarchy given a DTE project.
     ''' </summary>
-    ''' <remarks></remarks>
     Friend Class ProjectUtilities
 
         Public Shared Function GetVsHierarchy(provider As IServiceProvider, project As Project) As IVsHierarchy

--- a/src/Microsoft.VisualStudio.Editors/interop/NativeMethods.vb
+++ b/src/Microsoft.VisualStudio.Editors/interop/NativeMethods.vb
@@ -362,8 +362,6 @@ Namespace Microsoft.VisualStudio.Editors.Interop
         ''' <summary>
         ''' The GetNextDlgTabItem function retrieves a handle to the first control that has the WS_TABSTOP style that precedes (or follows) the specified control. 
         ''' </summary>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         <PreserveSig()> Friend Declare Auto Function _
             GetNextDlgTabItem _
                 Lib "user32" (hDlg As IntPtr, hCtl As IntPtr, bPrevious As Boolean) As IntPtr

--- a/src/Microsoft.VisualStudio.Editors/package/InternalException.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/InternalException.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 
@@ -10,7 +10,6 @@ Namespace Microsoft.VisualStudio.Editors.Package
     '''   (obviously not very helpful, but it doesn't make sense to localize and doc messages for errors which shouldn't
     '''   be happening).
     ''' </summary>
-    ''' <remarks></remarks>
     <Serializable()>
     Friend Class InternalException
         Inherits ApplicationException
@@ -28,7 +27,6 @@ Namespace Microsoft.VisualStudio.Editors.Package
         ''' Constructor
         ''' </summary>
         ''' <param name="Message">The message for the exception.</param>
-        ''' <remarks></remarks>
         Public Sub New(Message As String)
             Me.New(Message, Nothing)
         End Sub
@@ -49,7 +47,6 @@ Namespace Microsoft.VisualStudio.Editors.Package
         ''' </summary>
         ''' <param name="Message">The message for the exception.</param>
         ''' <param name="InnerException">The inner exception, if any (Nothing = none).</param>
-        ''' <remarks></remarks>
         Public Sub New(Message As String, InnerException As Exception)
             MyBase.New(Message, InnerException)
         End Sub
@@ -62,7 +59,6 @@ Namespace Microsoft.VisualStudio.Editors.Package
         ''' </summary>
         ''' <param name="info"></param>
         ''' <param name="context"></param>
-        ''' <remarks></remarks>
         <EditorBrowsable(EditorBrowsableState.Advanced)>
         Protected Sub New(info As System.Runtime.Serialization.SerializationInfo, context As System.Runtime.Serialization.StreamingContext)
             MyBase.New(info, context)

--- a/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
@@ -56,7 +56,6 @@ Namespace Microsoft.VisualStudio.Editors
         ''' <summary>
         ''' Constructor
         ''' </summary>
-        ''' <remarks></remarks>
         Public Sub New()
 
             ' Make sure we persist this 
@@ -66,7 +65,6 @@ Namespace Microsoft.VisualStudio.Editors
         ''' <summary>
         ''' Initialize package (register editor factories, add services)
         ''' </summary>
-        ''' <remarks></remarks>
         Protected Overrides Sub Initialize()
             Debug.Assert(s_instance Is Nothing, "VBPackage initialized multiple times?")
             s_instance = Me
@@ -132,8 +130,6 @@ Namespace Microsoft.VisualStudio.Editors
         ''' </summary>
         ''' <param name="container"></param>
         ''' <param name="serviceType"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Private Function OnCreateService(container As IServiceContainer, serviceType As Type) As Object
 
             ' Is the Permission Set Service being requested?
@@ -217,7 +213,6 @@ Namespace Microsoft.VisualStudio.Editors
         ''' Dispose our resources....
         ''' </summary>
         ''' <param name="disposing"></param>
-        ''' <remarks></remarks>
         Protected Overrides Sub Dispose(disposing As Boolean)
             If disposing Then
                 If _userConfigCleaner IsNot Nothing Then
@@ -249,7 +244,6 @@ Namespace Microsoft.VisualStudio.Editors
         ''' </summary>
         ''' <param name="key">Added in the constructor using AddOptionKey </param>
         ''' <param name="stream">Stream to read from</param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnLoadOptions(key As String, stream As IO.Stream)
             If String.Equals(key, ProjectDesignerSUOKey, StringComparison.Ordinal) Then
                 Dim reader As New IO.BinaryReader(stream)
@@ -276,7 +270,6 @@ Namespace Microsoft.VisualStudio.Editors
         ''' </summary>
         ''' <param name="key">Added in the constructor using AddOptionKey</param>
         ''' <param name="stream">Stream to read data from</param>
-        ''' <remarks></remarks>
         Protected Overrides Sub OnSaveOptions(key As String, stream As IO.Stream)
             If String.Equals(key, ProjectDesignerSUOKey, StringComparison.Ordinal) Then
                 ' This is the project designer's last active tab
@@ -311,8 +304,6 @@ Namespace Microsoft.VisualStudio.Editors
         ''' Get the project guid (VSHPROPID_ProjectIDGuid) from a IVsHierarchy
         ''' </summary>
         ''' <param name="hierarchy"></param>
-        ''' <returns></returns>
-        ''' <remarks></remarks>
         Public Shared Function ProjectGUID(hierarchy As IVsHierarchy) As Guid
             Dim projGuid As Guid = Guid.Empty
             Try
@@ -330,7 +321,6 @@ Namespace Microsoft.VisualStudio.Editors
         ''' </summary>
         ''' <param name="projectHierarchy"></param>
         ''' <returns>Last active tab number</returns>
-        ''' <remarks></remarks>
         Public Function GetLastShownApplicationDesignerTab(projectHierarchy As IVsHierarchy) As Integer Implements IVBPackage.GetLastShownApplicationDesignerTab
             Dim value As Byte
             If _lastViewedProjectDesignerTab IsNot Nothing AndAlso _lastViewedProjectDesignerTab.TryGetValue(ProjectGUID(projectHierarchy), value) Then
@@ -346,7 +336,6 @@ Namespace Microsoft.VisualStudio.Editors
         ''' </summary>
         ''' <param name="projectHierarchy">Hierarchy</param>
         ''' <param name="tab">Tab number</param>
-        ''' <remarks></remarks>
         Public Sub SetLastShownApplicationDesignerTab(projectHierarchy As IVsHierarchy, tab As Integer) Implements IVBPackage.SetLastShownApplicationDesignerTab
             If _lastViewedProjectDesignerTab Is Nothing Then
                 _lastViewedProjectDesignerTab = New Dictionary(Of Guid, Byte)
@@ -367,7 +356,6 @@ Namespace Microsoft.VisualStudio.Editors
         ''' The User.config files are created by the ClientConfig API, which is used by the runtime to
         ''' save user scoped settings created by the settings designer.
         ''' </summary>
-        ''' <remarks></remarks>
         Private Class UserConfigCleaner
             Implements IVsSolutionEvents, IDisposable
 
@@ -384,7 +372,6 @@ Namespace Microsoft.VisualStudio.Editors
             ''' Create a new instance of this class
             ''' </summary>
             ''' <param name="sp"></param>
-            ''' <remarks></remarks>
             Public Sub New(sp As IServiceProvider)
                 _solution = TryCast(sp.GetService(GetType(IVsSolution)), IVsSolution)
                 Debug.Assert(_solution IsNot Nothing, "Failed to get IVsSolution - clean up of user config files in ZIP projects will not work...")
@@ -402,7 +389,6 @@ Namespace Microsoft.VisualStudio.Editors
             ''' <summary>
             ''' Unadvise solution events
             ''' </summary>
-            ''' <remarks></remarks>
             Private Sub UnadviseSolutionEvents()
                 If _cookie <> 0 AndAlso _solution IsNot Nothing Then
                     Dim hr As Integer = _solution.UnadviseSolutionEvents(_cookie)
@@ -420,8 +406,6 @@ Namespace Microsoft.VisualStudio.Editors
             ''' solution is actually closed...
             ''' </summary>
             ''' <param name="pUnkReserved"></param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Function OnAfterCloseSolution(pUnkReserved As Object) As Integer Implements IVsSolutionEvents.OnAfterCloseSolution
                 SettingsDesigner.SettingsDesigner.DeleteFilesAndDirectories(_filesToCleanUp, Nothing)
                 _filesToCleanUp.Clear()
@@ -434,8 +418,6 @@ Namespace Microsoft.VisualStudio.Editors
             ''' we'll delete when the solution is closed
             ''' </summary>
             ''' <param name="pUnkReserved"></param>
-            ''' <returns></returns>
-            ''' <remarks></remarks>
             Public Function OnBeforeCloseSolution(pUnkReserved As Object) As Integer Implements IVsSolutionEvents.OnBeforeCloseSolution
                 Try
                     _filesToCleanUp.Clear()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/IVsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/IVsContainedLanguageComponentsFactory.cs
@@ -23,7 +23,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         /// <param name="hierarchy">Project hierarchy containing given file for current language service</param>
         /// <param name="itemid">item id of the given file</param>
         /// <param name="containedLanguageFactory">an instance of IVsContainedLanguageFactory specific for current language service</param>
-        /// <returns></returns>
         int GetContainedLanguageFactoryForFile(string filePath,
                                                out IVsHierarchy hierarchy,
                                                out uint itemid,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ComparableExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ComparableExtensions.cs
@@ -20,7 +20,6 @@ namespace Microsoft.VisualStudio
         ///     </para>
         ///     <paramref name="comparable"/> is <see langword="null"/>.
         /// </exception>
-        /// <returns></returns>
         public static bool IsLaterThan(this IComparable source, IComparable comparable)
         {
             Requires.NotNull(source, nameof(source));
@@ -40,7 +39,6 @@ namespace Microsoft.VisualStudio
         ///     </para>
         ///     <paramref name="comparable"/> is <see langword="null"/>.
         /// </exception>
-        /// <returns></returns>
         public static bool IsLaterThanOrEqualTo(this IComparable source, IComparable comparable)
         {
             Requires.NotNull(source, nameof(source));
@@ -60,7 +58,6 @@ namespace Microsoft.VisualStudio
         ///     </para>
         ///     <paramref name="comparable"/> is <see langword="null"/>.
         /// </exception>
-        /// <returns></returns>
         public static bool IsEarlierThan(this IComparable source, IComparable comparable)
         {
             Requires.NotNull(source, nameof(source));
@@ -80,7 +77,6 @@ namespace Microsoft.VisualStudio
         ///     </para>
         ///     <paramref name="comparable"/> is <see langword="null"/>.
         /// </exception>
-        /// <returns></returns>
         public static bool IsEarlierThanOrEqualTo(this IComparable source, IComparable comparable)
         {
             Requires.NotNull(source, nameof(source));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/ManagedPathHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/ManagedPathHelper.cs
@@ -15,7 +15,6 @@ namespace Microsoft.VisualStudio.IO
         /// Tests a path to see if it is absolute or not. More reliable than <see cref="System.IO.Path.IsPathRooted"/>.
         /// </summary>
         /// <param name="path"></param>
-        /// <returns></returns>
         public static bool IsRooted(string path)
         {
             Requires.NotNullOrEmpty(path, nameof(path));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledStringBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledStringBuilder.cs
@@ -59,7 +59,6 @@ namespace Microsoft.VisualStudio.Buffers.PooledObjects
         /// If someone need to create a private pool
         /// </summary>
         /// <param name="size">The size of the pool.</param>
-        /// <returns></returns>
         public static ObjectPool<PooledStringBuilder> CreatePool(int size = 32)
         {
             ObjectPool<PooledStringBuilder>? pool = null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
@@ -33,7 +33,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// Blocks until at least one snapshot has been generated.
         /// </summary>
         /// <param name="timeout">The timeout in milliseconds.</param>
-        /// <returns></returns>
         Task<ILaunchSettings> WaitForFirstSnapshot(int timeout);
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectConfigurationExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectConfigurationExtensions.cs
@@ -12,7 +12,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// This is true for a project with an explicit "TargetFrameworks" property, but no "TargetFrameworkMoniker" or "TargetFramework" property.
         /// </summary>
         /// <param name="projectConfiguration"></param>
-        /// <returns></returns>
         internal static bool IsCrossTargeting(this ProjectConfiguration projectConfiguration)
         {
             return projectConfiguration.Dimensions.ContainsKey(ConfigurationGeneral.TargetFrameworkProperty);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/SourceAssemblyAttributePropertyValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/SourceAssemblyAttributePropertyValueProvider.cs
@@ -63,7 +63,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// Sets the value of the property in the source assembly attribute.
         /// </summary>
         /// <param name="value"></param>
-        /// <returns></returns>
         public async Task SetPropertyValueAsync(string value)
         {
             Project? project = GetActiveProject();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
@@ -67,7 +67,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             /// persisted value in the project. So this method should never be called.
             /// </summary>
             /// <param name="userSuppliedValue"></param>
-            /// <returns></returns>
             public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue)
             {
                 throw new NotImplementedException();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependenciesTreeServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependenciesTreeServices.cs
@@ -24,7 +24,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <param name="expandedIcon"></param>
         /// <param name="visible"></param>
         /// <param name="flags"></param>
-        /// <returns></returns>
         IProjectTree CreateTree(
             string caption,
             IProjectPropertiesContext itemContext,
@@ -45,7 +44,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <param name="expandedIcon"></param>
         /// <param name="visible"></param>
         /// <param name="flags"></param>
-        /// <returns></returns>
         IProjectTree CreateTree(
             string caption,
             string? filePath,
@@ -61,7 +59,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         /// <param name="dependency"></param>
         /// <param name="catalogs"></param>
-        /// <returns></returns>
         Task<IRule?> GetBrowseObjectRuleAsync(IDependency dependency, IProjectCatalogSnapshot? catalogs);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependenciesTreeViewProvider.cs
@@ -34,7 +34,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         /// <param name="root">Node where we start searching</param>
         /// <param name="path">Path to find</param>
-        /// <returns></returns>
         IProjectTree? FindByPath(IProjectTree? root, string path);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Dependency.cs
@@ -286,7 +286,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// <param name="targetFramework"></param>
         /// <param name="providerType"></param>
         /// <param name="modelId"></param>
-        /// <returns></returns>
         public static string GetID(ITargetFramework targetFramework, string providerType, string modelId)
         {
             Requires.NotNull(targetFramework, nameof(targetFramework));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/AddDependencyContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/AddDependencyContext.cs
@@ -76,7 +76,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
         /// <summary>
         /// Returns an enumerator over all dependencies in the project tree.
         /// </summary>
-        /// <returns></returns>
         public ImmutableDictionary<string, IDependency>.Enumerator GetEnumerator()
         {
             return _worldBuilder.GetEnumerator();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/RemoveDependencyContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/RemoveDependencyContext.cs
@@ -77,7 +77,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
         /// <summary>
         /// Returns an enumerator over all dependencies in the project tree.
         /// </summary>
-        /// <returns></returns>
         public ImmutableDictionary<string, IDependency>.Enumerator GetEnumerator()
         {
             return _worldBuilder.GetEnumerator();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -436,7 +436,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// Returns a list of direct child nodes for given dependency
         /// </summary>
         /// <param name="dependency"></param>
-        /// <returns></returns>
         public ImmutableArray<IDependency> GetDependencyChildren(IDependency dependency)
         {
             if (dependency.DependencyIDs.Length == 0)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectLayoutTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectLayoutTestBase.cs
@@ -198,7 +198,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// Creates <paramref name="project"/> on disk and opens it, returning its test extension object.
         /// </summary>
         /// <param name="project"></param>
-        /// <returns></returns>
         protected ProjectTestExtension CreateProject(Project project)
         {
             var rootPath = CreateRootPath();


### PR DESCRIPTION
The VB files are long enough as they are. This helps cut some of them down a bit.

This deletes 3606 lines across 207 files.

Done with regex:

```regex
^\s*('''|///)\s*<(\w+)>(\s*\r?\n(\s*('''|///)\s*\r?\n)*\s*('''|///)\s*)?</\2>\s*\r?\n
```

This explicitly doesn't remove empty `<param>` elements as doing so could lead to warnings in cases where not all elements are removed.

Some BOMs seem to have been updated (hence 55 insertions).