### PR TITLE
Add CODE_OF_CONDUCT file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+This project has adopted the code of conduct defined by the Contributor Covenant
+to clarify expected behavior in our community.
+For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).


### PR DESCRIPTION
This project's code of conduct is currently referenced from the [README](https://github.com/dotnet/project-system/blob/master/README.md#how-do-i-engage-and-contribute) file. It's standard to have a file in the root of the repo called `CODE_OF_CONDUCT.md` that includes this information.

GitHub understands this file and includes information about it in data returned by its API.