### PR TITLE
VB code simplifications

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
@@ -29,14 +29,14 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Private Shared ReadOnly s_commandUIGuid As New Guid("{d06cd5e3-d961-44dc-9d80-c89a1a8d9d56}")
 
         'Exposing the GUID for the rest of the assembly to see
-        Public Shared ReadOnly Property EditorGuid() As Guid
+        Public Shared ReadOnly Property EditorGuid As Guid
             Get
                 Return s_editorGuid
             End Get
         End Property
 
         'Exposing the GUID for the rest of the assembly to see
-        Public Shared ReadOnly Property CommandUIGuid() As Guid
+        Public Shared ReadOnly Property CommandUIGuid As Guid
             Get
                 Return s_commandUIGuid
             End Get

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerPanel.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerPanel.vb
@@ -128,13 +128,13 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Returns the PropertyPageInfo for this designer panel, if it corresponds to a property page.
         ''' Otherwise returns Nothing.
         ''' </summary>
-        Public ReadOnly Property PropertyPageInfo() As PropertyPageInfo
+        Public ReadOnly Property PropertyPageInfo As PropertyPageInfo
             Get
                 Return _propertyPageInfo
             End Get
         End Property
 
-        Public ReadOnly Property IsPropertyPage() As Boolean
+        Public ReadOnly Property IsPropertyPage As Boolean
             Get
                 Dim ReturnValue As Boolean = (_propertyPageInfo IsNot Nothing)
                 Debug.Assert(Not ReturnValue OrElse EditorGuid.Equals(GetType(PropPageDesigner.PropPageDesignerEditorFactory).GUID),
@@ -143,19 +143,19 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             End Get
         End Property
 
-        Public ReadOnly Property Hierarchy() As IVsHierarchy
+        Public ReadOnly Property Hierarchy As IVsHierarchy
             Get
                 Return _hierarchy
             End Get
         End Property
 
-        Public ReadOnly Property ItemId() As UInteger
+        Public ReadOnly Property ItemId As UInteger
             Get
                 Return _itemId
             End Get
         End Property
 
-        Public ReadOnly Property DocCookie() As UInteger
+        Public ReadOnly Property DocCookie As UInteger
             Get
                 Return _docCookie
             End Get
@@ -165,11 +165,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Provides a custom view control that can be displayed instead of hosting a designer.  We can display either
         '''   a custom view provider or a hosted designer, but not both at once.
         ''' </summary>
-        Public Property CustomViewProvider() As CustomViewProvider
+        Public Property CustomViewProvider As CustomViewProvider
             Get
                 Return _customViewProvider
             End Get
-            Set(value As CustomViewProvider)
+            Set
                 If _customViewProvider Is value Then
                     Exit Property
                 End If
@@ -646,11 +646,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Get/set the window frame owned by this panel
         ''' </summary>
-        Public Property VsWindowFrame() As IVsWindowFrame
+        Public Property VsWindowFrame As IVsWindowFrame
             Get
                 Return _vsWindowFrame
             End Get
-            Set(Value As IVsWindowFrame)
+            Set
                 If Value IsNot _vsWindowFrame Then
                     Common.Switches.TracePDFocus(TraceLevel.Info, "ApplicationDesignerPanel.set_VsWindowFrame")
                     CloseFrame()
@@ -669,11 +669,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' The Guid used by the editor for this panel.  For property pages, this is always
         '''   PropPageDesignerView's guid.
         ''' </summary>
-        Public Property EditorGuid() As Guid
+        Public Property EditorGuid As Guid
             Get
                 Return _editorGuid
             End Get
-            Set(Value As Guid)
+            Set
                 If IsPropertyPage Then
                     Debug.Fail("Cannot change EditorGuid for property page designer panels")
                     Exit Property
@@ -687,7 +687,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' The Guid used by the object actually represented in this panel.  For property pages,
         '''   this is the guid of the property page.  For all others, this is the same as EditorGuid.
         ''' </summary>
-        Public ReadOnly Property ActualGuid() As Guid
+        Public ReadOnly Property ActualGuid As Guid
             Get
                 If _propertyPageInfo IsNot Nothing Then
                     Return _propertyPageInfo.Guid
@@ -700,11 +700,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Physical view guid for the editor
         ''' </summary>
-        Public Property PhysicalView() As String
+        Public Property PhysicalView As String
             Get
                 Return _physicalView
             End Get
-            Set(Value As String)
+            Set
                 _physicalView = Value
             End Set
         End Property
@@ -712,11 +712,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The editor's caption
         ''' </summary>
-        Public Property EditorCaption() As String
+        Public Property EditorCaption As String
             Get
                 Return _editorCaption
             End Get
-            Set(Value As String)
+            Set
                 _editorCaption = Value
             End Set
         End Property
@@ -724,7 +724,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The filename moniker of the file which is being edited by the editor
         ''' </summary>
-        Public Property MkDocument() As String
+        Public Property MkDocument As String
             Get
                 If _mkDocument <> "" Then
                     Return _mkDocument
@@ -734,7 +734,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                     Return ""
                 End If
             End Get
-            Set(Value As String)
+            Set
                 Debug.Assert(_mkDocument Is Nothing, "MkDocument set multiple times")
                 _mkDocument = Value
             End Set
@@ -743,11 +743,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The filename moniker of the file which is being edited by the editor
         ''' </summary>
-        Public Property CustomMkDocumentProvider() As CustomDocumentMonikerProvider
+        Public Property CustomMkDocumentProvider As CustomDocumentMonikerProvider
             Get
                 Return _customMkDocumentProvider
             End Get
-            Set(Value As CustomDocumentMonikerProvider)
+            Set
                 Debug.Assert(_customMkDocumentProvider Is Nothing OrElse Value Is Nothing, "m_CustomMkDocumentProvider set multiple times")
                 _customMkDocumentProvider = Value
             End Set
@@ -756,11 +756,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The DocData for the editor
         ''' </summary>
-        Public Property DocData() As Object
+        Public Property DocData As Object
             Get
                 Return _docData
             End Get
-            Set(Value As Object)
+            Set
                 _docData = Value
             End Set
         End Property
@@ -768,11 +768,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The DocView for the editor
         ''' </summary>
-        Public Property DocView() As Control
+        Public Property DocView As Control
             Get
                 Return _docView
             End Get
-            Set(Value As Control)
+            Set
                 _docView = Value
             End Set
         End Property
@@ -780,11 +780,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Flags to be passed to VsUIShellOpenDocument
         ''' </summary>
-        Public Property EditFlags() As UInteger
+        Public Property EditFlags As UInteger
             Get
                 Return _editFlags
             End Get
-            Set(Value As UInteger)
+            Set
                 _editFlags = Value
             End Set
         End Property
@@ -792,11 +792,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The title that should be used for this panel's tab
         ''' </summary>
-        Public Property TabTitle() As String
+        Public Property TabTitle As String
             Get
                 Return _tabTitle
             End Get
-            Set(value As String)
+            Set
                 _tabTitle = value
 
                 ' We set Window.Text to be the page Title to help screen reader.
@@ -813,11 +813,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The name for the tab that is not localized and is seen by QA automation tools
         ''' </summary>
-        Public Property TabAutomationName() As String
+        Public Property TabAutomationName As String
             Get
                 Return _tabAutomationName
             End Get
-            Set(value As String)
+            Set
                 _tabAutomationName = value
             End Set
         End Property
@@ -1033,7 +1033,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''<summary>
         ''' Initialize layout...
         '''</summary>
-        <DebuggerStepThrough()>
+        <DebuggerStepThrough>
         Private Sub InitializeComponent()
             _pageHostingPanel = New Panel
             _pageNameLabel = New Label

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerRootComponent.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerRootComponent.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''   resx file to be edited by the user.
         ''' </summary>
         ''' <value>The associated ResourceEditorRootDesigner.</value>
-        Public ReadOnly Property RootDesigner() As ApplicationDesignerRootDesigner
+        Public ReadOnly Property RootDesigner As ApplicationDesignerRootDesigner
             Get
                 If _rootDesigner Is Nothing Then
                     'Not yet cached - get this info from the designer host
@@ -42,11 +42,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The IVsHierarchy associated with the AppDesigner node
         ''' </summary>
-        Public Property Hierarchy() As IVsHierarchy
+        Public Property Hierarchy As IVsHierarchy
             Get
                 Return _hierarchy
             End Get
-            Set(Value As IVsHierarchy)
+            Set
                 _hierarchy = Value
             End Set
         End Property
@@ -54,11 +54,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The ItemId associated with the AppDesigner node
         ''' </summary>
-        Public Property ItemId() As UInteger
+        Public Property ItemId As UInteger
             Get
                 Return _itemId
             End Get
-            Set(Value As UInteger)
+            Set
                 _itemId = Value
             End Set
         End Property

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerRootDesigner.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Returns the ApplicationDesignerRootComponent component that is being edited by this designer.
         ''' </summary>
         ''' <value>The ApplicationDesignerRootComponent object.</value>
-        Public Shadows ReadOnly Property Component() As ApplicationDesignerRootComponent
+        Public Shadows ReadOnly Property Component As ApplicationDesignerRootComponent
             Get
                 Dim RootComponent As ApplicationDesignerRootComponent = CType(MyBase.Component, ApplicationDesignerRootComponent)
                 Debug.Assert(Not RootComponent Is Nothing)
@@ -77,7 +77,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <remarks>
         ''' The view technology we support, which is currently only Windows Forms
         ''' </remarks>
-        Private ReadOnly Property IRootDesigner_SupportedTechnologies() As ViewTechnology() Implements IRootDesigner.SupportedTechnologies
+        Private ReadOnly Property IRootDesigner_SupportedTechnologies As ViewTechnology() Implements IRootDesigner.SupportedTechnologies
             Get
                 Return New ViewTechnology() {ViewTechnology.Default}
             End Get

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
@@ -253,7 +253,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             End If
         End Sub
 
-        Public ReadOnly Property WindowFrame() As IVsWindowFrame
+        Public ReadOnly Property WindowFrame As IVsWindowFrame
             Get
                 Return CType(GetService(GetType(IVsWindowFrame)), IVsWindowFrame)
             End Get
@@ -262,13 +262,13 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Retrieves the DTE project object associated with this project designer instance.
         ''' </summary>
-        Public ReadOnly Property DTEProject() As Project
+        Public ReadOnly Property DTEProject As Project
             Get
                 Return _dteProject
             End Get
         End Property
 
-        Public ReadOnly Property SpecialFiles() As IVsProjectSpecialFiles
+        Public ReadOnly Property SpecialFiles As IVsProjectSpecialFiles
             Get
                 Return _specialFiles
             End Get
@@ -278,7 +278,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Instance of the loaded IVBPackage
         ''' </summary>
         ''' <remarks>Used to persist user data</remarks>
-        Private ReadOnly Property Package() As IVBPackage
+        Private ReadOnly Property Package As IVBPackage
             Get
                 If _editorsPackage Is Nothing Then
                     Dim shell As IVsShell = DirectCast(GetService(GetType(IVsShell)), IVsShell)
@@ -297,7 +297,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Get/set the last viewed tab of for this application page...
         ''' </summary>
-        Private Property LastShownTab() As Integer
+        Private Property LastShownTab As Integer
             Get
                 Dim editorsPackage As IVBPackage = Package
                 If editorsPackage IsNot Nothing Then
@@ -308,7 +308,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 End If
                 Return 0
             End Get
-            Set(value As Integer)
+            Set
                 Dim editorsPackage As IVBPackage = Package
                 If editorsPackage IsNot Nothing Then
                     editorsPackage.SetLastShownApplicationDesignerTab(_projectHierarchy, value)
@@ -564,7 +564,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         End Function
 
         Private _vsCfgProvider As IVsCfgProvider2
-        Private ReadOnly Property VsCfgProvider() As IVsCfgProvider2
+        Private ReadOnly Property VsCfgProvider As IVsCfgProvider2
             Get
                 If _vsCfgProvider Is Nothing Then
                     Dim Value As Object = Nothing
@@ -586,7 +586,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         End Function
 
 
-        Public Property ActiveView() As Guid
+        Public Property ActiveView As Guid
             Get
                 If _activePanelIndex < 0 OrElse _activePanelIndex >= _designerPanels.Length OrElse _designerPanels(_activePanelIndex) Is Nothing Then
                     Return Guid.Empty
@@ -597,7 +597,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 Return Panel.ActualGuid
             End Get
 
-            Set(Value As Guid)
+            Set
                 Common.Switches.TracePDFocus(TraceLevel.Info, "ApplicationDesignerView: set_ActiveView")
                 'Find the guid and switch to that tab
                 'Keep the current tab if guid not found
@@ -1328,7 +1328,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''   by ApplicationDesignerPanel to delay any window frame activations until after
         '''   initialization.
         ''' </summary>
-        Public ReadOnly Property InitializationComplete() As Boolean
+        Public ReadOnly Property InitializationComplete As Boolean
             Get
                 Return _initializationComplete
             End Get

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerWindowPane.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerWindowPane.vb
@@ -55,7 +55,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
         End Sub
 
-        Public Overrides ReadOnly Property EditorView() As Object
+        Public Overrides ReadOnly Property EditorView As Object
             Get
                 Return Me
             End Get
@@ -125,7 +125,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             End Select
         End Sub
 
-        Public Overrides ReadOnly Property Window() As IWin32Window
+        Public Overrides ReadOnly Property Window As IWin32Window
             Get
                 Return _view
             End Get
@@ -286,7 +286,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         End Sub
 
 
-        Public ReadOnly Property AppDesignerView() As ApplicationDesignerView
+        Public ReadOnly Property AppDesignerView As ApplicationDesignerView
             Get
                 If _view IsNot Nothing AndAlso _view.Controls.Count > 0 Then
                     Return TryCast(_view.Controls(0), ApplicationDesignerView)
@@ -452,7 +452,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Retrieves the IVsUIShell service
         ''' </summary>
-        Public ReadOnly Property VsUIShellService() As IVsUIShell
+        Public ReadOnly Property VsUIShellService As IVsUIShell
             Get
                 If (_uiShellService Is Nothing) Then
                     If Common.VBPackageInstance IsNot Nothing Then
@@ -469,7 +469,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Retrieves the IVsUIShell2 service
         ''' </summary>
-        Public ReadOnly Property VsUIShell2Service() As IVsUIShell2
+        Public ReadOnly Property VsUIShell2Service As IVsUIShell2
             Get
                 If (_uiShell2Service Is Nothing) Then
                     Dim VsUiShell As IVsUIShell = VsUIShellService
@@ -485,7 +485,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Retrieves the IVsUIShell5 service
         ''' </summary>
-        Public ReadOnly Property VsUIShell5Service() As IVsUIShell5
+        Public ReadOnly Property VsUIShell5Service As IVsUIShell5
             Get
                 If (_uiShell5Service Is Nothing) Then
                     Dim VsUiShell As IVsUIShell = VsUIShellService

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/CustomViewProvider.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/CustomViewProvider.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Returns the view control (if already created)
         ''' </summary>
-        Public MustOverride ReadOnly Property View() As Control
+        Public MustOverride ReadOnly Property View As Control
 
         ''' <summary>
         ''' Creates the view control, if it doesn't already exist

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DeferrableWindowPaneProviderService.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DeferrableWindowPaneProviderService.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ' <devdoc>
         '     We override this to always get the current extension from the doc data.
         ' </devdoc>
-        Protected Overrides ReadOnly Property Extension() As String
+        Protected Overrides ReadOnly Property Extension As String
             Get
                 If _docData Is Nothing Then
                     Return ""

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ErrorControlCustomViewProvider.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ErrorControlCustomViewProvider.vb
@@ -37,7 +37,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Returns the view control (if already created)
         ''' </summary>
-        Public Overrides ReadOnly Property View() As Control
+        Public Overrides ReadOnly Property View As Control
             Get
                 Return _view
             End Get

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ProjectDesignerTabButton.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ProjectDesignerTabButton.vb
@@ -36,11 +36,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' True if the dirty indicator should be display
         ''' </summary>
-        Public Property DirtyIndicator() As Boolean
+        Public Property DirtyIndicator As Boolean
             Get
                 Return _dirtyIndicator
             End Get
-            Set(value As Boolean)
+            Set
                 If value <> _dirtyIndicator Then
                     _dirtyIndicator = value
                     Invalidate()
@@ -52,7 +52,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Returns the text of the tab button, with the dirty indicator if it is on.
         ''' </summary>
-        Public ReadOnly Property TextWithDirtyIndicator() As String
+        Public ReadOnly Property TextWithDirtyIndicator As String
             Get
                 'If the dirty indicator is on, append "*" to the text
                 Dim ButtonText As String = Text
@@ -69,17 +69,17 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' The location of the button.  Should not be changed directly except
         '''   by the tab control itself.
         ''' </summary>
-        Public Shadows Property Location() As Point
+        Public Shadows Property Location As Point
             Get
                 Return MyBase.Location
             End Get
-            Set(value As Point) 'Make inaccessible except to this assembly 'CONSIDER: this is non-CLS-compliant, should change if make control public
+            Set 'Make inaccessible except to this assembly 'CONSIDER: this is non-CLS-compliant, should change if make control public
                 MyBase.Location = value
             End Set
         End Property
 
 
-        Public ReadOnly Property ButtonIndex() As Integer
+        Public ReadOnly Property ButtonIndex As Integer
             Get
                 Return _index
             End Get
@@ -90,7 +90,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         End Sub
 
 
-        Private ReadOnly Property ParentTabControl() As ProjectDesignerTabControl
+        Private ReadOnly Property ParentTabControl As ProjectDesignerTabControl
             Get
                 Return DirectCast(Parent, ProjectDesignerTabControl)
             End Get
@@ -195,7 +195,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             Get
                 Return _focusedFromKeyboardNav
             End Get
-            Set(value As Boolean)
+            Set
                 _focusedFromKeyboardNav = value
             End Set
         End Property
@@ -228,7 +228,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' accessible state
         ''' </summary>
-        Public ReadOnly Property AccessibleState() As AccessibleStates
+        Public ReadOnly Property AccessibleState As AccessibleStates
             Get
                 Dim parent As ProjectDesignerTabControl = ParentTabControl
                 If parent IsNot Nothing AndAlso Me Is parent.SelectedItem Then
@@ -256,7 +256,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             ''' <summary>
             ''' accessible state
             ''' </summary>
-            Public Overrides ReadOnly Property State() As AccessibleStates
+            Public Overrides ReadOnly Property State As AccessibleStates
                 Get
                     Return MyBase.State Or _button.AccessibleState
                 End Get
@@ -265,7 +265,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             ''' <summary>
             ''' Default action name.
             ''' </summary>
-            Public Overrides ReadOnly Property DefaultAction() As String
+            Public Overrides ReadOnly Property DefaultAction As String
                 Get
                     Return My.Resources.Designer.APPDES_TabButtonDefaultAction
                 End Get
@@ -274,7 +274,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             ''' <summary>
             ''' Role - it is a tab page
             ''' </summary>
-            Public Overrides ReadOnly Property Role() As AccessibleRole
+            Public Overrides ReadOnly Property Role As AccessibleRole
                 Get
                     Return AccessibleRole.PageTab
                 End Get

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ProjectDesignerTabControl.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ProjectDesignerTabControl.vb
@@ -150,11 +150,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''   shell (e.g., colors will default to system or fallback colors instead of using the
         '''   shell's color service). 
         ''' </summary>
-        Public Property ServiceProvider() As IServiceProvider
+        Public Property ServiceProvider As IServiceProvider
             Get
                 Return _serviceProvider
             End Get
-            Set(value As IServiceProvider)
+            Set
                 _serviceProvider = value
                 _renderer.ServiceProvider = value
 
@@ -243,7 +243,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Returns an enumerable set of tab buttons
         ''' </summary>
-        Public ReadOnly Property TabButtons() As IEnumerable(Of ProjectDesignerTabButton)
+        Public ReadOnly Property TabButtons As IEnumerable(Of ProjectDesignerTabButton)
             Get
                 Return _buttonCollection
             End Get
@@ -271,7 +271,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The number of tab buttons, including those not currently visible
         ''' </summary>
-        Public ReadOnly Property TabButtonCount() As Integer
+        Public ReadOnly Property TabButtonCount As Integer
             Get
                 Return _buttonCollection.Count
             End Get
@@ -281,7 +281,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Get the panel that is used to host controls on the right-hand side
         ''' </summary>
-        Public ReadOnly Property HostingPanel() As Panel
+        Public ReadOnly Property HostingPanel As Panel
             Get
                 Return _hostingPanel
             End Get
@@ -344,7 +344,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Tracks the last item for paint logic
         ''' </summary>
-        Public ReadOnly Property HoverItem() As ProjectDesignerTabButton
+        Public ReadOnly Property HoverItem As ProjectDesignerTabButton
             Get
                 Return _hoverItem
             End Get
@@ -354,11 +354,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Currently selected button
         ''' </summary>
-        Public Property SelectedItem() As ProjectDesignerTabButton
+        Public Property SelectedItem As ProjectDesignerTabButton
             Get
                 Return _selectedItem
             End Get
-            Set(value As ProjectDesignerTabButton)
+            Set
                 Dim oldSelectedItem As ProjectDesignerTabButton = Nothing
 
                 If _selectedItem Is value Then
@@ -397,7 +397,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Currently selected button
         ''' </summary>
-        Public Property SelectedIndex() As Integer
+        Public Property SelectedIndex As Integer
             Get
                 If _selectedItem Is Nothing Then
                     Return -1
@@ -405,7 +405,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
                 Return _selectedItem.ButtonIndex
             End Get
-            Set(value As Integer)
+            Set
                 If value = -1 Then
                     SelectedItem = Nothing
                 Else
@@ -493,7 +493,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Retrieves the renderer used for this tab control
         ''' </summary>
-        Public ReadOnly Property Renderer() As ProjectDesignerTabRenderer
+        Public ReadOnly Property Renderer As ProjectDesignerTabRenderer
             Get
                 Return _renderer
             End Get
@@ -673,7 +673,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             ''' <summary>
             ''' Description
             ''' </summary>
-            Public Overrides ReadOnly Property Description() As String
+            Public Overrides ReadOnly Property Description As String
                 Get
                     Return My.Resources.Designer.APPDES_TabListDescription
                 End Get
@@ -682,7 +682,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             ''' <summary>
             ''' Role - it is a tab List
             ''' </summary>
-            Public Overrides ReadOnly Property Role() As AccessibleRole
+            Public Overrides ReadOnly Property Role As AccessibleRole
                 Get
                     Return AccessibleRole.PageTabList
                 End Get
@@ -691,7 +691,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             ''' <summary>
             ''' Value - the name of the active page
             ''' </summary>
-            Public Overrides Property Value() As String
+            Public Overrides Property Value As String
                 Get
                     If _tabControl.SelectedItem IsNot Nothing Then
                         Return _tabControl.SelectedItem.Text
@@ -699,7 +699,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                         Return Nothing
                     End If
                 End Get
-                Set(value As String)
+                Set
                 End Set
             End Property
 

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ProjectDesignerTabRenderer.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ProjectDesignerTabRenderer.vb
@@ -138,11 +138,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''   shell (e.g., colors will default to system or fallback colors instead of using the
         '''   shell's color service). 
         ''' </summary>
-        Public Property ServiceProvider() As IServiceProvider
+        Public Property ServiceProvider As IServiceProvider
             Get
                 Return _serviceProvider
             End Get
-            Set(value As IServiceProvider)
+            Set
                 _serviceProvider = value
                 If _gdiObjectsCreated Then
                     'If we've already created GDI stuff/layout, we will need to re-create them.  Otherwise
@@ -158,7 +158,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <value>The IVsUIShell service if found, otherwise null</value>
         ''' <remarks>Uses the publicly-obtained ServiceProvider property, if it was set.</remarks>
-        Private ReadOnly Property VsUIShellService() As IVsUIShell
+        Private ReadOnly Property VsUIShellService As IVsUIShell
             Get
                 If (_uiShellService Is Nothing) Then
                     If Common.VBPackageInstance IsNot Nothing Then
@@ -177,7 +177,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <value>The IVsUIShell5 service if found, otherwise null</value>
         ''' <remarks>Uses the publicly-obtained ServiceProvider property, if it was set.</remarks>
-        Private ReadOnly Property VsUIShell5Service() As IVsUIShell5
+        Private ReadOnly Property VsUIShell5Service As IVsUIShell5
             Get
                 If (_uiShell5Service Is Nothing) Then
                     Dim VsUIShell = VsUIShellService
@@ -202,11 +202,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Note: this is not necessarily the same as the currently-selected button, because once a button
         '''   is pulled into the switchable slot, we want it to stay there unless we have to change it.
         ''' </summary>
-        Public Property PreferredButtonForSwitchableSlot() As ProjectDesignerTabButton
+        Public Property PreferredButtonForSwitchableSlot As ProjectDesignerTabButton
             Get
                 Return _preferredButtonForSwitchableSlot
             End Get
-            Set(value As ProjectDesignerTabButton)
+            Set
                 If value IsNot _preferredButtonForSwitchableSlot Then
                     _preferredButtonForSwitchableSlot = value
                     _owner.Invalidate()

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/PropertyPageInfo.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/PropertyPageInfo.vb
@@ -80,7 +80,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The GUID for the property page
         ''' </summary>
-        Public ReadOnly Property Guid() As Guid
+        Public ReadOnly Property Guid As Guid
             Get
                 Return _guid
             End Get
@@ -90,7 +90,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' True if the page's properties can have different values in different configurations
         ''' </summary>
-        Public ReadOnly Property IsConfigPage() As Boolean
+        Public ReadOnly Property IsConfigPage As Boolean
             Get
                 Return _isConfigPage
             End Get
@@ -100,7 +100,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The exception that occurred while loading the page, if any
         ''' </summary>
-        Public ReadOnly Property LoadException() As Exception
+        Public ReadOnly Property LoadException As Exception
             Get
                 Return _loadException
             End Get
@@ -110,7 +110,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Returns the IPropertyPage for the property page
         ''' </summary>
-        Public ReadOnly Property ComPropPageInstance() As OleInterop.IPropertyPage
+        Public ReadOnly Property ComPropPageInstance As OleInterop.IPropertyPage
             Get
                 TryLoadPropertyPage()
                 Return _comPropPageInstance
@@ -121,7 +121,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Returns the PropertyPageSite for the property page
         ''' </summary>
-        Public ReadOnly Property Site() As PropertyPageSite
+        Public ReadOnly Property Site As PropertyPageSite
             Get
                 TryLoadPropertyPage()
                 Return _site
@@ -223,7 +223,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' PERF: This property used a cached version of the title to avoid having to
         '''   instantiate the COM object for the property page.
         ''' </remarks>
-        Public ReadOnly Property Title() As String
+        Public ReadOnly Property Title As String
             Get
                 If _loadAlreadyAttempted Then
                     If _loadException Is Nothing AndAlso _info.pszTitle <> "" Then
@@ -253,7 +253,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Gets the current locale ID that's being used by the project designer.
         ''' </summary>
-        Private ReadOnly Property CurrentLocaleID() As UInteger
+        Private ReadOnly Property CurrentLocaleID As UInteger
             Get
                 Return CType(_parentView, IPropertyPageSiteOwner).GetLocaleID()
             End Get
@@ -264,7 +264,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' Retrieves the name of the registry value name to place into the
         '''   registry for this property page.
         ''' </summary>
-        Private ReadOnly Property CachedTitleValueName() As String
+        Private ReadOnly Property CachedTitleValueName As String
             Get
                 'We must include both the property page GUID and the locale ID
                 '  so that we react properly to user language changes.
@@ -276,7 +276,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Attempts to retrieve or set the cached title of this page from the registry.
         ''' </summary>
-        Private Property CachedTitle() As String
+        Private Property CachedTitle As String
             Get
                 Dim KeyPath As String = _parentView.DTEProject.DTE.RegistryRoot & REGKEY_CachedPageTitles
                 Dim Key As Win32.RegistryKey = Nothing
@@ -299,7 +299,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 'No cached title yet.
                 Return Nothing
             End Get
-            Set(value As String)
+            Set
                 If value Is Nothing Then
                     value = String.Empty
                 End If

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/PropertyPageSite.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/PropertyPageSite.vb
@@ -55,11 +55,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' The service provider to delegate to when responding to QueryService requests (for both
         '''   native and managed IServiceProvider).
         ''' </summary>
-        Public Property BackingServiceProvider() As IServiceProvider
+        Public Property BackingServiceProvider As IServiceProvider
             Get
                 Return _backingServiceProvider
             End Get
-            Set(value As IServiceProvider)
+            Set
 #If DEBUG Then
                 If value IsNot Nothing Then
                     Dim NativeServiceProvider As OleInterop.IServiceProvider = TryCast(value.GetService(GetType(OleInterop.IServiceProvider)), OleInterop.IServiceProvider)
@@ -79,16 +79,16 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         '''   point or another.  The flag will have to be set to False when the project designer is saved, because it
         '''   won't normally be set to False by the page.
         ''' </summary>
-        Public Property HasBeenSetDirty() As Boolean
+        Public Property HasBeenSetDirty As Boolean
             Get
                 Return _hasBeenSetDirty
             End Get
-            Set(value As Boolean)
+            Set
                 _hasBeenSetDirty = value
             End Set
         End Property
 
-        Friend ReadOnly Property Owner() As IPropertyPageSiteOwner
+        Friend ReadOnly Property Owner As IPropertyPageSiteOwner
             Get
                 Return _appDesView
             End Get

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/SpecialFileCustomViewProvider.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/SpecialFileCustomViewProvider.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The text of the link message to display.
         ''' </summary>
-        Public ReadOnly Property LinkText() As String
+        Public ReadOnly Property LinkText As String
             Get
                 Return _linkText
             End Get
@@ -48,7 +48,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The ApplicationDesignerView which owns this view.
         ''' </summary>
-        Public ReadOnly Property DesignerView() As ApplicationDesignerView
+        Public ReadOnly Property DesignerView As ApplicationDesignerView
             Get
                 Return _designerView
             End Get
@@ -57,7 +57,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The special file ID to create when the user clicks the link.  Used by IVsProjectSpecialFiles.
         ''' </summary>
-        Public ReadOnly Property SpecialFileId() As Integer
+        Public ReadOnly Property SpecialFileId As Integer
             Get
                 Return _specialFileId
             End Get
@@ -66,7 +66,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' The ApplicationDesignerPanel in which this view will be displayed.
         ''' </summary>
-        Public ReadOnly Property DesignerPanel() As ApplicationDesignerPanel
+        Public ReadOnly Property DesignerPanel As ApplicationDesignerPanel
             Get
                 Return _designerPanel
             End Get
@@ -76,7 +76,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <summary>
         ''' Returns the view control (if already created)
         ''' </summary>
-        Public Overrides ReadOnly Property View() As Control
+        Public Overrides ReadOnly Property View As Control
             Get
                 Return _view
             End Get

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/switches.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/switches.vb
@@ -423,7 +423,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             ''' <summary>
             ''' True iff the switch has a non-empty value
             ''' </summary>
-            Public ReadOnly Property ValueDefined() As Boolean
+            Public ReadOnly Property ValueDefined As Boolean
                 Get
                     Return MyBase.Value <> "" AndAlso CInt(Convert.ChangeType(Value, TypeCode.Int32)) <> 0
                 End Get
@@ -432,11 +432,11 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             ''' <summary>
             ''' Gets/sets the current value of the switch
             ''' </summary>
-            Public Shadows Property Value() As T
+            Public Shadows Property Value As T
                 Get
                     Return CType([Enum].Parse(GetType(T), MyBase.Value), T)
                 End Get
-                Set(value As T)
+                Set
                     MyBase.Value = value.ToString()
                 End Set
             End Property

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/BaseDialog.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/BaseDialog.vb
@@ -105,11 +105,11 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         'Summary:
         '   Gets or sets the IServiceProvider for this dialog.
         '**************************************************************************
-        Public Property ServiceProvider() As IServiceProvider
+        Public Property ServiceProvider As IServiceProvider
             Get
                 Return _serviceProvider
             End Get
-            Set(Value As IServiceProvider)
+            Set
                 Debug.Assert(Value IsNot Nothing, "Bad service provider")
                 _serviceProvider = Value
             End Set
@@ -126,11 +126,11 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         'Summary:
         '   Gets or sets the help keyword for this dialog.
         '**************************************************************************
-        Protected Overridable Property F1Keyword() As String
+        Protected Overridable Property F1Keyword As String
             Get
                 Return _helpKeyword
             End Get
-            Set(Value As String)
+            Set
                 _helpKeyword = Value
             End Set
         End Property
@@ -141,7 +141,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         'Summary:
         '   Gets the current designer host.
         '**************************************************************************
-        Protected ReadOnly Property CurrentDesignerHost() As IDesignerHost
+        Protected ReadOnly Property CurrentDesignerHost As IDesignerHost
             Get
                 Return CType(GetService(GetType(IDesignerHost)), IDesignerHost)
             End Get

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/BaseRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/BaseRootDesigner.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         '''  Returns a cached ISelectionService.
         ''' </summary>
         ''' <value>The cached ISelectionService.</value>
-        Public ReadOnly Property SelectionService() As ISelectionService
+        Public ReadOnly Property SelectionService As ISelectionService
             Get
                 If _selectionService Is Nothing Then
                     SyncLock _syncLockObject
@@ -147,7 +147,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' </summary>
         ''' <value>The IMenuCommandService from the shell.</value>
         ''' <remarks>Don't want to expose this one to other classes to encourage using RegisterMenuCommands.</remarks>
-        Private ReadOnly Property MenuCommandService() As IMenuCommandService
+        Private ReadOnly Property MenuCommandService As IMenuCommandService
             Get
                 If _menuCommandService Is Nothing Then
                     SyncLock _syncLockObject
@@ -165,7 +165,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         '''  Returns an arraylist containing all the current registered commands from this designer.
         ''' </summary>
         ''' <value>An ArrayList contains MenuCommand.</value>
-        Private ReadOnly Property MenuCommands() As ArrayList
+        Private ReadOnly Property MenuCommands As ArrayList
             Get
                 Return _menuCommands
             End Get

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/DesignerMenuCommand.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/DesignerMenuCommand.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         '   m_AlwaysCheckStatus and m_StatusValid flag.
         '**************************************************************************
         <SuppressMessage("Microsoft.Security", "CA2123:OverrideLinkDemandsShouldBeIdenticalToBase")>
-        Public Overrides ReadOnly Property OleStatus() As Integer
+        Public Overrides ReadOnly Property OleStatus As Integer
             Get
                 If _alwaysCheckStatus OrElse Not _statusValid Then
                     UpdateStatus()

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/DesignerWindowPaneProviderBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/DesignerWindowPaneProviderBase.vb
@@ -103,7 +103,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             ''' <summary>
             ''' Returns the view control for the window pane.
             ''' </summary>
-            Protected ReadOnly Property View() As Control
+            Protected ReadOnly Property View As Control
                 Get
                     Return _view
                 End Get
@@ -135,7 +135,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             ''' <summary>
             ''' Retrieves our view.
             ''' </summary>
-            Public Overrides ReadOnly Property Window() As IWin32Window
+            Public Overrides ReadOnly Property Window As IWin32Window
                 Get
                     ' This should always happen, but in case we never
                     ' got a load event we check.  We might not receive
@@ -470,7 +470,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
                 ''' <summary>
                 ''' Overrides CreateParams to make sure it is created as a child window
                 ''' </summary>
-                Protected Overrides ReadOnly Property CreateParams() As CreateParams
+                Protected Overrides ReadOnly Property CreateParams As CreateParams
                     Get
                         Dim cp As CreateParams = MyBase.CreateParams()
                         cp.Style = cp.Style Or Constants.WS_CHILD Or Constants.WS_CLIPSIBLINGS

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/ErrorControl.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/ErrorControl.vb
@@ -67,11 +67,11 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' <summary>
         ''' Constructor
         ''' </summary>
-        Public Overrides Property Text() As String
+        Public Overrides Property Text As String
             Get
                 Return ErrorText.Text
             End Get
-            Set(value As String)
+            Set
                 MyBase.Text = value
                 ErrorText.Text = value
             End Set

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/SourceCodeControlManager.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/SourceCodeControlManager.vb
@@ -59,11 +59,11 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' <summary>
         ''' Get a list of the files currently managed by this service...
         ''' </summary>
-        Public Property ManagedFiles() As List(Of String)
+        Public Property ManagedFiles As List(Of String)
             Get
                 Return New List(Of String)(_managedFiles.Keys)
             End Get
-            Set(value As List(Of String))
+            Set
                 _managedFiles.Clear()
                 For Each file As String In value
                     _managedFiles(file) = True

--- a/src/Microsoft.VisualStudio.AppDesigner/IVbpackage.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/IVbpackage.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.VisualStudio.Editors
 
         ReadOnly Property GetService(serviceType As Type) As Object
 
-        ReadOnly Property MenuCommandService() As IMenuCommandService
+        ReadOnly Property MenuCommandService As IMenuCommandService
 
     End Interface
 

--- a/src/Microsoft.VisualStudio.AppDesigner/InternalException.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/InternalException.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.VisualStudio.Editors.Package
     '''   (obviously not very helpful, but it doesn't make sense to localize and doc messages for errors which shouldn't
     '''   be happening).
     ''' </summary>
-    <Serializable()>
+    <Serializable>
     Public Class InternalException
         Inherits ApplicationException
 

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/ConfigurationState.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/ConfigurationState.vb
@@ -189,7 +189,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Returns the index of the item to be the currently selected item in the configuration dropdown of all
         '''   config-dependent property pages
         ''' </summary>
-        Public ReadOnly Property SelectedConfigIndex() As Integer
+        Public ReadOnly Property SelectedConfigIndex As Integer
             Get
                 Return _selectedConfigIndex
             End Get
@@ -200,7 +200,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Returns the index of the item to be the currently selected item in the platform dropdown of all
         '''   config-dependent property pages        
         ''' </summary>
-        Public ReadOnly Property SelectedPlatformIndex() As Integer
+        Public ReadOnly Property SelectedPlatformIndex As Integer
             Get
                 Return _selectedPlatformIndex
             End Get
@@ -220,7 +220,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' All current entries to be displayed in each pages' configuration combobox
         ''' </summary>
-        Public ReadOnly Property ConfigurationDropdownEntries() As DropdownItem()
+        Public ReadOnly Property ConfigurationDropdownEntries As DropdownItem()
             Get
                 If _platformDropdownEntries Is Nothing OrElse _configurationDropdownEntries Is Nothing Then
                     UpdateDropdownEntries()
@@ -233,7 +233,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' All current entries to be displayed in each pages' platform combobox
         ''' </summary>
-        Public ReadOnly Property PlatformDropdownEntries() As DropdownItem()
+        Public ReadOnly Property PlatformDropdownEntries As DropdownItem()
             Get
                 If _platformDropdownEntries Is Nothing OrElse _configurationDropdownEntries Is Nothing Then
                     UpdateDropdownEntries()
@@ -317,7 +317,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Retrieves the project associated with this configuration state
         ''' </summary>
-        Public ReadOnly Property Project() As EnvDTE.Project
+        Public ReadOnly Property Project As EnvDTE.Project
             Get
                 Debug.Assert(_project IsNot Nothing)
                 Return _project
@@ -328,7 +328,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Configuration provider for the project (IVsCfgProvider2)
         ''' </summary>
-        Public ReadOnly Property VsCfgProvider() As IVsCfgProvider2
+        Public ReadOnly Property VsCfgProvider As IVsCfgProvider2
             Get
                 Debug.Assert(_vsCfgProvider IsNot Nothing)
                 Return _vsCfgProvider
@@ -340,7 +340,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Returns whether or not we're in simplified config mode for this project, which means that
         '''   we hide the configuration/platform comboboxes.
         ''' </summary>
-        Public ReadOnly Property IsSimplifiedConfigMode() As Boolean
+        Public ReadOnly Property IsSimplifiedConfigMode As Boolean
             Get
                 Return Common.ShellUtil.GetIsSimplifiedConfigMode(_projectHierarchy)
             End Get
@@ -731,7 +731,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             ''' <summary>
             ''' Returns the display string to show in the combobox
             ''' </summary>
-            Public ReadOnly Property DisplayName() As String
+            Public ReadOnly Property DisplayName As String
                 Get
                     Select Case SelectionType
                         Case SelectionTypes.Active

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/MultipleValuesStore.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/MultipleValuesStore.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
     ''' for different configurations, to enable undo/redo in "All configurations" and 
     ''' "All Platforms" modes.
     ''' </summary>
-    <Serializable()>
+    <Serializable>
     Public Class MultipleValuesStore
 
         'Note: the sizes of these arrays are all the same

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerDocData.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerDocData.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Creates VsTextBuffer if necessary and returns the instance of VsTextBuffer
         ''' </summary>
-        Private ReadOnly Property VsTextStream() As IVsTextBuffer
+        Private ReadOnly Property VsTextStream As IVsTextBuffer
             Get
                 If _vsTextBuffer IsNot Nothing Then
                     Return _vsTextBuffer

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerEditorFactory.vb
@@ -29,14 +29,14 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         Private Shared ReadOnly s_commandUIGuid As New Guid("{86670efa-3c28-4115-8776-a4d5bb1f27cc}")
 
         'Exposing the GUID for the rest of the assembly to see
-        Public Shared ReadOnly Property EditorGuid() As Guid
+        Public Shared ReadOnly Property EditorGuid As Guid
             Get
                 Return s_editorGuid
             End Get
         End Property
 
         'Exposing the GUID for the rest of the assembly to see
-        Public Shared ReadOnly Property CommandUIGuid() As Guid
+        Public Shared ReadOnly Property CommandUIGuid As Guid
             Get
                 Return s_commandUIGuid
             End Get

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerRootComponent.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerRootComponent.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         Private _rootDesigner As PropPageDesignerRootDesigner
         Private ReadOnly _name As String = "PropPageDesignerRootComponent"
 
-        Public ReadOnly Property Name() As String
+        Public ReadOnly Property Name As String
             Get
                 Return _name
             End Get
@@ -34,7 +34,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''   resx file to be edited by the user.
         ''' </summary>
         ''' <value>The associated ResourceEditorRootDesigner.</value>
-        Public ReadOnly Property RootDesigner() As PropPageDesignerRootDesigner
+        Public ReadOnly Property RootDesigner As PropPageDesignerRootDesigner
             Get
                 If _rootDesigner Is Nothing Then
                     'Not yet cached - get this info from the designer host
@@ -51,11 +51,11 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' The IVsHierarchy associated with the AppDesigner node
         ''' </summary>
-        Public Property Hierarchy() As IVsHierarchy
+        Public Property Hierarchy As IVsHierarchy
             Get
                 Return _hierarchy
             End Get
-            Set(Value As IVsHierarchy)
+            Set
                 _hierarchy = Value
             End Set
         End Property
@@ -63,11 +63,11 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' The ItemId associated with the AppDesigner node
         ''' </summary>
-        Public Property ItemId() As UInteger
+        Public Property ItemId As UInteger
             Get
                 Return _itemId
             End Get
-            Set(Value As UInteger)
+            Set
                 _itemId = Value
             End Set
         End Property

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerRootDesigner.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Returns the PropPageDesignerRootComponent component that is being edited by this designer.
         ''' </summary>
         ''' <value>The PropPageDesignerRootComponent object.</value>
-        Public Shadows ReadOnly Property Component() As PropPageDesignerRootComponent
+        Public Shadows ReadOnly Property Component As PropPageDesignerRootComponent
             Get
                 Dim RootComponent As PropPageDesignerRootComponent = CType(MyBase.Component, PropPageDesignerRootComponent)
                 Debug.Assert(Not RootComponent Is Nothing)
@@ -52,7 +52,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <remarks>
         ''' The view technology we support, which is currently only Windows Forms
         ''' </remarks>
-        Private ReadOnly Property IRootDesigner_SupportedTechnologies() As ViewTechnology() Implements IRootDesigner.SupportedTechnologies
+        Private ReadOnly Property IRootDesigner_SupportedTechnologies As ViewTechnology() Implements IRootDesigner.SupportedTechnologies
             Get
                 Return New ViewTechnology() {ViewTechnology.Default}
             End Get

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
@@ -295,7 +295,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Get DesignerHost
         ''' </summary>
-        Public ReadOnly Property DesignerHost() As IDesignerHost
+        Public ReadOnly Property DesignerHost As IDesignerHost
             Get
                 Return TryCast(GetService(GetType(IDesignerHost)), IDesignerHost)
             End Get
@@ -305,18 +305,18 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Property page we host
         ''' </summary>
-        Public ReadOnly Property PropPage() As OleInterop.IPropertyPage
+        Public ReadOnly Property PropPage As OleInterop.IPropertyPage
             Get
                 Return _loadedPage
             End Get
         End Property
 
         Private _isConfigPage As Boolean
-        Public Property IsConfigPage() As Boolean
+        Public Property IsConfigPage As Boolean
             Get
                 Return _isConfigPage
             End Get
-            Set(Value As Boolean)
+            Set
                 _isConfigPage = Value
             End Set
         End Property
@@ -324,7 +324,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Retrieves the IVsUIShell service
         ''' </summary>
-        Private ReadOnly Property VsUIShellService() As IVsUIShell
+        Private ReadOnly Property VsUIShellService As IVsUIShell
             Get
                 If (_uiShellService Is Nothing) Then
                     If VBPackageInstance IsNot Nothing Then
@@ -341,7 +341,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Retrieves the IVsUIShell5 service
         ''' </summary>
-        Private ReadOnly Property VsUIShell5Service() As IVsUIShell5
+        Private ReadOnly Property VsUIShell5Service As IVsUIShell5
             Get
                 If (_uiShell5Service Is Nothing) Then
                     Dim VsUiShell As IVsUIShell = VsUIShellService
@@ -357,7 +357,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
 
         Private _dteProject As EnvDTE.Project
 
-        Public ReadOnly Property DTEProject() As EnvDTE.Project
+        Public ReadOnly Property DTEProject As EnvDTE.Project
             Get
                 Return _dteProject
             End Get
@@ -368,7 +368,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' True iff the property page is hosted through native SetParent and not as a Windows Form child control.
         ''' Returns False if the property page is not currently activated
         ''' </summary>
-        Public ReadOnly Property IsNativeHostedPropertyPageActivated() As Boolean
+        Public ReadOnly Property IsNativeHostedPropertyPageActivated As Boolean
             Get
                 Return _isPageActivated AndAlso _isNativeHostedPropertyPage
             End Get
@@ -386,7 +386,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
 
 
         Private _vsCfgProvider As IVsCfgProvider2
-        Private ReadOnly Property VsCfgProvider() As IVsCfgProvider2
+        Private ReadOnly Property VsCfgProvider As IVsCfgProvider2
             Get
                 If _vsCfgProvider Is Nothing Then
                     Dim Value As Object = Nothing
@@ -844,7 +844,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Pick font to use in this dialog page
         ''' </summary>
-        Private ReadOnly Property GetDialogFont() As Font
+        Private ReadOnly Property GetDialogFont As Font
             Get
                 Dim uiSvc As IUIService = CType(GetService(GetType(IUIService)), IUIService)
                 If uiSvc IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPagePropertyDescriptor.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPagePropertyDescriptor.vb
@@ -53,7 +53,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Returns the type of the instance this property is bound to, which is PropPageDesignerRootComponent.
         ''' </summary>
         ''' <value>The component type.</value>
-        Public Overrides ReadOnly Property ComponentType() As Type
+        Public Overrides ReadOnly Property ComponentType As Type
             Get
                 Return GetType(PropPageDesignerRootComponent)
             End Get
@@ -64,7 +64,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''  Returns a value indicating whether this property is read-only.
         ''' </summary>
         ''' <value>True if the property is read-only, False otherwise.</value>
-        Public Overrides ReadOnly Property IsReadOnly() As Boolean
+        Public Overrides ReadOnly Property IsReadOnly As Boolean
             Get
                 Return _isReadOnly
             End Get
@@ -75,7 +75,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' Returns the type of the property.
         ''' </summary>
         ''' <value>A Type that represents the type of the property.</value>
-        Public Overrides ReadOnly Property PropertyType() As Type
+        Public Overrides ReadOnly Property PropertyType As Type
             Get
                 Return _propertyType
             End Get
@@ -153,7 +153,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Returns the converter for the contained property
         ''' </summary>
-        Public Overrides ReadOnly Property Converter() As TypeConverter
+        Public Overrides ReadOnly Property Converter As TypeConverter
             Get
                 Return _typeConverter
             End Get
@@ -162,7 +162,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <summary>
         ''' Returns the name of the property.
         ''' </summary>
-        Public Overrides ReadOnly Property Name() As String
+        Public Overrides ReadOnly Property Name As String
             Get
                 If _name = "" Then
                     Return MyBase.Name
@@ -177,7 +177,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' be displayed in a properties window.  This will be the same as the property
         ''' name for most properties.
         ''' </summary>
-        Public Overrides ReadOnly Property DisplayName() As String
+        Public Overrides ReadOnly Property DisplayName As String
             Get
                 Return _displayName
             End Get

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPageSerializationService_Store.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPageSerializationService_Store.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         '''      interface to avoid confusion.  The IDisposable pattern is provided 
         '''      for languages that support a "using" syntax like C# and VB .NET.
         '''</remarks>
-        <Serializable()>
+        <Serializable>
         Private NotInheritable Class PropertyPageSerializationStore
             Inherits Serialization.SerializationStore
             Implements ISerializable
@@ -54,7 +54,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
 
             ' default impl of abstract base member.  see serialization store for details
             '	
-            Public Overrides ReadOnly Property Errors() As ICollection
+            Public Overrides ReadOnly Property Errors As ICollection
                 Get
                     Return Array.Empty(Of Object)
                 End Get
@@ -380,7 +380,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' <summary>
                 ''' The component from which we want to serialize stuff.
                 ''' </summary>
-                Public ReadOnly Property Component() As PropPageDesignerRootComponent
+                Public ReadOnly Property Component As PropPageDesignerRootComponent
                     Get
                         Return _component
                     End Get
@@ -391,11 +391,11 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' If True, the entire Component instance should be serialized.  If false,
                 '''   then only the properties in PropertiesToSerialize should be serialized.
                 ''' </summary>
-                Public Property IsEntireObject() As Boolean
+                Public Property IsEntireObject As Boolean
                     Get
                         Return _isEntireObject
                     End Get
-                    Set(Value As Boolean)
+                    Set
                         Debug.Assert(Value = False, "Not supported/needed")
                         If Value AndAlso _propertiesToSerialize IsNot Nothing Then
                             _propertiesToSerialize.Clear()
@@ -409,7 +409,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' A list of PropertyDescriptors representing the properties on
                 '''   the Component which should be serialized.
                 ''' </summary>
-                Public ReadOnly Property PropertiesToSerialize() As IList
+                Public ReadOnly Property PropertiesToSerialize As IList
                     Get
                         If _propertiesToSerialize Is Nothing Then
                             _propertiesToSerialize = New ArrayList
@@ -444,7 +444,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             ''' <summary>
             ''' Stores a single binary serialized Component instance or Component property value
             ''' </summary>
-            <Serializable()>
+            <Serializable>
             Private NotInheritable Class SerializedProperty
 
                 'The name of the component from which this was serialized.
@@ -501,7 +501,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' <summary>
                 ''' Gets the name of the component from which this was serialized.
                 ''' </summary>
-                Public ReadOnly Property ComponentName() As String
+                Public ReadOnly Property ComponentName As String
                     Get
                         Return _componentName
                     End Get
@@ -512,7 +512,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' Gets the name of the property which was serialized (or Nothing if
                 '''   not a property serialization).
                 ''' </summary>
-                Public ReadOnly Property PropertyName() As String
+                Public ReadOnly Property PropertyName As String
                     Get
                         Return _propertyName
                     End Get
@@ -523,7 +523,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' Returns True iff an entire Component object has been serialized, as opposed
                 '''   to just a property from it.
                 ''' </summary>
-                Public ReadOnly Property IsEntireComponentObject() As Boolean
+                Public ReadOnly Property IsEntireComponentObject As Boolean
                     Get
                         Return (PropertyName = "")
                     End Get

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/ChildPageSite.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/ChildPageSite.vb
@@ -48,7 +48,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns whether or not the property page hosted in this site should be with 
         '''   immediate-apply mode or not)
         ''' </summary>
-        Private ReadOnly Property IsImmediateApply() As Boolean Implements IPropertyPageSiteInternal.IsImmediateApply
+        Private ReadOnly Property IsImmediateApply As Boolean Implements IPropertyPageSiteInternal.IsImmediateApply
             Get
                 'Child pages are always non-immediate apply (we wait until the user clicks
                 '  OK or Cancel)

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/ControlDataFlags.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/ControlDataFlags.vb
@@ -7,7 +7,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' <summary>
     ''' Flags which help control the behavior of a PropertyControlData instance.
     ''' </summary>
-    <Flags()>
+    <Flags>
     Public Enum ControlDataFlags
         None = 0                 'No flags
         UserPersisted = &H10       'Property is persisted using custom code (see ReadUserDefinedProperty, WriteUserDefinedProperty, GetUserDefinedProperty).  Note that this is completely independent of whether a custom getter and setter are defined.

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/ProjectReloadedException.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/ProjectReloadedException.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' <remarks>
     ''' This exception should not be allowed to bubble up to the user.
     ''' </remarks>
-    <Serializable()>
+    <Serializable>
     Public Class ProjectReloadedException
         Inherits Exception
 

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
@@ -65,11 +65,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Function GetLocaleID() As Integer
         Function TranslateAccelerator(msg As Message) As Integer
         Function GetService(ServiceType As Type) As Object
-        ReadOnly Property IsImmediateApply() As Boolean
+        ReadOnly Property IsImmediateApply As Boolean
     End Interface
 
 
-    <Flags(), ComVisible(False)>
+    <Flags, ComVisible(False)>
     Public Enum PROPPAGESTATUS
         Dirty = 1
         Validate = 2
@@ -186,7 +186,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns whether or not the property page hosted in this site should be with 
         '''   immediate-apply mode or not
         ''' </summary>
-        Private ReadOnly Property IsImmediateApply() As Boolean Implements IPropertyPageSiteInternal.IsImmediateApply
+        Private ReadOnly Property IsImmediateApply As Boolean Implements IPropertyPageSiteInternal.IsImmediateApply
             Get
                 'Current implementation is always immediate-apply for
                 '  modeless property pages
@@ -198,47 +198,47 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 #End Region
 
 
-        Protected Overridable Property DocString() As String
+        Protected Overridable Property DocString As String
             Get
                 Return _docString
             End Get
-            Set(value As String)
+            Set
                 _docString = value
             End Set
         End Property
 
 
-        Protected MustOverride ReadOnly Property ControlType() As Type
+        Protected MustOverride ReadOnly Property ControlType As Type
 
-        Protected Overridable ReadOnly Property ControlTypeForResources() As Type
+        Protected Overridable ReadOnly Property ControlTypeForResources As Type
             Get
                 Return ControlType
             End Get
         End Property
 
 
-        Protected MustOverride ReadOnly Property Title() As String
+        Protected MustOverride ReadOnly Property Title As String
 
-        Protected Overridable Property HelpFile() As String
+        Protected Overridable Property HelpFile As String
             Get
                 Return _helpFile
             End Get
-            Set(value As String)
+            Set
                 _helpFile = value
             End Set
         End Property
 
 
-        Protected Overridable Property HelpContext() As UInteger
+        Protected Overridable Property HelpContext As UInteger
             Get
                 Return _helpContext
             End Get
-            Set(value As UInteger)
+            Set
                 _helpContext = value
             End Set
         End Property
 
-        Protected Overridable Property DefaultSize() As Drawing.Size
+        Protected Overridable Property DefaultSize As Drawing.Size
             Get
                 If _defaultSize.Width = 0 Then 'CONSIDER: Need a better mechanism than assuming the resources are available.  Perf hit?
                     Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(ControlTypeForResources)
@@ -251,19 +251,19 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 End If
                 Return _defaultSize
             End Get
-            Set(value As Drawing.Size)
+            Set
                 _defaultSize = value
             End Set
         End Property
 
 
-        Protected Overridable ReadOnly Property Objects() As Object()
+        Protected Overridable ReadOnly Property Objects As Object()
             Get
                 Return _objects
             End Get
         End Property
 
-        Public Overridable ReadOnly Property SupportsTheming() As Boolean
+        Public Overridable ReadOnly Property SupportsTheming As Boolean
             Get
                 Return False
             End Get

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageHostDialog.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageHostDialog.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Gets the F1 keyword to push into the user context for this property page
         ''' </summary>
-        Protected Overrides Property F1Keyword() As String
+        Protected Overrides Property F1Keyword As String
             Get
                 Dim keyword As String = MyBase.F1Keyword
                 If String.IsNullOrEmpty(keyword) AndAlso _propPage IsNot Nothing Then
@@ -30,16 +30,16 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 End If
                 Return keyword
             End Get
-            Set(Value As String)
+            Set
                 MyBase.F1Keyword = Value
             End Set
         End Property
 
-        Public Property PropPage() As PropPageUserControlBase
+        Public Property PropPage As PropPageUserControlBase
             Get
                 Return _propPage
             End Get
-            Set(Value As PropPageUserControlBase)
+            Set
                 SuspendLayout()
                 If _propPage IsNot Nothing Then
                     'Remove previous page if any

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -310,7 +310,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''    There is one exception: the delay validation only works for warning messages, fatal errors are still reported immediately when the change is applied
         ''' </summary>
         ''' <remarks>Only pages supporting delay-validation need return value</remarks>
-        Protected Overridable ReadOnly Property ValidationControlGroups() As Control()()
+        Protected Overridable ReadOnly Property ValidationControlGroups As Control()()
             Get
                 Return Nothing
             End Get
@@ -319,13 +319,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         '''  Return a boolean value that indicates whether or not the control supports the color theming service
         ''' </summary>
-        Public Overridable ReadOnly Property SupportsTheming() As Boolean
+        Public Overridable ReadOnly Property SupportsTheming As Boolean
             Get
                 Return False
             End Get
         End Property
 
-        Public ReadOnly Property ProjectHierarchy() As IVsHierarchy
+        Public ReadOnly Property ProjectHierarchy As IVsHierarchy
             Get
                 Return _projectHierarchy
             End Get
@@ -336,11 +336,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   WARNING: It is recommended to turn this off and use AutoScaleMode.Font.
         ''' </summary>
         ''' <value>True if the page should not be scaled automatically</value>
-        Protected Property PageRequiresScaling() As Boolean 'CONSIDER: This should be opt-in, not opt-out
+        Protected Property PageRequiresScaling As Boolean 'CONSIDER: This should be opt-in, not opt-out
             Get
                 Return _pageRequiresScaling
             End Get
-            Set(Value As Boolean)
+            Set
                 _pageRequiresScaling = Value
             End Set
         End Property
@@ -350,11 +350,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <value>true if the page should not be scaled</value>
         ''' <remarks>Used only by the Publish page for now</remarks>
-        Protected Property ManualPageScaling() As Boolean
+        Protected Property ManualPageScaling As Boolean
             Get
                 Return _manualPageScaling
             End Get
-            Set(value As Boolean)
+            Set
                 _manualPageScaling = value
             End Set
         End Property
@@ -362,7 +362,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         '''  Return true if the page can be resized...
         ''' </summary>
-        Public Overridable ReadOnly Property PageResizable() As Boolean
+        Public Overridable ReadOnly Property PageResizable As Boolean
             Get
                 Return False
             End Get
@@ -374,11 +374,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   and keeps the page disabled during break mode.  Once the app stops, the page is set
         '''   to the state requested here.
         ''' </summary>
-        Protected Shadows Property Enabled() As Boolean
+        Protected Shadows Property Enabled As Boolean
             Get
                 Return _pageEnabledState
             End Get
-            Set(value As Boolean)
+            Set
                 _pageEnabledState = value
                 SetEnabledState()
             End Set
@@ -387,7 +387,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Determines whether the property page is activated
         ''' </summary>
-        Protected ReadOnly Property IsActivated() As Boolean
+        Protected ReadOnly Property IsActivated As Boolean
             Get
                 Return _activated
             End Get
@@ -442,7 +442,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns the actual site (IPropertyPageSite, rather than IPropertyPageSiteInternal) for the property page
         ''' </summary>
-        Protected ReadOnly Property PropertyPageSite() As OLE.Interop.IPropertyPageSite
+        Protected ReadOnly Property PropertyPageSite As OLE.Interop.IPropertyPageSite
             Get
                 If _site IsNot Nothing Then
                     Dim OleSite As OLE.Interop.IPropertyPageSite =
@@ -480,7 +480,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <remarks>
         ''' See "About 'common' properties" in PropertyControlData for information on "common" properties.
         ''' </remarks>
-        Public ReadOnly Property CommonPropertiesObject() As Object
+        Public ReadOnly Property CommonPropertiesObject As Object
             Get
                 If _projectPropertiesObject IsNot Nothing Then
                     'Used by VB and C#-based projects
@@ -522,7 +522,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' True iff this property page is configuration-specific (like the compile page) instead of
         '''   configuration-independent (like the application pages)
         ''' </summary>
-        Public ReadOnly Property IsConfigurationSpecificPage() As Boolean
+        Public ReadOnly Property IsConfigurationSpecificPage As Boolean
             Get
                 Return _fConfigurationSpecificPage
             End Get
@@ -565,7 +565,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   behavior and display a different set of objects.  These are cached after the first call and not updated
         '''   again until another SetObjects call.
         ''' </remarks>
-        Private ReadOnly Property RawPropertiesObjectsOfAllProperties() As Object()
+        Private ReadOnly Property RawPropertiesObjectsOfAllProperties As Object()
             Get
                 If _cachedRawPropertiesSuperset Is Nothing Then
                     If m_Objects Is Nothing Then
@@ -723,13 +723,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <remarks>When the user selects multiple projects, certain functionality is disabled</remarks>
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
-        Public ReadOnly Property MultiProjectSelect() As Boolean
+        Public ReadOnly Property MultiProjectSelect As Boolean
             Get
                 Return _multiProjectSelect
             End Get
         End Property
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
-        Protected ReadOnly Property ServiceProvider() As ServiceProvider
+        Protected ReadOnly Property ServiceProvider As ServiceProvider
             Get
                 If _serviceProvider Is Nothing Then
                     Dim isp As OLE.Interop.IServiceProvider = Nothing
@@ -753,7 +753,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns the DTE object associated with the objects passed to SetObjects.  If there is none, returns Nothing.
         ''' </summary>
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
-        Protected ReadOnly Property DTE() As EnvDTE.DTE
+        Protected ReadOnly Property DTE As EnvDTE.DTE
             Get
                 Return _dte
             End Get
@@ -763,7 +763,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns the EnvDTE.Project object associated with the objects passed to SetObjects.  If there is none, returns Nothing.
         ''' </summary>
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
-        Public ReadOnly Property DTEProject() As EnvDTE.Project
+        Public ReadOnly Property DTEProject As EnvDTE.Project
             Get
                 Return _dteProject
             End Get
@@ -775,7 +775,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   project type.  Otherwise, use CommonPropertiesObject.
         ''' </summary>
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
-        Public ReadOnly Property ProjectProperties() As VSLangProj.ProjectProperties
+        Public ReadOnly Property ProjectProperties As VSLangProj.ProjectProperties
             Get
                 Return _projectPropertiesObject
             End Get
@@ -866,7 +866,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' If true, the project has been reloaded between a call to EnterProjectCheckoutSection and 
         '''   LeaveProjectCheckoutSection.  See EnterProjectCheckoutSection() for more information.
         ''' </summary>
-        Public ReadOnly Property ProjectReloadedDuringCheckout() As Boolean
+        Public ReadOnly Property ProjectReloadedDuringCheckout As Boolean
             Get
                 Return _projectReloadedDuringCheckout
             End Get
@@ -877,7 +877,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' If true, a call to EnterProjectCheckoutSection has been made, and the matching LeaveProjectCheckoutSection
         '''   call has not yet been made.
         ''' </summary>
-        Protected ReadOnly Property IsInProjectCheckoutSection() As Boolean
+        Protected ReadOnly Property IsInProjectCheckoutSection As Boolean
             Get
                 Return _checkoutSectionCount > 0
             End Get
@@ -1408,7 +1408,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   PropertyControlData.  No need to call the base's default version.
         ''' </remarks>
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
-        Protected Overridable ReadOnly Property ControlData() As PropertyControlData()
+        Protected Overridable ReadOnly Property ControlData As PropertyControlData()
             Get
                 Return Array.Empty(Of PropertyControlData)
             End Get
@@ -2734,11 +2734,11 @@ NextControl:
             Return False
         End Function
 
-        Protected Property CanApplyNow() As Boolean
+        Protected Property CanApplyNow As Boolean
             Get
                 Return _canApplyNow
             End Get
-            Set(Value As Boolean)
+            Set
                 _canApplyNow = Value
             End Set
         End Property
@@ -2747,11 +2747,11 @@ NextControl:
         ''' Indicates whether this property page is dirty or not.
         ''' </summary>
         <Browsable(False)>
-        Public Property IsDirty() As Boolean
+        Public Property IsDirty As Boolean
             Get
                 Return m_IsDirty
             End Get
-            Set(Value As Boolean)
+            Set
                 If m_fInsideInit Then
                     Return
                 End If
@@ -2823,7 +2823,7 @@ NextControl:
         End Sub
         <Browsable(False),
         DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
-        Protected ReadOnly Property VsUIShellService() As IVsUIShell
+        Protected ReadOnly Property VsUIShellService As IVsUIShell
             Get
                 If (_uiShellService Is Nothing) Then
                     _uiShellService = CType(ServiceProvider.GetService(GetType(IVsUIShell)), IVsUIShell)
@@ -2833,7 +2833,7 @@ NextControl:
         End Property
         <Browsable(False),
         DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
-        Protected ReadOnly Property VsUIShell2Service() As IVsUIShell2
+        Protected ReadOnly Property VsUIShell2Service As IVsUIShell2
             Get
                 If (_uiShell2Service Is Nothing) Then
                     Dim VsUiShell As IVsUIShell = Nothing
@@ -2849,7 +2849,7 @@ NextControl:
                 Return _uiShell2Service
             End Get
         End Property
-        Protected ReadOnly Property VsUIShell5Service() As IVsUIShell5
+        Protected ReadOnly Property VsUIShell5Service As IVsUIShell5
             Get
                 If (_uiShell5Service Is Nothing) Then
                     Dim VsUiShell As IVsUIShell = Nothing
@@ -3243,7 +3243,7 @@ NextControl:
             End If
         End Function
 
-        Protected ReadOnly Property IsUndoEnabled() As Boolean
+        Protected ReadOnly Property IsUndoEnabled As Boolean
             Get
                 Return (_propPageUndoSite IsNot Nothing)
             End Get
@@ -3259,7 +3259,7 @@ NextControl:
         ''' <remarks>
         ''' Don't cache this as it can change with a SetObjects call.
         ''' </remarks>
-        Protected ReadOnly Property ProjectKind() As String
+        Protected ReadOnly Property ProjectKind As String
             Get
                 Debug.Assert(_dteProject IsNot Nothing, "Can't get ProjectKind because DTEProject not available")
                 If _dteProject IsNot Nothing Then
@@ -3274,7 +3274,7 @@ NextControl:
         ''' If there is a DTEProject associated with the objects passed in to SetObjects, returns the language of project
         '''   that it is (a GUID as a string).  Otherwise, returns empty string.
         ''' </summary>
-        Protected ReadOnly Property ProjectLanguage() As String
+        Protected ReadOnly Property ProjectLanguage As String
             Get
                 Debug.Assert(_dteProject IsNot Nothing, "Can't get ProjectLanguage because DTEProject not available")
                 If _dteProject IsNot Nothing Then
@@ -3572,7 +3572,7 @@ NextControl:
         ''' <summary>
         ''' Pick font to use in this dialog page
         ''' </summary>
-        Protected ReadOnly Property GetDialogFont() As Font
+        Protected ReadOnly Property GetDialogFont As Font
             Get
                 If ServiceProvider IsNot Nothing Then
                     Dim uiSvc As IUIService = CType(ServiceProvider.GetService(GetType(IUIService)), IUIService)
@@ -3857,7 +3857,7 @@ NextControl:
         ''' <summary>
         ''' Determines whether the entire property page should be disabled while building.  Override to change default behavior.
         ''' </summary>
-        Protected Overridable ReadOnly Property DisableOnBuild() As Boolean
+        Protected Overridable ReadOnly Property DisableOnBuild As Boolean
             Get
                 Return True
             End Get
@@ -3866,7 +3866,7 @@ NextControl:
         ''' <summary>
         ''' Determines whether the entire property page should be disabled while in debugging mode.  Override to change default behavior.
         ''' </summary>
-        Protected Overridable ReadOnly Property DisableOnDebug() As Boolean
+        Protected Overridable ReadOnly Property DisableOnDebug As Boolean
             Get
                 Return True
             End Get

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyControlData.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyControlData.vb
@@ -249,7 +249,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Protected ReadOnly Property ObjectsPropertyDescriptorsArray() As PropertyDescriptorCollection()
+        Protected ReadOnly Property ObjectsPropertyDescriptorsArray As PropertyDescriptorCollection()
             Get
                 Return m_PropPage.m_ObjectsPropertyDescriptorsArray
             End Get
@@ -258,7 +258,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' The DISPID that corresponds to the property in the project.  See comments at top of PropertyControlData.vb.
         ''' </summary>
-        Public ReadOnly Property DispId() As Integer
+        Public ReadOnly Property DispId As Integer
             Get
                 Return _dispId
             End Get
@@ -269,7 +269,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''  are looked up by name (not DISPID).  This allows project flavors to hide one property and add another with the same name but
         '''  a different DISPID in order to "override" a property.
         ''' </summary>
-        Public ReadOnly Property PropertyName() As String
+        Public ReadOnly Property PropertyName As String
             Get
                 Return _propertyName
             End Get
@@ -278,7 +278,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns the page where this property is hosted.
         ''' </summary>
-        Protected ReadOnly Property PropPage() As PropPageUserControlBase
+        Protected ReadOnly Property PropPage As PropPageUserControlBase
             Get
                 Return m_PropPage
             End Get
@@ -289,7 +289,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Retrieves the object to be used for querying for common property values.  The object
         '''   used may vary, depending on the project type and what it supports.
         ''' </summary>
-        Protected ReadOnly Property CommonPropertiesObject() As Object
+        Protected ReadOnly Property CommonPropertiesObject As Object
             Get
                 Debug.Assert(m_PropPage IsNot Nothing, "PropertyControlData not initialized?")
                 Return m_PropPage.CommonPropertiesObject
@@ -307,7 +307,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   be cached after that.  Properties should return the same set of values when given the same set of 
         '''   objects and under the same circumstances.
         ''' </remarks>
-        Public Overridable ReadOnly Property RawPropertiesObjects() As Object()
+        Public Overridable ReadOnly Property RawPropertiesObjects As Object()
             Get
                 Debug.Assert(m_PropPage IsNot Nothing, "PropertyControlData not initialized?")
                 Debug.Assert(m_PropPage.m_Objects IsNot Nothing)
@@ -321,7 +321,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   based on the set of objects passed in to the page through SetObjects.  However, it may be modified by subclasses to 
         '''   contain a superset or subset for special purposes.
         ''' </summary>
-        Public Overridable ReadOnly Property ExtendedPropertiesObjects() As Object()
+        Public Overridable ReadOnly Property ExtendedPropertiesObjects As Object()
             Get
                 Debug.Assert(m_PropPage IsNot Nothing, "PropertyControlData not initialized?")
                 Debug.Assert(m_PropPage.m_ExtendedObjects IsNot Nothing, "Extended objects array is Nothing")
@@ -332,7 +332,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' The control, if any, which is automatically managed by this class instance to correspond to the property's value.  May be Nothing.
         ''' </summary>
-        Public ReadOnly Property FormControl() As Control
+        Public ReadOnly Property FormControl As Control
             Get
                 Return m_FormControl
             End Get
@@ -343,11 +343,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' True iff this property is user-persisted (i.e., rather than getting/setting it directly through the project
         '''   system, the storage/retrieval of the property's value is handled by the page).
         ''' </summary>
-        Public Property IsUserPersisted() As Boolean
+        Public Property IsUserPersisted As Boolean
             Get
                 Return ((Flags And ControlDataFlags.UserPersisted) <> 0)
             End Get
-            Set(Value As Boolean)
+            Set
                 If Value Then
                     Flags = Flags Or ControlDataFlags.UserPersisted
                 Else
@@ -356,11 +356,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Set
         End Property
 
-        Public Property IsUserHandledEvents() As Boolean
+        Public Property IsUserHandledEvents As Boolean
             Get
                 Return ((Flags And ControlDataFlags.UserHandledEvents) <> 0)
             End Get
-            Set(Value As Boolean)
+            Set
                 If Value Then
                     Flags = Flags Or ControlDataFlags.UserHandledEvents
                 Else
@@ -369,7 +369,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Set
         End Property
 
-        Private ReadOnly Property RefreshAllPropertiesWhenChanged() As Boolean
+        Private ReadOnly Property RefreshAllPropertiesWhenChanged As Boolean
             Get
                 Return 0 <> (Flags And ControlDataFlags.RefreshAllPropertiesWhenChanged)
             End Get
@@ -382,11 +382,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Note that this is *not* equivalent to whether or not the property is configuration-dependent - no properties on
         '''   a non-configuration-page are "common" properties, even though they are non-configuration-dependent
         ''' </summary>
-        Public Property IsCommonProperty() As Boolean
+        Public Property IsCommonProperty As Boolean
             Get
                 Return ((Flags And ControlDataFlags.CommonProperty) = ControlDataFlags.CommonProperty)
             End Get
-            Set(Value As Boolean)
+            Set
                 If Value Then
                     Flags = Flags Or ControlDataFlags.CommonProperty
                 Else
@@ -400,7 +400,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns true iff this property is configuration-specific.  This is not the opposite of
         '''   a "common" property (but all common properties are non-configuration-specific).
         ''' </summary>
-        Public ReadOnly Property IsConfigurationSpecificProperty() As Boolean
+        Public ReadOnly Property IsConfigurationSpecificProperty As Boolean
             Get
                 Debug.Assert(m_PropPage IsNot Nothing)
                 If m_PropPage.IsConfigurationSpecificPage Then
@@ -420,11 +420,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' True iff this property instance is currently dirty
         ''' </summary>
-        Public Property IsDirty() As Boolean
+        Public Property IsDirty As Boolean
             Get
                 Return ((Flags And ControlDataFlags.Dirty) = ControlDataFlags.Dirty)
             End Get
-            Set(Value As Boolean)
+            Set
                 If Value Then
                     If m_PropPage.m_fInsideInit OrElse m_Initializing Then
                         Return
@@ -472,7 +472,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   project.
         ''' </summary>
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
-        Public Shared ReadOnly Property MissingProperty() As Object
+        Public Shared ReadOnly Property MissingProperty As Object
             Get
                 'Note: what is referred to here as "missing" is simply that a flavor's implementation
                 '  of IFilterProperties has returned vsFilterPropertiesAll, indicating that the
@@ -496,7 +496,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   and therefore cannot be determined.
         ''' </summary>
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
-        Public Shared ReadOnly Property Indeterminate() As Object
+        Public Shared ReadOnly Property Indeterminate As Object
             Get
                 Return s_indeterminateValue
             End Get
@@ -507,7 +507,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   property has different values in the currently selected configurations
         '''   and therefore cannot be determined.
         ''' </summary>
-        Public ReadOnly Property IsIndeterminate() As Boolean
+        Public ReadOnly Property IsIndeterminate As Boolean
             Get
 #If DEBUG Then
                 Debug.Assert(_isInitialized, "Why are we checking if the property is indeterminate before the value is initialized!?")
@@ -521,7 +521,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   property represented by this class instance is missing in the current
         '''   project.
         ''' </summary>
-        Public ReadOnly Property IsMissing() As Boolean
+        Public ReadOnly Property IsMissing As Boolean
             Get
 #If DEBUG Then
                 Debug.Assert(_isInitialized, "Why are we checking if the property is missing before the value is initialized!?")
@@ -546,11 +546,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return (Value Is s_missingValue) OrElse (Value Is s_indeterminateValue)
         End Function
 
-        Public Property IsHidden() As Boolean
+        Public Property IsHidden As Boolean
             Get
                 Return (Flags And ControlDataFlags.Hidden) <> 0
             End Get
-            Set(Value As Boolean)
+            Set
                 If Value Then
                     Flags = Flags Or ControlDataFlags.Hidden
                 Else
@@ -565,7 +565,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   will have the value IndeterminateValue (and m_AllInitialValues will contain the array of differing values).
         '''   If the property was not found, this will have the value MissingValue.
         ''' </summary>
-        Public ReadOnly Property InitialValue() As Object
+        Public ReadOnly Property InitialValue As Object
             Get
                 Return _initialValue
             End Get
@@ -577,7 +577,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   for this property.  Generally only stored if the values were actually different.  Otherwise, this may
         '''   simply be Nothing.
         ''' </summary>
-        Public ReadOnly Property AllInitialValues() As Object()
+        Public ReadOnly Property AllInitialValues As Object()
             Get
                 Debug.Assert(_allInitialValues Is Nothing OrElse _allInitialValues.Length = RawPropertiesObjects.Length AndAlso _allInitialValues.Length = ExtendedPropertiesObjects.Length,
                     "AllInitialValues should always be the same length as the array returned by RawPropertiesObjects and ExtendedPropertiesObjects")
@@ -593,7 +593,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   as each element.  Never returns Nothing, but always returns an array of the same size
         '''   as RawPropertiesObjects.
         ''' </summary>
-        Public ReadOnly Property AllInitialValuesExpanded() As Object()
+        Public ReadOnly Property AllInitialValuesExpanded As Object()
             Get
                 Dim Values() As Object = AllInitialValues
                 If Values Is Nothing Then
@@ -1001,7 +1001,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Function
 
 #Region "Control getter/setter helpers"
-        Public ReadOnly Property IsReadOnly() As Boolean
+        Public ReadOnly Property IsReadOnly As Boolean
             Get
                 If PropDesc IsNot Nothing Then
                     Return PropDesc.IsReadOnly

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyPageException.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyPageException.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     '''   intended to be shown to the end user in an error dialog, rather than to be
     '''   programmatically manipulated (although that of course is possible).
     ''' </summary>
-    <Serializable()>
+    <Serializable>
     Public Class PropertyPageException
         Inherits ApplicationException
 
@@ -50,11 +50,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             MyBase.New(Info, Context)
         End Sub
 
-        Public Property ShowHeaderAndFooterInErrorControl() As Boolean
+        Public Property ShowHeaderAndFooterInErrorControl As Boolean
             Get
                 Return _showHeaderAndFooterInErrorControl
             End Get
-            Set(value As Boolean)
+            Set
                 _showHeaderAndFooterInErrorControl = value
             End Set
         End Property

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/ValidationException.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/ValidationException.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             _control = control
         End Sub
 
-        Public ReadOnly Property Result() As ValidationResult
+        Public ReadOnly Property Result As ValidationResult
             Get
                 Return _validationResult
             End Get

--- a/src/Microsoft.VisualStudio.AppDesigner/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.AppDesigner/PublicAPI.Shipped.txt
@@ -119,7 +119,7 @@ Microsoft.VisualStudio.Editors.AppDesDesignerFramework.SourceCodeControlManager
 Microsoft.VisualStudio.Editors.AppDesDesignerFramework.SourceCodeControlManager.AreFilesEditable() -> Boolean
 Microsoft.VisualStudio.Editors.AppDesDesignerFramework.SourceCodeControlManager.EnsureFilesEditable() -> Void
 Microsoft.VisualStudio.Editors.AppDesDesignerFramework.SourceCodeControlManager.ManagedFiles() -> System.Collections.Generic.List(Of String)
-Microsoft.VisualStudio.Editors.AppDesDesignerFramework.SourceCodeControlManager.ManagedFiles(value As System.Collections.Generic.List(Of String)) -> Void
+Microsoft.VisualStudio.Editors.AppDesDesignerFramework.SourceCodeControlManager.ManagedFiles(Value As System.Collections.Generic.List(Of String)) -> Void
 Microsoft.VisualStudio.Editors.AppDesDesignerFramework.SourceCodeControlManager.ManageFile(mkDocument As String) -> Void
 Microsoft.VisualStudio.Editors.AppDesDesignerFramework.SourceCodeControlManager.New(sp As System.IServiceProvider, Hierarchy As Microsoft.VisualStudio.Shell.Interop.IVsHierarchy) -> Void
 Microsoft.VisualStudio.Editors.AppDesDesignerFramework.SourceCodeControlManager.StopManagingFile(mkDocument As String) -> Void
@@ -152,7 +152,7 @@ Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.Crea
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.CustomMkDocumentProvider() -> Microsoft.VisualStudio.Editors.ApplicationDesigner.CustomDocumentMonikerProvider
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.CustomMkDocumentProvider(Value As Microsoft.VisualStudio.Editors.ApplicationDesigner.CustomDocumentMonikerProvider) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.CustomViewProvider() -> Microsoft.VisualStudio.Editors.ApplicationDesigner.CustomViewProvider
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.CustomViewProvider(value As Microsoft.VisualStudio.Editors.ApplicationDesigner.CustomViewProvider) -> Void
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.CustomViewProvider(Value As Microsoft.VisualStudio.Editors.ApplicationDesigner.CustomViewProvider) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.DocCookie() -> UInteger
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.DocData() -> Object
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.DocData(Value As Object) -> Void
@@ -180,9 +180,9 @@ Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.Phys
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.PropertyPageInfo() -> Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageInfo
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.ShowDesigner(Show As Boolean = True) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.TabAutomationName() -> String
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.TabAutomationName(value As String) -> Void
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.TabAutomationName(Value As String) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.TabTitle() -> String
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.TabTitle(value As String) -> Void
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.TabTitle(Value As String) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.UpdateWindowFrameBounds() -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.VsUIShell5() -> Microsoft.VisualStudio.Shell.Interop.IVsUIShell5
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.VsWindowFrame() -> Microsoft.VisualStudio.Shell.Interop.IVsWindowFrame
@@ -274,9 +274,9 @@ Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.AccessibleState() -> System.Windows.Forms.AccessibleStates
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.ButtonIndex() -> Integer
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.DirtyIndicator() -> Boolean
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.DirtyIndicator(value As Boolean) -> Void
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.DirtyIndicator(Value As Boolean) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.Location() -> System.Drawing.Point
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.Location(value As System.Drawing.Point) -> Void
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.Location(Value As System.Drawing.Point) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.New() -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.SetIndex(index As Integer) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.TextWithDirtyIndicator() -> String
@@ -292,11 +292,11 @@ Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.OnI
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.OnItemLeave(e As System.EventArgs, item As Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.Renderer() -> Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.SelectedIndex() -> Integer
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.SelectedIndex(value As Integer) -> Void
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.SelectedIndex(Value As Integer) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.SelectedItem() -> Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.SelectedItem(value As Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton) -> Void
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.SelectedItem(Value As Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.ServiceProvider() -> System.IServiceProvider
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.ServiceProvider(value As System.IServiceProvider) -> Void
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.ServiceProvider(Value As System.IServiceProvider) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.TabButtonCount() -> Integer
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.TabButtons() -> System.Collections.Generic.IEnumerable(Of Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.ThemeChanged(sender As Object, args As System.EventArgs) -> Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.ThemeChangedEventHandler
@@ -308,11 +308,11 @@ Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.Cr
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.New(owner As Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.PerformLayout() -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.PreferredButtonForSwitchableSlot() -> Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.PreferredButtonForSwitchableSlot(value As Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton) -> Void
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.PreferredButtonForSwitchableSlot(Value As Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.RenderBackground(g As System.Drawing.Graphics) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.RenderButton(g As System.Drawing.Graphics, button As Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton, IsSelected As Boolean, IsHovered As Boolean) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.ServiceProvider() -> System.IServiceProvider
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.ServiceProvider(value As System.IServiceProvider) -> Void
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.ServiceProvider(Value As System.IServiceProvider) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.UpdateCacheState() -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageInfo
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageInfo.ComPropPageInstance() -> Microsoft.VisualStudio.OLE.Interop.IPropertyPage
@@ -324,13 +324,13 @@ Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageInfo.Site() -> Mi
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageInfo.Title() -> String
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.BackingServiceProvider() -> System.IServiceProvider
-Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.BackingServiceProvider(value As System.IServiceProvider) -> Void
+Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.BackingServiceProvider(Value As System.IServiceProvider) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.CommitPendingChanges() -> Boolean
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.GetLocaleID(ByRef pLocaleID As UInteger) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.GetPageContainer(ByRef ppunk As Object) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.GetService(serviceType As System.Type) -> Object
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.HasBeenSetDirty() -> Boolean
-Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.HasBeenSetDirty(value As Boolean) -> Void
+Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.HasBeenSetDirty(Value As Boolean) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.New(View As Microsoft.VisualStudio.Editors.ApplicationDesigner.IPropertyPageSiteOwner, PropPage As Microsoft.VisualStudio.OLE.Interop.IPropertyPage) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.OnStatusChange(dwFlags As UInteger) -> Void
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.QueryService(ByRef guidService As System.Guid, ByRef riid As System.Guid, ByRef ppvObject As System.IntPtr) -> Integer
@@ -473,7 +473,7 @@ Microsoft.VisualStudio.Editors.PropertyPages.PropertyPageException.New(message A
 Microsoft.VisualStudio.Editors.PropertyPages.PropertyPageException.New(message As String, innerException As System.Exception) -> Void
 Microsoft.VisualStudio.Editors.PropertyPages.PropertyPageException.New(message As String) -> Void
 Microsoft.VisualStudio.Editors.PropertyPages.PropertyPageException.ShowHeaderAndFooterInErrorControl() -> Boolean
-Microsoft.VisualStudio.Editors.PropertyPages.PropertyPageException.ShowHeaderAndFooterInErrorControl(value As Boolean) -> Void
+Microsoft.VisualStudio.Editors.PropertyPages.PropertyPageException.ShowHeaderAndFooterInErrorControl(Value As Boolean) -> Void
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.FinishPendingValidations() -> Boolean
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.GetLocaleID() -> Integer
@@ -505,7 +505,7 @@ Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.DTE() -> En
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.DTEProject() -> EnvDTE.Project
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.EnableControl(control As System.Windows.Forms.Control, enabled As Boolean) -> Void
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.Enabled() -> Boolean
-Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.Enabled(value As Boolean) -> Void
+Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.Enabled(Value As Boolean) -> Void
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.EnterProjectCheckoutSection() -> Void
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.ExtendedPropertiesObjects(Data As Microsoft.VisualStudio.Editors.PropertyPages.PropertyControlData) -> Object()
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.GetCommonPropertyDescriptor(PropertyName As String) -> System.ComponentModel.PropertyDescriptor
@@ -549,7 +549,7 @@ Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.m_Objects -
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.m_ObjectsPropertyDescriptorsArray -> System.ComponentModel.PropertyDescriptorCollection()
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.m_ScalingCompleted -> Boolean
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.ManualPageScaling() -> Boolean
-Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.ManualPageScaling(value As Boolean) -> Void
+Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.ManualPageScaling(Value As Boolean) -> Void
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.MultiProjectSelect() -> Boolean
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.New() -> Void
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.New(serviceProvider As Microsoft.VisualStudio.Shell.ServiceProvider) -> Void
@@ -823,16 +823,16 @@ Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.Apply() ->
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.ControlTypeForResources() -> System.Type
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.Deactivate() -> Void
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.DefaultSize() -> System.Drawing.Size
-Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.DefaultSize(value As System.Drawing.Size) -> Void
+Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.DefaultSize(Value As System.Drawing.Size) -> Void
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.DocString() -> String
-Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.DocString(value As String) -> Void
+Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.DocString(Value As String) -> Void
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.GetProperty(PropertyName As String) -> Object
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.GetPropertyMultipleValues(PropertyName As String, ByRef Objects As Object(), ByRef Values As Object()) -> Boolean
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.Help(strHelpDir As String) -> Void
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.HelpContext() -> UInteger
-Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.HelpContext(value As UInteger) -> Void
+Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.HelpContext(Value As UInteger) -> Void
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.HelpFile() -> String
-Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.HelpFile(value As String) -> Void
+Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.HelpFile(Value As String) -> Void
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.IsPageDirty() -> Integer
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.Objects() -> Object()
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.SetObjects(cObjects As UInteger, objects As Object()) -> Void
@@ -950,7 +950,7 @@ Overrides Microsoft.VisualStudio.Editors.AppDesDesignerFramework.DesignerMenuCom
 Overrides Microsoft.VisualStudio.Editors.AppDesDesignerFramework.DesignerMenuCommand.OleStatus() -> Integer
 Overrides Microsoft.VisualStudio.Editors.AppDesDesignerFramework.ErrorControl.GetPreferredSize(proposedSize As System.Drawing.Size) -> System.Drawing.Size
 Overrides Microsoft.VisualStudio.Editors.AppDesDesignerFramework.ErrorControl.Text() -> String
-Overrides Microsoft.VisualStudio.Editors.AppDesDesignerFramework.ErrorControl.Text(value As String) -> Void
+Overrides Microsoft.VisualStudio.Editors.AppDesDesignerFramework.ErrorControl.Text(Value As String) -> Void
 Overrides Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerLoader.Dispose() -> Void
 Overrides Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.Dispose(disposing As Boolean) -> Void
 Overrides Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.OnLayout(levent As System.Windows.Forms.LayoutEventArgs) -> Void

--- a/src/Microsoft.VisualStudio.AppDesigner/VSProductSKU.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/VSProductSKU.vb
@@ -52,7 +52,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns the product SKU as an enum.
         ''' </summary>
-        Public Shared ReadOnly Property ProductSKU() As VSASKUEdition
+        Public Shared ReadOnly Property ProductSKU As VSASKUEdition
             Get
                 EnsureInited()
                 Return s_productSKU
@@ -62,7 +62,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns the product Sub-SKU as an enum.
         ''' </summary>
-        Public Shared ReadOnly Property ProductSubSKU() As VSASubSKUEdition
+        Public Shared ReadOnly Property ProductSubSKU As VSASubSKUEdition
             Get
                 EnsureInited()
                 Return s_productSubSKU
@@ -73,7 +73,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns True iff this is a Standard SKU
         ''' </summary>
         ''' <remarks>From a macro in vsappid.idl</remarks>
-        Public Shared ReadOnly Property IsStandard() As Boolean
+        Public Shared ReadOnly Property IsStandard As Boolean
             Get
                 EnsureInited()
                 Return (s_productSKU >= VSASKUEdition.Standard AndAlso s_productSKU < VSASKUEdition.VSTO)
@@ -84,7 +84,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns True iff this is a VSTO SKU
         ''' </summary>
-        Public Shared ReadOnly Property IsVSTO() As Boolean
+        Public Shared ReadOnly Property IsVSTO As Boolean
             Get
                 EnsureInited()
                 Return (s_productSKU >= VSASKUEdition.VSTO AndAlso s_productSKU < VSASKUEdition.Professional)
@@ -95,7 +95,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns True iff this is a Professional SKU
         ''' </summary>
         ''' <remarks>From a macro in vsappid.idl</remarks>
-        Public Shared ReadOnly Property IsProfessional() As Boolean
+        Public Shared ReadOnly Property IsProfessional As Boolean
             Get
                 EnsureInited()
                 Return (s_productSKU >= VSASKUEdition.Professional AndAlso s_productSKU < VSASKUEdition.Enterprise)
@@ -107,7 +107,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns True iff this is an Express SKU
         ''' </summary>
         ''' <remarks>From a macro in vsappid.idl</remarks>
-        Public Shared ReadOnly Property IsExpress() As Boolean
+        Public Shared ReadOnly Property IsExpress As Boolean
             Get
                 EnsureInited()
                 Return (s_productSKU = VSASKUEdition.Express)
@@ -119,7 +119,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns True iff this is an Academic SKU
         ''' </summary>
         ''' <remarks>From a macro in vsappid.idl</remarks>
-        Public Shared ReadOnly Property IsAcademic() As Boolean
+        Public Shared ReadOnly Property IsAcademic As Boolean
             Get
                 EnsureInited()
                 Return (s_productSKU = VSASKUEdition.AcademicStudent)
@@ -131,7 +131,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Returns True iff this is an Enterprise SKU
         ''' </summary>
         ''' <remarks>From a macro in vsappid.idl</remarks>
-        Public Shared ReadOnly Property IsEnterprise() As Boolean
+        Public Shared ReadOnly Property IsEnterprise As Boolean
             Get
                 EnsureInited()
                 Return (s_productSKU >= VSASKUEdition.Enterprise)
@@ -142,7 +142,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns True iff this is a VB SKU
         ''' </summary>
-        Public Shared ReadOnly Property IsVB() As Boolean
+        Public Shared ReadOnly Property IsVB As Boolean
             Get
                 EnsureInited()
                 Return (s_productSubSKU = VSASubSKUEdition.VB)
@@ -153,7 +153,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Returns True iff this is a VC SKU
         ''' </summary>
-        Public Shared ReadOnly Property IsVC() As Boolean
+        Public Shared ReadOnly Property IsVC As Boolean
             Get
                 EnsureInited()
                 Return (s_productSubSKU = VSASubSKUEdition.VC)

--- a/src/Microsoft.VisualStudio.AppDesigner/interop/ILangInactiveCfgPropertyNotifySink.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/interop/ILangInactiveCfgPropertyNotifySink.vb
@@ -5,12 +5,12 @@ Imports System.Runtime.InteropServices
 Namespace Microsoft.VisualStudio.Editors.AppDesInterop
 
 
-    <ComImport(), Guid("20bd130e-bcd6-4977-a7da-121555dca33b"),
+    <ComImport, Guid("20bd130e-bcd6-4977-a7da-121555dca33b"),
     InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
     CLSCompliant(False), ComVisible(False)>
     Public Interface ILangInactiveCfgPropertyNotifySink
 
-        <PreserveSig()>
+        <PreserveSig>
         Function OnChanged(dispid As Integer, <MarshalAs(UnmanagedType.LPWStr)> wszConfigName As String) As Integer
 
     End Interface

--- a/src/Microsoft.VisualStudio.AppDesigner/interop/IVsAppId.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/interop/IVsAppId.vb
@@ -10,7 +10,7 @@ Imports System.Runtime.InteropServices
 Namespace Microsoft.VisualStudio.Editors.AppDesInterop
 
     <ComVisible(False),
-    ComImport(),
+    ComImport,
     Guid("1EAA526A-0898-11d3-B868-00C04F79F802"),
     InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
     Friend Interface IVsAppId
@@ -20,23 +20,23 @@ Namespace Microsoft.VisualStudio.Editors.AppDesInterop
 
         ' HRESULT GetProperty([in] VSAPROPID propid,
         '                     [out] VARIANT *pvar);
-        <PreserveSig()>
+        <PreserveSig>
         Function GetProperty(propid As Integer,
-                         <Out(), MarshalAs(UnmanagedType.Struct)> ByRef pvar As Object) As Integer
+                         <Out, MarshalAs(UnmanagedType.Struct)> ByRef pvar As Object) As Integer
 
         ' HRESULT SetProperty([in] VSAPROPID propid,
         '                     [in] VARIANT var);
         Sub SetProperty(propid As Integer,
-                         <[In](), MarshalAs(UnmanagedType.Struct)> var As Object)
+                         <[In], MarshalAs(UnmanagedType.Struct)> var As Object)
 
         ' HRESULT GetGuidProperty([in] VSAPROPID propid,
         '                         [out] GUID *pguid);
         Sub GetGuidProperty(propid As Integer,
-                             <Out()> ByRef pguid As Guid)
+                             <Out> ByRef pguid As Guid)
 
         ' HRESULT SetGuidProperty([in] VSAPROPID propid,
         '                         [in] REFGUID rguid);
-        Sub SetGuidProperty(propid As Integer, <[In]()> ByRef rguid As Guid)
+        Sub SetGuidProperty(propid As Integer, <[In]> ByRef rguid As Guid)
 
         ' HRESULT Initialize();  ' called after main initialization and before command executing and entering main loop
         Sub Initialize()

--- a/src/Microsoft.VisualStudio.AppDesigner/interop/NativeMethods.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/interop/NativeMethods.vb
@@ -235,81 +235,81 @@ Namespace Microsoft.VisualStudio.Editors.AppDesInterop
         '
         'Public Declare Unicode Sub StrongNameFreeBuffer Lib "mscoree.dll" (ppbKeyBlob As IntPtr)
 
-        <PreserveSig()> Public Declare Function _
+        <PreserveSig> Public Declare Function _
             SetParent _
                 Lib "user32" (hwnd As IntPtr, hWndParent As IntPtr) As IntPtr
 
 
-        <PreserveSig()> Public Declare Function _
+        <PreserveSig> Public Declare Function _
             GetParent _
                 Lib "user32" (hwnd As IntPtr) As IntPtr
 
-        <PreserveSig()> Public Declare Function _
+        <PreserveSig> Public Declare Function _
             GetFocus _
                 Lib "user32" () As IntPtr
 
-        <PreserveSig()> Public Declare Function _
+        <PreserveSig> Public Declare Function _
             SetFocus _
                 Lib "user32" (hwnd As IntPtr) As Integer
 
-        <PreserveSig()> Public Declare Auto Function _
+        <PreserveSig> Public Declare Auto Function _
             SendMessage _
                 Lib "user32" (hwnd As HandleRef, msg As Integer, wParam As Integer, lParam As Integer) As IntPtr
 
-        <PreserveSig()> Public Declare Auto Function _
+        <PreserveSig> Public Declare Auto Function _
             SendMessage _
                 Lib "user32" (hwnd As HandleRef, msg As Integer, wParam As Integer, ByRef lParam As TVITEM) As IntPtr
 
-        <PreserveSig()> Public Declare Auto Function _
+        <PreserveSig> Public Declare Auto Function _
             SendMessage _
                 Lib "user32" (hwnd As IntPtr, msg As Integer, wParam As IntPtr, lParam As IntPtr) As IntPtr
 
-        <PreserveSig()> Public Declare Auto Function _
+        <PreserveSig> Public Declare Auto Function _
             PostMessage _
                 Lib "user32" (hwnd As IntPtr, msg As Integer, wParam As Integer, lParam As Integer) As IntPtr
 
-        <PreserveSig()> Public Declare Auto Function _
+        <PreserveSig> Public Declare Auto Function _
             WaitMessage _
                 Lib "user32" () As Boolean
 
-        <PreserveSig()> Public Declare Auto Function _
+        <PreserveSig> Public Declare Auto Function _
             IsDialogMessage _
                 Lib "user32" (hwnd As HandleRef, ByRef msg As MSG) As Boolean
 
-        <PreserveSig()> Public Declare Auto Function _
+        <PreserveSig> Public Declare Auto Function _
             TranslateMessage _
                 Lib "user32" (ByRef msg As MSG) As Boolean
 
-        <PreserveSig()> Public Declare Auto Function _
+        <PreserveSig> Public Declare Auto Function _
             GetKeyState _
                 Lib "user32" (nVirtKey As Keys) As Short
 
         ''' <summary>
         ''' The GetNextDlgTabItem function retrieves a handle to the first control that has the WS_TABSTOP style that precedes (or follows) the specified control. 
         ''' </summary>
-        <PreserveSig()> Public Declare Auto Function _
+        <PreserveSig> Public Declare Auto Function _
             GetNextDlgTabItem _
                 Lib "user32" (hDlg As IntPtr, hCtl As IntPtr, bPrevious As Boolean) As IntPtr
 
 
-        <PreserveSig()>
+        <PreserveSig>
         Public Declare Auto Function GetWindow Lib "user32" (Hwnd As IntPtr, uCmd As UInteger) As IntPtr
 
-        <PreserveSig()>
+        <PreserveSig>
         Public Declare Auto Function DragQueryFile Lib "shell32" (hDrop As IntPtr, iFile As Integer, lpszFile As String, cch As Integer) As Integer
 
-        <PreserveSig()>
+        <PreserveSig>
         Public Declare Function GetUserDefaultLCID Lib "kernel32" () As UInteger
 
-        <PreserveSig()>
+        <PreserveSig>
         Public Declare Function GetTopWindow Lib "user32" (Hwnd As IntPtr) As IntPtr
 
-        <PreserveSig()>
+        <PreserveSig>
         Public Declare Auto Function SetWindowLong Lib "user32" (hWnd As IntPtr, Index As Integer, Value As IntPtr) As IntPtr
-        <PreserveSig()>
+        <PreserveSig>
         Public Declare Auto Function GetWindowLong Lib "user32" (Hwnd As IntPtr, Index As Integer) As IntPtr
 
-        <PreserveSig()>
+        <PreserveSig>
         Public Declare Auto Function GetWindowText Lib "user32" (hWnd As IntPtr, lpString As String, nMaxCount As Integer) As Integer
 
         <DllImport("user32", CharSet:=CharSet.Auto)>
@@ -331,10 +331,10 @@ Namespace Microsoft.VisualStudio.Editors.AppDesInterop
             Public bottom As Integer
         End Structure
 
-        <PreserveSig()>
+        <PreserveSig>
         Public Declare Auto Function IsChild Lib "user32" (hWndParent As IntPtr, hWnd As IntPtr) As Boolean
 
-        <PreserveSig()>
+        <PreserveSig>
         Public Declare Auto Function EnableWindow Lib "user32" (hWnd As IntPtr, bEnable As Boolean) As Boolean
 
         '<PreserveSig()> _
@@ -344,10 +344,10 @@ Namespace Microsoft.VisualStudio.Editors.AppDesInterop
         'Public Declare Auto Function SetWindowPos Lib "user32" (Hwnd As IntPtr, HwndInsertAfter As IntPtr, x As Integer, _
         '    y As Integer, cx As Integer, cy As Integer, flags As Integer) As Boolean
 
-        <PreserveSig()>
+        <PreserveSig>
         Public Declare Auto Function SystemParametersInfo Lib "user32" (uiAction As UInteger, uiParam As UInteger, pvParam As IntPtr, fWinIni As UInteger) As Integer
 
-        <PreserveSig()>
+        <PreserveSig>
         Public Declare Auto Function MsgWaitForMultipleObjects Lib "user32" (nCount As Integer, pHandles As IntPtr, fWaitAll As Boolean, dwMilliSeconds As Integer, dwWakeMask As Integer) As Integer
 
         Public Const GWL_EXSTYLE As Integer = -20
@@ -397,15 +397,15 @@ Namespace Microsoft.VisualStudio.Editors.AppDesInterop
     '
     ' ILangPropertyProvideBatchUpdate
     '
-    <ComImport(), Guid("F8828A38-5208-4497-991A-F8034C8D5A69"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
+    <ComImport, Guid("F8828A38-5208-4497-991A-F8034C8D5A69"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
     Public Interface ILangPropertyProvideBatchUpdate
         Sub BeginBatch()
         Sub EndBatch()
-        Sub IsBatchModeEnabled(<[In](), Out()> ByRef BatchModeEnabled As Boolean)
+        Sub IsBatchModeEnabled(<[In], Out> ByRef BatchModeEnabled As Boolean)
         Sub PushOptionsToCompiler(dispid As UInteger)
     End Interface
 
-    <ComImport()>
+    <ComImport>
     <Guid("E5CB7A31-7512-11d2-89CE-0080C792E5D8")>
     <TypeLibType(TypeLibTypeFlags.FCanCreate)>
     <ClassInterface(ClassInterfaceType.None)>

--- a/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AddImportDialogBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AddImportDialogBase.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.VisualStudio.Editors.AddImports
             MyBase.OnLoad(e)
         End Sub
 
-        Protected ReadOnly Property DialogFont() As Font
+        Protected ReadOnly Property DialogFont As Font
             Get
                 Dim hostLocale As VsShell.IUIHostLocale2 = CType(_serviceProvider.GetService(GetType(VsShell.SUIHostLocale)), VsShell.IUIHostLocale2)
                 If hostLocale IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AutoAddImportsCollisionDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AutoAddImportsCollisionDialog.vb
@@ -73,7 +73,7 @@ Namespace Microsoft.VisualStudio.Editors.AddImports
             End If
         End Sub
 
-        Public ReadOnly Property ShouldImportAnyways() As Boolean
+        Public ReadOnly Property ShouldImportAnyways As Boolean
             Get
                 Return m_rbImportsAnyways.Checked
             End Get

--- a/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/Interop.vb
+++ b/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/Interop.vb
@@ -6,7 +6,7 @@ Namespace Microsoft.VisualStudio.Editors.AddImports
 
     <Guid("544D52A6-04C6-4771-863D-EFB1542C8025")>
     <InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
-    <ComImport()>
+    <ComImport>
     Friend Interface IVBAddImportsDialogHelpCallback
         Sub InvokeHelp()
     End Interface
@@ -24,7 +24,7 @@ Namespace Microsoft.VisualStudio.Editors.AddImports
 
     <Guid("71CC3B66-3E89-45eb-BDDA-D6A5599F4C20")>
     <InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
-    <ComImport()>
+    <ComImport>
     Friend Interface IVBAddImportsDialogService
         Function ShowDialog _
         (

--- a/src/Microsoft.VisualStudio.Editors/AttributeEditor/Interop.vb
+++ b/src/Microsoft.VisualStudio.Editors/AttributeEditor/Interop.vb
@@ -15,28 +15,28 @@ Namespace Microsoft.VisualStudio.Editors.VBAttributeEditor.Interop
     <Guid("9DDDA35B-A903-4eca-AAFF-5716AF592D74")>
     <InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
     <CLSCompliant(False)>
-    <ComImport()>
+    <ComImport>
     Friend Interface IVbPermissionSetService
 
         <MethodImpl(MethodImplOptions.InternalCall)>
         Function ComputeZonePermissionSet(
-            <[In](), MarshalAs(UnmanagedType.BStr)> strAppManifestFileName As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strTargetZone As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strExcludedPermissions As String) _
+            <[In], MarshalAs(UnmanagedType.BStr)> strAppManifestFileName As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> strTargetZone As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> strExcludedPermissions As String) _
             As <MarshalAs(UnmanagedType.IUnknown)> Object
 
-        <MethodImpl(MethodImplOptions.InternalCall), PreserveSig()>
+        <MethodImpl(MethodImplOptions.InternalCall), PreserveSig>
         Function IsAvailableInProject(
-            <[In](), MarshalAs(UnmanagedType.BStr)> strPermissionSet As String,
-            <[In](), MarshalAs(UnmanagedType.IUnknown)> ProjectPermissionSet As Object,
-            <Out(), MarshalAs(UnmanagedType.Bool)> ByRef isAvailable As Boolean) _
+            <[In], MarshalAs(UnmanagedType.BStr)> strPermissionSet As String,
+            <[In], MarshalAs(UnmanagedType.IUnknown)> ProjectPermissionSet As Object,
+            <Out, MarshalAs(UnmanagedType.Bool)> ByRef isAvailable As Boolean) _
             As Integer
 
         ' Returns S_FALSE if there is no tip
-        <MethodImpl(MethodImplOptions.InternalCall), PreserveSig()>
+        <MethodImpl(MethodImplOptions.InternalCall), PreserveSig>
         Function GetRequiredPermissionsTip(
-            <[In](), MarshalAs(UnmanagedType.BStr)> strPermissionSet As String,
-            <Out(), MarshalAs(UnmanagedType.BStr)> ByRef strTip As String) _
+            <[In], MarshalAs(UnmanagedType.BStr)> strPermissionSet As String,
+            <Out, MarshalAs(UnmanagedType.BStr)> ByRef strTip As String) _
             As Integer
 
     End Interface

--- a/src/Microsoft.VisualStudio.Editors/Common/ListViewComparer.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/ListViewComparer.vb
@@ -23,11 +23,11 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <summary>
         '''  Which column should be used to sort the list. Start from 0
         ''' </summary>
-        Public Property SortColumn() As Integer
+        Public Property SortColumn As Integer
             Get
                 Return _sortColumn
             End Get
-            Set(value As Integer)
+            Set
                 _sortColumn = value
             End Set
         End Property
@@ -35,11 +35,11 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <summary>
         '''  which order, Ascending or Descending
         ''' </summary>
-        Public Property Sorting() As SortOrder
+        Public Property Sorting As SortOrder
             Get
                 Return _sorting
             End Get
-            Set(value As SortOrder)
+            Set
                 _sorting = value
             End Set
         End Property

--- a/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
@@ -457,7 +457,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
         '''<summary>
         ''' a fake IVSDProjectProperties definition. We only use this to check whether the project supports this interface, but don't pay attention to the detail.
         '''</summary>
-        <System.Runtime.InteropServices.ComImport(), System.Runtime.InteropServices.ComVisible(False), System.Runtime.InteropServices.Guid("1A27878B-EE15-41CE-B427-58B10390C821"), System.Runtime.InteropServices.InterfaceType(System.Runtime.InteropServices.ComInterfaceType.InterfaceIsDual)>
+        <System.Runtime.InteropServices.ComImport, System.Runtime.InteropServices.ComVisible(False), System.Runtime.InteropServices.Guid("1A27878B-EE15-41CE-B427-58B10390C821"), System.Runtime.InteropServices.InterfaceType(System.Runtime.InteropServices.ComInterfaceType.InterfaceIsDual)>
         Private Interface IVSDProjectProperties
         End Interface
 

--- a/src/Microsoft.VisualStudio.Editors/Common/SplitButton.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/SplitButton.vb
@@ -231,11 +231,11 @@ Namespace Microsoft.VisualStudio.Editors.Common
             End If
         End Sub
 
-        Private Property State() As PushButtonState
+        Private Property State As PushButtonState
             Get
                 Return _state
             End Get
-            Set(value As PushButtonState)
+            Set
                 If Not _state.Equals(value) Then
                     _state = value
                     Invalidate()

--- a/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
@@ -234,7 +234,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             Return (CType(color.A, UInteger) << 24 Or CType(color.R, UInteger) << 16 Or CType(color.G, UInteger) << 8 Or CType(color.B, UInteger))
         End Function
 
-        Private ReadOnly Property ImageService() As IVsImageService2
+        Private ReadOnly Property ImageService As IVsImageService2
             Get
                 If (s_imageService Is Nothing) Then
                     Dim serviceProvider As ServiceProvider
@@ -1435,7 +1435,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
 
         Private s_instance As New Helper
 
-        Friend ReadOnly Property Instance() As Helper
+        Friend ReadOnly Property Instance As Helper
             Get
                 Return s_instance
             End Get

--- a/src/Microsoft.VisualStudio.Editors/Common/switches.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/switches.vb
@@ -421,7 +421,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             ''' <summary>
             ''' True iff the switch has a non-empty value
             ''' </summary>
-            Public ReadOnly Property ValueDefined() As Boolean
+            Public ReadOnly Property ValueDefined As Boolean
                 Get
                     Return MyBase.Value <> "" AndAlso CInt(Convert.ChangeType(Value, TypeCode.Int32)) <> 0
                 End Get
@@ -430,11 +430,11 @@ Namespace Microsoft.VisualStudio.Editors.Common
             ''' <summary>
             ''' Gets/sets the current value of the switch
             ''' </summary>
-            Public Shadows Property Value() As T
+            Public Shadows Property Value As T
                 Get
                     Return CType([Enum].Parse(GetType(T), MyBase.Value), T)
                 End Get
-                Set(value As T)
+                Set
                     MyBase.Value = value.ToString()
                 End Set
             End Property

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
@@ -95,8 +95,8 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 _customToolValue = customToolValue
             End Sub
 
-            Public MustOverride ReadOnly Property DisplayName() As String
-            Public ReadOnly Property CustomToolValue() As String
+            Public MustOverride ReadOnly Property DisplayName As String
+            Public ReadOnly Property CustomToolValue As String
                 Get
                     Return _customToolValue
                 End Get
@@ -115,7 +115,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 _displayName = displayName
             End Sub
 
-            Public Overrides ReadOnly Property DisplayName() As String
+            Public Overrides ReadOnly Property DisplayName As String
                 Get
                     Return _displayName
                 End Get
@@ -137,7 +137,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 _serviceProvider = serviceProvider
             End Sub
 
-            Public Overrides ReadOnly Property DisplayName() As String
+            Public Overrides ReadOnly Property DisplayName As String
                 Get
                     Dim codeDomProvider As CodeDomProvider = Nothing
                     Dim vsmdCodeDomProvider As IVSMDCodeDomProvider = TryCast(_serviceProvider.GetService(GetType(IVSMDCodeDomProvider)), IVSMDCodeDomProvider)
@@ -351,7 +351,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             End If
         End Sub
 
-        Protected ReadOnly Property RootDesigner() As BaseRootDesigner
+        Protected ReadOnly Property RootDesigner As BaseRootDesigner
             Get
                 Return _rootDesigner
             End Get
@@ -540,7 +540,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Demand check if the custom tools that we know about are registered for the current project system.
         ''' </summary>
-        Protected Overridable ReadOnly Property CustomToolRegistered() As Boolean
+        Protected Overridable ReadOnly Property CustomToolRegistered As Boolean
             Get
                 If Not _customToolsRegistered.HasValue Then
                     ' If one or more of the custom tools in the drop-down are not registered for the current
@@ -562,7 +562,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Get the hierarchy from the associated project item
         ''' </summary>
-        Protected Overridable ReadOnly Property Hierarchy() As IVsHierarchy
+        Protected Overridable ReadOnly Property Hierarchy As IVsHierarchy
             Get
                 Return ShellUtil.VsHierarchyFromDTEProject(_serviceProvider, _projectItem.ContainingProject)
             End Get

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
@@ -114,7 +114,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' file isn't in the project and needs to be added) or the newly added file. One example is the settings designer's handling
         ''' of the app.config file
         '''</remarks>
-        Protected Overridable ReadOnly Property ManagingDynamicSetOfFiles() As Boolean
+        Protected Overridable ReadOnly Property ManagingDynamicSetOfFiles As Boolean
             Get
                 Return False
             End Get
@@ -123,7 +123,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Get the list of files that you want to check out in the ManualCheckout
         ''' </summary>
-        Friend Overridable ReadOnly Property FilesToCheckOut() As List(Of String)
+        Friend Overridable ReadOnly Property FilesToCheckOut As List(Of String)
             Get
                 Dim projItem As EnvDTE.ProjectItem = ProjectItem
                 Return ShellUtil.FileNameAndGeneratedFileName(projItem)
@@ -235,7 +235,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '  being designed by this editor.  This information is required by the managed VSIP classes.
         Protected MustOverride Function GetBaseComponentClassName() As String
 
-        Protected ReadOnly Property DocData() As DocData
+        Protected ReadOnly Property DocData As DocData
             Get
                 Debug.Assert(m_DocData IsNot Nothing)
                 Return m_DocData
@@ -277,13 +277,13 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         Private _vsHierarchy As IVsHierarchy
         Private _punkDocData As Object
 
-        Friend ReadOnly Property VsHierarchy() As IVsHierarchy
+        Friend ReadOnly Property VsHierarchy As IVsHierarchy
             Get
                 Return _vsHierarchy
             End Get
         End Property
 
-        Friend ReadOnly Property ProjectItemid() As UInteger
+        Friend ReadOnly Property ProjectItemid As UInteger
             Get
                 Return _projectItemid
             End Get
@@ -292,7 +292,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Project Item of the current Document
         ''' </summary>
-        Friend ReadOnly Property ProjectItem() As EnvDTE.ProjectItem
+        Friend ReadOnly Property ProjectItem As EnvDTE.ProjectItem
             Get
                 Return DTEUtils.ProjectItemFromItemId(VsHierarchy, ProjectItemid)
             End Get
@@ -354,7 +354,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '      Determines if this file is read only.
         ' </devdoc>
 
-        Public ReadOnly Property DocDataIsReadOnly() As Boolean
+        Public ReadOnly Property DocDataIsReadOnly As Boolean
             Get
                 Return GetDocDataState(BUFFERSTATEFLAGS.BSF_FILESYS_READONLY Or BUFFERSTATEFLAGS.BSF_USER_READONLY)
             End Get
@@ -604,7 +604,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' For performance reasons, this defaults to false.  If the designer should support the toolbox, override
         '''   this and return True.
         ''' </remarks>
-        Protected Overridable ReadOnly Property SupportToolbox() As Boolean
+        Protected Overridable ReadOnly Property SupportToolbox As Boolean
             Get
                 Return False
             End Get

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerView.vb
@@ -82,7 +82,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' If true, the project has been reloaded between a call to EnterProjectCheckoutSection and 
         '''   LeaveProjectCheckoutSection.  See EnterProjectCheckoutSection() for more information.
         ''' </summary>
-        Protected Friend ReadOnly Property ProjectReloadedDuringCheckout() As Boolean
+        Protected Friend ReadOnly Property ProjectReloadedDuringCheckout As Boolean
             Get
                 Return _projectReloadedDuringCheckout
             End Get
@@ -93,7 +93,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' If true, a call to EnterProjectCheckoutSection has been made, and the matching LeaveProjectCheckoutSection
         '''   call has not yet been made.
         ''' </summary>
-        Protected ReadOnly Property IsInProjectCheckoutSection() As Boolean
+        Protected ReadOnly Property IsInProjectCheckoutSection As Boolean
             Get
                 Return _checkoutSectionCount > 0
             End Get

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDialog.vb
@@ -102,12 +102,12 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         'Summary:
         '   Gets or sets the IServiceProvider for this dialog.
         '**************************************************************************
-        Friend Property ServiceProvider() As IServiceProvider
+        Friend Property ServiceProvider As IServiceProvider
             Get
                 Debug.Assert(_serviceProvider IsNot Nothing, "No service provider.  Did you call the wrong constructor?")
                 Return _serviceProvider
             End Get
-            Set(Value As IServiceProvider)
+            Set
                 Debug.Assert(Value IsNot Nothing, "Bad service provider")
                 _serviceProvider = Value
             End Set
@@ -124,11 +124,11 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         'Summary:
         '   Gets or sets the help keyword for this dialog.
         '**************************************************************************
-        Protected Overridable Property F1Keyword() As String
+        Protected Overridable Property F1Keyword As String
             Get
                 Return _helpKeyword
             End Get
-            Set(Value As String)
+            Set
                 _helpKeyword = Value
             End Set
         End Property
@@ -139,7 +139,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         'Summary:
         '   Gets the current designer host.
         '**************************************************************************
-        Protected ReadOnly Property CurrentDesignerHost() As IDesignerHost
+        Protected ReadOnly Property CurrentDesignerHost As IDesignerHost
             Get
                 Return CType(GetService(GetType(IDesignerHost)), IDesignerHost)
             End Get

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseEditorFactory.vb
@@ -173,13 +173,13 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Must be overridden.  Be sure to use the same GUID on the GUID attribute
         '''   attached to the inheriting class.
         ''' </remarks>
-        Protected MustOverride ReadOnly Property EditorGuid() As Guid
+        Protected MustOverride ReadOnly Property EditorGuid As Guid
 
         ''' <summary>
         ''' Provides the (constant) GUID for the command UI.  This is the guid used in the
         '''   CTC file for keybindings, toolbars, etc.
         ''' </summary>
-        Protected MustOverride ReadOnly Property CommandUIGuid() As Guid
+        Protected MustOverride ReadOnly Property CommandUIGuid As Guid
 
 
 #Region "Private implementation"
@@ -451,7 +451,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <remarks>
         ''' Will not be available before OnSited is called.
         ''' </remarks>
-        Protected ReadOnly Property ServiceProvider() As Shell.ServiceProvider
+        Protected ReadOnly Property ServiceProvider As Shell.ServiceProvider
             Get
                 Return _serviceProvider
             End Get

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseRootDesigner.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''  Returns a cached ISelectionService.
         ''' </summary>
         ''' <value>The cached ISelectionService.</value>
-        Friend ReadOnly Property SelectionService() As ISelectionService
+        Friend ReadOnly Property SelectionService As ISelectionService
             Get
                 If _selectionService Is Nothing Then
                     SyncLock _syncLockObject
@@ -158,7 +158,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <value>The IMenuCommandService from the shell.</value>
         ''' <remarks>Don't want to expose this one to other classes to encourage using RegisterMenuCommands.</remarks>
-        Private ReadOnly Property MenuCommandService() As IMenuCommandService
+        Private ReadOnly Property MenuCommandService As IMenuCommandService
             Get
                 If _menuCommandService Is Nothing Then
                     SyncLock _syncLockObject
@@ -176,7 +176,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''  Returns an arraylist containing all the current registered commands from this designer.
         ''' </summary>
         ''' <value>An ArrayList contains MenuCommand.</value>
-        Private ReadOnly Property MenuCommands() As ArrayList
+        Private ReadOnly Property MenuCommands As ArrayList
             Get
                 Return _menuCommands
             End Get

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerDataGridView.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerDataGridView.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Return whether the DataGridView is in MultiSelection Mode...
         ''' </summary>
-        Friend ReadOnly Property InMultiSelectionMode() As Boolean
+        Friend ReadOnly Property InMultiSelectionMode As Boolean
             Get
                 Return _inMultiSelectionMode
             End Get
@@ -245,11 +245,11 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 End If
             End Sub
 
-            Public Overrides Property [ReadOnly]() As Boolean
+            Public Overrides Property [ReadOnly] As Boolean
                 Get
                     Return MyBase.ReadOnly
                 End Get
-                Set(value As Boolean)
+                Set
                     MyBase.ReadOnly = value
                     If value Then
                         DisplayStyle = DataGridViewComboBoxDisplayStyle.Nothing

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerMenuCommand.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerMenuCommand.vb
@@ -35,7 +35,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '   We also update the status of this menu item in this property based on 
         '   m_AlwaysCheckStatus and m_StatusValid flag.
         '**************************************************************************
-        Public Overrides ReadOnly Property OleStatus() As Integer
+        Public Overrides ReadOnly Property OleStatus As Integer
             Get
                 If _alwaysCheckStatus OrElse Not _statusValid Then
                     UpdateStatus()
@@ -363,7 +363,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Get the collection of commands that are in this group
         ''' </summary>
-        Public ReadOnly Property Commands() As ICollection
+        Public ReadOnly Property Commands As ICollection
             Get
                 Return _commands.Values
             End Get

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerWindowPaneProviderBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerWindowPaneProviderBase.vb
@@ -103,7 +103,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' Returns the view control for the window pane.
             ''' </summary>
-            Protected ReadOnly Property View() As Control
+            Protected ReadOnly Property View As Control
                 Get
                     Return _view
                 End Get
@@ -135,7 +135,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' Retrieves our view.
             ''' </summary>
-            Public Overrides ReadOnly Property Window() As IWin32Window
+            Public Overrides ReadOnly Property Window As IWin32Window
                 Get
                     ' This should always happen, but in case we never
                     ' got a load event we check.  We might not receive
@@ -464,7 +464,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 ''' <summary>
                 ''' Overrides CreateParams to make sure it is created as a child window
                 ''' </summary>
-                Protected Overrides ReadOnly Property CreateParams() As CreateParams
+                Protected Overrides ReadOnly Property CreateParams As CreateParams
                     Get
                         Dim cp As CreateParams = MyBase.CreateParams()
                         cp.Style = cp.Style Or Constants.WS_CHILD Or Constants.WS_CLIPSIBLINGS

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/ErrorControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/ErrorControl.vb
@@ -67,11 +67,11 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Constructor
         ''' </summary>
-        Public Overrides Property Text() As String
+        Public Overrides Property Text As String
             Get
                 Return ErrorText.Text
             End Get
-            Set(value As String)
+            Set
                 MyBase.Text = value
                 ErrorText.Text = value
             End Set

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationService.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationService.vb
@@ -193,11 +193,11 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' Get/set the service provider
         ''' </summary>
         ''' <remarks>Not used by this class, may be useful for derived classes</remarks>
-        Protected Property ServiceProvider() As IServiceProvider
+        Protected Property ServiceProvider As IServiceProvider
             Get
                 Return _serviceProvider
             End Get
-            Set(Value As IServiceProvider)
+            Set
                 _serviceProvider = Value
             End Set
         End Property

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationStore.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationStore.vb
@@ -38,7 +38,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
 
         ' default impl of abstract base member.  see serialization store for details.
         '	
-        Public Overrides ReadOnly Property Errors() As ICollection
+        Public Overrides ReadOnly Property Errors As ICollection
             Get
                 Return Array.Empty(Of Object)
             End Get
@@ -332,7 +332,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''   object instance. (either the entire object itself, or a set of
         '''   its properties)
         ''' </summary>
-        <Serializable()>
+        <Serializable>
         Protected Class ObjectData
 
             'Backing for public properties
@@ -369,7 +369,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' Get tha name of this object
             ''' </summary>
-            Public ReadOnly Property Name() As String
+            Public ReadOnly Property Name As String
                 Get
                     Return _objectName
                 End Get
@@ -378,7 +378,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <summary>
             ''' The object from which we want to serialize stuff.
             ''' </summary>
-            Public ReadOnly Property Value() As Object
+            Public ReadOnly Property Value As Object
                 Get
                     Return _value
                 End Get
@@ -389,11 +389,11 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' If True, the entire Resource instance should be serialized.  If false,
             '''   then only the properties in PropertiesToSerialize should be serialized.
             ''' </summary>
-            Public Property IsEntireObject() As Boolean
+            Public Property IsEntireObject As Boolean
                 Get
                     Return _isEntireObject
                 End Get
-                Set(Value As Boolean)
+                Set
                     If Value AndAlso _members IsNot Nothing Then
                         _members.Clear()
                     End If
@@ -406,7 +406,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' A list of PropertyDescriptors representing the properties on
             '''   the Resource which should be serialized.
             ''' </summary>
-            Public ReadOnly Property Members() As ArrayList
+            Public ReadOnly Property Members As ArrayList
                 Get
                     If _members Is Nothing Then
                         _members = New ArrayList
@@ -426,7 +426,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''   Resource instance (either the entire Resource itself, or a set of
         '''   its properties)
         ''' </summary>
-        <Serializable()>
+        <Serializable>
         Private Class SerializedObjectData
 
             'Backing for public properties
@@ -462,19 +462,19 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' If True, the entire Resource instance should be serialized.  If false,
             '''   then only the properties in PropertiesToSerialize should be serialized.
             ''' </summary>
-            Friend ReadOnly Property IsEntireObject() As Boolean
+            Friend ReadOnly Property IsEntireObject As Boolean
                 Get
                     Return _propertyName = ""
                 End Get
             End Property
 
-            Friend ReadOnly Property ObjectName() As String
+            Friend ReadOnly Property ObjectName As String
                 Get
                     Return _objectName
                 End Get
             End Property
 
-            Friend ReadOnly Property PropertyName() As String
+            Friend ReadOnly Property PropertyName As String
                 Get
                     Return _propertyName
                 End Get

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/SourceCodeControlManager.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/SourceCodeControlManager.vb
@@ -58,11 +58,11 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <summary>
         ''' Get a list of the files currently managed by this service...
         ''' </summary>
-        Public Property ManagedFiles() As List(Of String)
+        Public Property ManagedFiles As List(Of String)
             Get
                 Return New List(Of String)(_managedFiles.Keys)
             End Get
-            Set(value As List(Of String))
+            Set
                 _managedFiles.Clear()
                 For Each file As String In value
                     _managedFiles(file) = True

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/ThemedBorderUserControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/ThemedBorderUserControl.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             _borderPen = New Pen(VisualStyleInformation.TextControlBorder)
         End Sub
 
-        Protected Overrides ReadOnly Property CreateParams() As CreateParams
+        Protected Overrides ReadOnly Property CreateParams As CreateParams
             Get
                 Dim cp As CreateParams = MyBase.CreateParams
                 cp.ExStyle = cp.ExStyle And Not WS_EX_CLIENTEDGE
@@ -53,13 +53,13 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             MyBase.OnPaint(e)
         End Sub
 
-        Protected Overrides ReadOnly Property DefaultPadding() As Padding
+        Protected Overrides ReadOnly Property DefaultPadding As Padding
             Get
                 Return New Padding(1)
             End Get
         End Property
 
-        Private Shared ReadOnly Property UseVisualStyles() As Boolean
+        Private Shared ReadOnly Property UseVisualStyles As Boolean
             Get
                 Return VisualStyleRenderer.IsSupported
             End Get

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' Returns a type for System.Diagnostics.DebuggerStepThrough so that we can create
         ''' attribute-declarations for the CodeDom to spit them out.
         ''' </summary>
-        Private Shared ReadOnly Property DebuggerStepThroughAttribute() As Type
+        Private Shared ReadOnly Property DebuggerStepThroughAttribute As Type
             Get
                 Return GetType(DebuggerStepThroughAttribute)
             End Get
@@ -406,7 +406,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' Demand-create a CodeDomProvider corresponding to my projects current language
         ''' </summary>
         ''' <value>A CodeDomProvider</value>
-        Private Property CodeDomProvider() As CodeDomProvider
+        Private Property CodeDomProvider As CodeDomProvider
             Get
                 If _codeDomProvider Is Nothing Then
                     Dim VSMDCodeDomProvider As IVSMDCodeDomProvider = CType(GetService(GetType(IVSMDCodeDomProvider)), IVSMDCodeDomProvider)
@@ -417,7 +417,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                 End If
                 Return _codeDomProvider
             End Get
-            Set(Value As CodeDomProvider)
+            Set
                 If Value Is Nothing Then
                     Throw New ArgumentNullException()
                 End If
@@ -794,7 +794,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Demand-create service provider from my site
         ''' </summary>
-        Private ReadOnly Property ServiceProvider() As ServiceProvider
+        Private ReadOnly Property ServiceProvider As ServiceProvider
             Get
                 If _serviceProvider Is Nothing Then
                     Dim OleSp As IServiceProvider = CType(_site, IServiceProvider)

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationData.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationData.vb
@@ -26,90 +26,90 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
 
         Private _dirty As Boolean
 
-        Public Property IsDirty() As Boolean
+        Public Property IsDirty As Boolean
             Get
                 Return _dirty
             End Get
-            Set(value As Boolean)
+            Set
                 _dirty = value
             End Set
         End Property
 
-        Public Property MySubMain() As Boolean 'True indicates My.MyApplication will be StartupObject
+        Public Property MySubMain As Boolean 'True indicates My.MyApplication will be StartupObject
             Get
                 Return _mySubMain
             End Get
-            Set(value As Boolean)
+            Set
                 _mySubMain = value
                 IsDirty = True
             End Set
         End Property
 
-        Public Property MainFormNoRootNS() As String 'Form for My.MyApplication to instantiate for main window (not including the root namespace)
+        Public Property MainFormNoRootNS As String 'Form for My.MyApplication to instantiate for main window (not including the root namespace)
             Get
                 Return _mainFormNoRootNS
             End Get
-            Set(value As String)
+            Set
                 _mainFormNoRootNS = value
                 IsDirty = True
             End Set
         End Property
 
-        Public Property SingleInstance() As Boolean
+        Public Property SingleInstance As Boolean
             Get
                 Return _singleInstance
             End Get
-            Set(value As Boolean)
+            Set
                 _singleInstance = value
                 IsDirty = True
             End Set
         End Property
 
-        Public Property ShutdownMode() As Integer
+        Public Property ShutdownMode As Integer
             Get
                 Return _shutdownMode
             End Get
-            Set(value As Integer)
+            Set
                 _shutdownMode = value
                 IsDirty = True
             End Set
         End Property
 
-        Public Property EnableVisualStyles() As Boolean
+        Public Property EnableVisualStyles As Boolean
             Get
                 Return _enableVisualStyles
             End Get
-            Set(value As Boolean)
+            Set
                 _enableVisualStyles = value
                 IsDirty = True
             End Set
         End Property
 
-        Public Property AuthenticationMode() As Integer
+        Public Property AuthenticationMode As Integer
             Get
                 Return _authenticationMode
             End Get
-            Set(value As Integer)
+            Set
                 _authenticationMode = value
                 IsDirty = True
             End Set
         End Property
 
-        Public Property SplashScreenNoRootNS() As String
+        Public Property SplashScreenNoRootNS As String
             Get
                 Return _splashScreenNoRootNS
             End Get
-            Set(value As String)
+            Set
                 _splashScreenNoRootNS = value
                 IsDirty = True
             End Set
         End Property
 
-        Public Property SaveMySettingsOnExit() As Boolean
+        Public Property SaveMySettingsOnExit As Boolean
             Get
                 Return _saveMySettingsOnExit
             End Get
-            Set(value As Boolean)
+            Set
                 _saveMySettingsOnExit = value
                 IsDirty = True
             End Set

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
@@ -60,18 +60,18 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
     ''' <remarks>
     ''' This interface is defined in vseditors.idl
     ''' </remarks>
-    <ComImport(), Guid("365cb21a-0f0f-47bc-9653-3c81e0e3f9d6"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
+    <ComImport, Guid("365cb21a-0f0f-47bc-9653-3c81e0e3f9d6"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
     Friend Interface IVsMyAppManager
-        <PreserveSig()>
-        Function Init(<[In]()> ProjectHierarchy As IVsHierarchy) As Integer 'Initialize the MyApplicationProperties object, etc.
+        <PreserveSig>
+        Function Init(<[In]> ProjectHierarchy As IVsHierarchy) As Integer 'Initialize the MyApplicationProperties object, etc.
 
-        <PreserveSig()>
-        Function GetProperties(<Out(), MarshalAs(UnmanagedType.IDispatch)> ByRef MyAppProps As Object) As Integer 'Get MyApplicationProperties object
+        <PreserveSig>
+        Function GetProperties(<Out, MarshalAs(UnmanagedType.IDispatch)> ByRef MyAppProps As Object) As Integer 'Get MyApplicationProperties object
 
-        <PreserveSig()>
+        <PreserveSig>
         Function Save() As Integer 'Save any MyApplicationProperties changes to disk (in MyApplication.myapp), if dirty
 
-        <PreserveSig()>
+        <PreserveSig>
         Function Close() As Integer 'Called by the project system upon closing a project.  Any unpersisted data at this point is discarded
     End Interface
 
@@ -102,15 +102,15 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
     ''' </remarks>
     <ComVisible(True), Guid("6fec8bad-4bec-4447-a4ce-b48543a31165"), InterfaceType(ComInterfaceType.InterfaceIsDual)>
     Public Interface IVsMyApplicationProperties
-        <DispId(MyAppDISPIDs.CustomSubMain)> Property CustomSubMain() As Boolean
-        <DispId(MyAppDISPIDs.MainForm)> Property MainForm() As String
-        <DispId(MyAppDISPIDs.SingleInstance)> Property SingleInstance() As Boolean
-        <DispId(MyAppDISPIDs.ShutdownMode)> Property ShutdownMode() As Integer
-        <DispId(MyAppDISPIDs.EnableVisualStyles)> Property EnableVisualStyles() As Boolean
-        <DispId(MyAppDISPIDs.AuthenticationMode)> Property AuthenticationMode() As Integer
-        <DispId(MyAppDISPIDs.SplashScreen)> Property SplashScreen() As String
+        <DispId(MyAppDISPIDs.CustomSubMain)> Property CustomSubMain As Boolean
+        <DispId(MyAppDISPIDs.MainForm)> Property MainForm As String
+        <DispId(MyAppDISPIDs.SingleInstance)> Property SingleInstance As Boolean
+        <DispId(MyAppDISPIDs.ShutdownMode)> Property ShutdownMode As Integer
+        <DispId(MyAppDISPIDs.EnableVisualStyles)> Property EnableVisualStyles As Boolean
+        <DispId(MyAppDISPIDs.AuthenticationMode)> Property AuthenticationMode As Integer
+        <DispId(MyAppDISPIDs.SplashScreen)> Property SplashScreen As String
         ' <DispId(MyAppDISPIDs.ApplicationType)> Property ApplicationType() As Integer ' OBSOLETE
-        <DispId(MyAppDISPIDs.SaveMySettingsOnExit)> Property SaveMySettingsOnExit() As Boolean
+        <DispId(MyAppDISPIDs.SaveMySettingsOnExit)> Property SaveMySettingsOnExit As Boolean
     End Interface
 
 
@@ -119,9 +119,9 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         Inherits IVsMyApplicationProperties
 
         Sub RunCustomTool()
-        ReadOnly Property CustomSubMainRaw() As Boolean
-        Property SplashScreenNoRootNS() As String
-        Property MainFormNoRootNamespace() As String
+        ReadOnly Property CustomSubMainRaw As Boolean
+        Property SplashScreenNoRootNS As String
+        Property MainFormNoRootNamespace As String
         Sub NavigateToEvents()
     End Interface
 
@@ -367,13 +367,13 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             Return ProjectItem
         End Function
 
-        Private ReadOnly Property ServiceProvider() As Shell.ServiceProvider
+        Private ReadOnly Property ServiceProvider As Shell.ServiceProvider
             Get
                 Return _serviceProvider
             End Get
         End Property
 
-        Private ReadOnly Property ProjectDesignerProjectItem() As ProjectItem
+        Private ReadOnly Property ProjectDesignerProjectItem As ProjectItem
             Get
                 Return _projectDesignerProjectItem
             End Get
@@ -393,18 +393,18 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         '''   project's current state.  This can be important to access if the face of undo/redo
         '''   and other issues, but it's not what we public expose via DTE.
         ''' </summary>
-        Friend ReadOnly Property CustomSubMainRaw() As Boolean Implements IMyApplicationPropertiesInternal.CustomSubMainRaw
+        Friend ReadOnly Property CustomSubMainRaw As Boolean Implements IMyApplicationPropertiesInternal.CustomSubMainRaw
             Get
                 Return Not _myAppData.MySubMain
             End Get
         End Property
 
 
-        Public Property CustomSubMain() As Boolean Implements IVsMyApplicationProperties.CustomSubMain
+        Public Property CustomSubMain As Boolean Implements IVsMyApplicationProperties.CustomSubMain
             Get
                 Return Not _myAppData.MySubMain AndAlso IsMySubMainSupported(_projectHierarchy)
             End Get
-            Set(value As Boolean)
+            Set
                 If _myAppData.MySubMain <> (Not value) Then
                     CheckOutDocData()
                     _myAppData.MySubMain = Not value
@@ -426,7 +426,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <remarks>
         ''' If this property is not currently set to a meaningful value, we return empty string.
         ''' </remarks>
-        Public Property MainForm() As String Implements IVsMyApplicationProperties.MainForm
+        Public Property MainForm As String Implements IVsMyApplicationProperties.MainForm
             Get
                 If _myAppData.MainFormNoRootNS = "" Then
                     Return ""
@@ -434,7 +434,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                     Return AddNamespace(GetRootNamespace(), _myAppData.MainFormNoRootNS)
                 End If
             End Get
-            Set(value As String)
+            Set
                 MainFormNoRootNamespace = RemoveRootNamespace(value, GetRootNamespace())
             End Set
         End Property
@@ -447,11 +447,11 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <remarks>
         ''' If this property is not currently set to a meaningful value, we return empty string.
         ''' </remarks>
-        Friend Property MainFormNoRootNamespace() As String Implements IMyApplicationPropertiesInternal.MainFormNoRootNamespace
+        Friend Property MainFormNoRootNamespace As String Implements IMyApplicationPropertiesInternal.MainFormNoRootNamespace
             Get
                 Return NothingToEmptyString(_myAppData.MainFormNoRootNS)
             End Get
-            Set(value As String)
+            Set
                 If String.CompareOrdinal(NothingToEmptyString(_myAppData.MainFormNoRootNS), NothingToEmptyString(value)) <> 0 Then
                     CheckOutDocData()
                     _myAppData.MainFormNoRootNS = EmptyStringToNothing(value)
@@ -467,11 +467,11 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             End Set
         End Property
 
-        Public Property SingleInstance() As Boolean Implements IVsMyApplicationProperties.SingleInstance
+        Public Property SingleInstance As Boolean Implements IVsMyApplicationProperties.SingleInstance
             Get
                 Return _myAppData.SingleInstance
             End Get
-            Set(value As Boolean)
+            Set
                 If _myAppData.SingleInstance <> value Then
                     CheckOutDocData()
                     _myAppData.SingleInstance = value
@@ -483,11 +483,11 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             End Set
         End Property
 
-        Public Property ShutdownMode() As Integer Implements IVsMyApplicationProperties.ShutdownMode
+        Public Property ShutdownMode As Integer Implements IVsMyApplicationProperties.ShutdownMode
             Get
                 Return _myAppData.ShutdownMode
             End Get
-            Set(value As Integer)
+            Set
                 Select Case value
                     Case _
                     ApplicationServices.ShutdownMode.AfterMainFormCloses,
@@ -508,11 +508,11 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             End Set
         End Property
 
-        Public Property EnableVisualStyles() As Boolean Implements IVsMyApplicationProperties.EnableVisualStyles
+        Public Property EnableVisualStyles As Boolean Implements IVsMyApplicationProperties.EnableVisualStyles
             Get
                 Return _myAppData.EnableVisualStyles
             End Get
-            Set(value As Boolean)
+            Set
                 If _myAppData.EnableVisualStyles <> value Then
                     CheckOutDocData()
                     _myAppData.EnableVisualStyles = value
@@ -524,11 +524,11 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             End Set
         End Property
 
-        Public Property SaveMySettingsOnExit() As Boolean Implements IVsMyApplicationProperties.SaveMySettingsOnExit
+        Public Property SaveMySettingsOnExit As Boolean Implements IVsMyApplicationProperties.SaveMySettingsOnExit
             Get
                 Return _myAppData.SaveMySettingsOnExit
             End Get
-            Set(value As Boolean)
+            Set
                 If _myAppData.SaveMySettingsOnExit <> value Then
                     CheckOutDocData()
                     _myAppData.SaveMySettingsOnExit = value
@@ -540,11 +540,11 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             End Set
         End Property
 
-        Public Property AuthenticationMode() As Integer Implements IVsMyApplicationProperties.AuthenticationMode
+        Public Property AuthenticationMode As Integer Implements IVsMyApplicationProperties.AuthenticationMode
             Get
                 Return _myAppData.AuthenticationMode
             End Get
-            Set(value As Integer)
+            Set
                 Select Case value
                     Case _
                     ApplicationServices.AuthenticationMode.Windows,
@@ -569,7 +569,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' Retrieves the MainForm property, including the root namespace
         ''' </summary>
         ''' If this property is not currently set to a meaningful value, we return empty string.
-        Public Property SplashScreen() As String Implements IVsMyApplicationProperties.SplashScreen
+        Public Property SplashScreen As String Implements IVsMyApplicationProperties.SplashScreen
             Get
                 If _myAppData.SplashScreenNoRootNS = "" Then
                     Return ""
@@ -577,7 +577,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                     Return AddNamespace(GetRootNamespace(), _myAppData.SplashScreenNoRootNS)
                 End If
             End Get
-            Set(value As String)
+            Set
                 SplashScreenNoRootNS = RemoveRootNamespace(value, GetRootNamespace())
             End Set
         End Property
@@ -590,11 +590,11 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <remarks>
         ''' If this property is not currently set to a meaningful value, we return empty string.
         ''' </remarks>
-        Friend Property SplashScreenNoRootNS() As String Implements IMyApplicationPropertiesInternal.SplashScreenNoRootNS
+        Friend Property SplashScreenNoRootNS As String Implements IMyApplicationPropertiesInternal.SplashScreenNoRootNS
             Get
                 Return NothingToEmptyString(_myAppData.SplashScreenNoRootNS)
             End Get
-            Set(value As String)
+            Set
                 If String.CompareOrdinal(NothingToEmptyString(_myAppData.SplashScreenNoRootNS), NothingToEmptyString(value)) <> 0 Then
                     CheckOutDocData()
                     _myAppData.SplashScreenNoRootNS = EmptyStringToNothing(value)
@@ -686,7 +686,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Returns the DTE ProjectItem for the .myapp file
         ''' </summary>
-        Private ReadOnly Property MyAppProjectItem() As ProjectItem
+        Private ReadOnly Property MyAppProjectItem As ProjectItem
             Get
                 'First see if it is already in the project
                 For Each ProjectItem As ProjectItem In ProjectDesignerProjectItem.ProjectItems
@@ -709,7 +709,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' Returns the docdata after initializing for the .myapp file
         ''' </summary>
-        Private ReadOnly Property MyAppDocData() As DocData
+        Private ReadOnly Property MyAppDocData As DocData
             Get
                 Return _myAppDocData
             End Get
@@ -718,7 +718,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' <summary>
         ''' DocDataService provides SCC checkin/out interaction with VS
         ''' </summary>
-        Private ReadOnly Property DocDataService() As DesignerDocDataService
+        Private ReadOnly Property DocDataService As DesignerDocDataService
             Get
                 Return _docDataService
             End Get
@@ -1209,7 +1209,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
 
             End Sub
 
-            Public Overrides ReadOnly Property Encoding() As System.Text.Encoding
+            Public Overrides ReadOnly Property Encoding As System.Text.Encoding
                 Get
                     Return System.Text.Encoding.UTF8
                 End Get

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/AddMyExtensionsDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/AddMyExtensionsDialog.vb
@@ -65,7 +65,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' <summary>
         ''' The selected extension templates to add to the project.
         ''' </summary>
-        Public ReadOnly Property ExtensionTemplatesToAdd() As List(Of MyExtensionTemplate)
+        Public ReadOnly Property ExtensionTemplatesToAdd As List(Of MyExtensionTemplate)
             Get
                 Return _extensionTemplatesToAdd
             End Get

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/AssemblyOptionDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/AssemblyOptionDialog.vb
@@ -99,7 +99,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         End Sub
 #End If
 
-        Public ReadOnly Property OptionChecked() As Boolean
+        Public ReadOnly Property OptionChecked As Boolean
             Get
                 Return checkBoxOption.Checked
             End Get

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/INamedDescribedObject.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/INamedDescribedObject.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
     ''' to display them in a list view / list box.
     ''' </summary>
     Friend Interface INamedDescribedObject
-        ReadOnly Property DisplayName() As String
-        ReadOnly Property Description() As String
+        ReadOnly Property DisplayName As String
+        ReadOnly Property Description As String
     End Interface
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectService.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectService.vb
@@ -177,7 +177,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' this will be __VSHPROPID2.VSHPROPID_AddItemTemplatesGuid, or __VSHPROPID.VSHPROPID_TypeGuid,
         ''' or EnvDTE.Project.Kind.
         ''' </summary>
-        Private ReadOnly Property ProjectTypeID() As String
+        Private ReadOnly Property ProjectTypeID As String
             Get
                 If _projectTypeID Is Nothing Then
                     Dim projGuid As Guid = Guid.Empty
@@ -562,32 +562,32 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                 _changeType = actionType
             End Sub
 
-            Public ReadOnly Property AssemblyName() As String
+            Public ReadOnly Property AssemblyName As String
                 Get
                     Return _assemblyName
                 End Get
             End Property
 
-            Public ReadOnly Property ChangeType() As AddRemoveAction
+            Public ReadOnly Property ChangeType As AddRemoveAction
                 Get
                     Return _changeType
                 End Get
             End Property
 
-            Public Property ExtensionTemplates() As List(Of MyExtensionTemplate)
+            Public Property ExtensionTemplates As List(Of MyExtensionTemplate)
                 Get
                     Return _extensionTemplates
                 End Get
-                Set(value As List(Of MyExtensionTemplate))
+                Set
                     _extensionTemplates = value
                 End Set
             End Property
 
-            Public Property ExtensionProjectItemGroups() As List(Of MyExtensionProjectItemGroup)
+            Public Property ExtensionProjectItemGroups As List(Of MyExtensionProjectItemGroup)
                 Get
                     Return _extensionProjectFiles
                 End Get
-                Set(value As List(Of MyExtensionProjectItemGroup))
+                Set
                     _extensionProjectFiles = value
                 End Set
             End Property

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityPropPageComClass.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityPropPageComClass.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Public Class MyExtensibilityPropPageComClass
         Inherits VBPropPageBase
 
-        Protected Overrides ReadOnly Property ControlType() As Type
+        Protected Overrides ReadOnly Property ControlType As Type
             Get
                 Return GetType(MyExtensibilityPropPage)
             End Get
@@ -28,7 +28,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return New MyExtensibilityPropPage()
         End Function
 
-        Protected Overrides ReadOnly Property Title() As String
+        Protected Overrides ReadOnly Property Title As String
             Get
                 Return Res.PropertyPageTab
             End Get

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySettings.vb
@@ -453,7 +453,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' <summary>
         ''' Cached and lazy-init TypeConverter for AssemblyOption enumeration.
         ''' </summary>
-        Private Shared ReadOnly Property AssemblyOptionConverter() As TypeConverter
+        Private Shared ReadOnly Property AssemblyOptionConverter As TypeConverter
             Get
                 If s_assemblyOptionConverter Is Nothing Then
                     s_assemblyOptionConverter = TypeDescriptor.GetConverter(GetType(AssemblyOption))

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySettingsHelper.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySettingsHelper.vb
@@ -18,20 +18,20 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                 _autoRemove = autoRemove
             End Sub
 
-            Public Property AutoAdd() As AssemblyOption
+            Public Property AutoAdd As AssemblyOption
                 Get
                     Return _autoAdd
                 End Get
-                Set(value As AssemblyOption)
+                Set
                     _autoAdd = value
                 End Set
             End Property
 
-            Public Property AutoRemove() As AssemblyOption
+            Public Property AutoRemove As AssemblyOption
                 Get
                     Return _autoRemove
                 End Get
-                Set(value As AssemblyOption)
+                Set
                     _autoRemove = value
                 End Set
             End Property

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySolutionService.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySolutionService.vb
@@ -40,7 +40,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' Shared property to obtain the instance of MyExtensibilityManager associated with
         ''' the current VS environment.
         ''' </summary>
-        Public Shared ReadOnly Property Instance() As MyExtensibilitySolutionService
+        Public Shared ReadOnly Property Instance As MyExtensibilitySolutionService
             Get
                 If s_sharedInstance Is Nothing Then
                     s_sharedInstance = New MyExtensibilitySolutionService(VBPackage.Instance)
@@ -55,7 +55,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' <summary>
         ''' Shared property to obtain the current VS status bar.
         ''' </summary>
-        Public Shared ReadOnly Property IdeStatusBar() As VsStatusBarWrapper
+        Public Shared ReadOnly Property IdeStatusBar As VsStatusBarWrapper
             Get
                 If s_ideStatusBar Is Nothing Then
                     Dim vsStatusBar As IVsStatusbar = TryCast(
@@ -168,7 +168,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
 
         End Function
 
-        Public ReadOnly Property TrackProjectDocumentsEvents() As TrackProjectDocumentsEventsHelper
+        Public ReadOnly Property TrackProjectDocumentsEvents As TrackProjectDocumentsEventsHelper
             Get
                 If _trackProjectDocumentsEvents Is Nothing Then
                     _trackProjectDocumentsEvents = TrackProjectDocumentsEventsHelper.GetInstance(_vbPackage)
@@ -192,7 +192,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' <summary>
         ''' Lazy-initialized My Extensibility settings containing information about extension templates.
         ''' </summary>
-        Private ReadOnly Property ExtensibilitySettings() As MyExtensibilitySettings
+        Private ReadOnly Property ExtensibilitySettings As MyExtensibilitySettings
             Get
                 If _extensibilitySettings Is Nothing Then
 

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensionDataGridView.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensionDataGridView.vb
@@ -20,12 +20,12 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         Public Event AddExtension(sender As Object, e As EventArgs)
         Public Event RemoveExtension(sender As Object, e As EventArgs)
 
-        Public Property MenuCommandService() As IMenuCommandService
+        Public Property MenuCommandService As IMenuCommandService
             Get
                 Debug.Assert(_menuCommandService IsNot Nothing)
                 Return _menuCommandService
             End Get
-            Set(value As IMenuCommandService)
+            Set
                 Debug.Assert(value IsNot Nothing)
                 UnregisterMenuCommands()
                 _menuCommandService = value

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensionProjectItemGroup.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensionProjectItemGroup.vb
@@ -33,31 +33,31 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             _extensionDescription = extensionDescription
         End Sub
 
-        Public ReadOnly Property ExtensionProjectItems() As List(Of ProjectItem)
+        Public ReadOnly Property ExtensionProjectItems As List(Of ProjectItem)
             Get
                 Return _projectItems
             End Get
         End Property
 
-        Public ReadOnly Property ExtensionID() As String
+        Public ReadOnly Property ExtensionID As String
             Get
                 Return _extensionID
             End Get
         End Property
 
-        Public ReadOnly Property ExtensionVersion() As Version
+        Public ReadOnly Property ExtensionVersion As Version
             Get
                 Return _extensionVersion
             End Get
         End Property
 
-        Public ReadOnly Property ExtensionDescription() As String Implements INamedDescribedObject.Description
+        Public ReadOnly Property ExtensionDescription As String Implements INamedDescribedObject.Description
             Get
                 Return _extensionDescription
             End Get
         End Property
 
-        Public ReadOnly Property DisplayName() As String Implements INamedDescribedObject.DisplayName
+        Public ReadOnly Property DisplayName As String Implements INamedDescribedObject.DisplayName
             Get
                 If StringIsNullEmptyOrBlank(_extensionName) Then
                     Return _extensionID

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensionTemplate.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensionTemplate.vb
@@ -89,25 +89,25 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             Return New MyExtensionTemplate(templateID, templateVersion, template, assemblyFullName)
         End Function
 
-        Public ReadOnly Property AssemblyFullName() As String
+        Public ReadOnly Property AssemblyFullName As String
             Get
                 Return _assemblyFullName
             End Get
         End Property
 
-        Public ReadOnly Property ID() As String
+        Public ReadOnly Property ID As String
             Get
                 Return _id
             End Get
         End Property
 
-        Public ReadOnly Property Version() As Version
+        Public ReadOnly Property Version As Version
             Get
                 Return _version
             End Get
         End Property
 
-        Public ReadOnly Property Description() As String Implements INamedDescribedObject.Description
+        Public ReadOnly Property Description As String Implements INamedDescribedObject.Description
             Get
                 Return _template.Description
             End Get
@@ -117,7 +117,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' <summary>
         ''' The extension template's name specified in .vstemplate file, or the template ID specified in CustomData.xml.
         ''' </summary>
-        Public ReadOnly Property DisplayName() As String Implements INamedDescribedObject.DisplayName
+        Public ReadOnly Property DisplayName As String Implements INamedDescribedObject.DisplayName
             Get
                 If StringIsNullEmptyOrBlank(_template.Name) Then
                     Return _id
@@ -127,13 +127,13 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             End Get
         End Property
 
-        Public ReadOnly Property FilePath() As String
+        Public ReadOnly Property FilePath As String
             Get
                 Return _template.FilePath
             End Get
         End Property
 
-        Public ReadOnly Property BaseName() As String
+        Public ReadOnly Property BaseName As String
             Get
                 Return _template.BaseName
             End Get

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/SDKStyleProjectOptionsData.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/SDKStyleProjectOptionsData.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
             Get
                 Return _fastUpToDateCheckEnabled
             End Get
-            Set(value As Boolean)
+            Set
                 If value = _fastUpToDateCheckEnabled Then
                     Return
                 End If
@@ -49,7 +49,7 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
             Get
                 Return _fastUpToDateCheckLogLevel
             End Get
-            Set(value As LogLevel)
+            Set
                 If value = _fastUpToDateCheckLogLevel Then
                     Return
                 End If

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.ComboItem.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.ComboItem.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             ''' <summary>
             ''' Gets the value
             ''' </summary>
-            Public ReadOnly Property Value() As String
+            Public ReadOnly Property Value As String
                 Get
                     Return _value
                 End Get

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             TelemetryLogger.LogAdvBuildSettingsPropPageEvent(TelemetryLogger.AdvBuildSettingsPropPageEvent.FormOpened)
         End Sub
 
-        Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
+        Protected Overrides ReadOnly Property ControlData As PropertyControlData()
             Get
                 If m_ControlData Is Nothing Then
                     m_ControlData = New PropertyControlData() {

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvCompilerSettingsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvCompilerSettingsPropPage.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             WARNINGS_NONE
         End Enum
 
-        Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
+        Protected Overrides ReadOnly Property ControlData As PropertyControlData()
             Get
                 If m_ControlData Is Nothing Then
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
@@ -66,7 +66,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private Sub AssemblyInfoButton_Click(sender As Object, e As EventArgs) Handles AssemblyInfoButton.Click
             ShowChildPage(My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_AssemblyInfo_Title, GetType(AssemblyInfoPropPage), HelpKeywords.VBProjPropAssemblyInfo)
         End Sub
-        Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
+        Protected Overrides ReadOnly Property ControlData As PropertyControlData()
             Get
                 If m_ControlData Is Nothing Then
 
@@ -111,7 +111,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Get
         End Property
 
-        Protected Overrides ReadOnly Property ValidationControlGroups() As Control()()
+        Protected Overrides ReadOnly Property ValidationControlGroups As Control()()
             Get
                 If _controlGroup Is Nothing Then
                     _controlGroup = New Control()() {

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageBase.vb
@@ -46,7 +46,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Retrieves the last set value for the Icon (as a path)
         ''' </summary>
-        Protected ReadOnly Property LastIconImage() As String
+        Protected ReadOnly Property LastIconImage As String
             Get
                 Return _lastIconImage
             End Get

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBBase.vb
@@ -205,7 +205,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Retrieves the current root namespace property value
         ''' </summary>
-        Protected ReadOnly Property CurrentRootNamespace() As String
+        Protected ReadOnly Property CurrentRootNamespace As String
             Get
                 Return DirectCast(GetControlValue(Const_RootNamespace), String)
             End Get
@@ -346,25 +346,25 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Sub
 
 #Region "Trivial property get:ers"
-            Public ReadOnly Property ApplicationType() As ApplicationTypes
+            Public ReadOnly Property ApplicationType As ApplicationTypes
                 Get
                     Return _applicationType
                 End Get
             End Property
 
-            Public ReadOnly Property DisplayName() As String
+            Public ReadOnly Property DisplayName As String
                 Get
                     Return _displayName
                 End Get
             End Property
 
-            Public ReadOnly Property Name() As String
+            Public ReadOnly Property Name As String
                 Get
                     Return _name
                 End Get
             End Property
 
-            Public ReadOnly Property SupportedInExpress() As Boolean
+            Public ReadOnly Property SupportedInExpress As Boolean
                 Get
                     Return _supportedInExpress
                 End Get
@@ -375,7 +375,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             ''' <summary>
             ''' Get the references required for each project type...
             ''' </summary>
-            Public ReadOnly Property References() As String()
+            Public ReadOnly Property References As String()
                 Get
                     Select Case ApplicationType
                         Case ApplicationTypes.WindowsApp

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
@@ -117,7 +117,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             CommonControls = New CommonPageControls(
                 IconCombobox, IconLabel, IconPicturebox)
         End Sub
-        Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
+        Protected Overrides ReadOnly Property ControlData As PropertyControlData()
             Get
                 Dim ControlsThatDependOnStartupObjectProperty As Control() = {
                     StartupObjectLabel, UseApplicationFrameworkCheckBox, WindowsAppGroupBox
@@ -207,7 +207,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Sub
 
 
-        Private ReadOnly Property MyApplicationPropertiesSupported() As Boolean
+        Private ReadOnly Property MyApplicationPropertiesSupported As Boolean
             Get
                 Return MyApplicationProperties IsNot Nothing
             End Get
@@ -218,7 +218,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Gets the MyApplication.MyApplicationProperties object returned by the project system (which the project system creates by calling into us)
         ''' </summary>
         ''' <value>The value of the MyApplication property, or else Nothing if it is not supported.</value>
-        Private ReadOnly Property MyApplicationProperties() As IMyApplicationPropertiesInternal
+        Private ReadOnly Property MyApplicationProperties As IMyApplicationPropertiesInternal
             Get
                 Debug.Assert(Implies(_myApplicationPropertiesCache IsNot Nothing, _isMyApplicationPropertiesCached))
                 Debug.Assert(Implies(_myApplicationPropertiesNotifyPropertyChanged IsNot Nothing, _isMyApplicationPropertiesCached))

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.vb
@@ -53,7 +53,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 AssemblyVersionMajorTextBox, AssemblyVersionMinorTextBox, AssemblyVersionBuildTextBox, AssemblyVersionRevisionTextBox}
         End Sub
 
-        Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
+        Protected Overrides ReadOnly Property ControlData As PropertyControlData()
             Get
                 If m_ControlData Is Nothing Then
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialog.vb
@@ -46,23 +46,23 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return ParseAndPopulateTokens()
         End Function
 
-        Public WriteOnly Property DTE() As EnvDTE.DTE
-            Set(Value As EnvDTE.DTE)
+        Public WriteOnly Property DTE As EnvDTE.DTE
+            Set
                 _dte = Value
             End Set
         End Property
 
-        Public WriteOnly Property Page() As PropPageUserControlBase
-            Set(Value As PropPageUserControlBase)
+        Public WriteOnly Property Page As PropPageUserControlBase
+            Set
                 _page = Value
             End Set
         End Property
 
-        Public Property EventCommandLine() As String
+        Public Property EventCommandLine As String
             Get
                 Return _eventCommandLine
             End Get
-            Set(Value As String)
+            Set
                 _eventCommandLine = Value
                 CommandLine.Text = _eventCommandLine
 
@@ -73,7 +73,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Set
         End Property
 
-        Public Property HelpTopic() As String
+        Public Property HelpTopic As String
             Get
                 If _helpTopic Is Nothing Then
                     If _page IsNot Nothing AndAlso _page.IsVBProject() Then
@@ -85,12 +85,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                 Return _helpTopic
             End Get
-            Set(value As String)
+            Set
                 _helpTopic = value
             End Set
         End Property
 
-        Private Property ServiceProvider() As IServiceProvider
+        Private Property ServiceProvider As IServiceProvider
             Get
                 If _serviceProvider Is Nothing AndAlso _dte IsNot Nothing Then
                     Dim isp As OLE.Interop.IServiceProvider = CType(_dte, OLE.Interop.IServiceProvider)
@@ -100,7 +100,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 End If
                 Return _serviceProvider
             End Get
-            Set(value As IServiceProvider)
+            Set
                 _serviceProvider = value
             End Set
         End Property

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
@@ -68,7 +68,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             "SolutionExt"
         }
 
-        Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
+        Protected Overrides ReadOnly Property ControlData As PropertyControlData()
             Get
                 If m_ControlData Is Nothing Then
                     m_ControlData = New PropertyControlData() {

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
@@ -59,7 +59,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             MyBase.EnableAllControls(enabled)
         End Sub
 
-        Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
+        Protected Overrides ReadOnly Property ControlData As PropertyControlData()
             Get
                 If m_ControlData Is Nothing Then
                     m_ControlData = New PropertyControlData() {

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.vb
@@ -61,7 +61,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             RefreshInstalledFxCopAnalyzersVersionAndButtons()
         End Sub
 
-        Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
+        Protected Overrides ReadOnly Property ControlData As PropertyControlData()
             Get
                 If m_ControlData Is Nothing Then
                     m_ControlData = New PropertyControlData() {

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
@@ -209,7 +209,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Sub
 #End Region
 
-        Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
+        Protected Overrides ReadOnly Property ControlData As PropertyControlData()
             Get
                 If _objectCache IsNot Nothing Then
                     _objectCache.Reset(ProjectHierarchy, ServiceProvider, False)
@@ -683,7 +683,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' We shouldn't be in this situation unless the user has messed around manually with
         ''' the project file...
         ''' </remarks>
-        Private ReadOnly Property IndeterminateWarningsState() As Boolean
+        Private ReadOnly Property IndeterminateWarningsState As Boolean
             Get
                 If WarningsAsErrorCheckBox.CheckState = CheckState.Indeterminate Then
                     Return True
@@ -1415,7 +1415,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 ''' <summary>
                 ''' Private getter for the IVsCfgProvider2 for the associated proppage's hierarchy
                 ''' </summary>
-                Private ReadOnly Property VsCfgProvider() As IVsCfgProvider2
+                Private ReadOnly Property VsCfgProvider As IVsCfgProvider2
                     Get
                         If _vscfgprovider Is Nothing Then
                             Dim Value As Object = Nothing
@@ -1431,7 +1431,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 ''' Getter for the raw config objects. We override this to always return the properties for all
                 ''' configurations to make this property look like a config independent-ish property
                 ''' </summary>
-                Friend ReadOnly Property ConfigRawPropertiesObjects() As Object()
+                Friend ReadOnly Property ConfigRawPropertiesObjects As Object()
                     Get
                         Dim tmpRawObjects() As IVsCfg
                         Dim ConfigCount As UInteger() = New UInteger(0) {} 'Interop declaration requires us to use an array
@@ -1451,7 +1451,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 ''' Getter for the extended config objects. We override this to always return the properties for all
                 ''' configurations to make this property look like a config independent-ish property
                 ''' </summary>
-                Friend ReadOnly Property ConfigExtendedPropertiesObjects() As Object()
+                Friend ReadOnly Property ConfigExtendedPropertiesObjects As Object()
                     Get
                         If _extendedObjects Is Nothing Then
                             Dim aem As AutomationExtenderManager
@@ -1477,7 +1477,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             ''' Getter for the raw config objects. We override this to always return the properties for all
             ''' configurations to make this property look like a config independent-ish property
             ''' </summary>
-            Public Overrides ReadOnly Property RawPropertiesObjects() As Object()
+            Public Overrides ReadOnly Property RawPropertiesObjects As Object()
                 Get
                     Return _configurationObjectCache.ConfigRawPropertiesObjects()
                 End Get
@@ -1487,7 +1487,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             ''' Getter for the extended config objects. We override this to always return the properties for all
             ''' configurations to make this property look like a config independent-ish property
             ''' </summary>
-            Public Overrides ReadOnly Property ExtendedPropertiesObjects() As Object()
+            Public Overrides ReadOnly Property ExtendedPropertiesObjects As Object()
                 Get
                     Return _configurationObjectCache.ConfigExtendedPropertiesObjects()
                 End Get

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ComponentWrapper.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ComponentWrapper.vb
@@ -20,11 +20,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' the original object
         ''' </summary>
-        Protected Friend Property CurrentObject() As Object
+        Protected Friend Property CurrentObject As Object
             Get
                 Return _currentObject
             End Get
-            Set(value As Object)
+            Set
                 Debug.Assert(value IsNot Nothing, "can not support Nothing")
                 _currentObject = value
             End Set

--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
@@ -57,7 +57,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 #End Region
 
-        Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
+        Protected Overrides ReadOnly Property ControlData As PropertyControlData()
             Get
                 If m_ControlData Is Nothing Then
                     Dim datalist As List(Of PropertyControlData) = New List(Of PropertyControlData)
@@ -109,7 +109,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Property
 
 
-        Protected Overrides ReadOnly Property ValidationControlGroups() As Control()()
+        Protected Overrides ReadOnly Property ValidationControlGroups As Control()()
             Get
                 If _controlGroup Is Nothing Then
                     _controlGroup = New Control()() {

--- a/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
@@ -249,7 +249,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return ValidationResult.Succeeded
         End Function
 
-        Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
+        Protected Overrides ReadOnly Property ControlData As PropertyControlData()
             Get
                 If (m_ControlData Is Nothing) Then
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/PropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PropPage.vb
@@ -29,13 +29,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Public NotInheritable Class ApplicationPropPageComClass 'See class hierarchy comments above
         Inherits VBPropPageBase
 
-        Protected Overrides ReadOnly Property Title() As String
+        Protected Overrides ReadOnly Property Title As String
             Get
                 Return My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_ApplicationTitle
             End Get
         End Property
 
-        Protected Overrides ReadOnly Property ControlType() As Type
+        Protected Overrides ReadOnly Property ControlType As Type
             Get
                 Return GetType(ApplicationPropPage)
             End Get
@@ -56,13 +56,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Public NotInheritable Class ApplicationWithMyPropPageComClass 'See class hierarchy comments above
         Inherits VBPropPageBase
 
-        Protected Overrides ReadOnly Property Title() As String
+        Protected Overrides ReadOnly Property Title As String
             Get
                 Return My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_ApplicationTitle
             End Get
         End Property
 
-        Protected Overrides ReadOnly Property ControlType() As Type
+        Protected Overrides ReadOnly Property ControlType As Type
             Get
                 Return GetType(ApplicationPropPageVBWinForms)
             End Get
@@ -83,13 +83,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Inherits VBPropPageBase
 
 
-        Protected Overrides ReadOnly Property Title() As String
+        Protected Overrides ReadOnly Property Title As String
             Get
                 Return My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_ApplicationTitle
             End Get
         End Property
 
-        Protected Overrides ReadOnly Property ControlType() As Type
+        Protected Overrides ReadOnly Property ControlType As Type
             Get
                 Return GetType(WPF.ApplicationPropPageVBWPF)
             End Get
@@ -109,13 +109,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Public NotInheritable Class CSharpApplicationPropPageComClass 'See class hierarchy comments above
         Inherits VBPropPageBase
 
-        Protected Overrides ReadOnly Property Title() As String
+        Protected Overrides ReadOnly Property Title As String
             Get
                 Return My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_ApplicationTitle
             End Get
         End Property
 
-        Protected Overrides ReadOnly Property ControlType() As Type
+        Protected Overrides ReadOnly Property ControlType As Type
             Get
                 Return GetType(CSharpApplicationPropPage)
             End Get
@@ -137,13 +137,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Public NotInheritable Class PackagePropPageComClass 'See class hierarchy comments above
         Inherits VBPropPageBase
 
-        Protected Overrides ReadOnly Property Title() As String
+        Protected Overrides ReadOnly Property Title As String
             Get
                 Return My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_PackageTitle
             End Get
         End Property
 
-        Protected Overrides ReadOnly Property ControlType() As Type
+        Protected Overrides ReadOnly Property ControlType As Type
             Get
                 Return GetType(PackagePropPage)
             End Get
@@ -163,13 +163,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Public NotInheritable Class CompilePropPageComClass
         Inherits VBPropPageBase
 
-        Protected Overrides ReadOnly Property Title() As String
+        Protected Overrides ReadOnly Property Title As String
             Get
                 Return My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_CompileTitle
             End Get
         End Property
 
-        Protected Overrides ReadOnly Property ControlType() As Type
+        Protected Overrides ReadOnly Property ControlType As Type
             Get
                 Return GetType(CompilePropPage2)
             End Get
@@ -180,7 +180,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Function
 
 
-        Protected Overrides Property DefaultSize() As Drawing.Size
+        Protected Overrides Property DefaultSize As Drawing.Size
             Get
                 ' This is somewhat hacky, but the compile's size page can sometimes exceed the default
                 ' minimum size for a property page. The PropPageDesignerView will query for this in order to
@@ -190,7 +190,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 ' should be fine
                 Return New Drawing.Size(Integer.MaxValue, Integer.MaxValue)
             End Get
-            Set(value As Drawing.Size)
+            Set
                 MyBase.DefaultSize = value
             End Set
         End Property
@@ -205,13 +205,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Public NotInheritable Class ServicesPropPageComClass
         Inherits VBPropPageBase
 
-        Protected Overrides ReadOnly Property Title() As String
+        Protected Overrides ReadOnly Property Title As String
             Get
                 Return My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_Services
             End Get
         End Property
 
-        Protected Overrides ReadOnly Property ControlType() As Type
+        Protected Overrides ReadOnly Property ControlType As Type
             Get
                 Return GetType(ServicesPropPage)
             End Get
@@ -231,13 +231,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Public NotInheritable Class DebugPropPageComClass
         Inherits VBPropPageBase
 
-        Protected Overrides ReadOnly Property Title() As String
+        Protected Overrides ReadOnly Property Title As String
             Get
                 Return My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_DebugTitle
             End Get
         End Property
 
-        Protected Overrides ReadOnly Property ControlType() As Type
+        Protected Overrides ReadOnly Property ControlType As Type
             Get
                 Return GetType(DebugPropPage)
             End Get
@@ -257,13 +257,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Public NotInheritable Class ReferencePropPageComClass
         Inherits VBPropPageBase
 
-        Protected Overrides ReadOnly Property Title() As String
+        Protected Overrides ReadOnly Property Title As String
             Get
                 Return My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_ReferencesTitle
             End Get
         End Property
 
-        Protected Overrides ReadOnly Property ControlType() As Type
+        Protected Overrides ReadOnly Property ControlType As Type
             Get
                 Return GetType(ReferencePropPage)
             End Get
@@ -283,13 +283,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Public NotInheritable Class BuildPropPageComClass
         Inherits VBPropPageBase
 
-        Protected Overrides ReadOnly Property Title() As String
+        Protected Overrides ReadOnly Property Title As String
             Get
                 Return My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_BuildTitle
             End Get
         End Property
 
-        Protected Overrides ReadOnly Property ControlType() As Type
+        Protected Overrides ReadOnly Property ControlType As Type
             Get
                 Return GetType(BuildPropPage)
             End Get
@@ -308,13 +308,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Public NotInheritable Class BuildEventsPropPageComClass
         Inherits VBPropPageBase
 
-        Protected Overrides ReadOnly Property Title() As String
+        Protected Overrides ReadOnly Property Title As String
             Get
                 Return My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_BuildEventsTitle
             End Get
         End Property
 
-        Protected Overrides ReadOnly Property ControlType() As Type
+        Protected Overrides ReadOnly Property ControlType As Type
             Get
                 Return GetType(BuildEventsPropPage)
             End Get
@@ -333,13 +333,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Public NotInheritable Class ReferencePathsPropPageComClass
         Inherits VBPropPageBase
 
-        Protected Overrides ReadOnly Property Title() As String
+        Protected Overrides ReadOnly Property Title As String
             Get
                 Return My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_ReferencePathsTitle
             End Get
         End Property
 
-        Protected Overrides ReadOnly Property ControlType() As Type
+        Protected Overrides ReadOnly Property ControlType As Type
             Get
                 Return GetType(ReferencePathsPropPage)
             End Get
@@ -358,13 +358,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Public NotInheritable Class CodeAnalysisPropPageComClass 'See class hierarchy comments above
         Inherits VBPropPageBase
 
-        Protected Overrides ReadOnly Property Title() As String
+        Protected Overrides ReadOnly Property Title As String
             Get
                 Return My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_CodeAnalysisTitle
             End Get
         End Property
 
-        Protected Overrides ReadOnly Property ControlType() As Type
+        Protected Overrides ReadOnly Property ControlType As Type
             Get
                 Return GetType(CodeAnalysisPropPage)
             End Get

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferenceComponent.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferenceComponent.vb
@@ -16,13 +16,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' The original reference object in DTE.Project
         ''' </summary>
-        Friend ReadOnly Property CodeReference() As VSLangProj.Reference
+        Friend ReadOnly Property CodeReference As VSLangProj.Reference
             Get
                 Return CType(CurrentObject, VSLangProj.Reference)
             End Get
         End Property
 
-        Friend ReadOnly Property Name() As String
+        Friend ReadOnly Property Name As String
             Get
                 Return CodeReference.Name
             End Get

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePathsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePathsPropPage.vb
@@ -56,7 +56,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             AddHandler SystemEvents.UserPreferenceChanged, AddressOf SystemEvents_UserPreferenceChanged
         End Sub
 
-        Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
+        Protected Overrides ReadOnly Property ControlData As PropertyControlData()
             Get
                 If m_ControlData Is Nothing Then
                     m_ControlData = New PropertyControlData() {
@@ -69,7 +69,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         '''  Return true if the page can be resized...
         ''' </summary>
-        Public Overrides ReadOnly Property PageResizable() As Boolean
+        Public Overrides ReadOnly Property PageResizable As Boolean
             Get
                 Return True
             End Get

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
@@ -111,7 +111,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             GetPropertyControlData("ImportList").EnableControls(enabled)
         End Sub
 
-        Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
+        Protected Overrides ReadOnly Property ControlData As PropertyControlData()
             Get
                 If m_ControlData Is Nothing Then
                     m_ControlData = New PropertyControlData() {
@@ -126,7 +126,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' The designer host of this page
         ''' NOTE: we currently get the designer host from the propertyPageDesignerView, it is a workaround. The right solution should be the parent page pass in the right serviceProvider when it creates/initializes this page
         ''' </summary>
-        Private ReadOnly Property DesignerHost() As IDesignerHost
+        Private ReadOnly Property DesignerHost As IDesignerHost
             Get
                 If _designerHost Is Nothing Then
                     Dim designerView As PropPageDesigner.PropPageDesignerView = FindPropPageDesignerView()
@@ -145,7 +145,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' not we are hiding the selection currently to work around the by-design CheckedListBox
         ''' behavior of visually looking like it has focus when it really doesn't.
         ''' </summary>
-        Private ReadOnly Property ImportListSelectedItem() As String
+        Private ReadOnly Property ImportListSelectedItem As String
             Get
                 Debug.Assert(ImportList.SelectedItems.Count <= 1, "the ImportList is not set up to support multiple selection")
 
@@ -164,7 +164,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' ITrackSelection -- we are using this service to push objects to the propertyPage.
         '''  We should get this service from DesignerHost, but not other service provider. Each designer has its own ITrackSelection
         ''' </summary>
-        Private ReadOnly Property TrackSelection() As ITrackSelection
+        Private ReadOnly Property TrackSelection As ITrackSelection
             Get
                 If _trackSelection Is Nothing Then
                     Dim host As IDesignerHost = DesignerHost
@@ -1934,25 +1934,25 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 _serviceReference = item
             End Sub
 
-            Friend ReadOnly Property UpdateType() As ReferenceUpdateType
+            Friend ReadOnly Property UpdateType As ReferenceUpdateType
                 Get
                     Return _updateType
                 End Get
             End Property
 
-            Friend ReadOnly Property Reference() As VSLangProj.Reference
+            Friend ReadOnly Property Reference As VSLangProj.Reference
                 Get
                     Return _reference
                 End Get
             End Property
 
-            Friend ReadOnly Property WebReference() As EnvDTE.ProjectItem
+            Friend ReadOnly Property WebReference As EnvDTE.ProjectItem
                 Get
                     Return _webReference
                 End Get
             End Property
 
-            Friend ReadOnly Property ServiceReference() As IVsWCFReferenceGroup
+            Friend ReadOnly Property ServiceReference As IVsWCFReferenceGroup
                 Get
                     Return _serviceReference
                 End Get

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServiceReferenceComponent.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServiceReferenceComponent.vb
@@ -25,11 +25,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         <VBDescription(My.Resources.Microsoft_VisualStudio_Editors_Designer.ConstantResourceIDs.PPG_ServiceReferenceNamespaceDescription)>
         <MergableProperty(False)>
         <HelpKeyword("ServiceReference Properties.Namespace")>
-        Public Property [Namespace]() As String
+        Public Property [Namespace] As String
             Get
                 Return _referenceGroup.GetNamespace()
             End Get
-            Set(value As String)
+            Set
                 _referenceGroup.SetNamespace(value)
             End Set
         End Property
@@ -43,7 +43,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         <VBDescription(My.Resources.Microsoft_VisualStudio_Editors_Designer.ConstantResourceIDs.PPG_ServiceReferenceUrlDescription)>
         <HelpKeyword("ServiceReference Properties.ServiceReferenceURL")>
         <MergableProperty(False)>
-        Public Property ServiceReferenceURL() As String
+        Public Property ServiceReferenceURL As String
             Get
                 If _referenceGroup.GetReferenceCount() = 1 Then
                     Return _referenceGroup.GetReferenceUrl(0)
@@ -54,7 +54,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 End If
                 Return String.Empty
             End Get
-            Set(value As String)
+            Set
                 value = value.Trim()
                 Dim currentCount As Integer = _referenceGroup.GetReferenceCount()
                 If currentCount = 1 Then
@@ -88,7 +88,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Service reference instance
         ''' </summary>
-        Friend ReadOnly Property ReferenceGroup() As IVsWCFReferenceGroup
+        Friend ReadOnly Property ReferenceGroup As IVsWCFReferenceGroup
             Get
                 Return _referenceGroup
             End Get

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServicesAuthenticationForm.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServicesAuthenticationForm.vb
@@ -20,19 +20,19 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 
         <SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings")>
-        Public ReadOnly Property AuthenticationUrl() As String
+        Public ReadOnly Property AuthenticationUrl As String
             Get
                 Return _authenticationUrl
             End Get
         End Property
 
-        Public ReadOnly Property UserName() As String
+        Public ReadOnly Property UserName As String
             Get
                 Return UserNameTextBox.Text
             End Get
         End Property
 
-        Public ReadOnly Property Password() As String
+        Public ReadOnly Property Password As String
             Get
                 Return PasswordTextBox.Text
             End Get
@@ -60,11 +60,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Sub
 
         Private _loadAnonymous As Boolean
-        Public Property LoadAnonymously() As Boolean
+        Public Property LoadAnonymously As Boolean
             Get
                 Return _loadAnonymous
             End Get
-            Set(value As Boolean)
+            Set
                 _loadAnonymous = value
             End Set
         End Property

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPage.vb
@@ -62,11 +62,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Try
         End Sub
 
-        Private Property CurrentAppConfigDocument() As XmlDocument
+        Private Property CurrentAppConfigDocument As XmlDocument
             Get
                 Return _currentAppConfigDocument
             End Get
-            Set(value As XmlDocument)
+            Set
                 _currentAppConfigDocument = value
                 If value IsNot Nothing Then SetApplicationServicesEnabled(ServicesPropPageAppConfigHelper.ApplicationServicesAreEnabled(CurrentAppConfigDocument, ProjectHierarchy))
             End Set

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPageConfigHelper.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPageConfigHelper.vb
@@ -984,19 +984,19 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return val & "/" & suffix
         End Function
 
-        Friend Shared ReadOnly Property AuthenticationSuffix() As String
+        Friend Shared ReadOnly Property AuthenticationSuffix As String
             Get
                 Return GetSuffix("Authentication")
             End Get
         End Property
 
-        Friend Shared ReadOnly Property RolesSuffix() As String
+        Friend Shared ReadOnly Property RolesSuffix As String
             Get
                 Return GetSuffix("Role")
             End Get
         End Property
 
-        Friend Shared ReadOnly Property ProfileSuffix() As String
+        Friend Shared ReadOnly Property ProfileSuffix As String
             Get
                 Return GetSuffix("Profile")
             End Get

--- a/src/Microsoft.VisualStudio.Editors/PropPages/SingleConfigPropertyControlData.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/SingleConfigPropertyControlData.vb
@@ -88,7 +88,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   passed in to the page through SetObjects.  However, it may be modified by subclasses to contain a superset
         '''   or subset for special purposes.
         ''' </summary>
-        Public Overrides ReadOnly Property RawPropertiesObjects() As Object()
+        Public Overrides ReadOnly Property RawPropertiesObjects As Object()
             Get
                 Dim AllObjects As Object() = MyBase.RawPropertiesObjects
                 Dim SpecificConfigIndex As Integer = IndexOfSpecificConfig(AllObjects)
@@ -110,7 +110,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   based on the set of objects passed in to the page through SetObjects.  However, it may be modified by subclasses to 
         '''   contain a superset or subset for special purposes.
         ''' </summary>
-        Public Overrides ReadOnly Property ExtendedPropertiesObjects() As Object()
+        Public Overrides ReadOnly Property ExtendedPropertiesObjects As Object()
             Get
                 'We must pass the raw setobjects array to IndexOfSpecificConfig - it won't work with the extended objects
                 '  because they will not be IVsCfg objects - but we return an array based on the extended objects.

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkAssemblies.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkAssemblies.vb
@@ -25,13 +25,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 _description = description
             End Sub
 
-            Public ReadOnly Property Version() As UInteger
+            Public ReadOnly Property Version As UInteger
                 Get
                     Return _version
                 End Get
             End Property
 
-            Public ReadOnly Property Description() As String
+            Public ReadOnly Property Description As String
                 Get
                     Return _description
                 End Get

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
@@ -37,7 +37,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Gets the target framework moniker
         ''' </summary>
-        Public ReadOnly Property Moniker() As String
+        Public ReadOnly Property Moniker As String
             Get
                 Return _moniker
             End Get

--- a/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
@@ -54,7 +54,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         '''  Return true if the page can be resized...
         ''' </summary>
-        Public Overrides ReadOnly Property PageResizable() As Boolean
+        Public Overrides ReadOnly Property PageResizable As Boolean
             Get
                 Return True
             End Get

--- a/src/Microsoft.VisualStudio.Editors/PropPages/UserPropertyDescriptor.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/UserPropertyDescriptor.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return False
         End Function
 
-        Public Overrides ReadOnly Property ComponentType() As Type
+        Public Overrides ReadOnly Property ComponentType As Type
             Get
                 Return Nothing
             End Get
@@ -39,13 +39,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return Nothing
         End Function
 
-        Public Overrides ReadOnly Property IsReadOnly() As Boolean
+        Public Overrides ReadOnly Property IsReadOnly As Boolean
             Get
                 Return _isReadOnly
             End Get
         End Property
 
-        Public Overrides ReadOnly Property PropertyType() As Type
+        Public Overrides ReadOnly Property PropertyType As Type
             Get
                 Return _propertyType
             End Get

--- a/src/Microsoft.VisualStudio.Editors/PropPages/VBDescriptionAttribute.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/VBDescriptionAttribute.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             MyBase.New(description)
         End Sub
 
-        Public Overrides ReadOnly Property Description() As String
+        Public Overrides ReadOnly Property Description As String
             Get
                 If Not _replaced Then
                     _replaced = True

--- a/src/Microsoft.VisualStudio.Editors/PropPages/VBDisplayNameAttribute.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/VBDisplayNameAttribute.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             MyBase.New(description)
         End Sub
 
-        Public Overrides ReadOnly Property DisplayName() As String
+        Public Overrides ReadOnly Property DisplayName As String
             Get
                 If Not _replaced Then
                     _replaced = True

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlDocument.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlDocument.vb
@@ -189,7 +189,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             '''   appears in the .xaml file.  If DefinitionIncludesQuotes=True, then this
             '''   includes the beginning/ending quote
             ''' </summary>
-            Public Overridable ReadOnly Property ActualDefinitionText() As String
+            Public Overridable ReadOnly Property ActualDefinitionText As String
                 Get
                     Dim buffer As String = Nothing
                     ErrorHandler.ThrowOnFailure(VsTextLines.GetLineText(DefinitionStart.LineIndex, DefinitionStart.CharIndex, DefinitionEndPlusOne.LineIndex, DefinitionEndPlusOne.CharIndex, buffer))
@@ -197,19 +197,19 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 End Get
             End Property
 
-            Public ReadOnly Property UnescapedValue() As String
+            Public ReadOnly Property UnescapedValue As String
                 Get
                     Return _unescapedValue
                 End Get
             End Property
 
-            Public ReadOnly Property DefinitionStart() As Location
+            Public ReadOnly Property DefinitionStart As Location
                 Get
                     Return _startLocation
                 End Get
             End Property
 
-            Public ReadOnly Property DefinitionEndPlusOne() As Location
+            Public ReadOnly Property DefinitionEndPlusOne As Location
                 Get
                     Return _endLocationPlusOne
                 End Get
@@ -297,7 +297,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 _fullyQualifiedPropertyName = fullyQualifiedPropertyName
             End Sub
 
-            Public Overrides ReadOnly Property ActualDefinitionText() As String
+            Public Overrides ReadOnly Property ActualDefinitionText As String
                 Get
                     Return ""
                 End Get

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlErrorControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlErrorControl.vb
@@ -25,11 +25,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             RaiseEvent EditXamlClicked()
         End Sub
 
-        Public Property ErrorText() As String
+        Public Property ErrorText As String
             Get
                 Return ErrorControl.Text
             End Get
-            Set(value As String)
+            Set
                 ErrorControl.Text = value
             End Set
         End Property

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
@@ -146,7 +146,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 #End Region
 
 #Region "PropertyControlData"
-        Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
+        Protected Overrides ReadOnly Property ControlData As PropertyControlData()
             Get
                 Dim ControlsThatDependOnStartupObjectOrUriProperty As Control() = {
                     StartupObjectOrUriLabel, UseApplicationFrameworkCheckBox, WindowsAppGroupBox
@@ -854,7 +854,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         '''   (depending on the setting of the Enable Application Framework
         '''   checkbox)
         ''' </summary>
-        <Serializable()>
+        <Serializable>
         Friend MustInherit Class StartupObjectOrUri
             Private ReadOnly _value As String
             Private ReadOnly _description As String
@@ -878,13 +878,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 Return Description
             End Function
 
-            Public ReadOnly Property Value() As String
+            Public ReadOnly Property Value As String
                 Get
                     Return _value
                 End Get
             End Property
 
-            Public ReadOnly Property Description() As String
+            Public ReadOnly Property Description As String
                 Get
                     Return _description
                 End Get
@@ -908,7 +908,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 
         End Class
 
-        <Serializable()>
+        <Serializable>
         Friend Class StartupObject
             Inherits StartupObjectOrUri
 
@@ -916,7 +916,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 MyBase.New(value, description)
             End Sub
 
-            Protected Overridable ReadOnly Property IsEquivalentToSubMain() As Boolean
+            Protected Overridable ReadOnly Property IsEquivalentToSubMain As Boolean
                 Get
                     Return Value = "" OrElse Value.Equals(STARTUPOBJECT_SubMain, StringComparison.OrdinalIgnoreCase)
                 End Get
@@ -945,7 +945,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 
         End Class
 
-        <Serializable()>
+        <Serializable>
         Friend Class StartupObjectNone
             Inherits StartupObject
 
@@ -953,7 +953,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 MyBase.New("", s_noneText)
             End Sub
 
-            Protected Overrides ReadOnly Property IsEquivalentToSubMain() As Boolean
+            Protected Overrides ReadOnly Property IsEquivalentToSubMain As Boolean
                 Get
                     Return False
                 End Get
@@ -961,7 +961,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 
         End Class
 
-        <Serializable()>
+        <Serializable>
         Friend Class StartupUri
             Inherits StartupObjectOrUri
 
@@ -1328,13 +1328,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 _description = description
             End Sub
 
-            Public ReadOnly Property Value() As String
+            Public ReadOnly Property Value As String
                 Get
                     Return _value
                 End Get
             End Property
 
-            Public ReadOnly Property Description() As String
+            Public ReadOnly Property Description As String
                 Get
                     Return _description
                 End Get

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/XamlReadWriteException.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/XamlReadWriteException.vb
@@ -4,7 +4,7 @@ Imports System.Runtime.Serialization
 
 Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 
-    <Serializable()>
+    <Serializable>
     Friend Class XamlReadWriteException
         Inherits PropertyPageException
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WebReferenceComponent.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WebReferenceComponent.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         <VBDescription(My.Resources.Microsoft_VisualStudio_Editors_Designer.ConstantResourceIDs.PPG_WebReferenceNameDescription)>
         <MergableProperty(False)>
         <HelpKeyword("Folder Properties.FileName")>
-        Public Property Name() As String
+        Public Property Name As String
             Get
                 Try
                     Return _projectItem.Name
@@ -31,7 +31,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Return String.Empty
                 End Try
             End Get
-            Set(value As String)
+            Set
                 _projectItem.Name = value
                 _page.OnWebReferencePropertyChanged(Me)
             End Set
@@ -42,7 +42,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return False
         End Function
 
-        Friend ReadOnly Property WebReference() As EnvDTE.ProjectItem
+        Friend ReadOnly Property WebReference As EnvDTE.ProjectItem
             Get
                 Return _projectItem
             End Get
@@ -51,7 +51,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         <VBDisplayName(My.Resources.Microsoft_VisualStudio_Editors_Designer.ConstantResourceIDs.PPG_UrlBehaviorName)>
         <VBDescription(My.Resources.Microsoft_VisualStudio_Editors_Designer.ConstantResourceIDs.PPG_UrlBehaviorDescription)>
         <HelpKeyword("Folder Properties.UrlBehavior")>
-        Public Property UrlBehavior() As UrlBehaviorType
+        Public Property UrlBehavior As UrlBehaviorType
             Get
                 Dim prop As EnvDTE.[Property] = GetItemProperty(NameOf(UrlBehavior))
                 If prop IsNot Nothing Then
@@ -61,7 +61,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Return UrlBehaviorType.Static
                 End If
             End Get
-            Set(value As UrlBehaviorType)
+            Set
                 Dim prop As EnvDTE.[Property] = GetItemProperty(NameOf(UrlBehavior))
                 If prop IsNot Nothing Then
                     prop.Value = CInt(value)
@@ -81,7 +81,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         <VBDescription(My.Resources.Microsoft_VisualStudio_Editors_Designer.ConstantResourceIDs.PPG_WebReferenceUrlDescription)>
         <HelpKeyword("Folder Properties.WebReference")>
         <MergableProperty(False)>
-        Public Property WebReferenceURL() As String
+        Public Property WebReferenceURL As String
             Get
                 Dim prop As EnvDTE.[Property] = GetItemProperty(NameOf(WebReference))
                 If prop IsNot Nothing Then
@@ -91,7 +91,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Return String.Empty
                 End If
             End Get
-            Set(value As String)
+            Set
                 If value Is Nothing Then
                     value = String.Empty
                 End If
@@ -215,7 +215,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private Shared s_displayValues As String()
 
         ' a help collection to hold localized strings
-        Private Shared ReadOnly Property DisplayValues() As String()
+        Private Shared ReadOnly Property DisplayValues As String()
             Get
                 If s_displayValues Is Nothing Then
                     s_displayValues = New String() {My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_UrlBehavior_Static, My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_UrlBehavior_Dynamic}

--- a/src/Microsoft.VisualStudio.Editors/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Editors/PublicAPI.Shipped.txt
@@ -23,7 +23,7 @@ Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.Crea
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.CustomMkDocumentProvider() -> Microsoft.VisualStudio.Editors.ApplicationDesigner.CustomDocumentMonikerProvider (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.CustomMkDocumentProvider(Value As Microsoft.VisualStudio.Editors.ApplicationDesigner.CustomDocumentMonikerProvider) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.CustomViewProvider() -> Microsoft.VisualStudio.Editors.ApplicationDesigner.CustomViewProvider (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.CustomViewProvider(value As Microsoft.VisualStudio.Editors.ApplicationDesigner.CustomViewProvider) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.CustomViewProvider(Value As Microsoft.VisualStudio.Editors.ApplicationDesigner.CustomViewProvider) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.DocCookie() -> UInteger (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.DocData() -> Object (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.DocData(Value As Object) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
@@ -49,9 +49,9 @@ Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.Phys
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.PropertyPageInfo() -> Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageInfo (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.ShowDesigner(Show As Boolean = True) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.TabAutomationName() -> String (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.TabAutomationName(value As String) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.TabAutomationName(Value As String) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.TabTitle() -> String (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.TabTitle(value As String) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.TabTitle(Value As String) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.UpdateWindowFrameBounds() -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.VsUIShell5() -> Microsoft.VisualStudio.Shell.Interop.IVsUIShell5 (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.VsWindowFrame() -> Microsoft.VisualStudio.Shell.Interop.IVsWindowFrame (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
@@ -145,9 +145,9 @@ Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton (for
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.AccessibleState() -> System.Windows.Forms.AccessibleStates (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.ButtonIndex() -> Integer (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.DirtyIndicator() -> Boolean (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.DirtyIndicator(value As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.DirtyIndicator(Value As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.Location() -> System.Drawing.Point (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.Location(value As System.Drawing.Point) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.Location(Value As System.Drawing.Point) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.New() -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.SetIndex(index As Integer) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton.TextWithDirtyIndicator() -> String (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
@@ -163,11 +163,11 @@ Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.OnI
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.OnItemLeave(e As System.EventArgs, item As Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.Renderer() -> Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.SelectedIndex() -> Integer (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.SelectedIndex(value As Integer) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.SelectedIndex(Value As Integer) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.SelectedItem() -> Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.SelectedItem(value As Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.SelectedItem(Value As Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.ServiceProvider() -> System.IServiceProvider (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.ServiceProvider(value As System.IServiceProvider) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.ServiceProvider(Value As System.IServiceProvider) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.TabButtonCount() -> Integer (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.TabButtons() -> System.Collections.Generic.IEnumerable(Of Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton) (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.ThemeChanged -> Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl.ThemeChangedEventHandler (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
@@ -181,11 +181,11 @@ Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.Cr
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.New(owner As Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.PerformLayout() -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.PreferredButtonForSwitchableSlot() -> Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.PreferredButtonForSwitchableSlot(value As Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.PreferredButtonForSwitchableSlot(Value As Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.RenderBackground(g As System.Drawing.Graphics) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.RenderButton(g As System.Drawing.Graphics, button As Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabButton, IsSelected As Boolean, IsHovered As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.ServiceProvider() -> System.IServiceProvider (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.ServiceProvider(value As System.IServiceProvider) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.ServiceProvider(Value As System.IServiceProvider) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabRenderer.UpdateCacheState() -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageInfo (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageInfo.ComPropPageInstance() -> Microsoft.VisualStudio.OLE.Interop.IPropertyPage (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
@@ -197,13 +197,13 @@ Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageInfo.Site() -> Mi
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageInfo.Title() -> String (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.BackingServiceProvider() -> System.IServiceProvider (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.BackingServiceProvider(value As System.IServiceProvider) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.BackingServiceProvider(Value As System.IServiceProvider) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.CommitPendingChanges() -> Boolean (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.GetLocaleID(ByRef pLocaleID As UInteger) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.GetPageContainer(ByRef ppunk As Object) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.GetService(serviceType As System.Type) -> Object (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.HasBeenSetDirty() -> Boolean (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.HasBeenSetDirty(value As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.HasBeenSetDirty(Value As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.New(View As Microsoft.VisualStudio.Editors.ApplicationDesigner.IPropertyPageSiteOwner, PropPage As Microsoft.VisualStudio.OLE.Interop.IPropertyPage) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.OnStatusChange(dwFlags As UInteger) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageSite.QueryService(ByRef guidService As System.Guid, ByRef riid As System.Guid, ByRef ppvObject As System.IntPtr) -> Integer (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
@@ -224,7 +224,7 @@ Microsoft.VisualStudio.Editors.DesignerFramework.SourceCodeControlManager.AreFil
 Microsoft.VisualStudio.Editors.DesignerFramework.SourceCodeControlManager.EnsureFilesEditable() -> Void
 Microsoft.VisualStudio.Editors.DesignerFramework.SourceCodeControlManager.ManageFile(mkDocument As String) -> Void
 Microsoft.VisualStudio.Editors.DesignerFramework.SourceCodeControlManager.ManagedFiles() -> System.Collections.Generic.List(Of String)
-Microsoft.VisualStudio.Editors.DesignerFramework.SourceCodeControlManager.ManagedFiles(value As System.Collections.Generic.List(Of String)) -> Void
+Microsoft.VisualStudio.Editors.DesignerFramework.SourceCodeControlManager.ManagedFiles(Value As System.Collections.Generic.List(Of String)) -> Void
 Microsoft.VisualStudio.Editors.DesignerFramework.SourceCodeControlManager.New(sp As System.IServiceProvider, Hierarchy As Microsoft.VisualStudio.Shell.Interop.IVsHierarchy) -> Void
 Microsoft.VisualStudio.Editors.DesignerFramework.SourceCodeControlManager.StopManagingFile(mkDocument As String) -> Void
 Microsoft.VisualStudio.Editors.MyApplication.ApplicationTypes
@@ -256,22 +256,22 @@ Microsoft.VisualStudio.Editors.MyApplication.MyApplicationManager
 Microsoft.VisualStudio.Editors.MyApplication.MyApplicationManager.New() -> Void
 Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties
 Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.AuthenticationMode() -> Integer
-Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.AuthenticationMode(value As Integer) -> Void
+Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.AuthenticationMode(Value As Integer) -> Void
 Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.CustomSubMain() -> Boolean
-Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.CustomSubMain(value As Boolean) -> Void
+Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.CustomSubMain(Value As Boolean) -> Void
 Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.EnableVisualStyles() -> Boolean
-Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.EnableVisualStyles(value As Boolean) -> Void
+Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.EnableVisualStyles(Value As Boolean) -> Void
 Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.MainForm() -> String
-Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.MainForm(value As String) -> Void
+Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.MainForm(Value As String) -> Void
 Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler
 Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.SaveMySettingsOnExit() -> Boolean
-Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.SaveMySettingsOnExit(value As Boolean) -> Void
+Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.SaveMySettingsOnExit(Value As Boolean) -> Void
 Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.ShutdownMode() -> Integer
-Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.ShutdownMode(value As Integer) -> Void
+Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.ShutdownMode(Value As Integer) -> Void
 Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.SingleInstance() -> Boolean
-Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.SingleInstance(value As Boolean) -> Void
+Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.SingleInstance(Value As Boolean) -> Void
 Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.SplashScreen() -> String
-Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.SplashScreen(value As String) -> Void
+Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.SplashScreen(Value As String) -> Void
 Microsoft.VisualStudio.Editors.PropPageDesigner.ConfigurationState (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropPageDesigner.ConfigurationState.ChangeSelection(ConfigIndex As Integer, PlatformIndex As Integer, FireNotifications As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropPageDesigner.ConfigurationState.ChangeSelection(ConfigName As String, ConfigSelectionType As Microsoft.VisualStudio.Editors.PropPageDesigner.ConfigurationState.SelectionTypes, PlatformName As String, PlatformSelectionType As Microsoft.VisualStudio.Editors.PropPageDesigner.ConfigurationState.SelectionTypes, PreferExactMatch As Boolean, FireNotifications As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
@@ -530,7 +530,7 @@ Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.DTEProject(
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.DelayValidate(dataControl As System.Windows.Forms.Control) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.EnableControl(control As System.Windows.Forms.Control, enabled As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.Enabled() -> Boolean (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.Enabled(value As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.Enabled(Value As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.EnterProjectCheckoutSection() -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.ExtendedPropertiesObjects(Data As Microsoft.VisualStudio.Editors.PropertyPages.PropertyControlData) -> Object() (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.GetCommonPropertyDescriptor(PropertyName As String) -> System.ComponentModel.PropertyDescriptor (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
@@ -566,7 +566,7 @@ Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.IsUndoEnabl
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.IsVBProject() -> Boolean (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.LeaveProjectCheckoutSection() -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.ManualPageScaling() -> Boolean (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.ManualPageScaling(value As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.ManualPageScaling(Value As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.MultiProjectSelect() -> Boolean (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.New() -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.New(serviceProvider As Microsoft.VisualStudio.Shell.ServiceProvider) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
@@ -694,7 +694,7 @@ Microsoft.VisualStudio.Editors.PropertyPages.PropertyPageException.New(message A
 Microsoft.VisualStudio.Editors.PropertyPages.PropertyPageException.New(message As String, innerException As System.Exception) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropertyPages.PropertyPageException.New(message As String, innerException As System.Exception, ShowHeaderAndFooterInErrorControl As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropertyPages.PropertyPageException.ShowHeaderAndFooterInErrorControl() -> Boolean (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Microsoft.VisualStudio.Editors.PropertyPages.PropertyPageException.ShowHeaderAndFooterInErrorControl(value As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Microsoft.VisualStudio.Editors.PropertyPages.PropertyPageException.ShowHeaderAndFooterInErrorControl(Value As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropertyPages.ReferencePathsPropPageComClass
 Microsoft.VisualStudio.Editors.PropertyPages.ReferencePathsPropPageComClass.New() -> Void
 Microsoft.VisualStudio.Editors.PropertyPages.ReferencePropPageComClass
@@ -838,16 +838,16 @@ Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.Apply() ->
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.ControlTypeForResources() -> System.Type (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.Deactivate() -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.DefaultSize() -> System.Drawing.Size (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.DefaultSize(value As System.Drawing.Size) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.DefaultSize(Value As System.Drawing.Size) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.DocString() -> String (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.DocString(value As String) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.DocString(Value As String) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.GetProperty(PropertyName As String) -> Object (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.GetPropertyMultipleValues(PropertyName As String, ByRef Objects As Object(), ByRef Values As Object()) -> Boolean (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.Help(strHelpDir As String) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.HelpContext() -> UInteger (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.HelpContext(value As UInteger) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.HelpContext(Value As UInteger) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.HelpFile() -> String (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.HelpFile(value As String) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.HelpFile(Value As String) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.IsPageDirty() -> Integer (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.Objects() -> Object() (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.SetObjects(cObjects As UInteger, objects As Object()) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Category.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Category.vb
@@ -95,7 +95,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' All resource type editors that are displayed in this category.  A particular
         '''   resource type editor may only be displayed in a single category.
         ''' </summary>
-        Public ReadOnly Property AssociatedResourceTypeEditors() As ResourceTypeEditor()
+        Public ReadOnly Property AssociatedResourceTypeEditors As ResourceTypeEditor()
             Get
                 Return _associatedResourceTypeEditors
             End Get
@@ -106,7 +106,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Indicates whether this category displays its resources in a stringtable
         '''   or a listview.
         ''' </summary>
-        Public ReadOnly Property CategoryDisplay() As Display
+        Public ReadOnly Property CategoryDisplay As Display
             Get
                 Return _categoryDisplay
             End Get
@@ -116,7 +116,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Command to execute if you want to show this category
         ''' </summary>
-        Public ReadOnly Property CommandToShow() As MenuCommand
+        Public ReadOnly Property CommandToShow As MenuCommand
             Get
                 Return _menuCommand
             End Get
@@ -126,11 +126,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' The command used to add a new resources of appropriate type
         ''' for the current category
         ''' </summary>
-        Public Property AddCommand() As EventHandler
+        Public Property AddCommand As EventHandler
             Get
                 Return _addCommand
             End Get
-            Set(value As EventHandler)
+            Set
                 _addCommand = value
             End Set
         End Property
@@ -139,7 +139,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Returns the friendly (localized) category name, which is shown to the
         '''   user in the category buttons.
         ''' </summary>
-        Public ReadOnly Property LocalizedName() As String
+        Public ReadOnly Property LocalizedName As String
             Get
                 Return _localizedName
             End Get
@@ -150,7 +150,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Returns a programmatic name which is never localized and never shown to
         '''   the user.  Used when searching for a category by name key.
         ''' </summary>
-        Public ReadOnly Property ProgrammaticName() As String
+        Public ReadOnly Property ProgrammaticName As String
             Get
                 Return _programmaticName
             End Get
@@ -166,11 +166,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   button will be normal.  When there is at least one resource in this category,
         '''   the button's font will be made bold.
         ''' </remarks>
-        Public Property ResourceCount() As Integer
+        Public Property ResourceCount As Integer
             Get
                 Return _resourceCount
             End Get
-            Set(Value As Integer)
+            Set
                 Dim ResourcesExisted As Boolean = ResourcesExist
                 _resourceCount = Value
 
@@ -189,7 +189,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns true iff there are resources in this category (ResourceCount > 0)
         ''' </summary>
-        Public ReadOnly Property ResourcesExist() As Boolean
+        Public ReadOnly Property ResourcesExist As Boolean
             Get
                 Return _resourceCount > 0
             End Get
@@ -201,11 +201,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   a listview.  This is the "Details", "Icons", "List" option for
         '''   the display mode of the listview.
         ''' </summary>
-        Public Property ResourceView() As ResourceListView.ResourceView
+        Public Property ResourceView As ResourceListView.ResourceView
             Get
                 Return _resourceView
             End Get
-            Set(Value As ResourceListView.ResourceView)
+            Set
                 _resourceView = Value
             End Set
         End Property
@@ -215,11 +215,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' If this category uses a string table, indicates whether or not the "Type"
         '''   column is displayed (shows the type of resource, e.g. System.Drawing.Image)
         ''' </summary>
-        Public Property ShowTypeColumnInStringTable() As Boolean
+        Public Property ShowTypeColumnInStringTable As Boolean
             Get
                 Return _showTypeColumnInStringTable
             End Get
-            Set(Value As Boolean)
+            Set
                 Debug.Assert(_categoryDisplay = Display.StringTable, "This property only applies to string table categories")
                 _showTypeColumnInStringTable = Value
             End Set
@@ -228,7 +228,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         '''  how to sort the resource items in the category...
         ''' </summary>
-        Public Property Sorter() As IComparer(Of Resource)
+        Public Property Sorter As IComparer(Of Resource)
             Get
                 Return _sorter
             End Get
@@ -242,11 +242,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   to add new entries in this string table, via an add/new row at the bottom of
         '''   the table.
         ''' </summary>
-        Public Property AllowNewEntriesInStringTable() As Boolean
+        Public Property AllowNewEntriesInStringTable As Boolean
             Get
                 Return _allowNewEntriesInStringTable
             End Get
-            Set(Value As Boolean)
+            Set
                 Debug.Assert(_categoryDisplay = Display.StringTable, "This property only applies to string table categories")
                 _allowNewEntriesInStringTable = Value
             End Set

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
@@ -74,7 +74,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns the number of directories being watched.
         ''' </summary>
-        Public ReadOnly Property DirectoryWatchersCount() As Integer
+        Public ReadOnly Property DirectoryWatchersCount As Integer
             Get
                 Return _directoryWatchers.Count
             End Get
@@ -266,7 +266,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' The directory path being watched.
             ''' </summary>
-            Public ReadOnly Property DirectoryPath() As String
+            Public ReadOnly Property DirectoryPath As String
                 Get
                     Return _directoryPath
                 End Get
@@ -276,7 +276,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Returns the number of files being watched in this directory
             ''' </summary>
-            Public ReadOnly Property FileCount() As Integer
+            Public ReadOnly Property FileCount As Integer
                 Get
                     Return _fileWatcherEntries.Count
                 End Get
@@ -503,7 +503,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Gets the path and filename of the file.
             ''' </summary>
-            Public ReadOnly Property PathAndFileName() As String
+            Public ReadOnly Property PathAndFileName As String
                 Get
                     Return Path.Combine(_directoryWatcher.DirectoryPath, _fileNameOnly)
                 End Get
@@ -513,7 +513,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Retrieves the current number of listeners.
             ''' </summary>
-            Public ReadOnly Property ListenerCount() As Integer
+            Public ReadOnly Property ListenerCount As Integer
                 Get
                     Return _listeners.Count
                 End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
@@ -631,7 +631,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns the resource editor view associated with this designer.
         ''' </summary>
-        Private ReadOnly Property View() As ResourceEditorView
+        Private ReadOnly Property View As ResourceEditorView
             Get
                 Return _rootDesigner.GetView()
             End Get
@@ -641,7 +641,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns True iff there a View has already been created.
         ''' </summary>
-        Private ReadOnly Property HasView() As Boolean
+        Private ReadOnly Property HasView As Boolean
             Get
                 Return _rootDesigner.HasView()
             End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/OpenFileWarningDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/OpenFileWarningDialog.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' returns whether we need pop up a warning dialog for this extension again
         ''' </summary>
-        Public ReadOnly Property AlwaysCheckForThisExtension() As Boolean
+        Public ReadOnly Property AlwaysCheckForThisExtension As Boolean
             Get
                 Return alwaysCheckCheckBox.Checked
             End Get
@@ -79,7 +79,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         'NOTE: The following procedure is required by the Windows Form Designer
         'It can be modified using the Windows Form Designer.  
         'Do not modify it using the code editor.
-        <DebuggerStepThrough()>
+        <DebuggerStepThrough>
         Private Sub InitializeComponent()
             Dim resources As ComponentModel.ComponentResourceManager = New ComponentModel.ComponentResourceManager(GetType(OpenFileWarningDialog))
             dialogLayoutPanel = New Windows.Forms.TableLayoutPanel

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     '''  - Implements IComponent to be able to push the resource through SelectionService, so that the name of the resource 
     '''      appears on the Property Window's drop down list.
     ''' </remarks>
-    <Serializable()>
+    <Serializable>
     <TypeDescriptionProvider(GetType(ResourceTypeDescriptionProvider))>
     Friend NotInheritable Class Resource
         Implements IComponent
@@ -529,11 +529,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' The parent resource file in which this Resource is contained.  Will be Nothing until the resource is
         '''  actually added to a ResourceFile.
         ''' </summary>
-        Public Property ParentResourceFile() As ResourceFile
+        Public Property ParentResourceFile As ResourceFile
             Get
                 Return _parentResourceFile
             End Get
-            Set(Value As ResourceFile)
+            Set
                 Debug.Assert(Value Is Nothing OrElse _parentResourceFile Is Nothing, "ParentResourceFile already set!")
                 _parentResourceFile = Value
 
@@ -551,7 +551,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns whether this object has been disposed
         ''' </summary>
-        Public ReadOnly Property IsDisposed() As Boolean
+        Public ReadOnly Property IsDisposed As Boolean
             Get
                 Return _isDisposed
             End Get
@@ -561,7 +561,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves the ResXDataNode associated with this resource
         ''' </summary>
-        Friend ReadOnly Property ResXDataNode() As ResXDataNode
+        Friend ReadOnly Property ResXDataNode As ResXDataNode
             Get
                 Return _resXDataNode
             End Get
@@ -577,11 +577,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   used normally (including changing the Name in response to user manipulation), since it
         '''   enables the undo engine to undo this change.
         ''' </summary>
-        Public Property Name() As String
+        Public Property Name As String
             Get
                 Return _resXDataNode.Name
             End Get
-            Set(Value As String)
+            Set
                 'To enable Undo, we must go through a property descriptor...
 
                 If _parentResourceFile IsNot Nothing Then
@@ -607,8 +607,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Sets/Gets the Name property of the Resource component, without undo support, and without causing the 
         '''  designer to be dirtied (because ComponentChangeService notifications won't get sent)
         ''' </summary>
-        Public WriteOnly Property NameWithoutUndo() As String
-            Set(Value As String)
+        Public WriteOnly Property NameWithoutUndo As String
+            Set
                 If Value = "" Then
                     Throw NewException(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Err_NameBlank, HelpIDs.Err_NameBlank)
                 End If
@@ -645,11 +645,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <remarks>Can't be private because ResourceFile needs access to it.</remarks>
         <EditorBrowsable(EditorBrowsableState.Never)>
-        Friend Property NameRawWithoutUndo() As String
+        Friend Property NameRawWithoutUndo As String
             Get
                 Return _resXDataNode.Name
             End Get
-            Set(Value As String)
+            Set
                 Debug.Assert(Value <> "", "Shouldn't have reached here without a valid name")
                 _resXDataNode.Name = Value
                 If _parentResourceFile IsNot Nothing Then
@@ -665,11 +665,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   used normally (including changing the property in response to user manipulation), since it
         '''   enables the undo engine to undo this change.
         ''' </summary>
-        Public Property Comment() As String
+        Public Property Comment As String
             Get
                 Return _resXDataNode.Comment
             End Get
-            Set(Value As String)
+            Set
                 'To enable Undo, we must go through a property descriptor...
                 s_propertyDescriptor_Comment.SetValue(Me, Value)
             End Set
@@ -680,8 +680,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Sets/Gets the Comment property of the Resource component, without undo support, and without causing the 
         '''  designer to be dirtied (because ComponentChangeService notifications won't get sent)
         ''' </summary>
-        Private WriteOnly Property CommentWithoutUndo() As String
-            Set(Value As String)
+        Private WriteOnly Property CommentWithoutUndo As String
+            Set
                 _resXDataNode.Comment = Value
                 CheckCommentForErrors()
                 InvalidateUI()
@@ -692,7 +692,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         '''  Returns the ResourcePersistenceMode property.  (This property is shown in the properties window.)
         ''' </summary>
-        Public Property PersistenceMode() As ResourcePersistenceMode
+        Public Property PersistenceMode As ResourcePersistenceMode
             Get
                 If IsLink Then
                     Return ResourcePersistenceMode.Linked
@@ -700,7 +700,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Return ResourcePersistenceMode.Embedded
                 End If
             End Get
-            Set(Value As ResourcePersistenceMode)
+            Set
                 s_propertyDescriptor_Persistence.SetValue(Me, Value)
             End Set
         End Property
@@ -710,8 +710,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Sets/Gets the persistence mode for this resource, without undo support, and without causing the 
         '''  designer to be dirtied (because ComponentChangeService notifications won't get sent)
         ''' </summary>
-        Private WriteOnly Property PersistenceWithoutUndo() As ResourcePersistenceMode
-            Set(Value As ResourcePersistenceMode)
+        Private WriteOnly Property PersistenceWithoutUndo As ResourcePersistenceMode
+            Set
                 If PersistenceMode = Value Then
                     'Nothing changed
                     Exit Property
@@ -830,7 +830,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   property and not lose the original filename that the link was pointing to when changing
         '''   to a non-linked resource.
         ''' </summary>
-        Public Property FileName() As String
+        Public Property FileName As String
             Get
                 If IsLink Then
                     Return AbsoluteLinkPathAndFileName
@@ -838,7 +838,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Return ""
                 End If
             End Get
-            Set(Value As String)
+            Set
                 s_propertyDescriptor_Filename_ReadWrite.SetValue(Me, Value)
             End Set
         End Property
@@ -851,8 +851,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   property and not lose the original filename that the link was pointing to when changing
         '''   to a non-linked resource.
         ''' </summary>
-        Private WriteOnly Property FileNameWithoutUndo() As String
-            Set(Value As String)
+        Private WriteOnly Property FileNameWithoutUndo As String
+            Set
                 Dim PersistenceChanged As Boolean
 
                 If IsLink Then
@@ -901,7 +901,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   This is the member which should be used normally (including changing the property 
         '''   in response to user manipulation), since it enables the undo engine to undo this change.
         ''' </remarks>
-        Public Property Encoding() As Encoding
+        Public Property Encoding As Encoding
             Get
                 If IsLink Then
                     Return _resXDataNode.FileRef.TextFileEncoding
@@ -909,7 +909,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Return Nothing
                 End If
             End Get
-            Set(Value As Encoding)
+            Set
                 s_propertyDescriptor_Encoding.SetValue(Me, New SerializableEncoding(Value))
             End Set
         End Property
@@ -919,8 +919,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Sets/Gets the Encoding used for text file resources, without undo support, and without causing the 
         '''  designer to be dirtied (because ComponentChangeService notifications won't get sent)
         ''' </summary>
-        Private WriteOnly Property EncodingWithoutUndo() As Encoding
-            Set(Value As Encoding)
+        Private WriteOnly Property EncodingWithoutUndo As Encoding
+            Set
                 Debug.Assert(IsLink AndAlso ResourceTypeEditor.Equals(ResourceTypeEditors.TextFile))
                 If _resXDataNode.FileRef IsNot Nothing Then
                     _resXDataNode = NewResXDataNode(Name, Comment, AbsoluteLinkPathAndFileName, ValueTypeName, Value)
@@ -945,7 +945,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   This is the member which should be used normally (including changing the property 
         '''   in response to user manipulation), since it enables the undo engine to undo this change.
         ''' </summary>
-        Public Property FileType() As FileTypes
+        Public Property FileType As FileTypes
             Get
                 If TypeOf ResourceTypeEditor Is ResourceTypeEditorFileBase Then
                     If TryGetValueType().Equals(ResourceTypeEditorTextFile.TextFileValueType) Then
@@ -960,7 +960,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Return FileTypes.Binary
                 End If
             End Get
-            Set(Value As FileTypes)
+            Set
                 s_propertyDescriptor_FileType.SetValue(Me, Value)
             End Set
         End Property
@@ -970,8 +970,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets/sets the file type of a binary or text file resource, without undo support, and without causing the 
         '''  designer to be dirtied (because ComponentChangeService notifications won't get sent)
         ''' </summary>
-        Private WriteOnly Property FileTypeWithoutUndo() As FileTypes
-            Set(Value As FileTypes)
+        Private WriteOnly Property FileTypeWithoutUndo As FileTypes
+            Set
                 If Not IsLink OrElse Not TypeOf ResourceTypeEditor Is ResourceTypeEditorFileBase OrElse _resXDataNode.FileRef Is Nothing Then
                     Debug.Fail("")
                     Return
@@ -1041,7 +1041,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Returns True iff the resource is contained in a separate file which we have a link to.  If False,
         '''   the resource is stored as a binary blob encoded directly inside the .resx file.
         ''' </summary>
-        Public ReadOnly Property IsLink() As Boolean Implements ResourceTypeEditor.IResource.IsLink
+        Public ReadOnly Property IsLink As Boolean Implements ResourceTypeEditor.IResource.IsLink
             Get
                 Return _resXDataNode.FileRef IsNot Nothing
             End Get
@@ -1054,7 +1054,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks>
         ''' Note: if you need to change the link, use SetLink()
         ''' </remarks>
-        Public ReadOnly Property RelativeLinkPathAndFileName() As String
+        Public ReadOnly Property RelativeLinkPathAndFileName As String
             Get
                 If _resXDataNode.FileRef IsNot Nothing Then
                     If ParentResourceFile IsNot Nothing Then
@@ -1080,7 +1080,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Retrieves the absolute path to the linked file (if any)
         ''' </summary>
         ''' <remarks>Note: if you need to change the link, use SetLink()</remarks>
-        Public ReadOnly Property AbsoluteLinkPathAndFileName() As String Implements ResourceTypeEditor.IResource.LinkedFilePath
+        Public ReadOnly Property AbsoluteLinkPathAndFileName As String Implements ResourceTypeEditor.IResource.LinkedFilePath
             Get
                 If _resXDataNode.FileRef IsNot Nothing Then
                     Debug.Assert(ParentResourceFile Is Nothing OrElse ParentResourceFile.BasePath = "" OrElse Path.IsPathRooted(_resXDataNode.FileRef.FileName), "Shouldn't get relative paths from ResXDataNode")
@@ -1102,7 +1102,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' For NullResX values (i.e., a resource value of Nothing), returns Nothing.  In all other cases, this returns a non-empty string.
         ''' No exceptions should be thrown from this property
         ''' </remarks>
-        Public ReadOnly Property ValueTypeName() As String
+        Public ReadOnly Property ValueTypeName As String
             Get
                 Try
                     Dim TypeName As String = ""
@@ -1133,7 +1133,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <value>The cached or non-linked value if possible, or else Nothing.</value>
         ''' <remarks>No exceptions are thrown (that are not swallowed)</remarks>
-        Public ReadOnly Property CachedValue() As Object
+        Public ReadOnly Property CachedValue As Object
             Get
                 If _cachedValue Is Nothing Then
                     Return Nothing
@@ -1158,7 +1158,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns True iff this resource is a ResXNullRef (a Nothing value encoded into the resx).
         ''' </summary>
-        Public ReadOnly Property IsResXNullRef() As Boolean
+        Public ReadOnly Property IsResXNullRef As Boolean
             Get
                 Return IsResXNullRef(ValueTypeName)
             End Get
@@ -1185,7 +1185,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <value>The associated resource type editor.</value>
         ''' <remarks>This property is never allowed to return Nothing after initialization is complete.</remarks>
-        Public ReadOnly Property ResourceTypeEditor() As ResourceTypeEditor
+        Public ReadOnly Property ResourceTypeEditor As ResourceTypeEditor
             Get
                 If _resourceTypeEditor Is Nothing Then
                     DetermineResourceTypeEditor()
@@ -1198,7 +1198,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         '''  We keep the original order of the resource item, so we can keep the order when we save the file.
         ''' </summary>
-        Friend ReadOnly Property OrderID() As Integer
+        Friend ReadOnly Property OrderID As Integer
             Get
                 Return _orderID
             End Get
@@ -1218,11 +1218,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   sited.  Thus, we need to keep these two versions of the name separate but
         '''   in sync.
         ''' </remarks>
-        Friend Property IComponent_Site() As ISite Implements IComponent.Site
+        Friend Property IComponent_Site As ISite Implements IComponent.Site
             Get
                 Return _site
             End Get
-            Set(Value As ISite)
+            Set
                 _site = Value
                 Debug.Assert(_site Is Nothing OrElse _site.Name.Equals(Name, StringComparison.Ordinal), "Name property and ISite.Name are out of sync")
             End Set
@@ -1237,7 +1237,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   fully-qualified type name *without* the assembly information.  E.g., "System.Drawing.Bitmap".
         '''   This is used in the "Type" column of the resource string table.
         ''' </summary>
-        Public ReadOnly Property FriendlyValueTypeName() As String
+        Public ReadOnly Property FriendlyValueTypeName As String
             Get
                 Return ValueTypeNameWithoutAssemblyInfo
             End Get
@@ -1246,7 +1246,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns the fully-qualified type name *without* the assembly information.  E.g., "System.Drawing.Bitmap".
         ''' </summary>
-        Friend ReadOnly Property ValueTypeNameWithoutAssemblyInfo() As String
+        Friend ReadOnly Property ValueTypeNameWithoutAssemblyInfo As String
             Get
                 Dim TypeName As String = ValueTypeName
 
@@ -1272,7 +1272,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Retrieves a friendly description of the type of resource for the user (e.g., "Icon", "Windows Metafile").
         ''' Used in the type column of the resource listview.
         ''' </summary>
-        Public ReadOnly Property FriendlyTypeDescription() As String
+        Public ReadOnly Property FriendlyTypeDescription As String
             Get
                 CacheFriendlyTypeAndSize()
                 If _cachedImageProperties IsNot Nothing Then
@@ -1287,7 +1287,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves a string representing the "size" of the resource, e.g. "240 x 128"
         ''' </summary>
-        Public ReadOnly Property FriendlySize() As String
+        Public ReadOnly Property FriendlySize As String
             Get
                 CacheFriendlyTypeAndSize()
                 If _cachedImageProperties IsNot Nothing Then
@@ -1907,7 +1907,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Lazy-initializes and gets a list of names which are not recommended for use by 
         '''  the end user (because they cause compiler errors or other problems).
         ''' </summary>
-        Private Shared ReadOnly Property UnrecommendedResourceNames() As HashSet(Of String)
+        Private Shared ReadOnly Property UnrecommendedResourceNames As HashSet(Of String)
             Get
                 If s_unrecommendedResourceNames Is Nothing Then
                     s_unrecommendedResourceNames = New HashSet(Of String)(StringComparer.OrdinalIgnoreCase)
@@ -2769,7 +2769,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks>
         ''' This value is set either at construction time or upon the first call to SetTypeResolutionContext
         ''' </remarks>
-        Private ReadOnly Property TypeResolutionContext() As Object
+        Private ReadOnly Property TypeResolutionContext As Object
             Get
                 If _typeResolutionContext Is Nothing Then
                     Debug.Fail("Should have called SetTypeResolutionContext() by now.  Falling back to default set of assemblies.")

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorFactory.vb
@@ -48,7 +48,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Must overridde the base.  Be sure to use the same GUID on the GUID attribute
         '''    attached to the inheriting class.
         ''' </remarks>
-        Protected Overrides ReadOnly Property EditorGuid() As Guid
+        Protected Overrides ReadOnly Property EditorGuid As Guid
             Get
                 Return New Guid(ResourceEditor_EditorGuid)
             End Get
@@ -58,7 +58,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Provides the (constant) GUID for the command UI.
         ''' </summary>
-        Protected Overrides ReadOnly Property CommandUIGuid() As Guid
+        Protected Overrides ReadOnly Property CommandUIGuid As Guid
             Get
                 'This is required for key bindings hook-up to work properly.
                 Return Constants.MenuConstants.GUID_RESXEditorCommandUI

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootComponent.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootComponent.vb
@@ -105,7 +105,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' True iff the root component is being torn down or is already torn down.
         ''' </summary>
-        Friend ReadOnly Property IsTearingDown() As Boolean
+        Friend ReadOnly Property IsTearingDown As Boolean
             Get
                 Return _tearingDown
             End Get
@@ -115,7 +115,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the ResXResourceFile that is currently being edited.
         ''' </summary>
-        Friend ReadOnly Property ResourceFile() As ResourceFile
+        Friend ReadOnly Property ResourceFile As ResourceFile
             Get
                 Debug.Assert(Not _resourceFile Is Nothing, "m_ResourceFile should have already been created!  SetResXResourceFile not called?")
                 Return _resourceFile
@@ -125,7 +125,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the ResXResourceFileName that is currently being edited.
         ''' </summary>
-        Friend Property ResourceFileName() As String
+        Friend Property ResourceFileName As String
             Get
                 Return _resourceFileName
             End Get
@@ -139,7 +139,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   designer which is showing the UI to the user which allows this component's
         '''   resx file to be edited by the user.
         ''' </summary>
-        Friend ReadOnly Property RootDesigner() As ResourceEditorRootDesigner
+        Friend ReadOnly Property RootDesigner As ResourceEditorRootDesigner
             Get
                 If _rootDesigner Is Nothing Then
                     'Not yet cached - get this info from the designer host
@@ -156,7 +156,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''<summary>
         ''' Whether the resource file belongs to another file (form/userControl)
         '''</summary>
-        Friend ReadOnly Property IsDependentFile() As Boolean
+        Friend ReadOnly Property IsDependentFile As Boolean
             Get
                 Return _isDependentFile
             End Get
@@ -165,7 +165,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''<summary>
         ''' Whether the resource item belongs to a device project
         '''</summary>
-        Friend ReadOnly Property IsInsideDeviceProject() As Boolean
+        Friend ReadOnly Property IsInsideDeviceProject As Boolean
             Get
                 Return _isInsideDeviceProject
             End Get
@@ -174,7 +174,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         '''  Whether the resource item belongs to the global resource folder in ASP .Net application
         ''' </summary>
-        Friend ReadOnly Property IsGlobalResourceInASP() As Boolean
+        Friend ReadOnly Property IsGlobalResourceInASP As Boolean
             Get
                 Return _isGlobalResourceInASP
             End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
@@ -106,7 +106,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   encourage the use of the strongly-typed RootComponent instead.
         ''' </summary>
         <EditorBrowsable(EditorBrowsableState.Never)>
-        Friend Shadows ReadOnly Property Component() As ResourceEditorRootComponent
+        Friend Shadows ReadOnly Property Component As ResourceEditorRootComponent
             Get
                 Return RootComponent
             End Get
@@ -116,7 +116,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns the ResourceEditorRoot component that is being edited by this designer.
         ''' </summary>
-        Friend ReadOnly Property RootComponent() As ResourceEditorRootComponent
+        Friend ReadOnly Property RootComponent As ResourceEditorRootComponent
             Get
                 Dim Root As ResourceEditorRootComponent = CType(MyBase.Component, ResourceEditorRootComponent)
                 Debug.Assert(Not Root Is Nothing)
@@ -129,7 +129,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Returns the IDesignerHost from the RootDesigner.
         ''' </summary>
         ''' <value>An instance of IDesignerHost.</value>
-        Friend ReadOnly Property DesignerHost() As IDesignerHost
+        Friend ReadOnly Property DesignerHost As IDesignerHost
             Get
                 Debug.Assert(_designerHost IsNot Nothing, "Cannot get IDesignerHost!!!")
                 Return _designerHost
@@ -141,7 +141,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Returns the DesignerLoader associated with this RootDesigner.
         ''' </summary>
         ''' <value>The ResourceEditorDesignerLoader instance.</value>
-        Friend ReadOnly Property DesignerLoader() As ResourceEditorDesignerLoader
+        Friend ReadOnly Property DesignerLoader As ResourceEditorDesignerLoader
             Get
                 Dim DesignerLoaderService As Object = GetService(GetType(IDesignerLoaderService))
                 If DesignerLoaderService IsNot Nothing Then
@@ -159,11 +159,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  The designer will be destroyed, and a new designer will be created later, so we will never set it back.
         ''' </summary>
         ''' <value>Whether we are in reloading mode</value>
-        Friend Property IsInReloading() As Boolean
+        Friend Property IsInReloading As Boolean
             Get
                 Return _isInReloading
             End Get
-            Set(value As Boolean)
+            Set
                 _isInReloading = value
             End Set
         End Property
@@ -186,7 +186,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns True iff there a View has already been created.
         ''' </summary>
-        Public ReadOnly Property HasView() As Boolean
+        Public ReadOnly Property HasView As Boolean
             Get
                 Return _view IsNot Nothing
             End Get
@@ -198,7 +198,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   We currently support only "Default" (i.e., our designer view, ResourceEditorView,
         '''   inherits from System.Windows.Forms.Control).
         ''' </summary>
-        Private ReadOnly Property IRootDesigner_SupportedTechnologies() As ViewTechnology() Implements IRootDesigner.SupportedTechnologies
+        Private ReadOnly Property IRootDesigner_SupportedTechnologies As ViewTechnology() Implements IRootDesigner.SupportedTechnologies
             Get
                 Return New ViewTechnology() {ViewTechnology.Default}
             End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -346,7 +346,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves the set of categories handled by this instance of the resource editor.
         ''' </summary>
-        Public ReadOnly Property Categories() As CategoryCollection
+        Public ReadOnly Property Categories As CategoryCollection
             Get
                 Return _categories
             End Get
@@ -356,7 +356,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves the file watcher for this instance of the resource editor.  Creates one if necessary.
         ''' </summary>
-        Public ReadOnly Property FileWatcher() As FileWatcher
+        Public ReadOnly Property FileWatcher As FileWatcher
             Get
                 If _fileWatcher Is Nothing Then
                     If Handle.Equals(0) Then
@@ -372,7 +372,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Return true when we are editing a name label
         ''' </summary>
-        Friend ReadOnly Property IsInEditing() As Boolean
+        Friend ReadOnly Property IsInEditing As Boolean
             Get
                 Return _inEditingItem
             End Get
@@ -381,7 +381,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Return true when we are undoing/redoing
         ''' </summary>
-        Friend ReadOnly Property IsUndoing() As Boolean
+        Friend ReadOnly Property IsUndoing As Boolean
             Get
                 Return _inUndoing
             End Get
@@ -391,11 +391,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' ReadOnly Mode
         ''' </summary>
-        Friend Property ReadOnlyMode() As Boolean
+        Friend Property ReadOnlyMode As Boolean
             Get
                 Return _readOnlyMode
             End Get
-            Set(value As Boolean)
+            Set
                 If _readOnlyMode <> value Then
                     _readOnlyMode = value
                     RefreshCommandStatus()
@@ -406,7 +406,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the RootDesigner associated with this resource editor instance.
         ''' </summary>
-        Friend ReadOnly Property RootDesigner() As ResourceEditorRootDesigner
+        Friend ReadOnly Property RootDesigner As ResourceEditorRootDesigner
             Get
                 Debug.Assert(Not _rootDesigner Is Nothing, "Can't call RootDesigner before SetRootDesigner() - we don't have a root designer cached yet")
                 Return _rootDesigner
@@ -417,7 +417,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the ResourceFile that is being viewed/edited in this view.
         ''' </summary>
-        Public ReadOnly Property ResourceFile() As ResourceFile
+        Public ReadOnly Property ResourceFile As ResourceFile
             Get
                 Return _resourceFile
             End Get
@@ -427,7 +427,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' The component being edited - ResourceEditorRootComponent
         ''' </summary>
-        Friend ReadOnly Property RootComponent() As ResourceEditorRootComponent
+        Friend ReadOnly Property RootComponent As ResourceEditorRootComponent
             Get
                 If _rootDesigner IsNot Nothing AndAlso _rootDesigner.Component IsNot Nothing Then
                     Return _rootDesigner.Component
@@ -439,7 +439,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         End Property
 
 
-        Public ReadOnly Property CurrentCategory() As Category
+        Public ReadOnly Property CurrentCategory As Category
             Get
                 Debug.Assert(_currentCategory IsNot Nothing)
                 Return _currentCategory
@@ -449,7 +449,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Return the root Registry key of the Resource Editor
         ''' </summary>
-        Private ReadOnly Property RegistryRoot() As String
+        Private ReadOnly Property RegistryRoot As String
             Get
                 If _registryRoot Is Nothing Then
                     Dim localRegistry As ILocalRegistry2 = DirectCast(RootDesigner.GetService(GetType(ILocalRegistry)), ILocalRegistry2)
@@ -467,7 +467,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  We save a list of file extensions in the registry. All extensions were approved by the customer that they don't want to see
         '''  a warning dialog when they double-click the item to open it.
         ''' </summary>
-        Private Property SafeExtensions() As String
+        Private Property SafeExtensions As String
             Get
                 Dim registryPath As String = RegistryRoot
                 If registryPath IsNot Nothing Then
@@ -483,7 +483,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 End If
                 Return String.Empty
             End Get
-            Set(value As String)
+            Set
                 Dim registryPath As String = RegistryRoot
                 If registryPath IsNot Nothing Then
                     Try
@@ -2524,7 +2524,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Clipboard format for intra-editor and between resource editor instances.  Essentially just a list of
         '''   serialized Resources.
         ''' </summary>
-        <Serializable()>
+        <Serializable>
         Private NotInheritable Class ResourcesDataFormat
             'List of resources
             Private ReadOnly _resources() As Resource
@@ -2540,7 +2540,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Retrives the list of resources stored in this format.
             ''' </summary>
-            Public ReadOnly Property Resources() As Resource()
+            Public ReadOnly Property Resources As Resource()
                 Get
                     Return _resources
                 End Get
@@ -4681,7 +4681,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' The error glyph used in a large thumbnail
             ''' </summary>
-            Public ReadOnly Property ErrorGlyphLarge() As Image
+            Public ReadOnly Property ErrorGlyphLarge As Image
                 Get
                     Return _errorGlyphLarge
                 End Get
@@ -4690,7 +4690,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' The error glyph used in a small thumbnail (details or list view)
             ''' </summary>
-            Public ReadOnly Property ErrorGlyphSmall() As Image
+            Public ReadOnly Property ErrorGlyphSmall As Image
                 Get
                     Return _errorGlyphSmall
                 End Get
@@ -4699,7 +4699,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' The error glyph used next to a thumbnail as a state image
             ''' </summary>
-            Public ReadOnly Property ErrorGlyphState() As Image
+            Public ReadOnly Property ErrorGlyphState As Image
                 Get
                     Return _errorGlyphState
                 End Get
@@ -4708,7 +4708,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' The arrow glyph used in the ListView to show that it is column being sorted
             ''' </summary>
-            Public ReadOnly Property SortUpGlyph() As Image
+            Public ReadOnly Property SortUpGlyph As Image
                 Get
                     Return _sortUpGlyph
                 End Get
@@ -4717,7 +4717,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' The arrow glyph used in the ListView to show that it is column being sorted
             ''' </summary>
-            Public ReadOnly Property SortDownGlyph() As Image
+            Public ReadOnly Property SortDownGlyph As Image
                 Get
                     Return _sortDownGlyph
                 End Get
@@ -4729,7 +4729,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves the set of internal resources that we cache for this instance of the resource editor
         ''' </summary>
-        Public ReadOnly Property CachedResources() As CachedResourcesForView
+        Public ReadOnly Property CachedResources As CachedResourcesForView
             Get
                 Return _cachedResources
             End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView_EditorState.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView_EditorState.vb
@@ -54,7 +54,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Returns whether or not state has actually been persisted into this object.
             ''' </summary>
-            Public ReadOnly Property StatePersisted() As Boolean
+            Public ReadOnly Property StatePersisted As Boolean
                 Get
                     Return _statePersisted
                 End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
@@ -210,7 +210,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' The service provider provided by the designer host
         ''' </summary>
-        Public ReadOnly Property ServiceProvider() As IServiceProvider
+        Public ReadOnly Property ServiceProvider As IServiceProvider
             Get
                 Return _serviceProvider
             End Get
@@ -222,11 +222,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   change events, set this property to Nothing.  It does not need to be set up initially - it gets it
         '''   automatically from the service provider passed in.
         ''' </summary>
-        Public Property ComponentChangeService() As IComponentChangeService
+        Public Property ComponentChangeService As IComponentChangeService
             Get
                 Return _componentChangeService
             End Get
-            Set(Value As IComponentChangeService)
+            Set
                 _componentChangeService = Value
             End Set
         End Property
@@ -236,7 +236,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets the ResourceEditorView associated with this ResourceFile.
         ''' </summary>
         ''' <remarks>Overridable for unit testing.</remarks>
-        Public Overridable ReadOnly Property View() As ResourceEditorView
+        Public Overridable ReadOnly Property View As ResourceEditorView
             Get
                 Return RootComponent.RootDesigner.GetView()
             End Get
@@ -246,7 +246,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the root component associated with this resource file.
         ''' </summary>
-        Public ReadOnly Property RootComponent() As ResourceEditorRootComponent
+        Public ReadOnly Property RootComponent As ResourceEditorRootComponent
             Get
                 Return _rootComponent
             End Get
@@ -256,7 +256,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Retrieves the designer host for the resource editor
         ''' </summary>
-        Private ReadOnly Property DesignerHost() As IDesignerHost
+        Private ReadOnly Property DesignerHost As IDesignerHost
             Get
                 If RootComponent.RootDesigner Is Nothing Then
                     Debug.Fail("No root designer")
@@ -273,7 +273,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns the resources from this resource file
         ''' </summary>
-        Friend ReadOnly Property Resources() As Dictionary(Of String, Resource)
+        Friend ReadOnly Property Resources As Dictionary(Of String, Resource)
             Get
                 Return _resources
             End Get
@@ -284,7 +284,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' The base path to use for resolving relative paths in the resx file.  This should be the
         '''   directory where the resx file lives.
         ''' </summary>
-        Public ReadOnly Property BasePath() As String
+        Public ReadOnly Property BasePath As String
             Get
                 Return _basePath
             End Get
@@ -295,7 +295,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Get the taskProvider
         '''   directory where the resx file lives.
         ''' </summary>
-        Private ReadOnly Property ErrorListProvider() As ErrorListProvider
+        Private ReadOnly Property ErrorListProvider As ErrorListProvider
             Get
                 If _errorListProvider Is Nothing Then
                     If RootComponent.RootDesigner IsNot Nothing Then
@@ -310,7 +310,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         '''  Whether the resource item belongs to a device project
         ''' </summary>
-        Public ReadOnly Property IsInsideDeviceProject() As Boolean Implements ResourceTypeEditor.IResourceContentFile.IsInsideDeviceProject
+        Public ReadOnly Property IsInsideDeviceProject As Boolean Implements ResourceTypeEditor.IResourceContentFile.IsInsideDeviceProject
             Get
                 Return RootComponent IsNot Nothing AndAlso RootComponent.IsInsideDeviceProject()
             End Get
@@ -1096,7 +1096,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Gets the array (indexed by ResourceTaskType) of tasks in this set
             ''' </summary>
-            Public ReadOnly Property Tasks() As ResourceTask()
+            Public ReadOnly Property Tasks As ResourceTask()
                 Get
                     Return _tasks
                 End Get
@@ -1133,7 +1133,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' The resource associated with this task list entry.
             ''' </summary>
-            Public ReadOnly Property Resource() As Resource
+            Public ReadOnly Property Resource As Resource
                 Get
                     Return _resource
                 End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
@@ -226,7 +226,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' The current view of the listview (in ResourceView terms - shadows the
         '''   base ListView's View property)
         ''' </summary>
-        Public Shadows Property View() As ResourceView
+        Public Shadows Property View As ResourceView
             Get
                 Select Case MyBase.View
                     Case Windows.Forms.View.Details
@@ -239,7 +239,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         Debug.Fail("MyBase.View should not have been any other value")
                 End Select
             End Get
-            Set(Value As ResourceView)
+            Set
                 Select Case Value
                     Case ResourceView.Details
                         InitializeColumns()
@@ -259,11 +259,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' If this is turned on, attempted retrieval of listview items will simply return
         '''   a blank entry.  This is useful when the resource editor is being disposed of.
         ''' </summary>
-        Public Property DisableItemRetrieval() As Boolean
+        Public Property DisableItemRetrieval As Boolean
             Get
                 Return _disableItemRetrieval
             End Get
-            Set(Value As Boolean)
+            Set
                 _disableItemRetrieval = Value
             End Set
         End Property
@@ -271,7 +271,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the Parent of this ResourceListView control, which must be an instance of ResourceEditorView.
         ''' </summary>
-        Private ReadOnly Property ParentView() As ResourceEditorView
+        Private ReadOnly Property ParentView As ResourceEditorView
             Get
                 If TypeOf Parent Is ResourceEditorView Then
                     Return DirectCast(Parent, ResourceEditorView)
@@ -287,7 +287,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets the ResourceFile that was used to populate this listview.
         ''' </summary>
         ''' <remarks>Can be called only after population</remarks>
-        Private ReadOnly Property ResourceFile() As ResourceFile
+        Private ReadOnly Property ResourceFile As ResourceFile
             Get
                 Debug.Assert(_resourceFile IsNot Nothing, "Has Populate not yet been called?  m_ResourceFile is nothing")
                 Return _resourceFile
@@ -1417,11 +1417,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' which column is used to sort the list 
             ''' </summary>
-            Friend Property ColumnIndex() As Integer
+            Friend Property ColumnIndex As Integer
                 Get
                     Return _columnIndex
                 End Get
-                Set(value As Integer)
+                Set
                     _columnIndex = value
                 End Set
             End Property
@@ -1429,11 +1429,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' whether it is in reverseOrder
             ''' </summary>
-            Friend Property InReverseOrder() As Boolean
+            Friend Property InReverseOrder As Boolean
                 Get
                     Return _reverseOrder
                 End Get
-                Set(value As Boolean)
+                Set
                     _reverseOrder = value
                 End Set
             End Property

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcePropertyDescriptor.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcePropertyDescriptor.vb
@@ -80,7 +80,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Returns the type of the instance this property is bound to, which is Resource.
         ''' </summary>
         ''' <value>The Resource type.</value>
-        Public Overrides ReadOnly Property ComponentType() As Type
+        Public Overrides ReadOnly Property ComponentType As Type
             Get
                 Return GetType(Resource)
             End Get
@@ -91,7 +91,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Returns a value indicating whether this property is read-only.
         ''' </summary>
         ''' <value>True if the property is read-only, False otherwise.</value>
-        Public Overrides ReadOnly Property IsReadOnly() As Boolean
+        Public Overrides ReadOnly Property IsReadOnly As Boolean
             Get
                 Return _isReadOnly
             End Get
@@ -102,7 +102,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  Returns the type of the property.
         ''' </summary>
         ''' <value>A Type that represents the type of the property.</value>
-        Public Overrides ReadOnly Property PropertyType() As Type
+        Public Overrides ReadOnly Property PropertyType As Type
             Get
                 Return _propertyType
             End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService_Store.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService_Store.vb
@@ -57,7 +57,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   instances that no longer exist, or of re-applying old property values to
         '''   an existing Resource instance.
         ''' </summary>
-        <Serializable()>
+        <Serializable>
         Private NotInheritable Class ResourceSerializationStore
             Inherits Design.Serialization.SerializationStore
             Implements ISerializable
@@ -79,7 +79,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             ' default impl of abstract base member.  see serialization store for details.
             '	
-            Public Overrides ReadOnly Property Errors() As ICollection
+            Public Overrides ReadOnly Property Errors As ICollection
                 Get
                     Return Array.Empty(Of Object)
                 End Get
@@ -446,7 +446,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' <summary>
                 ''' The Resource from which we want to serialize stuff.
                 ''' </summary>
-                Public ReadOnly Property Resource() As Resource
+                Public ReadOnly Property Resource As Resource
                     Get
                         Return _resource
                     End Get
@@ -457,11 +457,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' If True, the entire Resource instance should be serialized.  If false,
                 '''   then only the properties in PropertiesToSerialize should be serialized.
                 ''' </summary>
-                Public Property EntireObject() As Boolean
+                Public Property EntireObject As Boolean
                     Get
                         Return _entireObject
                     End Get
-                    Set(Value As Boolean)
+                    Set
                         If Value AndAlso _propertiesToSerialize IsNot Nothing Then
                             _propertiesToSerialize.Clear()
                         End If
@@ -474,7 +474,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' A list of PropertyDescriptors representing the properties on
                 '''   the Resource which should be serialized.
                 ''' </summary>
-                Public ReadOnly Property PropertiesToSerialize() As IList
+                Public ReadOnly Property PropertiesToSerialize As IList
                     Get
                         If _propertiesToSerialize Is Nothing Then
                             _propertiesToSerialize = New ArrayList
@@ -510,7 +510,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Stores a single binary serialized Resource instance or Resource property value
             ''' </summary>
-            <Serializable()>
+            <Serializable>
             Private NotInheritable Class SerializedResourceOrProperty
 
                 'The name of the resource from which this was serialized.
@@ -572,7 +572,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' <summary>
                 ''' Gets the name of the resource from which this was serialized.
                 ''' </summary>
-                Public ReadOnly Property ResourceName() As String
+                Public ReadOnly Property ResourceName As String
                     Get
                         Return _resourceName
                     End Get
@@ -583,7 +583,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' Gets the name of the property which was serialized (or Nothing if
                 '''   not a property serialization).
                 ''' </summary>
-                Public ReadOnly Property PropertyName() As String
+                Public ReadOnly Property PropertyName As String
                     Get
                         Return _propertyName
                     End Get
@@ -594,7 +594,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' The name of the value type for this resource (needed to create a
                 '''   new resource if necessary)
                 ''' </summary>
-                Public ReadOnly Property ResourceValueTypeName() As String
+                Public ReadOnly Property ResourceValueTypeName As String
                     Get
                         Return _resourceValueTypeName
                     End Get
@@ -605,7 +605,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' Returns True iff an entire Resource object has been serialized, as opposed
                 '''   to just a property from it.
                 ''' </summary>
-                Public ReadOnly Property IsEntireResourceObject() As Boolean
+                Public ReadOnly Property IsEntireResourceObject As Boolean
                     Get
                         Return (PropertyName = "")
                     End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
@@ -103,7 +103,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         '''  Return true if the user selected whole lines in the DataGridView...
         ''' </summary>
-        Friend ReadOnly Property InLineSelectionMode() As Boolean
+        Friend ReadOnly Property InLineSelectionMode As Boolean
             Get
                 If MyBase.SelectionMode = DataGridViewSelectionMode.FullRowSelect Then
                     Return True
@@ -143,12 +143,12 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Indicates whether or not the "Type" column is visible to the user.  This
         '''   column is always present, but its visibility can be turned on/off.
         ''' </summary>
-        Public Property TypeColumnVisible() As Boolean
+        Public Property TypeColumnVisible As Boolean
             Get
                 Debug.Assert(ColumnCount >= COLUMN_TYPE, "Columns not set up properly?")
                 Return Columns(COLUMN_TYPE).Visible
             End Get
-            Set(Value As Boolean)
+            Set
                 Debug.Assert(ColumnCount >= COLUMN_TYPE, "Columns not set up properly?")
                 Debug.Assert(RowCountVirtual = 0, "Shouldn't be changing TypeColumnVisible after it's already been populated with data")
                 Columns(COLUMN_TYPE).Visible = Value
@@ -160,7 +160,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Return the ResourceEditorView which is the parent of this
         '''   control.
         ''' </summary>
-        Private ReadOnly Property ParentView() As ResourceEditorView
+        Private ReadOnly Property ParentView As ResourceEditorView
             Get
                 If TypeOf Parent Is ResourceEditorView Then
                     Return DirectCast(Parent, ResourceEditorView)
@@ -176,7 +176,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets the ResourceFile that was used to populate this grid.
         ''' </summary>
         ''' <remarks>Can be called only after population</remarks>
-        Private ReadOnly Property ResourceFile() As ResourceFile
+        Private ReadOnly Property ResourceFile As ResourceFile
             Get
                 Debug.Assert(_resourceFile IsNot Nothing, "Has Populate not yet been called?  m_ResourceFile is nothing")
                 Return _resourceFile
@@ -830,7 +830,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the number of Resource rows in this grid.  Does not include the "addnew" row at the bottom.
         ''' </summary>
-        Public ReadOnly Property RowCountVirtual() As Integer
+        Public ReadOnly Property RowCountVirtual As Integer
             Get
                 Return _virtualResourceList.Count
             End Get
@@ -845,7 +845,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <remarks>Marked invisible so it's less likely to be accidentally used.</remarks>
         <System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>
-        Public Shadows ReadOnly Property RowCount() As Integer
+        Public Shadows ReadOnly Property RowCount As Integer
             Get
                 Debug.Fail("Don't use this function - use RowCountVirtual instead - it doesn't include the add/new row at the bottom, just the actual entries")
                 Return RowCountVirtual 'defensive
@@ -1554,11 +1554,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' which column is used to sort the list 
             ''' </summary>
-            Friend Property ColumnIndex() As Integer
+            Friend Property ColumnIndex As Integer
                 Get
                     Return _columnIndex
                 End Get
-                Set(value As Integer)
+                Set
                     _columnIndex = value
                 End Set
             End Property
@@ -1566,11 +1566,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' whether it is in reverseOrder
             ''' </summary>
-            Friend Property InReverseOrder() As Boolean
+            Friend Property InReverseOrder As Boolean
                 Get
                     Return _reverseOrder
                 End Get
-                Set(value As Boolean)
+                Set
                     _reverseOrder = value
                 End Set
             End Property
@@ -1717,7 +1717,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '''  We override it to replace the default DataGridViewTextBoxEditingControl with ResourceStringTextBoxEditingControl
             '''  so we can handle some events to handle CheckOut correctly...
             ''' </summary>
-            Public Overrides ReadOnly Property EditType() As Type
+            Public Overrides ReadOnly Property EditType As Type
                 Get
                     Return GetType(ResourceStringTextBoxEditingControl)
                 End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditor.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditor.vb
@@ -123,12 +123,12 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Returns whether or not the resource is a link to a file (True) or a non-linked value (False).
             ''' </summary>
-            ReadOnly Property IsLink() As Boolean
+            ReadOnly Property IsLink As Boolean
 
             ''' <summary>
             ''' If IsLinked = True, returns the absolute path and filename to the linked file.  Otherwise, returns Nothing.
             ''' </summary>
-            ReadOnly Property LinkedFilePath() As String
+            ReadOnly Property LinkedFilePath As String
 
         End Interface
 
@@ -141,7 +141,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <summary>
             ''' Returns whether the resource file is inside a device project
             ''' </summary>
-            ReadOnly Property IsInsideDeviceProject() As Boolean
+            ReadOnly Property IsInsideDeviceProject As Boolean
 
             ''' <summary>
             ''' Returns whether the provided type is supported in the project containing this resource file
@@ -198,7 +198,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <value>True if this resources handled by this ResourceTypeEditor should be displayed
         '''   in a string table, and False if they should be displayed in a listview.</value>
-        Public Overridable ReadOnly Property DisplayInStringTable() As Boolean
+        Public Overridable ReadOnly Property DisplayInStringTable As Boolean
             Get
                 Return False
             End Get
@@ -212,7 +212,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks>
         '''   If true, the GetImageForThumbnail property must return a same image object. We won't keep duplicated items in the cache to improve the performance of the designer.
         ''' </remarks>
-        Public Overridable ReadOnly Property IsImageForThumbnailShared() As Boolean
+        Public Overridable ReadOnly Property IsImageForThumbnailShared As Boolean
             Get
                 Return False
             End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorAudio.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorAudio.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks>
         '''   If true, the GetImageForThumbnail property must return a same image object. We won't keep duplicated items in the cache to improve the performance of the designer.
         ''' </remarks>
-        Public Overrides ReadOnly Property IsImageForThumbnailShared() As Boolean
+        Public Overrides ReadOnly Property IsImageForThumbnailShared As Boolean
             Get
                 Return True
             End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorBinaryFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorBinaryFile.vb
@@ -35,7 +35,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks>
         '''   If true, the GetImageForThumbnail property must return a same image object. We won't keep duplicated items in the cache to improve the performance of the designer.
         ''' </remarks>
-        Public Overrides ReadOnly Property IsImageForThumbnailShared() As Boolean
+        Public Overrides ReadOnly Property IsImageForThumbnailShared As Boolean
             Get
                 Return True
             End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorNonStringConvertible.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorNonStringConvertible.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <value>True if this resources handled by this ResourceTypeEditor should be displayed
         '''   in a string table, and False if they should be displayed in a listview.</value>
-        Public Overrides ReadOnly Property StringValueCanBeEdited() As Boolean
+        Public Overrides ReadOnly Property StringValueCanBeEdited As Boolean
             Get
                 'We don't understand this resource value, so we don't know how to let the user edit it.
                 Return False

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorNothing.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorNothing.vb
@@ -31,7 +31,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <value>True if this resources handled by this ResourceTypeEditor should be displayed
         '''   in a string table, and False if they should be displayed in a listview.</value>
-        Public Overrides ReadOnly Property StringValueCanBeEdited() As Boolean
+        Public Overrides ReadOnly Property StringValueCanBeEdited As Boolean
             Get
                 'Can't change a Nothing/null value to anything else.
                 Return False

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorString.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorString.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets whether or not the strings handled by this resource type editor
         '''   are allowed to be edited by the user.
         ''' </summary>
-        Public Overrides ReadOnly Property StringValueCanBeEdited() As Boolean
+        Public Overrides ReadOnly Property StringValueCanBeEdited As Boolean
             Get
                 Return True
             End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorStringBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorStringBase.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <value>True if this resources handled by this ResourceTypeEditor should be displayed
         '''   in a string table, and False if they should be displayed in a listview.</value>
-        Public NotOverridable Overrides ReadOnly Property DisplayInStringTable() As Boolean
+        Public NotOverridable Overrides ReadOnly Property DisplayInStringTable As Boolean
             Get
                 Return True
             End Get
@@ -37,7 +37,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets whether or not the strings handled by this resource type editor
         '''   are allowed to be edited by the user.
         ''' </summary>
-        Public MustOverride ReadOnly Property StringValueCanBeEdited() As Boolean
+        Public MustOverride ReadOnly Property StringValueCanBeEdited As Boolean
 
 
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorStringConvertible.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorStringConvertible.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Gets whether or not the strings handled by this resource type editor
         '''   are allowed to be edited by the user.
         ''' </summary>
-        Public Overrides ReadOnly Property StringValueCanBeEdited() As Boolean
+        Public Overrides ReadOnly Property StringValueCanBeEdited As Boolean
             Get
                 Return True
             End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorTextFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorTextFile.vb
@@ -161,7 +161,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks>
         '''   If true, the GetImageForThumbnail property must return a same image object. We won't keep duplicated items in the cache to improve the performance of the designer.
         ''' </remarks>
-        Public Overrides ReadOnly Property IsImageForThumbnailShared() As Boolean
+        Public Overrides ReadOnly Property IsImageForThumbnailShared As Boolean
             Get
                 Return True
             End Get

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/SerializableEncoding.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/SerializableEncoding.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     '''   property on Resource for text files.  The Undo engine requires all the properties to be serializable, and 
     '''   System.Text.Encoding is not.
     ''' </summary>
-    <Serializable()>
+    <Serializable>
     Friend NotInheritable Class SerializableEncoding
         Implements ISerializable
 
@@ -51,11 +51,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Returns/sets the encoding wrapped by this class.  Nothing is an okay value (indicates a default encoding).
         ''' </summary>
-        Public Property Encoding() As Encoding
+        Public Property Encoding As Encoding
             Get
                 Return _encoding
             End Get
-            Set(Value As Encoding)
+            Set
                 _encoding = Encoding
             End Set
         End Property

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ThumbnailCache.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ThumbnailCache.vb
@@ -98,11 +98,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   but is less than this value, out of memory exceptions will be thrown.
         ''' </summary>
         ''' <remarks>Does not change the number of images in the cache, only affects future behavior.</remarks>
-        Public Property MinimumSizeBeforeRecycling() As Integer
+        Public Property MinimumSizeBeforeRecycling As Integer
             Get
                 Return _minimumSizeBeforeRecycling
             End Get
-            Set(Value As Integer)
+            Set
                 If Value > 0 Then
                     _minimumSizeBeforeRecycling = Value
                 Else
@@ -121,11 +121,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   number of images in the cache (because the caching hints from the ListView are not very accurate, no
         '''   need to get rid of items from the cache that we already had the memory to create).
         ''' </remarks>
-        Public Property MaximumSuggestedCacheSize() As Integer
+        Public Property MaximumSuggestedCacheSize As Integer
             Get
                 Return _maximumSuggestedCacheSize
             End Get
-            Set(Value As Integer)
+            Set
                 Debug.Assert(Value > 0)
                 _maximumSuggestedCacheSize = Value
             End Set
@@ -135,7 +135,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' Gets the number of thumbnails currently in the cache (not including the number of reserved images)
         ''' </summary>
-        Public ReadOnly Property ThumbnailCount() As Integer
+        Public ReadOnly Property ThumbnailCount As Integer
             Get
                 Debug.Assert(_imageList.Images.Count - _reservedImagesCount >= 0)
                 Return _imageList.Images.Count - _reservedImagesCount
@@ -147,7 +147,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Retrieves the actual, effective maximum size to which the cache can grow.  This is equal to 
         '''   the largest of the MaximumSuggestedCacheSize and MinimumSizeBeforeRecycling properties.
         ''' </summary>
-        Private ReadOnly Property EffectiveMaximumSuggestedCacheSize() As Integer
+        Private ReadOnly Property EffectiveMaximumSuggestedCacheSize As Integer
             Get
                 Return Math.Max(_minimumSizeBeforeRecycling, _maximumSuggestedCacheSize)
             End Get

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/AppConfigSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/AppConfigSerializer.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Indicate what changes were performed during deserialization
         ''' </summary>
-        <Flags()>
+        <Flags>
         Friend Enum DirtyState
             NoChange = 0            ' No changes made
             ValueAdded = 1          ' At least one value was modified

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorCell.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorCell.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Return the custom editing control used by this type
         ''' </summary>
-        Public Overrides ReadOnly Property EditType() As Type
+        Public Overrides ReadOnly Property EditType As Type
             Get
                 Return GetType(DataGridViewUITypeEditorEditingControl)
             End Get
@@ -54,7 +54,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Type of formatted value
         ''' </summary>
-        Public Overrides ReadOnly Property FormattedValueType() As Type
+        Public Overrides ReadOnly Property FormattedValueType As Type
             Get
                 Return GetType(String)
             End Get
@@ -267,17 +267,17 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
 #End Region
 
-        Friend Property ServiceProvider() As IServiceProvider
+        Friend Property ServiceProvider As IServiceProvider
             Get
                 Return _serviceProvider
             End Get
-            Set(Value As IServiceProvider)
+            Set
                 _serviceProvider = Value
             End Set
         End Property
 
 
-        Private ReadOnly Property UITypeEditor() As UITypeEditor
+        Private ReadOnly Property UITypeEditor As UITypeEditor
             Get
                 If ValueType IsNot Nothing Then
                     Return DirectCast(TypeDescriptor.GetEditor(ValueType, GetType(UITypeEditor)), UITypeEditor)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorEditingControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorEditingControl.vb
@@ -77,11 +77,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Set the datagridview instance I'm showing in
         ''' </summary>
-        Public Property DataGridView() As DataGridView Implements IDataGridViewEditingControl.EditingControlDataGridView
+        Public Property DataGridView As DataGridView Implements IDataGridViewEditingControl.EditingControlDataGridView
             Get
                 Return _dataGridView
             End Get
-            Set(Value As DataGridView)
+            Set
                 DisconnectDataGridViewEventHandlers()
                 _dataGridView = Value
                 ConnectDataGridViewEventHandlers()
@@ -92,17 +92,17 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Set the formatted representation of my current value
         ''' </summary>
         ''' <remarks>Will set my value to the deserialized value - nothing if deserialization fails</remarks>
-        Public Property FormattedValue() As Object Implements IDataGridViewEditingControl.EditingControlFormattedValue
+        Public Property FormattedValue As Object Implements IDataGridViewEditingControl.EditingControlFormattedValue
             Get
                 Return GetFormattedValue(DataGridViewDataErrorContexts.Formatting)
             End Get
-            Set(Value As Object)
+            Set
                 Debug.Assert(TypeOf Value Is String, String.Format("Why did someone try to set my formatted value to an object of type {0}? Expected type string!", Value.GetType().ToString()))
                 Text = DirectCast(Value, String)
             End Set
         End Property
 
-        Public ReadOnly Property IDataGridViewEditingPanel_Cursor() As Cursor Implements IDataGridViewEditingControl.EditingPanelCursor
+        Public ReadOnly Property IDataGridViewEditingPanel_Cursor As Cursor Implements IDataGridViewEditingControl.EditingPanelCursor
             Get
                 If _dataGridView IsNot Nothing Then
                     Return _dataGridView.Cursor
@@ -125,17 +125,17 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             End If
         End Function
 
-        Public ReadOnly Property RepositionOnValueChange() As Boolean Implements IDataGridViewEditingControl.RepositionEditingControlOnValueChange
+        Public ReadOnly Property RepositionOnValueChange As Boolean Implements IDataGridViewEditingControl.RepositionEditingControlOnValueChange
             Get
                 Return False
             End Get
         End Property
 
-        Public Property RowIndex() As Integer Implements IDataGridViewEditingControl.EditingControlRowIndex
+        Public Property RowIndex As Integer Implements IDataGridViewEditingControl.EditingControlRowIndex
             Get
                 Return _rowIndex
             End Get
-            Set(Value As Integer)
+            Set
                 _rowIndex = Value
             End Set
         End Property
@@ -220,11 +220,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ForeColor = dataGridViewCellStyle.ForeColor
         End Sub
 
-        Public Property ValueChanged() As Boolean Implements IDataGridViewEditingControl.EditingControlValueChanged
+        Public Property ValueChanged As Boolean Implements IDataGridViewEditingControl.EditingControlValueChanged
             Get
                 Return _valueChanged
             End Get
-            Set(Value As Boolean)
+            Set
                 _valueChanged = Value
                 If _dataGridView.CurrentCellAddress.X = -1 OrElse _dataGridView.CurrentCellAddress.Y = -1 Then
                     Debug.Assert(_dataGridView.IsCurrentCellInEditMode, "Why did the value change when we aren't in edit mode!?")
@@ -241,11 +241,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
 #Region "Service provider stuff"
         Private _serviceProvider As IServiceProvider
-        Friend Property ServiceProvider() As IServiceProvider
+        Friend Property ServiceProvider As IServiceProvider
             Get
                 Return _serviceProvider
             End Get
-            Set(Value As IServiceProvider)
+            Set
                 _serviceProvider = Value
             End Set
         End Property
@@ -302,7 +302,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' ITypeDescriptorContext to pass into UITypeEditors providing services and access to the current instance
         ''' </summary>
-        Public Overrides ReadOnly Property Context() As System.ComponentModel.ITypeDescriptorContext
+        Public Overrides ReadOnly Property Context As System.ComponentModel.ITypeDescriptorContext
             Get
                 Return New EditContext(TryCast(DataGridView.CurrentRow.Tag, DesignTimeSettingInstance))
             End Get
@@ -323,7 +323,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' <summary>
             ''' The container (site) that the current instance is hosted in
             ''' </summary>
-            Public ReadOnly Property Container() As System.ComponentModel.IContainer Implements System.ComponentModel.ITypeDescriptorContext.Container
+            Public ReadOnly Property Container As System.ComponentModel.IContainer Implements System.ComponentModel.ITypeDescriptorContext.Container
                 Get
                     If _instance IsNot Nothing AndAlso _instance.Site IsNot Nothing Then
                         Return _instance.Site.Container
@@ -336,7 +336,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' <summary>
             ''' The instance this value is associated with
             ''' </summary>
-            Public ReadOnly Property Instance() As Object Implements System.ComponentModel.ITypeDescriptorContext.Instance
+            Public ReadOnly Property Instance As Object Implements System.ComponentModel.ITypeDescriptorContext.Instance
                 Get
                     Return _instance
                 End Get
@@ -359,7 +359,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' <summary>
             ''' Get the associated instance's value property descriptor
             ''' </summary>
-            Public ReadOnly Property PropertyDescriptor() As System.ComponentModel.PropertyDescriptor Implements System.ComponentModel.ITypeDescriptorContext.PropertyDescriptor
+            Public ReadOnly Property PropertyDescriptor As System.ComponentModel.PropertyDescriptor Implements System.ComponentModel.ITypeDescriptorContext.PropertyDescriptor
                 Get
                     Return System.ComponentModel.TypeDescriptor.GetProperties(GetType(DesignTimeSettingInstance)).Item("Value")
                 End Get

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettingInstance.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettingInstance.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' A DesignTimeSettingInstance wraps a single setting. Each setting will generate 
     ''' a property with the appropriate attributes in the generated file.
     ''' </summary>
-    <Serializable()>
+    <Serializable>
     Friend Class DesignTimeSettingInstance
         Inherits Component
         Implements ICustomTypeDescriptor, System.Runtime.Serialization.ISerializable
@@ -172,13 +172,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 _owner = owner
             End Sub
 
-            Public ReadOnly Property Owner() As DesignTimeSettingInstance
+            Public ReadOnly Property Owner As DesignTimeSettingInstance
                 Get
                     Return _owner
                 End Get
             End Property
 
-            Public Overrides ReadOnly Property ComponentType() As Type
+            Public Overrides ReadOnly Property ComponentType As Type
                 Get
                     Return GetType(DesignTimeSettingInstance)
                 End Get
@@ -211,7 +211,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' Override to set the description (shown in the properties window) for this
             ''' property
             ''' </summary>
-            Protected MustOverride ReadOnly Property DescriptionAttributeText() As String
+            Protected MustOverride ReadOnly Property DescriptionAttributeText As String
 
             ''' <summary>
             ''' Override to get the value for the current component in a type-safe way
@@ -287,7 +287,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' <summary>
             ''' Override to provide the description showing up in the undo menu
             ''' </summary>
-            Protected MustOverride ReadOnly Property UndoDescription() As String
+            Protected MustOverride ReadOnly Property UndoDescription As String
 
             ''' <summary>
             ''' Override for the actual set of the value
@@ -313,13 +313,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Return component.GenerateDefaultValueInCode
             End Function
 
-            Public Overrides ReadOnly Property IsReadOnly() As Boolean
+            Public Overrides ReadOnly Property IsReadOnly As Boolean
                 Get
                     Return False
                 End Get
             End Property
 
-            Public Overrides ReadOnly Property PropertyType() As Type
+            Public Overrides ReadOnly Property PropertyType As Type
                 Get
                     Return GetType(Boolean)
                 End Get
@@ -329,13 +329,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 component.SetGenerateDefaultValueInCode(CBool(value))
             End Sub
 
-            Protected Overrides ReadOnly Property UndoDescription() As String
+            Protected Overrides ReadOnly Property UndoDescription As String
                 Get
                     Return My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_UndoTran_GenerateDefaultValueInCode
                 End Get
             End Property
 
-            Protected Overrides ReadOnly Property DescriptionAttributeText() As String
+            Protected Overrides ReadOnly Property DescriptionAttributeText As String
                 Get
                     Return My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_DESCR_GenerateDefaultValueInCode
                 End Get
@@ -357,13 +357,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Return component.Name
             End Function
 
-            Public Overrides ReadOnly Property IsReadOnly() As Boolean
+            Public Overrides ReadOnly Property IsReadOnly As Boolean
                 Get
                     Return IsNameReadOnly(Owner)
                 End Get
             End Property
 
-            Public Overrides ReadOnly Property PropertyType() As Type
+            Public Overrides ReadOnly Property PropertyType As Type
                 Get
                     Return GetType(String)
                 End Get
@@ -373,13 +373,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 component.SetName(DirectCast(value, String))
             End Sub
 
-            Protected Overrides ReadOnly Property UndoDescription() As String
+            Protected Overrides ReadOnly Property UndoDescription As String
                 Get
                     Return My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_UndoTran_NameChanged
                 End Get
             End Property
 
-            Protected Overrides ReadOnly Property DescriptionAttributeText() As String
+            Protected Overrides ReadOnly Property DescriptionAttributeText As String
                 Get
                     Return My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_DESCR_Name
                 End Get
@@ -397,13 +397,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Return component.Roaming
             End Function
 
-            Public Overrides ReadOnly Property IsReadOnly() As Boolean
+            Public Overrides ReadOnly Property IsReadOnly As Boolean
                 Get
                     Return IsRoamingReadOnly(Owner)
                 End Get
             End Property
 
-            Public Overrides ReadOnly Property PropertyType() As Type
+            Public Overrides ReadOnly Property PropertyType As Type
                 Get
                     Return GetType(Boolean)
                 End Get
@@ -413,13 +413,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 component.SetRoaming(CBool(value))
             End Sub
 
-            Protected Overrides ReadOnly Property UndoDescription() As String
+            Protected Overrides ReadOnly Property UndoDescription As String
                 Get
                     Return My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_UndoTran_RoamingChanged
                 End Get
             End Property
 
-            Protected Overrides ReadOnly Property DescriptionAttributeText() As String
+            Protected Overrides ReadOnly Property DescriptionAttributeText As String
                 Get
                     Return My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_DESCR_Roaming
                 End Get
@@ -437,13 +437,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Return component.Description
             End Function
 
-            Public Overrides ReadOnly Property IsReadOnly() As Boolean
+            Public Overrides ReadOnly Property IsReadOnly As Boolean
                 Get
                     Return False
                 End Get
             End Property
 
-            Public Overrides ReadOnly Property PropertyType() As Type
+            Public Overrides ReadOnly Property PropertyType As Type
                 Get
                     Return GetType(String)
                 End Get
@@ -453,13 +453,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 component.SetDescription(DirectCast(value, String))
             End Sub
 
-            Protected Overrides ReadOnly Property UndoDescription() As String
+            Protected Overrides ReadOnly Property UndoDescription As String
                 Get
                     Return My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_UndoTran_DescriptionChanged
                 End Get
             End Property
 
-            Protected Overrides ReadOnly Property DescriptionAttributeText() As String
+            Protected Overrides ReadOnly Property DescriptionAttributeText As String
                 Get
                     Return My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_DESCR_Description
                 End Get
@@ -477,13 +477,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Return component.Provider
             End Function
 
-            Public Overrides ReadOnly Property IsReadOnly() As Boolean
+            Public Overrides ReadOnly Property IsReadOnly As Boolean
                 Get
                     Return False
                 End Get
             End Property
 
-            Public Overrides ReadOnly Property PropertyType() As Type
+            Public Overrides ReadOnly Property PropertyType As Type
                 Get
                     Return GetType(String)
                 End Get
@@ -493,13 +493,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 component.SetProvider(DirectCast(value, String))
             End Sub
 
-            Protected Overrides ReadOnly Property UndoDescription() As String
+            Protected Overrides ReadOnly Property UndoDescription As String
                 Get
                     Return My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_UndoTran_ProviderChanged
                 End Get
             End Property
 
-            Protected Overrides ReadOnly Property DescriptionAttributeText() As String
+            Protected Overrides ReadOnly Property DescriptionAttributeText As String
                 Get
                     Return My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_DESCR_Provider
                 End Get
@@ -517,14 +517,14 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Return component.Scope
             End Function
 
-            Public Overrides ReadOnly Property IsReadOnly() As Boolean
+            Public Overrides ReadOnly Property IsReadOnly As Boolean
                 Get
                     ' Connection string typed settings are application scoped only...
                     Return IsScopeReadOnly(Owner, ProjectSupportsUserScopedSettings(Owner))
                 End Get
             End Property
 
-            Public Overrides ReadOnly Property PropertyType() As Type
+            Public Overrides ReadOnly Property PropertyType As Type
                 Get
                     Return GetType(SettingScope)
                 End Get
@@ -538,19 +538,19 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 component.SetScope(CType(value, SettingScope))
             End Sub
 
-            Protected Overrides ReadOnly Property UndoDescription() As String
+            Protected Overrides ReadOnly Property UndoDescription As String
                 Get
                     Return My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_UndoTran_ScopeChanged
                 End Get
             End Property
 
-            Protected Overrides ReadOnly Property DescriptionAttributeText() As String
+            Protected Overrides ReadOnly Property DescriptionAttributeText As String
                 Get
                     Return My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_DESCR_Scope
                 End Get
             End Property
 
-            Public Overrides ReadOnly Property Converter() As TypeConverter
+            Public Overrides ReadOnly Property Converter As TypeConverter
                 Get
                     Return New ScopeConverter
                 End Get
@@ -569,14 +569,14 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Return component.SettingTypeName
             End Function
 
-            Public Overrides ReadOnly Property IsReadOnly() As Boolean
+            Public Overrides ReadOnly Property IsReadOnly As Boolean
                 Get
                     ' The type name is always read-only in the property grid...
                     Return True
                 End Get
             End Property
 
-            Public Overrides ReadOnly Property PropertyType() As Type
+            Public Overrides ReadOnly Property PropertyType As Type
                 Get
                     Return GetType(String)
                 End Get
@@ -586,13 +586,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 component.SetSettingTypeName(DirectCast(value, String))
             End Sub
 
-            Protected Overrides ReadOnly Property UndoDescription() As String
+            Protected Overrides ReadOnly Property UndoDescription As String
                 Get
                     Return My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_UndoTran_TypeChanged
                 End Get
             End Property
 
-            Protected Overrides ReadOnly Property DescriptionAttributeText() As String
+            Protected Overrides ReadOnly Property DescriptionAttributeText As String
                 Get
                     Return My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_DESCR_SerializedSettingType
                 End Get
@@ -610,13 +610,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Return component.SerializedValue
             End Function
 
-            Public Overrides ReadOnly Property IsReadOnly() As Boolean
+            Public Overrides ReadOnly Property IsReadOnly As Boolean
                 Get
                     Return False
                 End Get
             End Property
 
-            Public Overrides ReadOnly Property PropertyType() As Type
+            Public Overrides ReadOnly Property PropertyType As Type
                 Get
                     Return GetType(String)
                 End Get
@@ -626,7 +626,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 component.SetSerializedValue(DirectCast(value, String))
             End Sub
 
-            Protected Overrides ReadOnly Property UndoDescription() As String
+            Protected Overrides ReadOnly Property UndoDescription As String
                 Get
                     Return My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_UndoTran_SerializedValueChanged
                 End Get
@@ -637,7 +637,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 attributeList.Add(New BrowsableAttribute(False))
             End Sub
 
-            Protected Overrides ReadOnly Property DescriptionAttributeText() As String
+            Protected Overrides ReadOnly Property DescriptionAttributeText As String
                 Get
                     Return My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_DESCR_Value
                 End Get
@@ -751,13 +751,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The name of a setting
         ''' </summary>
-        Public ReadOnly Property NameProperty() As PropertyDescriptor
+        Public ReadOnly Property NameProperty As PropertyDescriptor
             Get
                 Return _namePropertyDescriptor
             End Get
         End Property
 
-        Public ReadOnly Property Name() As String
+        Public ReadOnly Property Name As String
             Get
                 Return _name
             End Get
@@ -793,13 +793,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The scope for a setting
         ''' </summary>
-        Public ReadOnly Property ScopeProperty() As PropertyDescriptor
+        Public ReadOnly Property ScopeProperty As PropertyDescriptor
             Get
                 Return _scopePropertyDescriptor
             End Get
         End Property
 
-        Public ReadOnly Property Scope() As SettingScope
+        Public ReadOnly Property Scope As SettingScope
             Get
                 Return _settingScope
             End Get
@@ -815,13 +815,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The name of the type for a setting
         ''' </summary>
-        Public ReadOnly Property TypeNameProperty() As PropertyDescriptor
+        Public ReadOnly Property TypeNameProperty As PropertyDescriptor
             Get
                 Return _settingTypeNamePropertyDescriptor
             End Get
         End Property
 
-        Public ReadOnly Property SettingTypeName() As String
+        Public ReadOnly Property SettingTypeName As String
             Get
                 Return _settingTypeName
             End Get
@@ -837,13 +837,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The serialized (string) representation of the value of this setting
         ''' </summary>
-        Public ReadOnly Property SerializedValueProperty() As PropertyDescriptor
+        Public ReadOnly Property SerializedValueProperty As PropertyDescriptor
             Get
                 Return _serializedValuePropertyDescriptor
             End Get
         End Property
 
-        Public ReadOnly Property SerializedValue() As String
+        Public ReadOnly Property SerializedValue As String
             Get
                 Return _serializedValue
             End Get
@@ -860,7 +860,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Flag indicating if this is a roaming setting 
         ''' (value is stored in the roaming user.config by the runtime)
         ''' </summary>
-        Public ReadOnly Property Roaming() As Boolean
+        Public ReadOnly Property Roaming As Boolean
             Get
                 Return _roaming
             End Get
@@ -876,7 +876,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The description for this setting
         ''' </summary>
-        Public ReadOnly Property Description() As String
+        Public ReadOnly Property Description As String
             Get
                 Return _description
             End Get
@@ -892,7 +892,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The settings provider for this setting
         ''' </summary>
-        Public ReadOnly Property Provider() As String
+        Public ReadOnly Property Provider As String
             Get
                 Return _provider
             End Get
@@ -912,7 +912,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Flag indicating if we should generate a defaultsettingsvalue attribute
         ''' on this setting
         ''' </summary>
-        Public ReadOnly Property GenerateDefaultValueInCode() As Boolean
+        Public ReadOnly Property GenerateDefaultValueInCode As Boolean
             Get
                 Return _generateDefaultValueInCode
             End Get

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettings.vb
@@ -37,7 +37,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         End Function
 
         <Browsable(False)>
-        Public ReadOnly Property Count() As Integer
+        Public ReadOnly Property Count As Integer
             Get
                 Return _settings.Count
             End Get
@@ -48,11 +48,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Is the UseMySettingsClassName flag set in the underlying .settings file?
         ''' If so, we may want to special-case the class name...
         ''' </summary>
-        Friend Property UseSpecialClassName() As Boolean
+        Friend Property UseSpecialClassName As Boolean
             Get
                 Return _useSpecialClassName
             End Get
-            Set(value As Boolean)
+            Set
                 _useSpecialClassName = value
             End Set
         End Property
@@ -61,18 +61,18 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' The namespace as persisted in the .settings file
         ''' </summary>
         ''' <remarks>May return NULL if no namespace was persisted!!!</remarks>
-        Friend Property PersistedNamespace() As String
+        Friend Property PersistedNamespace As String
             Get
                 Return _persistedNamespace
             End Get
-            Set(value As String)
+            Set
                 _persistedNamespace = value
             End Set
         End Property
 
 #Region "Valid/unique name handling"
 
-        Private ReadOnly Property CodeProvider() As CodeDom.Compiler.CodeDomProvider
+        Private ReadOnly Property CodeProvider As CodeDom.Compiler.CodeDomProvider
             Get
                 Dim codeProviderInstance As CodeDom.Compiler.CodeDomProvider = Nothing
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/FakeCollectionEditor.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/FakeCollectionEditor.vb
@@ -42,7 +42,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             _parent.PaintValue(e)
         End Sub
 
-        Public Overrides ReadOnly Property IsDropDownResizable() As Boolean
+        Public Overrides ReadOnly Property IsDropDownResizable As Boolean
             Get
                 Return _parent.IsDropDownResizable()
             End Get

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/PublicSettingsSingleFileGenerator.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/PublicSettingsSingleFileGenerator.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Returns the default visibility of this properties
         ''' </summary>
         ''' <value>MemberAttributes indicating what visibility to make the generated properties.</value>
-        Friend Overrides ReadOnly Property SettingsClassVisibility() As TypeAttributes
+        Friend Overrides ReadOnly Property SettingsClassVisibility As TypeAttributes
             Get
                 Return TypeAttributes.Sealed Or TypeAttributes.Public
             End Get

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingTypeNameResolutionService.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingTypeNameResolutionService.vb
@@ -78,7 +78,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Is the current language case sensitive?
         ''' </summary>
-        Public ReadOnly Property IsCaseSensitive() As Boolean
+        Public ReadOnly Property IsCaseSensitive As Boolean
             Get
                 Return _caseSensitive
             End Get
@@ -134,14 +134,14 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         End Function
 
 #Region "Localized name of virtual types"
-        Private Shared ReadOnly Property DisplayTypeNameConnectionString() As String
+        Private Shared ReadOnly Property DisplayTypeNameConnectionString As String
             Get
                 Static VirtualTypeNameConnectionString As String = "(" & My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_ComboBoxItem_ConnectionStringType & ")"
                 Return VirtualTypeNameConnectionString
             End Get
         End Property
 
-        Private Shared ReadOnly Property DisplayTypeNameWebReference() As String
+        Private Shared ReadOnly Property DisplayTypeNameWebReference As String
             Get
                 Static VirtualTypeNameWebReference As String = "(" & My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_ComboBoxItem_WebReferenceType & ")"
                 Return VirtualTypeNameWebReference

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Trace switch used by all SettingsDesigner components - should be moved to the common Switches file
         ''' </summary>
-        Friend Shared ReadOnly Property TraceSwitch() As TraceSwitch
+        Friend Shared ReadOnly Property TraceSwitch As TraceSwitch
             Get
                 Static MyTraceSwitch As New TraceSwitch("SettingsDesigner", "Tracing for settings designer")
                 Return MyTraceSwitch
@@ -37,7 +37,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Demand-crete our designer view 
         ''' </summary>
-        Private ReadOnly Property View() As SettingsDesignerView
+        Private ReadOnly Property View As SettingsDesignerView
             Get
                 If _settingsDesignerViewProperty Is Nothing Then
                     Debug.WriteLineIf(TraceSwitch.TraceVerbose, "Creating SettingsDesignerView")
@@ -51,7 +51,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Have we already created a view?
         ''' </summary>
-        Friend ReadOnly Property HasView() As Boolean
+        Friend ReadOnly Property HasView As Boolean
             Get
                 Return _settingsDesignerViewProperty IsNot Nothing
             End Get
@@ -75,7 +75,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Our supported technologies
         ''' </summary>
-        Public ReadOnly Property SupportedTechnologies() As ViewTechnology() Implements IRootDesigner.SupportedTechnologies
+        Public ReadOnly Property SupportedTechnologies As ViewTechnology() Implements IRootDesigner.SupportedTechnologies
             Get
                 Return New ViewTechnology() {ViewTechnology.Default}
             End Get
@@ -84,7 +84,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get access to all our settings
         ''' </summary>
-        Friend ReadOnly Property Settings() As DesignTimeSettings
+        Friend ReadOnly Property Settings As DesignTimeSettings
             Get
                 Return Component
             End Get
@@ -105,7 +105,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Make component property type safe if we want to access the component through
         ''' a SettingsDesigner instance
         ''' </summary>
-        Public Shadows ReadOnly Property Component() As DesignTimeSettings
+        Public Shadows ReadOnly Property Component As DesignTimeSettings
             Get
                 Return CType(MyBase.Component, DesignTimeSettings)
             End Get

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerEditorFactory.vb
@@ -32,7 +32,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' My commandUI GUID
         ''' </summary>
-        Protected Overrides ReadOnly Property CommandUIGuid() As Guid
+        Protected Overrides ReadOnly Property CommandUIGuid As Guid
             Get
                 Return Constants.MenuConstants.GUID_SETTINGSDESIGNER_CommandUI
             End Get
@@ -41,7 +41,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Return my editor GUID
         ''' </summary>
-        Protected Overrides ReadOnly Property EditorGuid() As Guid
+        Protected Overrides ReadOnly Property EditorGuid As Guid
             Get
                 Return New Guid(EditorGuidString)
             End Get

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerLoader.vb
@@ -229,7 +229,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get access to "our" root component
         ''' </summary>
-        Private ReadOnly Property RootComponent() As DesignTimeSettings
+        Private ReadOnly Property RootComponent As DesignTimeSettings
             Get
                 Try
                     If LoaderHost Is Nothing Then
@@ -245,13 +245,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             End Get
         End Property
 
-        Friend ReadOnly Property GeneratedClassName() As String
+        Friend ReadOnly Property GeneratedClassName As String
             Get
                 Return SettingsDesigner.GeneratedClassName(VsHierarchy, ProjectItemid, RootComponent, DocData.Name)
             End Get
         End Property
 
-        Private ReadOnly Property GeneratedClassNamespace() As String
+        Private ReadOnly Property GeneratedClassNamespace As String
             Get
                 Return ProjectUtils.GeneratedSettingsClassNamespace(VsHierarchy, ProjectItemid)
             End Get
@@ -648,7 +648,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' We sometimes want to check out the project file (to add app.config) and sometimes we only want to 
         ''' check out the app.config file itself...
         ''' </summary>
-        Protected Overrides ReadOnly Property ManagingDynamicSetOfFiles() As Boolean
+        Protected Overrides ReadOnly Property ManagingDynamicSetOfFiles As Boolean
             Get
                 Return True
             End Get
@@ -658,7 +658,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Overridden in order to provide the app.config file name or the project name when as well as the project item
         ''' and dependent file...
         ''' </summary>
-        Friend Overrides ReadOnly Property FilesToCheckOut() As List(Of String)
+        Friend Overrides ReadOnly Property FilesToCheckOut As List(Of String)
             Get
                 Dim result As List(Of String) = MyBase.FilesToCheckOut
                 Dim projectItem As EnvDTE.ProjectItem = DTEUtils.ProjectItemFromItemId(VsHierarchy, ProjectItemid)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -82,11 +82,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
             Private _committingChanges As Boolean
 
-            Friend Property CommittingChanges() As Boolean
+            Friend Property CommittingChanges As Boolean
                 Get
                     Return _committingChanges
                 End Get
-                Set(value As Boolean)
+                Set
                     _committingChanges = value
                 End Set
             End Property
@@ -489,11 +489,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' The settings we are currently displaying in the grid...
         ''' </summary>
-        Private Property Settings() As DesignTimeSettings
+        Private Property Settings As DesignTimeSettings
             Get
                 Return _settingsProperty
             End Get
-            Set(Value As DesignTimeSettings)
+            Set
                 ' Setting the settings to the same instance is a NOOP
                 If Value IsNot Settings Then
                     ' Store this guy for later use!
@@ -518,11 +518,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Will unhook event handlers from old component changed service and hook up handlers
         ''' to the new service
         '''</remarks>
-        Friend Property ChangeService() As IComponentChangeService
+        Friend Property ChangeService As IComponentChangeService
             Get
                 Return _changeService
             End Get
-            Set(Value As IComponentChangeService)
+            Set
                 If Not Value Is _changeService Then
                     UnSubscribeChangeServiceNotifications()
                     _changeService = Value
@@ -682,7 +682,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' 2. We are showing the type picker dialog
         ''' 3. We are showing a UI type editor
         ''' </summary>
-        Private ReadOnly Property AllowCommitPendingChanges() As Boolean
+        Private ReadOnly Property AllowCommitPendingChanges As Boolean
             Get
                 If _isReportingError OrElse _isShowingTypePicker OrElse _inCellValidated OrElse _settingsGridView.CommittingChanges Then
                     Return False
@@ -763,7 +763,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Type safe accessor for the type column
         ''' </summary>
-        Private ReadOnly Property TypeColumn() As DataGridViewComboBoxColumn
+        Private ReadOnly Property TypeColumn As DataGridViewComboBoxColumn
             Get
                 Return DirectCast(_settingsGridView.Columns(TypeColumnNo), DataGridViewComboBoxColumn)
             End Get
@@ -772,7 +772,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Type safe accessor for the type column
         ''' </summary>
-        Private ReadOnly Property ScopeColumn() As DataGridViewComboBoxColumn
+        Private ReadOnly Property ScopeColumn As DataGridViewComboBoxColumn
             Get
                 Return DirectCast(_settingsGridView.Columns(ScopeColumnNo), DataGridViewComboBoxColumn)
             End Get
@@ -910,7 +910,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 #Region "Selection service"
 
         Private _selectionServiceProperty As ISelectionService
-        Private ReadOnly Property SelectionService() As ISelectionService
+        Private ReadOnly Property SelectionService As ISelectionService
             Get
                 If _selectionServiceProperty Is Nothing Then
                     _selectionServiceProperty = DirectCast(GetService(GetType(ISelectionService)), ISelectionService)
@@ -1254,7 +1254,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get access to a UI service - useful to pop up message boxes and getting fonts
         ''' </summary>
-        Private ReadOnly Property UIService() As IUIService
+        Private ReadOnly Property UIService As IUIService
             Get
                 Dim Result As IUIService
                 Result = CType(GetService(GetType(IUIService)), IUIService)
@@ -2082,7 +2082,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             Switches.TracePDPerf("   OnLayout END: SettingsDesignerView.OnLayout()")
         End Sub
 
-        Private ReadOnly Property DesignerLoader() As SettingsDesignerLoader
+        Private ReadOnly Property DesignerLoader As SettingsDesignerLoader
             Get
                 If _designerLoader Is Nothing Then
                     _designerLoader = TryCast(GetService(GetType(IDesignerLoaderService)), SettingsDesignerLoader)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
@@ -62,7 +62,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Returns the default visibility of this properties
         ''' </summary>
         ''' <remarks>MemberAttributes indicating what visibility to make the generated properties.</remarks>
-        Friend Shared ReadOnly Property SettingsPropertyVisibility() As MemberAttributes
+        Friend Shared ReadOnly Property SettingsPropertyVisibility As MemberAttributes
             Get
                 Return MemberAttributes.Public Or MemberAttributes.Final
             End Get
@@ -72,7 +72,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Returns the default visibility of this properties
         ''' </summary>
         ''' <value>MemberAttributes indicating what visibility to make the generated properties.</value>
-        Friend Overridable ReadOnly Property SettingsClassVisibility() As TypeAttributes
+        Friend Overridable ReadOnly Property SettingsClassVisibility As TypeAttributes
             Get
                 Return TypeAttributes.Sealed Or TypeAttributes.NestedAssembly
             End Get
@@ -244,7 +244,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                                       IsDesignTime As Boolean,
                                       GeneratedClassVisibility As TypeAttributes,
                                       Optional GenerateVBMyAutoSave As Boolean = False,
-                                      <Out()> Optional ByRef generatedType As CodeTypeDeclaration = Nothing) As CodeCompileUnit
+                                      <Out> Optional ByRef generatedType As CodeTypeDeclaration = Nothing) As CodeCompileUnit
 
             Dim CompileUnit As New CodeCompileUnit
 
@@ -530,7 +530,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get the type of the class that our strongly typed wrapper class is supposed to inherit from
         ''' </summary>
-        Friend Shared ReadOnly Property SettingsBaseClass() As Type
+        Friend Shared ReadOnly Property SettingsBaseClass As Type
             Get
                 Return GetType(Configuration.ApplicationSettingsBase)
             End Get
@@ -821,7 +821,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' Demand-create a CodeDomProvider corresponding to my projects current language
         ''' </summary>
         ''' <value>A CodeDomProvider</value>
-        Private Property CodeDomProvider() As CodeDomProvider
+        Private Property CodeDomProvider As CodeDomProvider
             Get
                 If _codeDomProvider Is Nothing Then
                     Dim VSMDCodeDomProvider As IVSMDCodeDomProvider = CType(GetService(GetType(IVSMDCodeDomProvider)), IVSMDCodeDomProvider)
@@ -832,7 +832,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 End If
                 Return _codeDomProvider
             End Get
-            Set(Value As CodeDomProvider)
+            Set
                 If Value Is Nothing Then
                     Throw New ArgumentNullException()
                 End If
@@ -843,7 +843,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Demand-create service provider from my site
         ''' </summary>
-        Private ReadOnly Property ServiceProvider() As ServiceProvider
+        Private ReadOnly Property ServiceProvider As ServiceProvider
             Get
                 If _serviceProvider Is Nothing AndAlso _site IsNot Nothing Then
                     Dim OleSp As IServiceProvider = CType(_site, IServiceProvider)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorDataGridViewColumn.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorDataGridViewColumn.vb
@@ -13,11 +13,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             MyBase.New(New DataGridViewUITypeEditorCell)
         End Sub
 
-        Public Overrides Property CellTemplate() As DataGridViewCell
+        Public Overrides Property CellTemplate As DataGridViewCell
             Get
                 Return MyBase.CellTemplate
             End Get
-            Set(Value As DataGridViewCell)
+            Set
                 If Value IsNot Nothing AndAlso Not TypeOf Value Is DataGridViewUITypeEditorCell Then
                     Throw New InvalidCastException()
                 End If

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorHostControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorHostControl.vb
@@ -132,11 +132,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
 #Region "Value & value type properties for value to edit"
 
-        Public Property ValueType() As Type
+        Public Property ValueType As Type
             Get
                 Return _innerValueType
             End Get
-            Set(Value As Type)
+            Set
                 _innerValueType = Value
 
                 ' Let's try and get a UITypeEditor for this type! 
@@ -200,7 +200,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             End Set
         End Property
 
-        Public Property Value() As Object
+        Public Property Value As Object
             Get
                 If TextValueDirty Then
                     _innerValue = ParseValue(EditControl.Text, ValueType)
@@ -208,7 +208,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 End If
                 Return _innerValue
             End Get
-            Set(Value As Object)
+            Set
                 If Value IsNot Nothing Then
                     ValueType = Value.GetType()
                 End If
@@ -222,7 +222,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             End Set
         End Property
 
-        Protected ReadOnly Property InnerValue() As Object
+        Protected ReadOnly Property InnerValue As Object
             Get
                 Return _innerValue
             End Get
@@ -322,8 +322,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Display the associated type editor if not already showing
         ''' </summary>
-        <Security.SecurityCritical()>
-        <System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions()>
+        <Security.SecurityCritical>
+        <System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions>
         Private Sub ShowUITypeEditor()
             If _typeEditor IsNot Nothing Then
                 If _isShowingUITypeEditor Then
@@ -516,7 +516,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Are we currently showing the UI type editor?
         ''' </summary>
-        Public ReadOnly Property IsShowingUITypeEditor() As Boolean
+        Public ReadOnly Property IsShowingUITypeEditor As Boolean
             Get
                 Return _isShowingUITypeEditor
             End Get
@@ -550,7 +550,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' <summary>
             ''' Override default create parameters for window
             ''' </summary>
-            Protected Overrides ReadOnly Property CreateParams() As CreateParams
+            Protected Overrides ReadOnly Property CreateParams As CreateParams
                 Get
                     Dim BaseParams As CreateParams = MyBase.CreateParams
 
@@ -582,7 +582,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' <summary>
             ''' Get/set the UI type editor that I'm hosting...
             ''' </summary>
-            Public Property Editor() As Control
+            Public Property Editor As Control
                 Get
                     If Controls.Count = 1 Then
                         Return Controls.Item(0)
@@ -590,7 +590,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                         Return Nothing
                     End If
                 End Get
-                Set(Value As Control)
+                Set
                     Controls.Clear()
                     If Not Value Is Nothing Then
                         Value.Dock = DockStyle.Fill
@@ -628,11 +628,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Is the text in the currently selected edit control dirty?
         ''' </summary>
-        Private Property TextValueDirty() As Boolean
+        Private Property TextValueDirty As Boolean
             Get
                 Return _textValueDirty
             End Get
-            Set(value As Boolean)
+            Set
                 _textValueDirty = value
             End Set
         End Property
@@ -652,7 +652,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Map the selection length property to the currently selected edit control
         ''' </summary>
-        Public Property SelectionLength() As Integer
+        Public Property SelectionLength As Integer
             Get
                 If _valueComboBox.Visible Then
                     Return _valueComboBox.SelectionLength
@@ -661,7 +661,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     Return _valueTextBox.SelectionLength
                 End If
             End Get
-            Set(value As Integer)
+            Set
                 If _valueComboBox.Visible Then
                     _valueComboBox.SelectionLength = value
                 Else
@@ -674,7 +674,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Map the selection start property to the currently selected edit control
         ''' </summary>
-        Public Property SelectionStart() As Integer
+        Public Property SelectionStart As Integer
             Get
                 If _valueComboBox.Visible Then
                     Return _valueComboBox.SelectionStart
@@ -683,7 +683,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     Return _valueTextBox.SelectionStart
                 End If
             End Get
-            Set(value As Integer)
+            Set
                 If _valueComboBox.Visible Then
                     _valueComboBox.SelectionStart = value
                 Else
@@ -696,7 +696,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Map the selected text to the currently selected edit control
         ''' </summary>
-        Public Property SelectedText() As String
+        Public Property SelectedText As String
             Get
                 If _valueComboBox.Visible Then
                     Return _valueComboBox.SelectedText
@@ -705,7 +705,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     Return _valueTextBox.SelectedText
                 End If
             End Get
-            Set(value As String)
+            Set
                 If _valueComboBox.Visible Then
                     _valueComboBox.SelectedText = value
                 Else
@@ -718,11 +718,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get the text in the edit control
         ''' </summary>
-        Public Overrides Property Text() As String
+        Public Overrides Property Text As String
             Get
                 Return EditControl.Text
             End Get
-            Set(value As String)
+            Set
                 Dim savedIgnoreTextChangeEvents As Boolean = _ignoreTextChangeEvents
                 Try
                     _ignoreTextChangeEvents = True
@@ -736,7 +736,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get the currently active edit control (textbox or combobox)
         ''' </summary>
-        Friend Property EditControl() As Control
+        Friend Property EditControl As Control
             Get
                 If _currentEditControl IsNot Nothing Then
                     Return _currentEditControl
@@ -744,7 +744,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     Return _valueTextBox
                 End If
             End Get
-            Set(value As Control)
+            Set
                 For Each ctrl As Control In _editControls
                     If ctrl Is value Then
                         ctrl.Visible = True
@@ -759,7 +759,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get an instance of a ITypeDescriptorContext to pass into the UITypeEditor
         ''' </summary>
-        Public Overridable ReadOnly Property Context() As ITypeDescriptorContext
+        Public Overridable ReadOnly Property Context As ITypeDescriptorContext
             Get
                 Return Nothing
             End Get
@@ -826,11 +826,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' Do we want to look like a browse button or like a 
             ''' combobox dropdown?
             ''' </summary>
-            Public Property PaintStyle() As PaintStyles
+            Public Property PaintStyle As PaintStyles
                 Get
                     Return _paintStyle
                 End Get
-                Set(value As PaintStyles)
+                Set
                     Select Case value
                         Case PaintStyles.DotDotDot, PaintStyles.DropDown
                             ' Everything is cool

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
@@ -229,11 +229,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' Get whatever type name the user selected
         ''' </summary>
-        Public Property TypeName() As String
+        Public Property TypeName As String
             Get
                 Return _typeTextBox.Text.Trim()
             End Get
-            Set(Value As String)
+            Set
                 _typeTextBox.Text = Value
             End Set
         End Property
@@ -245,7 +245,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <summary>
         ''' A collection of available types
         ''' </summary>
-        Private ReadOnly Property AvailableTypes() As AutoCompleteStringCollection
+        Private ReadOnly Property AvailableTypes As AutoCompleteStringCollection
             Get
                 Return _typeTextBox.AutoCompleteCustomSource
             End Get
@@ -529,26 +529,26 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
             End Sub
 
-            Public ReadOnly Property IsAssemblyNode() As Boolean
+            Public ReadOnly Property IsAssemblyNode As Boolean
                 Get
                     Return _nodeType = NodeType.ASSEMBLY_NODE
                 End Get
             End Property
 
-            Public ReadOnly Property HasDummyNode() As Boolean
+            Public ReadOnly Property HasDummyNode As Boolean
                 Get
                     Return Nodes.ContainsKey(DUMMY_ITEM_TEXT)
                 End Get
             End Property
 
 
-            Public ReadOnly Property IsNameSpaceNode() As Boolean
+            Public ReadOnly Property IsNameSpaceNode As Boolean
                 Get
                     Return _nodeType = NodeType.NAMESPACE_NODE
                 End Get
             End Property
 
-            Public ReadOnly Property IsTypeNode() As Boolean
+            Public ReadOnly Property IsTypeNode As Boolean
                 Get
                     Return _nodeType = NodeType.TYPE_NODE
                 End Get

--- a/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
@@ -63,7 +63,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         Protected Overrides Sub Finalize()
             Dispose(False)
         End Sub
-        Friend Shared ReadOnly Property GlobalSettings() As TraceSwitch
+        Friend Shared ReadOnly Property GlobalSettings As TraceSwitch
             Get
                 If (s_globalSettings Is Nothing) Then
                     s_globalSettings = New TraceSwitch("GlobalSettings", "Enable tracing for the Typed Settings GlobalObjectProvider.")
@@ -77,7 +77,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' gets the running-doc-table for the instance of VS
         ''' </summary>
         ''' <value>running-doc-table</value>
-        Friend ReadOnly Property RunningDocTable() As IVsRunningDocumentTable
+        Friend ReadOnly Property RunningDocTable As IVsRunningDocumentTable
             Get
                 If (_rdt Is Nothing) Then
                     Dim rdt As IVsRunningDocumentTable = TryCast(GetService(GetType(IVsRunningDocumentTable)), IVsRunningDocumentTable)
@@ -685,11 +685,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' the settings objects... That will only affect that particular object, and it should raise
         ''' it's own change notifications!
         ''' </summary>
-        Friend Property IgnoreAppConfigChanges() As Boolean
+        Friend Property IgnoreAppConfigChanges As Boolean
             Get
                 Return _ignoreAppConfigChanges
             End Get
-            Set(value As Boolean)
+            Set
 #If DEBUG Then
                 Debug.WriteLineIf(GlobalSettings.TraceVerbose, String.Format("SettingsGlobalObject:IgnoreAppConfigChanges set to {0}", value))
 #End If
@@ -1193,7 +1193,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' <summary>
         ''' access to the DesignTimeSettings class this global-object represents
         ''' </summary>
-        Friend ReadOnly Property Settings() As DesignTimeSettings
+        Friend ReadOnly Property Settings As DesignTimeSettings
             Get
                 Debug.Assert(_dtSettings IsNot Nothing, "missing the design-time settings collection?")
                 Return _dtSettings
@@ -1213,11 +1213,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' gets/sets the DocData associated with this global object, appropriately adding
         ''' or removing event listeners
         ''' </summary>
-        Private Property DocData() As DocData
+        Private Property DocData As DocData
             Get
                 Return _docData
             End Get
-            Set(Value As DocData)
+            Set
 
 #If DEBUG Then
                 Debug.WriteLineIf(SettingsGlobalObjectProvider.GlobalSettings.TraceVerbose, "SettingsFileGlobalObject.DocData-setter(" & Name & "), _docData is " _
@@ -1246,7 +1246,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' Interesting to know what project item we're related to.
         ''' </summary>
         ''' <value>the project we are contained in</value>
-        Friend ReadOnly Property ProjectItem() As ProjectItem
+        Friend ReadOnly Property ProjectItem As ProjectItem
             Get
                 Return _item
             End Get
@@ -1256,7 +1256,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' Interesting to know what file name our project item has
         ''' </summary>
         ''' <value>the project we are contained in</value>
-        Friend ReadOnly Property FileName() As String
+        Friend ReadOnly Property FileName As String
             Get
                 Return _fileName
             End Get
@@ -1956,7 +1956,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' <summary>
         ''' This class is the code serializer for SettingsFile global object.
         ''' </summary>
-        <Serializable()>
+        <Serializable>
         Private NotInheritable Class SettingsFileCodeDomSerializer
             Inherits CodeDomSerializer
 
@@ -1965,7 +1965,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             ''' <summary>
             ''' Provides a stock serializer instance.
             ''' </summary>
-            Friend Shared ReadOnly Property [Default]() As SettingsFileCodeDomSerializer
+            Friend Shared ReadOnly Property [Default] As SettingsFileCodeDomSerializer
                 Get
                     If (s_default Is Nothing) Then
                         s_default = New SettingsFileCodeDomSerializer()
@@ -2260,7 +2260,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             ''' be changed as well, so any client that cached a reference to this instance/collection should have released
             ''' it when it got a type changed event from the dynamic type service)
             ''' </remarks>
-            Public Overrides ReadOnly Property Properties() As SettingsPropertyCollection
+            Public Overrides ReadOnly Property Properties As SettingsPropertyCollection
                 Get
 #If DEBUG Then
                     Debug.WriteLineIf(SettingsGlobalObjectProvider.GlobalSettings.TraceVerbose, "ConcreteApplicationSettings.Properties-getter(" & CStr(_globalObject._className) & ")...")
@@ -2464,7 +2464,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             ''' <summary>
             ''' gets the GlobalObject associated with this value
             ''' </summary>
-            Friend ReadOnly Property GlobalObject() As SettingsFileGlobalObject
+            Friend ReadOnly Property GlobalObject As SettingsFileGlobalObject
                 Get
                     Return _globalObject
                 End Get
@@ -2473,7 +2473,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             ''' <summary>
             ''' Gets the property-name associated with this value
             ''' </summary>
-            Friend ReadOnly Property PropertyName() As String
+            Friend ReadOnly Property PropertyName As String
                 Get
                     Return _propertyName
                 End Get

--- a/src/Microsoft.VisualStudio.Editors/StrongNameHelpers.vb
+++ b/src/Microsoft.VisualStudio.Editors/StrongNameHelpers.vb
@@ -7,18 +7,18 @@ Imports System.Security
 Namespace Microsoft.Runtime.Hosting
     Friend Class StrongNameHelpers
         ' Methods
-        <SecurityCritical()>
+        <SecurityCritical>
         Public Shared Function StrongNameErrorInfo() As Integer
             Return s_lastStrongNameHR
         End Function
 
-        <SecurityCritical()>
+        <SecurityCritical>
         Public Shared Sub StrongNameFreeBuffer(pbMemory As IntPtr)
             StrongNameUsingIntPtr.StrongNameFreeBuffer(pbMemory)
         End Sub
 
-        <SecurityCritical()>
-        Public Shared Function StrongNameGetPublicKey(pwzKeyContainer As String, pbKeyBlob As IntPtr, cbKeyBlob As Integer, <Out()> ByRef ppbPublicKeyBlob As IntPtr, <Out()> ByRef pcbPublicKeyBlob As Integer) As Boolean
+        <SecurityCritical>
+        Public Shared Function StrongNameGetPublicKey(pwzKeyContainer As String, pbKeyBlob As IntPtr, cbKeyBlob As Integer, <Out> ByRef ppbPublicKeyBlob As IntPtr, <Out> ByRef pcbPublicKeyBlob As Integer) As Boolean
             Dim hr As Integer = StrongNameUsingIntPtr.StrongNameGetPublicKey(pwzKeyContainer, pbKeyBlob, cbKeyBlob, ppbPublicKeyBlob, pcbPublicKeyBlob)
             If (hr < 0) Then
                 s_lastStrongNameHR = hr
@@ -29,8 +29,8 @@ Namespace Microsoft.Runtime.Hosting
             Return True
         End Function
 
-        <SecurityCritical()>
-        Public Shared Function StrongNameGetPublicKey(pwzKeyContainer As String, bKeyBlob As Byte(), cbKeyBlob As Integer, <Out()> ByRef ppbPublicKeyBlob As IntPtr, <Out()> ByRef pcbPublicKeyBlob As Integer) As Boolean
+        <SecurityCritical>
+        Public Shared Function StrongNameGetPublicKey(pwzKeyContainer As String, bKeyBlob As Byte(), cbKeyBlob As Integer, <Out> ByRef ppbPublicKeyBlob As IntPtr, <Out> ByRef pcbPublicKeyBlob As Integer) As Boolean
             Dim hr As Integer = StrongName.StrongNameGetPublicKey(pwzKeyContainer, bKeyBlob, cbKeyBlob, ppbPublicKeyBlob, pcbPublicKeyBlob)
             If (hr < 0) Then
                 s_lastStrongNameHR = hr
@@ -41,7 +41,7 @@ Namespace Microsoft.Runtime.Hosting
             Return True
         End Function
 
-        <SecurityCritical()>
+        <SecurityCritical>
         Public Shared Function StrongNameKeyDelete(pwzKeyContainer As String) As Boolean
             Dim hr As Integer = StrongName.StrongNameKeyDelete(pwzKeyContainer)
             If (hr < 0) Then
@@ -51,8 +51,8 @@ Namespace Microsoft.Runtime.Hosting
             Return True
         End Function
 
-        <SecurityCritical()>
-        Public Shared Function StrongNameKeyGen(pwzKeyContainer As String, dwFlags As Integer, <Out()> ByRef ppbKeyBlob As IntPtr, <Out()> ByRef pcbKeyBlob As Integer) As Boolean
+        <SecurityCritical>
+        Public Shared Function StrongNameKeyGen(pwzKeyContainer As String, dwFlags As Integer, <Out> ByRef ppbKeyBlob As IntPtr, <Out> ByRef pcbKeyBlob As Integer) As Boolean
             Dim hr As Integer = StrongName.StrongNameKeyGen(pwzKeyContainer, dwFlags, ppbKeyBlob, pcbKeyBlob)
             If (hr < 0) Then
                 s_lastStrongNameHR = hr
@@ -63,7 +63,7 @@ Namespace Microsoft.Runtime.Hosting
             Return True
         End Function
 
-        <SecurityCritical()>
+        <SecurityCritical>
         Public Shared Function StrongNameKeyInstall(pwzKeyContainer As String, pbKeyBlob As IntPtr, cbKeyBlob As Integer) As Boolean
             Dim hr As Integer = StrongNameUsingIntPtr.StrongNameKeyInstall(pwzKeyContainer, pbKeyBlob, cbKeyBlob)
             If (hr < 0) Then
@@ -73,7 +73,7 @@ Namespace Microsoft.Runtime.Hosting
             Return True
         End Function
 
-        <SecurityCritical()>
+        <SecurityCritical>
         Public Shared Function StrongNameKeyInstall(pwzKeyContainer As String, bKeyBlob As Byte(), cbKeyBlob As Integer) As Boolean
             Dim hr As Integer = StrongName.StrongNameKeyInstall(pwzKeyContainer, bKeyBlob, cbKeyBlob)
             If (hr < 0) Then
@@ -83,22 +83,22 @@ Namespace Microsoft.Runtime.Hosting
             Return True
         End Function
 
-        <SecurityCritical()>
+        <SecurityCritical>
         Public Shared Function StrongNameSignatureGeneration(pwzFilePath As String, pwzKeyContainer As String, pbKeyBlob As IntPtr, cbKeyBlob As Integer) As Boolean
             Dim ppbSignatureBlob As IntPtr = IntPtr.Zero
             Dim cbSignatureBlob As Integer = 0
             Return StrongNameSignatureGeneration(pwzFilePath, pwzKeyContainer, pbKeyBlob, cbKeyBlob, (ppbSignatureBlob), cbSignatureBlob)
         End Function
 
-        <SecurityCritical()>
+        <SecurityCritical>
         Public Shared Function StrongNameSignatureGeneration(pwzFilePath As String, pwzKeyContainer As String, bKeyBlob As Byte(), cbKeyBlob As Integer) As Boolean
             Dim ppbSignatureBlob As IntPtr = IntPtr.Zero
             Dim cbSignatureBlob As Integer = 0
             Return StrongNameSignatureGeneration(pwzFilePath, pwzKeyContainer, bKeyBlob, cbKeyBlob, (ppbSignatureBlob), cbSignatureBlob)
         End Function
 
-        <SecurityCritical()>
-        Public Shared Function StrongNameSignatureGeneration(pwzFilePath As String, pwzKeyContainer As String, pbKeyBlob As IntPtr, cbKeyBlob As Integer, ByRef ppbSignatureBlob As IntPtr, <Out()> ByRef pcbSignatureBlob As Integer) As Boolean
+        <SecurityCritical>
+        Public Shared Function StrongNameSignatureGeneration(pwzFilePath As String, pwzKeyContainer As String, pbKeyBlob As IntPtr, cbKeyBlob As Integer, ByRef ppbSignatureBlob As IntPtr, <Out> ByRef pcbSignatureBlob As Integer) As Boolean
             Dim hr As Integer = StrongNameUsingIntPtr.StrongNameSignatureGeneration(pwzFilePath, pwzKeyContainer, pbKeyBlob, cbKeyBlob, ppbSignatureBlob, pcbSignatureBlob)
             If (hr < 0) Then
                 s_lastStrongNameHR = hr
@@ -108,8 +108,8 @@ Namespace Microsoft.Runtime.Hosting
             Return True
         End Function
 
-        <SecurityCritical()>
-        Public Shared Function StrongNameSignatureGeneration(pwzFilePath As String, pwzKeyContainer As String, bKeyBlob As Byte(), cbKeyBlob As Integer, ByRef ppbSignatureBlob As IntPtr, <Out()> ByRef pcbSignatureBlob As Integer) As Boolean
+        <SecurityCritical>
+        Public Shared Function StrongNameSignatureGeneration(pwzFilePath As String, pwzKeyContainer As String, bKeyBlob As Byte(), cbKeyBlob As Integer, ByRef ppbSignatureBlob As IntPtr, <Out> ByRef pcbSignatureBlob As Integer) As Boolean
             Dim hr As Integer = StrongName.StrongNameSignatureGeneration(pwzFilePath, pwzKeyContainer, bKeyBlob, cbKeyBlob, ppbSignatureBlob, pcbSignatureBlob)
             If (hr < 0) Then
                 s_lastStrongNameHR = hr
@@ -119,8 +119,8 @@ Namespace Microsoft.Runtime.Hosting
             Return True
         End Function
 
-        <SecurityCritical()>
-        Public Shared Function StrongNameSignatureSize(pbPublicKeyBlob As IntPtr, cbPublicKeyBlob As Integer, <Out()> ByRef pcbSize As Integer) As Boolean
+        <SecurityCritical>
+        Public Shared Function StrongNameSignatureSize(pbPublicKeyBlob As IntPtr, cbPublicKeyBlob As Integer, <Out> ByRef pcbSize As Integer) As Boolean
             Dim hr As Integer = StrongNameUsingIntPtr.StrongNameSignatureSize(pbPublicKeyBlob, cbPublicKeyBlob, pcbSize)
             If (hr < 0) Then
                 s_lastStrongNameHR = hr
@@ -130,8 +130,8 @@ Namespace Microsoft.Runtime.Hosting
             Return True
         End Function
 
-        <SecurityCritical()>
-        Public Shared Function StrongNameSignatureSize(bPublicKeyBlob As Byte(), cbPublicKeyBlob As Integer, <Out()> ByRef pcbSize As Integer) As Boolean
+        <SecurityCritical>
+        Public Shared Function StrongNameSignatureSize(bPublicKeyBlob As Byte(), cbPublicKeyBlob As Integer, <Out> ByRef pcbSize As Integer) As Boolean
             Dim hr As Integer = StrongName.StrongNameSignatureSize(bPublicKeyBlob, cbPublicKeyBlob, pcbSize)
             If (hr < 0) Then
                 s_lastStrongNameHR = hr
@@ -141,8 +141,8 @@ Namespace Microsoft.Runtime.Hosting
             Return True
         End Function
 
-        <SecurityCritical()>
-        Public Shared Function StrongNameSignatureVerification(pwzFilePath As String, dwInFlags As Integer, <Out()> ByRef pdwOutFlags As Integer) As Boolean
+        <SecurityCritical>
+        Public Shared Function StrongNameSignatureVerification(pwzFilePath As String, dwInFlags As Integer, <Out> ByRef pdwOutFlags As Integer) As Boolean
             Dim hr As Integer = StrongName.StrongNameSignatureVerification(pwzFilePath, dwInFlags, pdwOutFlags)
             If (hr < 0) Then
                 s_lastStrongNameHR = hr
@@ -152,8 +152,8 @@ Namespace Microsoft.Runtime.Hosting
             Return True
         End Function
 
-        <SecurityCritical()>
-        Public Shared Function StrongNameSignatureVerificationEx(pwzFilePath As String, fForceVerification As Boolean, <Out()> ByRef pfWasVerified As Boolean) As Boolean
+        <SecurityCritical>
+        Public Shared Function StrongNameSignatureVerificationEx(pwzFilePath As String, fForceVerification As Boolean, <Out> ByRef pfWasVerified As Boolean) As Boolean
             Dim hr As Integer = StrongName.StrongNameSignatureVerificationEx(pwzFilePath, fForceVerification, pfWasVerified)
             If (hr < 0) Then
                 s_lastStrongNameHR = hr
@@ -163,8 +163,8 @@ Namespace Microsoft.Runtime.Hosting
             Return True
         End Function
 
-        <SecurityCritical()>
-        Public Shared Function StrongNameTokenFromPublicKey(bPublicKeyBlob As Byte(), cbPublicKeyBlob As Integer, <Out()> ByRef ppbStrongNameToken As IntPtr, <Out()> ByRef pcbStrongNameToken As Integer) As Boolean
+        <SecurityCritical>
+        Public Shared Function StrongNameTokenFromPublicKey(bPublicKeyBlob As Byte(), cbPublicKeyBlob As Integer, <Out> ByRef ppbStrongNameToken As IntPtr, <Out> ByRef pcbStrongNameToken As Integer) As Boolean
             Dim hr As Integer = StrongName.StrongNameTokenFromPublicKey(bPublicKeyBlob, cbPublicKeyBlob, ppbStrongNameToken, pcbStrongNameToken)
             If (hr < 0) Then
                 s_lastStrongNameHR = hr
@@ -175,8 +175,8 @@ Namespace Microsoft.Runtime.Hosting
             Return True
         End Function
 
-        <SecurityCritical()>
-        Public Shared Function StrongNameTokenFromPublicKey(pbPublicKeyBlob As IntPtr, cbPublicKeyBlob As Integer, <Out()> ByRef ppbStrongNameToken As IntPtr, <Out()> ByRef pcbStrongNameToken As Integer) As Boolean
+        <SecurityCritical>
+        Public Shared Function StrongNameTokenFromPublicKey(pbPublicKeyBlob As IntPtr, cbPublicKeyBlob As Integer, <Out> ByRef ppbStrongNameToken As IntPtr, <Out> ByRef pcbStrongNameToken As Integer) As Boolean
             Dim hr As Integer = StrongNameUsingIntPtr.StrongNameTokenFromPublicKey(pbPublicKeyBlob, cbPublicKeyBlob, ppbStrongNameToken, pcbStrongNameToken)
             If (hr < 0) Then
                 s_lastStrongNameHR = hr
@@ -204,118 +204,118 @@ Namespace Microsoft.Runtime.Hosting
             End Get
         End Property
 
-        <SecurityCritical()>
-        <ThreadStatic()>
+        <SecurityCritical>
+        <ThreadStatic>
         Private Shared s_strongName As IClrStrongName
-        <ThreadStatic()>
+        <ThreadStatic>
         Private Shared s_lastStrongNameHR As Integer = 0
     End Class
 
-    <ComImport(), SecurityCritical(), ComConversionLoss(), InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("9FD93CCF-3280-4391-B3A9-96E1CDE77C8D")>
+    <ComImport, SecurityCritical, ComConversionLoss, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("9FD93CCF-3280-4391-B3A9-96E1CDE77C8D")>
     Friend Interface IClrStrongNameUsingIntPtr
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function GetHashFromAssemblyFile(<[In](), MarshalAs(UnmanagedType.LPStr)> pszFilePath As String, <[In](), Out(), MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out(), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function GetHashFromAssemblyFileW(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In](), Out(), MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out(), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function GetHashFromBlob(<[In]()> pbBlob As IntPtr, <[In](), MarshalAs(UnmanagedType.U4)> cchBlob As Integer, <[In](), Out(), MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out(), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=4)> pbHash As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function GetHashFromFile(<[In](), MarshalAs(UnmanagedType.LPStr)> pszFilePath As String, <[In](), Out(), MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out(), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function GetHashFromFileW(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In](), Out(), MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out(), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function GetHashFromHandle(<[In]()> hFile As IntPtr, <[In](), Out(), MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out(), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameCompareAssemblies(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzAssembly1 As String, <[In](), MarshalAs(UnmanagedType.LPWStr)> pwzAssembly2 As String, <Out(), MarshalAs(UnmanagedType.U4)> ByRef dwResult As Integer) As <MarshalAs(UnmanagedType.U4)> Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameFreeBuffer(<[In]()> pbMemory As IntPtr) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameGetBlob(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <Out(), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=2)> pbBlob As Byte(), <[In](), Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbBlob As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameGetBlobFromImage(<[In]()> pbBase As IntPtr, <[In](), MarshalAs(UnmanagedType.U4)> dwLength As Integer, <Out(), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbBlob As Byte(), <[In](), Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbBlob As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameGetPublicKey(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In]()> pbKeyBlob As IntPtr, <[In](), MarshalAs(UnmanagedType.U4)> cbKeyBlob As Integer, <Out()> ByRef ppbPublicKeyBlob As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbPublicKeyBlob As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameHashSize(<[In](), MarshalAs(UnmanagedType.U4)> ulHashAlg As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef cbSize As Integer) As <MarshalAs(UnmanagedType.U4)> Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameKeyDelete(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameKeyGen(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In](), MarshalAs(UnmanagedType.U4)> dwFlags As Integer, <Out()> ByRef ppbKeyBlob As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbKeyBlob As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameKeyGenEx(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In](), MarshalAs(UnmanagedType.U4)> dwFlags As Integer, <[In](), MarshalAs(UnmanagedType.U4)> dwKeySize As Integer, <Out()> ByRef ppbKeyBlob As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbKeyBlob As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameKeyInstall(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In]()> pbKeyBlob As IntPtr, <[In](), MarshalAs(UnmanagedType.U4)> cbKeyBlob As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameSignatureGeneration(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In](), MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In]()> pbKeyBlob As IntPtr, <[In](), MarshalAs(UnmanagedType.U4)> cbKeyBlob As Integer, <[In](), Out()> ppbSignatureBlob As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbSignatureBlob As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameSignatureGenerationEx(<[In](), MarshalAs(UnmanagedType.LPWStr)> wszFilePath As String, <[In](), MarshalAs(UnmanagedType.LPWStr)> wszKeyContainer As String, <[In]()> pbKeyBlob As IntPtr, <[In](), MarshalAs(UnmanagedType.U4)> cbKeyBlob As Integer, <[In](), Out()> ppbSignatureBlob As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbSignatureBlob As Integer, <[In](), MarshalAs(UnmanagedType.U4)> dwFlags As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameSignatureSize(<[In]()> pbPublicKeyBlob As IntPtr, <[In](), MarshalAs(UnmanagedType.U4)> cbPublicKeyBlob As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbSize As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameSignatureVerification(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In](), MarshalAs(UnmanagedType.U4)> dwInFlags As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef dwOutFlags As Integer) As <MarshalAs(UnmanagedType.U4)> Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameSignatureVerificationEx(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In](), MarshalAs(UnmanagedType.I1)> fForceVerification As Boolean, <Out(), MarshalAs(UnmanagedType.I1)> ByRef fWasVerified As Boolean) As <MarshalAs(UnmanagedType.U4)> Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameSignatureVerificationFromImage(<[In]()> pbBase As IntPtr, <[In](), MarshalAs(UnmanagedType.U4)> dwLength As Integer, <[In](), MarshalAs(UnmanagedType.U4)> dwInFlags As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef dwOutFlags As Integer) As <MarshalAs(UnmanagedType.U4)> Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameTokenFromAssembly(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <Out()> ByRef ppbStrongNameToken As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbStrongNameToken As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameTokenFromAssemblyEx(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <Out()> ByRef ppbStrongNameToken As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbStrongNameToken As Integer, <Out()> ByRef ppbPublicKeyBlob As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbPublicKeyBlob As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameTokenFromPublicKey(<[In]()> pbPublicKeyBlob As IntPtr, <[In](), MarshalAs(UnmanagedType.U4)> cbPublicKeyBlob As Integer, <Out()> ByRef ppbStrongNameToken As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbStrongNameToken As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function GetHashFromAssemblyFile(<[In], MarshalAs(UnmanagedType.LPStr)> pszFilePath As String, <[In], Out, MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function GetHashFromAssemblyFileW(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In], Out, MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function GetHashFromBlob(<[In]> pbBlob As IntPtr, <[In], MarshalAs(UnmanagedType.U4)> cchBlob As Integer, <[In], Out, MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=4)> pbHash As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function GetHashFromFile(<[In], MarshalAs(UnmanagedType.LPStr)> pszFilePath As String, <[In], Out, MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function GetHashFromFileW(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In], Out, MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function GetHashFromHandle(<[In]> hFile As IntPtr, <[In], Out, MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameCompareAssemblies(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzAssembly1 As String, <[In], MarshalAs(UnmanagedType.LPWStr)> pwzAssembly2 As String, <Out, MarshalAs(UnmanagedType.U4)> ByRef dwResult As Integer) As <MarshalAs(UnmanagedType.U4)> Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameFreeBuffer(<[In]> pbMemory As IntPtr) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameGetBlob(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=2)> pbBlob As Byte(), <[In], Out, MarshalAs(UnmanagedType.U4)> ByRef pcbBlob As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameGetBlobFromImage(<[In]> pbBase As IntPtr, <[In], MarshalAs(UnmanagedType.U4)> dwLength As Integer, <Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbBlob As Byte(), <[In], Out, MarshalAs(UnmanagedType.U4)> ByRef pcbBlob As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameGetPublicKey(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In]> pbKeyBlob As IntPtr, <[In], MarshalAs(UnmanagedType.U4)> cbKeyBlob As Integer, <Out> ByRef ppbPublicKeyBlob As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbPublicKeyBlob As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameHashSize(<[In], MarshalAs(UnmanagedType.U4)> ulHashAlg As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef cbSize As Integer) As <MarshalAs(UnmanagedType.U4)> Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameKeyDelete(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameKeyGen(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In], MarshalAs(UnmanagedType.U4)> dwFlags As Integer, <Out> ByRef ppbKeyBlob As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbKeyBlob As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameKeyGenEx(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In], MarshalAs(UnmanagedType.U4)> dwFlags As Integer, <[In], MarshalAs(UnmanagedType.U4)> dwKeySize As Integer, <Out> ByRef ppbKeyBlob As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbKeyBlob As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameKeyInstall(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In]> pbKeyBlob As IntPtr, <[In], MarshalAs(UnmanagedType.U4)> cbKeyBlob As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameSignatureGeneration(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In], MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In]> pbKeyBlob As IntPtr, <[In], MarshalAs(UnmanagedType.U4)> cbKeyBlob As Integer, <[In], Out> ppbSignatureBlob As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbSignatureBlob As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameSignatureGenerationEx(<[In], MarshalAs(UnmanagedType.LPWStr)> wszFilePath As String, <[In], MarshalAs(UnmanagedType.LPWStr)> wszKeyContainer As String, <[In]> pbKeyBlob As IntPtr, <[In], MarshalAs(UnmanagedType.U4)> cbKeyBlob As Integer, <[In], Out> ppbSignatureBlob As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbSignatureBlob As Integer, <[In], MarshalAs(UnmanagedType.U4)> dwFlags As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameSignatureSize(<[In]> pbPublicKeyBlob As IntPtr, <[In], MarshalAs(UnmanagedType.U4)> cbPublicKeyBlob As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbSize As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameSignatureVerification(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In], MarshalAs(UnmanagedType.U4)> dwInFlags As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef dwOutFlags As Integer) As <MarshalAs(UnmanagedType.U4)> Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameSignatureVerificationEx(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In], MarshalAs(UnmanagedType.I1)> fForceVerification As Boolean, <Out, MarshalAs(UnmanagedType.I1)> ByRef fWasVerified As Boolean) As <MarshalAs(UnmanagedType.U4)> Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameSignatureVerificationFromImage(<[In]> pbBase As IntPtr, <[In], MarshalAs(UnmanagedType.U4)> dwLength As Integer, <[In], MarshalAs(UnmanagedType.U4)> dwInFlags As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef dwOutFlags As Integer) As <MarshalAs(UnmanagedType.U4)> Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameTokenFromAssembly(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <Out> ByRef ppbStrongNameToken As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbStrongNameToken As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameTokenFromAssemblyEx(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <Out> ByRef ppbStrongNameToken As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbStrongNameToken As Integer, <Out> ByRef ppbPublicKeyBlob As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbPublicKeyBlob As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameTokenFromPublicKey(<[In]> pbPublicKeyBlob As IntPtr, <[In], MarshalAs(UnmanagedType.U4)> cbPublicKeyBlob As Integer, <Out> ByRef ppbStrongNameToken As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbStrongNameToken As Integer) As Integer
     End Interface
-    <ComImport(), SecurityCritical(), ComConversionLoss(), InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("9FD93CCF-3280-4391-B3A9-96E1CDE77C8D")>
+    <ComImport, SecurityCritical, ComConversionLoss, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("9FD93CCF-3280-4391-B3A9-96E1CDE77C8D")>
     Friend Interface IClrStrongName
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function GetHashFromAssemblyFile(<[In](), MarshalAs(UnmanagedType.LPStr)> pszFilePath As String, <[In](), Out(), MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out(), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function GetHashFromAssemblyFileW(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In](), Out(), MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out(), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function GetHashFromBlob(<[In]()> pbBlob As IntPtr, <[In](), MarshalAs(UnmanagedType.U4)> cchBlob As Integer, <[In](), Out(), MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out(), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=4)> pbHash As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function GetHashFromFile(<[In](), MarshalAs(UnmanagedType.LPStr)> pszFilePath As String, <[In](), Out(), MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out(), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function GetHashFromFileW(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In](), Out(), MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out(), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function GetHashFromHandle(<[In]()> hFile As IntPtr, <[In](), Out(), MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out(), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameCompareAssemblies(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzAssembly1 As String, <[In](), MarshalAs(UnmanagedType.LPWStr)> pwzAssembly2 As String, <Out(), MarshalAs(UnmanagedType.U4)> ByRef dwResult As Integer) As <MarshalAs(UnmanagedType.U4)> Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameFreeBuffer(<[In]()> pbMemory As IntPtr) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameGetBlob(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <Out(), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=2)> pbBlob As Byte(), <[In](), Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbBlob As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameGetBlobFromImage(<[In]()> pbBase As IntPtr, <[In](), MarshalAs(UnmanagedType.U4)> dwLength As Integer, <Out(), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbBlob As Byte(), <[In](), Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbBlob As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameGetPublicKey(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In](), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=2)> pbKeyBlob As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cbKeyBlob As Integer, <Out()> ByRef ppbPublicKeyBlob As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbPublicKeyBlob As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameHashSize(<[In](), MarshalAs(UnmanagedType.U4)> ulHashAlg As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef cbSize As Integer) As <MarshalAs(UnmanagedType.U4)> Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameKeyDelete(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameKeyGen(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In](), MarshalAs(UnmanagedType.U4)> dwFlags As Integer, <Out()> ByRef ppbKeyBlob As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbKeyBlob As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameKeyGenEx(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In](), MarshalAs(UnmanagedType.U4)> dwFlags As Integer, <[In](), MarshalAs(UnmanagedType.U4)> dwKeySize As Integer, <Out()> ByRef ppbKeyBlob As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbKeyBlob As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameKeyInstall(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In](), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=2)> pbKeyBlob As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cbKeyBlob As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameSignatureGeneration(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In](), MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In](), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbKeyBlob As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cbKeyBlob As Integer, <[In](), Out()> ppbSignatureBlob As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbSignatureBlob As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameSignatureGenerationEx(<[In](), MarshalAs(UnmanagedType.LPWStr)> wszFilePath As String, <[In](), MarshalAs(UnmanagedType.LPWStr)> wszKeyContainer As String, <[In](), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbKeyBlob As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cbKeyBlob As Integer, <[In](), Out()> ppbSignatureBlob As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbSignatureBlob As Integer, <[In](), MarshalAs(UnmanagedType.U4)> dwFlags As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameSignatureSize(<[In](), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=1)> pbPublicKeyBlob As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cbPublicKeyBlob As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbSize As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameSignatureVerification(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In](), MarshalAs(UnmanagedType.U4)> dwInFlags As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef dwOutFlags As Integer) As <MarshalAs(UnmanagedType.U4)> Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameSignatureVerificationEx(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In](), MarshalAs(UnmanagedType.I1)> fForceVerification As Boolean, <Out(), MarshalAs(UnmanagedType.I1)> ByRef fWasVerified As Boolean) As <MarshalAs(UnmanagedType.U4)> Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameSignatureVerificationFromImage(<[In]()> pbBase As IntPtr, <[In](), MarshalAs(UnmanagedType.U4)> dwLength As Integer, <[In](), MarshalAs(UnmanagedType.U4)> dwInFlags As Integer, <Out(), MarshalAs(UnmanagedType.U4)> ByRef dwOutFlags As Integer) As <MarshalAs(UnmanagedType.U4)> Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameTokenFromAssembly(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <Out()> ByRef ppbStrongNameToken As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbStrongNameToken As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameTokenFromAssemblyEx(<[In](), MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <Out()> ByRef ppbStrongNameToken As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbStrongNameToken As Integer, <Out()> ByRef ppbPublicKeyBlob As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbPublicKeyBlob As Integer) As Integer
-        <PreserveSig(), MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
-        Function StrongNameTokenFromPublicKey(<[In](), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=1)> pbPublicKeyBlob As Byte(), <[In](), MarshalAs(UnmanagedType.U4)> cbPublicKeyBlob As Integer, <Out()> ByRef ppbStrongNameToken As IntPtr, <Out(), MarshalAs(UnmanagedType.U4)> ByRef pcbStrongNameToken As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function GetHashFromAssemblyFile(<[In], MarshalAs(UnmanagedType.LPStr)> pszFilePath As String, <[In], Out, MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function GetHashFromAssemblyFileW(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In], Out, MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function GetHashFromBlob(<[In]> pbBlob As IntPtr, <[In], MarshalAs(UnmanagedType.U4)> cchBlob As Integer, <[In], Out, MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=4)> pbHash As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function GetHashFromFile(<[In], MarshalAs(UnmanagedType.LPStr)> pszFilePath As String, <[In], Out, MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function GetHashFromFileW(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In], Out, MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function GetHashFromHandle(<[In]> hFile As IntPtr, <[In], Out, MarshalAs(UnmanagedType.U4)> ByRef piHashAlg As Integer, <Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbHash As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cchHash As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef pchHash As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameCompareAssemblies(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzAssembly1 As String, <[In], MarshalAs(UnmanagedType.LPWStr)> pwzAssembly2 As String, <Out, MarshalAs(UnmanagedType.U4)> ByRef dwResult As Integer) As <MarshalAs(UnmanagedType.U4)> Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameFreeBuffer(<[In]> pbMemory As IntPtr) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameGetBlob(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=2)> pbBlob As Byte(), <[In], Out, MarshalAs(UnmanagedType.U4)> ByRef pcbBlob As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameGetBlobFromImage(<[In]> pbBase As IntPtr, <[In], MarshalAs(UnmanagedType.U4)> dwLength As Integer, <Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbBlob As Byte(), <[In], Out, MarshalAs(UnmanagedType.U4)> ByRef pcbBlob As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameGetPublicKey(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In], MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=2)> pbKeyBlob As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cbKeyBlob As Integer, <Out> ByRef ppbPublicKeyBlob As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbPublicKeyBlob As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameHashSize(<[In], MarshalAs(UnmanagedType.U4)> ulHashAlg As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef cbSize As Integer) As <MarshalAs(UnmanagedType.U4)> Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameKeyDelete(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameKeyGen(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In], MarshalAs(UnmanagedType.U4)> dwFlags As Integer, <Out> ByRef ppbKeyBlob As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbKeyBlob As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameKeyGenEx(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In], MarshalAs(UnmanagedType.U4)> dwFlags As Integer, <[In], MarshalAs(UnmanagedType.U4)> dwKeySize As Integer, <Out> ByRef ppbKeyBlob As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbKeyBlob As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameKeyInstall(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In], MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=2)> pbKeyBlob As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cbKeyBlob As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameSignatureGeneration(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In], MarshalAs(UnmanagedType.LPWStr)> pwzKeyContainer As String, <[In], MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbKeyBlob As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cbKeyBlob As Integer, <[In], Out> ppbSignatureBlob As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbSignatureBlob As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameSignatureGenerationEx(<[In], MarshalAs(UnmanagedType.LPWStr)> wszFilePath As String, <[In], MarshalAs(UnmanagedType.LPWStr)> wszKeyContainer As String, <[In], MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> pbKeyBlob As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cbKeyBlob As Integer, <[In], Out> ppbSignatureBlob As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbSignatureBlob As Integer, <[In], MarshalAs(UnmanagedType.U4)> dwFlags As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameSignatureSize(<[In], MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=1)> pbPublicKeyBlob As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cbPublicKeyBlob As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbSize As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameSignatureVerification(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In], MarshalAs(UnmanagedType.U4)> dwInFlags As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef dwOutFlags As Integer) As <MarshalAs(UnmanagedType.U4)> Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameSignatureVerificationEx(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <[In], MarshalAs(UnmanagedType.I1)> fForceVerification As Boolean, <Out, MarshalAs(UnmanagedType.I1)> ByRef fWasVerified As Boolean) As <MarshalAs(UnmanagedType.U4)> Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameSignatureVerificationFromImage(<[In]> pbBase As IntPtr, <[In], MarshalAs(UnmanagedType.U4)> dwLength As Integer, <[In], MarshalAs(UnmanagedType.U4)> dwInFlags As Integer, <Out, MarshalAs(UnmanagedType.U4)> ByRef dwOutFlags As Integer) As <MarshalAs(UnmanagedType.U4)> Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameTokenFromAssembly(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <Out> ByRef ppbStrongNameToken As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbStrongNameToken As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameTokenFromAssemblyEx(<[In], MarshalAs(UnmanagedType.LPWStr)> pwzFilePath As String, <Out> ByRef ppbStrongNameToken As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbStrongNameToken As Integer, <Out> ByRef ppbPublicKeyBlob As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbPublicKeyBlob As Integer) As Integer
+        <PreserveSig, MethodImpl(MethodImplOptions.InternalCall, MethodCodeType:=MethodCodeType.Runtime)>
+        Function StrongNameTokenFromPublicKey(<[In], MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=1)> pbPublicKeyBlob As Byte(), <[In], MarshalAs(UnmanagedType.U4)> cbPublicKeyBlob As Integer, <Out> ByRef ppbStrongNameToken As IntPtr, <Out, MarshalAs(UnmanagedType.U4)> ByRef pcbStrongNameToken As Integer) As Integer
     End Interface
 
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/VBRefChangedSvc/Interop.vb
+++ b/src/Microsoft.VisualStudio.Editors/VBRefChangedSvc/Interop.vb
@@ -12,25 +12,25 @@ Namespace Microsoft.VisualStudio.Editors.VBRefChangedSvc.Interop
     <Guid("B3017D1B-2FF7-4f22-828C-CD74B6A702DC")>
     <InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
     <CLSCompliant(False)>
-    <ComImport()>
+    <ComImport>
     Friend Interface IVbReferenceChangedService
 
-        <MethodImpl(MethodImplOptions.InternalCall), PreserveSig()>
+        <MethodImpl(MethodImplOptions.InternalCall), PreserveSig>
         Function ReferenceAdded(
-            <[In](), MarshalAs(UnmanagedType.IUnknown)> pHierarchy As Object,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strAssemblyPath As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strAssemblyName As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strAssemblyVersion As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strAssemblyInfo As String
+            <[In], MarshalAs(UnmanagedType.IUnknown)> pHierarchy As Object,
+            <[In], MarshalAs(UnmanagedType.BStr)> strAssemblyPath As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> strAssemblyName As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> strAssemblyVersion As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> strAssemblyInfo As String
         ) As Integer
 
-        <MethodImpl(MethodImplOptions.InternalCall), PreserveSig()>
+        <MethodImpl(MethodImplOptions.InternalCall), PreserveSig>
         Function ReferenceRemoved(
-            <[In](), MarshalAs(UnmanagedType.IUnknown)> pHierarchy As Object,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strAssemblyPath As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strAssemblyName As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strAssemblyVersion As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strAssemblyInfo As String
+            <[In], MarshalAs(UnmanagedType.IUnknown)> pHierarchy As Object,
+            <[In], MarshalAs(UnmanagedType.BStr)> strAssemblyPath As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> strAssemblyName As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> strAssemblyVersion As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> strAssemblyInfo As String
         ) As Integer
 
     End Interface

--- a/src/Microsoft.VisualStudio.Editors/VBRefChangedSvc/VBReferenceChangedService.vb
+++ b/src/Microsoft.VisualStudio.Editors/VBRefChangedSvc/VBReferenceChangedService.vb
@@ -27,11 +27,11 @@ Namespace Microsoft.VisualStudio.Editors.VBRefChangedSvc
         End Sub
 
         Private Function ReferenceAdded(
-            <[In](), MarshalAs(UnmanagedType.IUnknown)> pHierarchy As Object,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strAssemblyPath As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strAssemblyName As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strAssemblyVersion As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strAssemblyInfo As String
+            <[In], MarshalAs(UnmanagedType.IUnknown)> pHierarchy As Object,
+            <[In], MarshalAs(UnmanagedType.BStr)> strAssemblyPath As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> strAssemblyName As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> strAssemblyVersion As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> strAssemblyInfo As String
         ) As Integer _
         Implements Interop.IVbReferenceChangedService.ReferenceAdded
 
@@ -42,11 +42,11 @@ Namespace Microsoft.VisualStudio.Editors.VBRefChangedSvc
         End Function
 
         Private Function ReferenceRemoved(
-            <[In](), MarshalAs(UnmanagedType.IUnknown)> pHierarchy As Object,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strAssemblyPath As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strAssemblyName As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strAssemblyVersion As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> strAssemblyInfo As String
+            <[In], MarshalAs(UnmanagedType.IUnknown)> pHierarchy As Object,
+            <[In], MarshalAs(UnmanagedType.BStr)> strAssemblyPath As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> strAssemblyName As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> strAssemblyVersion As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> strAssemblyInfo As String
         ) As Integer _
         Implements Interop.IVbReferenceChangedService.ReferenceRemoved
 

--- a/src/Microsoft.VisualStudio.Editors/XmlIntellisense/XmlIntellisense.vb
+++ b/src/Microsoft.VisualStudio.Editors/XmlIntellisense/XmlIntellisense.vb
@@ -204,7 +204,7 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
         '   IMPORTANT: Do not attempt to use the event once this object has been
         '              released.
         '--------------------------------------------------------------------------
-        Public ReadOnly Property CompiledEvent() As IntPtr _
+        Public ReadOnly Property CompiledEvent As IntPtr _
             Implements IXmlIntellisenseSchemas.CompiledEvent
 
             Get
@@ -219,7 +219,7 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
         '   Gets array of all result target namespaces, which will form the basis
         '   of a dropdown list for the user to pick from.
         '--------------------------------------------------------------------------
-        Public ReadOnly Property TargetNamespaces() As String() _
+        Public ReadOnly Property TargetNamespaces As String() _
             Implements IXmlIntellisenseSchemas.TargetNamespaces
 
             Get
@@ -235,7 +235,7 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
         '   and attribute declaration in the schema set.  This list can be filtered
         '   by calling the various filter methods on IXmlIntellisenseMember.
         '--------------------------------------------------------------------------
-        Public ReadOnly Property MemberList() As IXmlIntellisenseMemberList _
+        Public ReadOnly Property MemberList As IXmlIntellisenseMemberList _
             Implements IXmlIntellisenseSchemas.MemberList
 
             Get
@@ -250,7 +250,7 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
         '   If non-null, contains the source uri of the file which triggered the
         '   first error (not warning) while compiling the schema set.
         '--------------------------------------------------------------------------
-        Public ReadOnly Property FirstErrorSource() As String _
+        Public ReadOnly Property FirstErrorSource As String _
             Implements IXmlIntellisenseSchemas.FirstErrorSource
 
             Get
@@ -386,7 +386,7 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
         '
         '   Shows element in XSD browser given namespace and local name.
         '--------------------------------------------------------------------------
-        Public ReadOnly Property IsEmpty() As <MarshalAs(UnmanagedType.Bool)> Boolean _
+        Public ReadOnly Property IsEmpty As <MarshalAs(UnmanagedType.Bool)> Boolean _
             Implements IXmlIntellisenseSchemas.IsEmpty
             Get
                 Return _data.SchemaSet Is Nothing OrElse _data.SchemaSet.Count = 0
@@ -400,8 +400,8 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
         '   Shows element in XSD browser given namespace and local name.
         '--------------------------------------------------------------------------
         Public Sub ShowInXmlSchemaExplorer(
-            <[In](), MarshalAs(UnmanagedType.BStr)> NamespaceName As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> LocalName As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> NamespaceName As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> LocalName As String,
             <MarshalAs(UnmanagedType.Bool)> ByRef ElementFound As Boolean,
             <MarshalAs(UnmanagedType.Bool)> ByRef NamespaceFound As Boolean) _
             Implements IXmlIntellisenseSchemas.ShowInXmlSchemaExplorer
@@ -545,68 +545,68 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
             _name = Attribute.QualifiedName
         End Sub
 
-        Friend ReadOnly Property Element() As XmlSchemaElement
+        Friend ReadOnly Property Element As XmlSchemaElement
             Get
                 Return _element
             End Get
         End Property
 
-        Public Property Children() As XmlIntellisenseMember
+        Public Property Children As XmlIntellisenseMember
             Get
                 Return _children
             End Get
-            Set(Value As XmlIntellisenseMember)
+            Set
                 _children = Value
             End Set
         End Property
 
-        Public Property NextMember() As XmlIntellisenseMember
+        Public Property NextMember As XmlIntellisenseMember
             Get
                 Return _nextMember
             End Get
-            Set(Value As XmlIntellisenseMember)
+            Set
                 _nextMember = Value
             End Set
         End Property
 
-        Public Property IsRoot() As Boolean
+        Public Property IsRoot As Boolean
             Get
                 Return (_flags And Flags.IsRoot) <> 0
             End Get
-            Set(Value As Boolean)
+            Set
                 Debug.Assert(Value, "IsRoot can only be set to true")
                 _flags = _flags Or Flags.IsRoot
             End Set
         End Property
 
-        Public ReadOnly Property IsAny() As Boolean
+        Public ReadOnly Property IsAny As Boolean
             Get
                 Return _name.IsEmpty
             End Get
         End Property
 
-        Public ReadOnly Property IsElement() As Boolean _
+        Public ReadOnly Property IsElement As Boolean _
             Implements IXmlIntellisenseMember.IsElement
             Get
                 Return (_flags And Flags.IsElement) <> 0
             End Get
         End Property
 
-        Public ReadOnly Property NamespaceName() As String _
+        Public ReadOnly Property NamespaceName As String _
             Implements IXmlIntellisenseMember.NamespaceName
             Get
                 Return _name.Namespace
             End Get
         End Property
 
-        Public ReadOnly Property LocalName() As String _
+        Public ReadOnly Property LocalName As String _
             Implements IXmlIntellisenseMember.LocalName
             Get
                 Return _name.Name
             End Get
         End Property
 
-        Public ReadOnly Property Name() As XmlQualifiedName
+        Public ReadOnly Property Name As XmlQualifiedName
             Get
                 Return _name
             End Get
@@ -664,25 +664,25 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
 
         End Sub
 
-        Public ReadOnly Property All() As XmlIntellisenseMemberList
+        Public ReadOnly Property All As XmlIntellisenseMemberList
             Get
                 Return _all
             End Get
         End Property
 
-        Public ReadOnly Property Document() As XmlIntellisenseMemberList
+        Public ReadOnly Property Document As XmlIntellisenseMemberList
             Get
                 Return _document
             End Get
         End Property
 
-        Public ReadOnly Property Roots() As XmlIntellisenseMemberList
+        Public ReadOnly Property Roots As XmlIntellisenseMemberList
             Get
                 Return _roots
             End Get
         End Property
 
-        Public ReadOnly Property Elements() As XmlIntellisenseMemberList
+        Public ReadOnly Property Elements As XmlIntellisenseMemberList
             Get
                 Return _elements
             End Get
@@ -961,7 +961,7 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
         '   of the schemas in the set.  More than one type may be matched only if
         '   the other types share the same expanded name.
         '--------------------------------------------------------------------------
-        Public ReadOnly Property MatchesNamedType() As Boolean _
+        Public ReadOnly Property MatchesNamedType As Boolean _
             Implements IXmlIntellisenseMemberList.MatchesNamedType
 
             Get
@@ -1088,7 +1088,7 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
         '   Get child elements of this list having the specified namespace.
         '--------------------------------------------------------------------------
         Public Function ElementsByNamespace(
-            <[In](), MarshalAs(UnmanagedType.BStr)> NamespaceName As String
+            <[In], MarshalAs(UnmanagedType.BStr)> NamespaceName As String
             ) As IXmlIntellisenseMemberList _
             Implements IXmlIntellisenseMemberList.ElementsByNamespace
 
@@ -1100,8 +1100,8 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
         '   Get child elements of this list having the specified name.
         '--------------------------------------------------------------------------
         Public Function ElementsByName(
-            <[In](), MarshalAs(UnmanagedType.BStr)> NamespaceName As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> LocalName As String
+            <[In], MarshalAs(UnmanagedType.BStr)> NamespaceName As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> LocalName As String
             ) As IXmlIntellisenseMemberList _
             Implements IXmlIntellisenseMemberList.ElementsByName
 
@@ -1113,7 +1113,7 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
         '   Get attributes of this list having the specified namespace.
         '--------------------------------------------------------------------------
         Public Function AttributesByNamespace(
-            <[In](), MarshalAs(UnmanagedType.BStr)> NamespaceName As String
+            <[In], MarshalAs(UnmanagedType.BStr)> NamespaceName As String
             ) As IXmlIntellisenseMemberList _
             Implements IXmlIntellisenseMemberList.AttributesByNamespace
 
@@ -1125,8 +1125,8 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
         '   Get attributes of this list having the specified name.
         '--------------------------------------------------------------------------
         Public Function AttributesByName(
-            <[In](), MarshalAs(UnmanagedType.BStr)> NamespaceName As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> LocalName As String
+            <[In], MarshalAs(UnmanagedType.BStr)> NamespaceName As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> LocalName As String
             ) As IXmlIntellisenseMemberList _
             Implements IXmlIntellisenseMemberList.AttributesByName
 
@@ -1138,7 +1138,7 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
         '   Get descendant elements of this list having the specified namespace.
         '--------------------------------------------------------------------------
         Public Function DescendantsByNamespace(
-            <[In](), MarshalAs(UnmanagedType.BStr)> NamespaceName As String
+            <[In], MarshalAs(UnmanagedType.BStr)> NamespaceName As String
             ) As IXmlIntellisenseMemberList _
             Implements IXmlIntellisenseMemberList.DescendantsByNamespace
 
@@ -1150,8 +1150,8 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
         '   Get descendant elements of this list having the specified name.
         '--------------------------------------------------------------------------
         Public Function DescendantsByName(
-            <[In](), MarshalAs(UnmanagedType.BStr)> NamespaceName As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> LocalName As String
+            <[In], MarshalAs(UnmanagedType.BStr)> NamespaceName As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> LocalName As String
             ) As IXmlIntellisenseMemberList _
             Implements IXmlIntellisenseMemberList.DescendantsByName
 

--- a/src/Microsoft.VisualStudio.Editors/XmlIntellisense/XmlIntellisenseInterop.vb
+++ b/src/Microsoft.VisualStudio.Editors/XmlIntellisense/XmlIntellisenseInterop.vb
@@ -14,12 +14,12 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
     '--------------------------------------------------------------------------
     <Guid("94B71D3D-628F-4036-BF89-7FE1508E78AE")>
     <InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
-    <ComImport()>
+    <ComImport>
     Friend Interface IXmlIntellisenseService
 
         <MethodImpl(MethodImplOptions.InternalCall)>
         Function CreateSchemas(
-            <[In]()> ProjectGuid As Guid
+            <[In]> ProjectGuid As Guid
             ) _
             As IXmlIntellisenseSchemas
 
@@ -33,26 +33,26 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
     '--------------------------------------------------------------------------
     <Guid("1E9E02D2-0532-4BD2-8114-A24262CC9770")>
     <InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
-    <ComImport()>
+    <ComImport>
     Friend Interface IXmlIntellisenseSchemas
 
         <MethodImpl(MethodImplOptions.InternalCall)>
         Sub AsyncCompile()
 
-        ReadOnly Property CompiledEvent() As IntPtr
+        ReadOnly Property CompiledEvent As IntPtr
 
-        ReadOnly Property TargetNamespaces() As String()
+        ReadOnly Property TargetNamespaces As String()
 
-        ReadOnly Property MemberList() As IXmlIntellisenseMemberList
+        ReadOnly Property MemberList As IXmlIntellisenseMemberList
 
-        ReadOnly Property FirstErrorSource() As String
+        ReadOnly Property FirstErrorSource As String
 
-        ReadOnly Property IsEmpty() As <MarshalAs(UnmanagedType.Bool)> Boolean
+        ReadOnly Property IsEmpty As <MarshalAs(UnmanagedType.Bool)> Boolean
 
         <MethodImpl(MethodImplOptions.InternalCall)>
         Sub ShowInXmlSchemaExplorer(
-            <[In](), MarshalAs(UnmanagedType.BStr)> NamespaceName As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> LocalName As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> NamespaceName As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> LocalName As String,
             <MarshalAs(UnmanagedType.Bool)> ByRef ElementFound As Boolean,
             <MarshalAs(UnmanagedType.Bool)> ByRef NamespaceFound As Boolean)
 
@@ -66,7 +66,7 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
     '--------------------------------------------------------------------------
     <Guid("E90363FC-4246-4df8-869E-7BA42D29F526")>
     <InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
-    <ComImport()>
+    <ComImport>
     Friend Interface IXmlIntellisenseMemberList
 
         <MethodImpl(MethodImplOptions.InternalCall)>
@@ -83,41 +83,41 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
 
         <MethodImpl(MethodImplOptions.InternalCall)>
         Function ElementsByNamespace(
-            <[In](), MarshalAs(UnmanagedType.BStr)> NamespaceName As String
+            <[In], MarshalAs(UnmanagedType.BStr)> NamespaceName As String
             ) As IXmlIntellisenseMemberList
 
         <MethodImpl(MethodImplOptions.InternalCall)>
         Function ElementsByName(
-            <[In](), MarshalAs(UnmanagedType.BStr)> NamespaceName As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> LocalName As String
+            <[In], MarshalAs(UnmanagedType.BStr)> NamespaceName As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> LocalName As String
             ) As IXmlIntellisenseMemberList
 
         <MethodImpl(MethodImplOptions.InternalCall)>
         Function AttributesByNamespace(
-            <[In](), MarshalAs(UnmanagedType.BStr)> NamespaceName As String
+            <[In], MarshalAs(UnmanagedType.BStr)> NamespaceName As String
             ) As IXmlIntellisenseMemberList
 
         <MethodImpl(MethodImplOptions.InternalCall)>
         Function AttributesByName(
-            <[In](), MarshalAs(UnmanagedType.BStr)> NamespaceName As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> LocalName As String
+            <[In], MarshalAs(UnmanagedType.BStr)> NamespaceName As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> LocalName As String
             ) As IXmlIntellisenseMemberList
 
         <MethodImpl(MethodImplOptions.InternalCall)>
         Function DescendantsByNamespace(
-            <[In](), MarshalAs(UnmanagedType.BStr)> NamespaceName As String
+            <[In], MarshalAs(UnmanagedType.BStr)> NamespaceName As String
             ) As IXmlIntellisenseMemberList
 
         <MethodImpl(MethodImplOptions.InternalCall)>
         Function DescendantsByName(
-            <[In](), MarshalAs(UnmanagedType.BStr)> NamespaceName As String,
-            <[In](), MarshalAs(UnmanagedType.BStr)> LocalName As String
+            <[In], MarshalAs(UnmanagedType.BStr)> NamespaceName As String,
+            <[In], MarshalAs(UnmanagedType.BStr)> LocalName As String
             ) As IXmlIntellisenseMemberList
 
         <MethodImpl(MethodImplOptions.InternalCall)>
         Function GetEnumerator() As IXmlIntellisenseMemberEnumerator
 
-        ReadOnly Property MatchesNamedType() As Boolean
+        ReadOnly Property MatchesNamedType As Boolean
 
     End Interface
 
@@ -128,7 +128,7 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
     '--------------------------------------------------------------------------
     <Guid("C5E8D87C-674B-4966-9245-AA32914B05F7")>
     <InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
-    <ComImport()>
+    <ComImport>
     Friend Interface IXmlIntellisenseMemberEnumerator
 
         <MethodImpl(MethodImplOptions.InternalCall)>
@@ -143,14 +143,14 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
     '--------------------------------------------------------------------------
     <Guid("AB892676-9227-4c8e-AD84-DE887646D416")>
     <InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
-    <ComImport()>
+    <ComImport>
     Friend Interface IXmlIntellisenseMember
 
-        ReadOnly Property IsElement() As Boolean
+        ReadOnly Property IsElement As Boolean
 
-        ReadOnly Property NamespaceName() As String
+        ReadOnly Property NamespaceName As String
 
-        ReadOnly Property LocalName() As String
+        ReadOnly Property LocalName As String
 
     End Interface
 

--- a/src/Microsoft.VisualStudio.Editors/XmlToSchema/PasteXmlDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/XmlToSchema/PasteXmlDialog.vb
@@ -8,8 +8,8 @@ Namespace Microsoft.VisualStudio.Editors.XmlToSchema
     <HelpKeyword("vb.XmlToSchemaWizard")>
     Friend NotInheritable Class PasteXmlDialog
         Private _xml As XElement
-        Public ReadOnly Property Xml() As XElement
-            <DebuggerStepThrough()>
+        Public ReadOnly Property Xml As XElement
+            <DebuggerStepThrough>
             Get
                 Return _xml
             End Get

--- a/src/Microsoft.VisualStudio.Editors/XmlToSchema/Utilities.vb
+++ b/src/Microsoft.VisualStudio.Editors/XmlToSchema/Utilities.vb
@@ -48,16 +48,16 @@ Namespace Microsoft.VisualStudio.Editors.XmlToSchema
             HelpButton = True
         End Sub
 
-        Public Property ServiceProvider() As IServiceProvider
+        Public Property ServiceProvider As IServiceProvider
             Get
                 Return _serviceProvider
             End Get
-            Set(value As IServiceProvider)
+            Set
                 _serviceProvider = value
             End Set
         End Property
 
-        Protected ReadOnly Property DialogFont() As Font
+        Protected ReadOnly Property DialogFont As Font
             Get
                 Dim hostLocale As VsShell.IUIHostLocale2 = CType(_serviceProvider.GetService(GetType(VsShell.SUIHostLocale)), VsShell.IUIHostLocale2)
                 If hostLocale IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/XmlToSchema/WebUrlDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/XmlToSchema/WebUrlDialog.vb
@@ -8,16 +8,16 @@ Namespace Microsoft.VisualStudio.Editors.XmlToSchema
     <HelpKeyword("vb.XmlToSchemaWizard")>
     Friend NotInheritable Class WebUrlDialog
         Private _url As String
-        Public ReadOnly Property Url() As String
-            <DebuggerStepThrough()>
+        Public ReadOnly Property Url As String
+            <DebuggerStepThrough>
             Get
                 Return _url
             End Get
         End Property
 
         Private _xml As XElement
-        Public ReadOnly Property Xml() As XElement
-            <DebuggerStepThrough()>
+        Public ReadOnly Property Xml As XElement
+            <DebuggerStepThrough>
             Get
                 Return _xml
             End Get

--- a/src/Microsoft.VisualStudio.Editors/interop/IInternetSecurityManager.vb
+++ b/src/Microsoft.VisualStudio.Editors/interop/IInternetSecurityManager.vb
@@ -4,18 +4,18 @@ Imports System.Runtime.InteropServices
 
 Namespace Microsoft.VisualStudio.Editors.Interop
 
-    <ComImport(), ComVisible(False), Guid("79eac9ee-baf9-11ce-8c82-00aa004ba90b"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
+    <ComImport, ComVisible(False), Guid("79eac9ee-baf9-11ce-8c82-00aa004ba90b"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
     Friend Interface IInternetSecurityManager
-        <PreserveSig()> Function SetSecuritySite() As Integer
-        <PreserveSig()> Function GetSecuritySite() As Integer
-        <PreserveSig()> Function MapUrlToZone(<[In](), MarshalAs(UnmanagedType.BStr)> url As String, <Out()> ByRef zone As Integer, <[In]()> flags As Integer) As Integer
-        <PreserveSig()> Function GetSecurityId() As Integer
-        <PreserveSig()> Function ProcessUrlAction(url As String, action As Integer,
-                <Out(), MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> policy() As Byte,
+        <PreserveSig> Function SetSecuritySite() As Integer
+        <PreserveSig> Function GetSecuritySite() As Integer
+        <PreserveSig> Function MapUrlToZone(<[In], MarshalAs(UnmanagedType.BStr)> url As String, <Out> ByRef zone As Integer, <[In]> flags As Integer) As Integer
+        <PreserveSig> Function GetSecurityId() As Integer
+        <PreserveSig> Function ProcessUrlAction(url As String, action As Integer,
+                <Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex:=3)> policy() As Byte,
                 cbPolicy As Integer, ByRef context As Byte, cbContext As Integer,
                 flags As Integer, reserved As Integer) As Integer
-        <PreserveSig()> Function QueryCustomPolicy() As Integer
-        <PreserveSig()> Function SetZoneMapping() As Integer
-        <PreserveSig()> Function GetZoneMappings() As Integer
+        <PreserveSig> Function QueryCustomPolicy() As Integer
+        <PreserveSig> Function SetZoneMapping() As Integer
+        <PreserveSig> Function GetZoneMappings() As Integer
     End Interface
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/interop/IVBEntryPointProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/interop/IVBEntryPointProvider.vb
@@ -4,7 +4,7 @@ Imports System.Runtime.InteropServices
 
 Namespace Microsoft.VisualStudio.Editors.Interop
 
-    <ComImport(), Guid("3EB048DA-F881-4a7f-A9D4-0258E19978AA"),
+    <ComImport, Guid("3EB048DA-F881-4a7f-A9D4-0258E19978AA"),
     InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
     CLSCompliant(False)>
     Friend Interface IVBEntryPointProvider
@@ -19,10 +19,10 @@ Namespace Microsoft.VisualStudio.Editors.Interop
         '                                       cItems As UInteger, _
         '                                      <MarshalAs(UnmanagedType.LPArray, arraysubtype:=UnmanagedType.BStr), [In](), Out()> ByRef c() As String, _
         '                                     <Out()> ByRef pcActualItems As UInteger) As Integer
-        Function GetFormEntryPointsList(<MarshalAs(UnmanagedType.IUnknown), [In]()> pHierarchy As Object,
+        Function GetFormEntryPointsList(<MarshalAs(UnmanagedType.IUnknown), [In]> pHierarchy As Object,
                                         cItems As UInteger,
-                                        <Out(), MarshalAs(UnmanagedType.LPArray)> bstrList As String(),
-                                        <Out()> ByRef pcActualItems As UInteger) As Integer
+                                        <Out, MarshalAs(UnmanagedType.LPArray)> bstrList As String(),
+                                        <Out> ByRef pcActualItems As UInteger) As Integer
 
     End Interface
 

--- a/src/Microsoft.VisualStudio.Editors/interop/IVBReferenceUsageProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/interop/IVBReferenceUsageProvider.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.VisualStudio.Editors.Interop
     End Enum
 
 
-    <ComImport(), Guid("12636E2C-D42A-4db3-8795-6F9A6ABD120D"),
+    <ComImport, Guid("12636E2C-D42A-4db3-8795-6F9A6ABD120D"),
     InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
     CLSCompliant(False)>
     Friend Interface IVBReferenceUsageProvider

--- a/src/Microsoft.VisualStudio.Editors/interop/IVsAppId.vb
+++ b/src/Microsoft.VisualStudio.Editors/interop/IVsAppId.vb
@@ -5,7 +5,7 @@ Imports System.Runtime.InteropServices
 Namespace Microsoft.VisualStudio.Editors.Interop
 
     <ComVisible(False),
-    ComImport(),
+    ComImport,
     Guid("1EAA526A-0898-11d3-B868-00C04F79F802"),
     InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
     Friend Interface IVsAppId
@@ -15,23 +15,23 @@ Namespace Microsoft.VisualStudio.Editors.Interop
 
         ' HRESULT GetProperty([in] VSAPROPID propid,
         '                     [out] VARIANT *pvar);
-        <PreserveSig()>
+        <PreserveSig>
         Function GetProperty(propid As Integer,
-                         <Out(), MarshalAs(UnmanagedType.Struct)> ByRef pvar As Object) As Integer
+                         <Out, MarshalAs(UnmanagedType.Struct)> ByRef pvar As Object) As Integer
 
         ' HRESULT SetProperty([in] VSAPROPID propid,
         '                     [in] VARIANT var);
         Sub SetProperty(propid As Integer,
-                         <[In](), MarshalAs(UnmanagedType.Struct)> var As Object)
+                         <[In], MarshalAs(UnmanagedType.Struct)> var As Object)
 
         ' HRESULT GetGuidProperty([in] VSAPROPID propid,
         '                         [out] GUID *pguid);
         Sub GetGuidProperty(propid As Integer,
-                             <Out()> ByRef pguid As Guid)
+                             <Out> ByRef pguid As Guid)
 
         ' HRESULT SetGuidProperty([in] VSAPROPID propid,
         '                         [in] REFGUID rguid);
-        Sub SetGuidProperty(propid As Integer, <[In]()> ByRef rguid As Guid)
+        Sub SetGuidProperty(propid As Integer, <[In]> ByRef rguid As Guid)
 
         ' HRESULT Initialize();  ' called after main initialization and before command executing and entering main loop
         Sub Initialize()

--- a/src/Microsoft.VisualStudio.Editors/interop/IVsBuildEventCommandLineDialogService.vb
+++ b/src/Microsoft.VisualStudio.Editors/interop/IVsBuildEventCommandLineDialogService.vb
@@ -4,16 +4,16 @@ Imports System.Runtime.InteropServices
 
 Namespace Microsoft.VisualStudio.Editors.Interop
 
-    <ComImport(), Guid("A0EBEE86-72AD-4a29-8C0E-D745F843BE1D"),
+    <ComImport, Guid("A0EBEE86-72AD-4a29-8C0E-D745F843BE1D"),
     InterfaceType(ComInterfaceType.InterfaceIsDual),
     CLSCompliant(False)>
     Friend Interface IVsBuildEventCommandLineDialogService
-        <PreserveSig()>
-        Function EditCommandLine(<[In](), MarshalAs(UnmanagedType.BStr)> WindowText As String,
-        <[In](), MarshalAs(UnmanagedType.BStr)> HelpID As String,
-        <[In](), MarshalAs(UnmanagedType.BStr)> OriginalCommandLine As String,
-        <[In]()> MacroProvider As IVsBuildEventMacroProvider,
-        <Out(), MarshalAs(UnmanagedType.BStr)> ByRef Result As String) As Integer
+        <PreserveSig>
+        Function EditCommandLine(<[In], MarshalAs(UnmanagedType.BStr)> WindowText As String,
+        <[In], MarshalAs(UnmanagedType.BStr)> HelpID As String,
+        <[In], MarshalAs(UnmanagedType.BStr)> OriginalCommandLine As String,
+        <[In]> MacroProvider As IVsBuildEventMacroProvider,
+        <Out, MarshalAs(UnmanagedType.BStr)> ByRef Result As String) As Integer
     End Interface
 
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/interop/IVsBuildEventMacroProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/interop/IVsBuildEventMacroProvider.vb
@@ -4,14 +4,14 @@ Imports System.Runtime.InteropServices
 
 Namespace Microsoft.VisualStudio.Editors.Interop
 
-    <ComImport(), Guid("ED895476-EF59-46fc-A985-581F58343E61"),
+    <ComImport, Guid("ED895476-EF59-46fc-A985-581F58343E61"),
     InterfaceType(ComInterfaceType.InterfaceIsDual),
     CLSCompliant(False)>
     Friend Interface IVsBuildEventMacroProvider
         Function GetCount() As Integer
-        Sub GetExpandedMacro(<[In]()> Index As Integer,
-           <Out(), MarshalAs(UnmanagedType.BStr)> ByRef MacroName As String,
-           <Out(), MarshalAs(UnmanagedType.BStr)> ByRef MacroValue As String)
+        Sub GetExpandedMacro(<[In]> Index As Integer,
+           <Out, MarshalAs(UnmanagedType.BStr)> ByRef MacroName As String,
+           <Out, MarshalAs(UnmanagedType.BStr)> ByRef MacroValue As String)
     End Interface
 
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/interop/NativeMethods.vb
+++ b/src/Microsoft.VisualStudio.Editors/interop/NativeMethods.vb
@@ -322,73 +322,73 @@ Namespace Microsoft.VisualStudio.Editors.Interop
             CERT_CLOSE_STORE_FORCE_FLAG = 1
         End Enum
 
-        <PreserveSig()> Friend Declare Function _
+        <PreserveSig> Friend Declare Function _
              SetParent _
                  Lib "user32" (hwnd As IntPtr, hWndParent As IntPtr) As IntPtr
 
 
-        <PreserveSig()> Friend Declare Function _
+        <PreserveSig> Friend Declare Function _
             GetParent _
                 Lib "user32" (hwnd As IntPtr) As IntPtr
 
-        <PreserveSig()> Friend Declare Function _
+        <PreserveSig> Friend Declare Function _
             GetFocus _
                 Lib "user32" () As IntPtr
 
-        <PreserveSig()> Friend Declare Function _
+        <PreserveSig> Friend Declare Function _
             SetFocus _
                 Lib "user32" (hwnd As IntPtr) As Integer
 
-        <PreserveSig()> Friend Declare Auto Function _
+        <PreserveSig> Friend Declare Auto Function _
             SendMessage _
                 Lib "user32" (hwnd As HandleRef, msg As Integer, wParam As Integer, lParam As Integer) As IntPtr
 
-        <PreserveSig()> Friend Declare Auto Function _
+        <PreserveSig> Friend Declare Auto Function _
             SendMessage _
                 Lib "user32" (hwnd As HandleRef, msg As Integer, wParam As Integer, ByRef lParam As TVITEM) As IntPtr
 
-        <PreserveSig()> Friend Declare Auto Function _
+        <PreserveSig> Friend Declare Auto Function _
             SendMessage _
                 Lib "user32" (hwnd As IntPtr, msg As Integer, wParam As IntPtr, lParam As IntPtr) As IntPtr
 
-        <PreserveSig()> Friend Declare Auto Function _
+        <PreserveSig> Friend Declare Auto Function _
             PostMessage _
                 Lib "user32" (hwnd As IntPtr, msg As Integer, wParam As Integer, lParam As Integer) As IntPtr
 
-        <PreserveSig()> Friend Declare Auto Function _
+        <PreserveSig> Friend Declare Auto Function _
             WaitMessage _
                 Lib "user32" () As Boolean
 
         ''' <summary>
         ''' The GetNextDlgTabItem function retrieves a handle to the first control that has the WS_TABSTOP style that precedes (or follows) the specified control. 
         ''' </summary>
-        <PreserveSig()> Friend Declare Auto Function _
+        <PreserveSig> Friend Declare Auto Function _
             GetNextDlgTabItem _
                 Lib "user32" (hDlg As IntPtr, hCtl As IntPtr, bPrevious As Boolean) As IntPtr
 
 
-        <PreserveSig()>
+        <PreserveSig>
         Friend Declare Auto Function GetWindow Lib "user32" (Hwnd As IntPtr, uCmd As UInteger) As IntPtr
 
-        <PreserveSig()>
+        <PreserveSig>
         Friend Declare Auto Function DragQueryFile Lib "shell32" (hDrop As IntPtr, iFile As Integer, lpszFile As String, cch As Integer) As Integer
 
-        <PreserveSig()>
+        <PreserveSig>
         Friend Declare Function GetUserDefaultLCID Lib "kernel32" () As UInteger
 
-        <PreserveSig()>
+        <PreserveSig>
         Friend Declare Function GetTopWindow Lib "user32" (Hwnd As IntPtr) As IntPtr
 
-        <PreserveSig()>
+        <PreserveSig>
         Friend Declare Auto Function SetWindowLong Lib "user32" (hWnd As IntPtr, Index As Integer, Value As IntPtr) As IntPtr
-        <PreserveSig()>
+        <PreserveSig>
         Friend Declare Auto Function GetWindowLong Lib "user32" (Hwnd As IntPtr, Index As Integer) As IntPtr
 
         ' Windows theme
-        <PreserveSig()>
+        <PreserveSig>
         Friend Declare Auto Function SetWindowTheme Lib "uxtheme" (Hwnd As IntPtr, appName As String, subIdList As String) As Integer
 
-        <PreserveSig()>
+        <PreserveSig>
         Friend Declare Auto Function GetWindowText Lib "user32" (hWnd As IntPtr, lpString As String, nMaxCount As Integer) As Integer
 
         <DllImport("user32", CharSet:=CharSet.Auto)>
@@ -410,10 +410,10 @@ Namespace Microsoft.VisualStudio.Editors.Interop
             Public bottom As Integer
         End Structure
 
-        <PreserveSig()>
+        <PreserveSig>
         Friend Declare Auto Function IsChild Lib "user32" (hWndParent As IntPtr, hWnd As IntPtr) As Boolean
 
-        <PreserveSig()>
+        <PreserveSig>
         Friend Declare Auto Function EnableWindow Lib "user32" (hWnd As IntPtr, bEnable As Boolean) As Boolean
 
         '<System.Runtime.InteropServices.PreserveSig()> _
@@ -423,10 +423,10 @@ Namespace Microsoft.VisualStudio.Editors.Interop
         'Friend Declare Auto Function SetWindowPos Lib "user32" (Hwnd As IntPtr, HwndInsertAfter As IntPtr, x As Integer, _
         '    y As Integer, cx As Integer, cy As Integer, flags As Integer) As Boolean
 
-        <PreserveSig()>
+        <PreserveSig>
         Friend Declare Auto Function SystemParametersInfo Lib "user32" (uiAction As UInteger, uiParam As UInteger, pvParam As IntPtr, fWinIni As UInteger) As Integer
 
-        <PreserveSig()>
+        <PreserveSig>
         Friend Declare Auto Function MsgWaitForMultipleObjects Lib "user32" (nCount As Integer, pHandles As IntPtr, fWaitAll As Boolean, dwMilliSeconds As Integer, dwWakeMask As Integer) As Integer
 
         Friend Const GWL_EXSTYLE As Integer = -20
@@ -476,29 +476,29 @@ Namespace Microsoft.VisualStudio.Editors.Interop
     '
     ' ILangPropertyProvideBatchUpdate
     '
-    <ComImport(), Guid("F8828A38-5208-4497-991A-F8034C8D5A69"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
+    <ComImport, Guid("F8828A38-5208-4497-991A-F8034C8D5A69"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
     Friend Interface ILangPropertyProvideBatchUpdate
         Sub BeginBatch()
         Sub EndBatch()
-        Sub IsBatchModeEnabled(<[In](), Out()> ByRef BatchModeEnabled As Boolean)
+        Sub IsBatchModeEnabled(<[In], Out> ByRef BatchModeEnabled As Boolean)
         Sub PushOptionsToCompiler(dispid As UInteger)
     End Interface
 
-    <ComImport()>
+    <ComImport>
     <Guid("E5CB7A31-7512-11d2-89CE-0080C792E5D8")>
     <TypeLibType(TypeLibTypeFlags.FCanCreate)>
     <ClassInterface(ClassInterfaceType.None)>
     Friend Class CorMetaDataDispenser
     End Class
 
-    <ComImport()>
+    <ComImport>
     <Guid("809c652e-7396-11d2-9771-00a0c9b4d50c")>
     <InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
     <TypeLibType(TypeLibTypeFlags.FRestricted)>
     Friend Interface IMetaDataDispenser
-        Function DefineScope(<[In]()> ByRef rclsid As Guid, <[In]()> dwCreateFlags As UInteger, <[In]()> ByRef riid As Guid) As <MarshalAs(UnmanagedType.Interface)> Object
-        <PreserveSig()> Function OpenScope(<[In](), MarshalAs(UnmanagedType.LPWStr)> szScope As String, <[In]()> dwOpenFlags As UInteger, <[In]()> ByRef riid As Guid, <Out(), MarshalAs(UnmanagedType.Interface)> ByRef obj As Object) As Integer
-        Function OpenScopeOnMemory(<[In]()> pData As IntPtr, <[In]()> cbData As UInteger, <[In]()> dwOpenFlags As UInteger, <[In]()> ByRef riid As Guid) As <MarshalAs(UnmanagedType.Interface)> Object
+        Function DefineScope(<[In]> ByRef rclsid As Guid, <[In]> dwCreateFlags As UInteger, <[In]> ByRef riid As Guid) As <MarshalAs(UnmanagedType.Interface)> Object
+        <PreserveSig> Function OpenScope(<[In], MarshalAs(UnmanagedType.LPWStr)> szScope As String, <[In]> dwOpenFlags As UInteger, <[In]> ByRef riid As Guid, <Out, MarshalAs(UnmanagedType.Interface)> ByRef obj As Object) As Integer
+        Function OpenScopeOnMemory(<[In]> pData As IntPtr, <[In]> cbData As UInteger, <[In]> dwOpenFlags As UInteger, <[In]> ByRef riid As Guid) As <MarshalAs(UnmanagedType.Interface)> Object
     End Interface
 
     <StructLayout(LayoutKind.Sequential)>

--- a/src/Microsoft.VisualStudio.Editors/package/InternalException.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/InternalException.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.VisualStudio.Editors.Package
     '''   (obviously not very helpful, but it doesn't make sense to localize and doc messages for errors which shouldn't
     '''   be happening).
     ''' </summary>
-    <Serializable()>
+    <Serializable>
     Friend Class InternalException
         Inherits ApplicationException
 

--- a/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
@@ -51,7 +51,7 @@ Namespace Microsoft.VisualStudio.Editors
         ' Map between unique project GUID and the last viewed tab in the project designer...
         Private _lastViewedProjectDesignerTab As Dictionary(Of Guid, Byte)
 
-        Public ReadOnly Property StickyProjectResourcePaths() As New Dictionary(Of Guid, Dictionary(Of String, String))
+        Public ReadOnly Property StickyProjectResourcePaths As New Dictionary(Of Guid, Dictionary(Of String, String))
 
         ''' <summary>
         ''' Constructor
@@ -119,7 +119,7 @@ Namespace Microsoft.VisualStudio.Editors
             _userConfigCleaner = New UserConfigCleaner(Me)
         End Sub 'New
 
-        Public ReadOnly Property MenuCommandService() As IMenuCommandService Implements IVBPackage.MenuCommandService
+        Public ReadOnly Property MenuCommandService As IMenuCommandService Implements IVBPackage.MenuCommandService
             Get
                 Return TryCast(GetService(GetType(IMenuCommandService)), IMenuCommandService)
             End Get
@@ -225,7 +225,7 @@ Namespace Microsoft.VisualStudio.Editors
 
         Private Shared s_instance As VBPackage
 
-        Public Shared ReadOnly Property Instance() As VBPackage
+        Public Shared ReadOnly Property Instance As VBPackage
             Get
                 Return s_instance
             End Get


### PR DESCRIPTION
- Remove redundant parenthesis on property declarations
- Remove redundant 'value' declaration on property setters
- Remove empty parenthesis in attribute usages

This changes the capitalisation of parameter passed to some setter methods, which is technically an API change but seems highly unlikely to cause problems in practice.