### PR TITLE
Use reference equality for type checks

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
@@ -169,7 +169,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="ServiceType"></param>
         Protected Function GetService(ServiceType As Type) As Object Implements IPropertyPageSiteInternal.GetService
             'Proffer the actual IPropertyPageSite as a service
-            If ServiceType.Equals(GetType(IPropertyPageSite)) Then
+            If ServiceType Is GetType(IPropertyPageSite) Then
                 Return _pageSite
             End If
 

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationDataSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationDataSerializer.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             End If
             If Not needType Then
                 Dim t As Type = o.GetType()
-                If Equals(t, GetType(MyApplicationData)) Then
+                If t Is GetType(MyApplicationData) Then
                 Else
                     Throw CreateUnknownTypeException(o)
                 End If
@@ -263,7 +263,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
 
         Protected Overrides Sub Serialize(objectToSerialize As Object, writer As XmlSerializationWriter)
 
-            If objectToSerialize IsNot Nothing AndAlso Not Equals(objectToSerialize.GetType(), GetType(MyApplicationData)) Then
+            If objectToSerialize IsNot Nothing AndAlso Not TypeOf objectToSerialize Is MyApplicationData Then
                 Debug.Fail("Cannot serialize object of type " + objectToSerialize.GetType().FullName + " with MyApplicationDataSerializer. Object of type " + GetType(MyApplicationDataSerializer).FullName + " expected.")
                 Throw New Package.InternalException()
             End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -12,6 +12,7 @@ Imports System.Reflection
 Imports System.Resources
 Imports System.Runtime.Serialization
 Imports System.Text
+Imports System.Windows.Forms
 
 Imports Microsoft.VisualStudio.Editors.Common.Utils
 Imports Microsoft.VisualStudio.Shell
@@ -145,7 +146,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '''      The converted object.
             ''' </returns>
             Public Overrides Function ConvertTo(context As ITypeDescriptorContext, culture As CultureInfo, value As Object, destinationType As Type) As Object
-                If destinationType.Equals(GetType(String)) Then
+                If destinationType Is GetType(String) Then
                     If value IsNot Nothing AndAlso TypeOf value Is ResourcePersistenceMode Then
                         Select Case CType(value, ResourcePersistenceMode)
                             Case ResourcePersistenceMode.Linked
@@ -948,9 +949,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Public Property FileType As FileTypes
             Get
                 If TypeOf ResourceTypeEditor Is ResourceTypeEditorFileBase Then
-                    If TryGetValueType().Equals(ResourceTypeEditorTextFile.TextFileValueType) Then
+                    If TryGetValueType() Is ResourceTypeEditorTextFile.TextFileValueType Then
                         Return FileTypes.Text
-                    ElseIf TryGetValueType().Equals(ResourceTypeEditorBinaryFile.BinaryFileValueType) Then
+                    ElseIf TryGetValueType() Is ResourceTypeEditorBinaryFile.BinaryFileValueType Then
                         Return FileTypes.Binary
                     Else
                         Debug.Fail("Unexpected resource value type for a file resource")
@@ -993,7 +994,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         Return
                 End Select
 
-                If NewResourceTypeEditor.Equals(ResourceTypeEditor) AndAlso NewResourceValueType.Equals(TryGetValueType) Then
+                If NewResourceTypeEditor.Equals(ResourceTypeEditor) AndAlso NewResourceValueType Is TryGetValueType() Then
                     'Nothing to do
                     Exit Property
                 End If
@@ -1481,11 +1482,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     'Value is not Nothing
 
                     'Verify that the new value is of the same type as before.
-                    If Not GetValueType().Equals(NewResourceValue.GetType()) Then
+                    If GetValueType() IsNot NewResourceValue.GetType() Then
                         'Exception to this rule.  We need to handle Byte() <-> MemoryStream conversion automatically
-                        If NewResourceValue.GetType().Equals(GetType(Byte())) AndAlso GetValueType().Equals(GetType(MemoryStream)) Then
+                        If TypeOf NewResourceValue Is Byte() AndAlso GetValueType() Is GetType(MemoryStream) Then
                             NewResourceValue = New MemoryStream(DirectCast(NewResourceValue, Byte()))
-                        ElseIf NewResourceValue.GetType().Equals(GetType(MemoryStream)) AndAlso GetValueType().Equals(GetType(Byte())) Then
+                        ElseIf TypeOf NewResourceValue Is MemoryStream AndAlso GetValueType() Is GetType(Byte()) Then
                             NewResourceValue = DirectCast(NewResourceValue, MemoryStream).ToArray()
                         Else
                             Throw NewException(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Err_UnexpectedResourceType, HelpIDs.Err_UnexpectedResourceType)
@@ -1684,13 +1685,13 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     'Apparently we couldn't load the type (assembly not found, etc.).  This item will have to show
                     '  up in the "Others" category.
                     TypeEditor = ResourceTypeEditors.NonStringConvertible
-                ElseIf IsLink AndAlso ValueType.Equals(ResourceTypeEditorTextFile.TextFileValueType) Then
+                ElseIf IsLink AndAlso ValueType Is ResourceTypeEditorTextFile.TextFileValueType Then
                     'It's a link to a text file
                     TypeEditor = ResourceTypeEditors.TextFile
-                ElseIf ValueType.Equals(GetType(Byte())) OrElse ValueType.Equals(GetType(MemoryStream)) Then
+                ElseIf ValueType Is GetType(Byte()) OrElse ValueType Is GetType(MemoryStream) Then
                     'It's a link to a binary or audio file or it might be an embedded audio file
 
-                    If IsLink AndAlso ValueType.Equals(GetType(Byte())) Then
+                    If IsLink AndAlso ValueType Is GetType(Byte()) Then
                         'Unless we decide specifically otherwise, we will normally treat binary files as
                         '  binary data.
                         TypeEditor = ResourceTypeEditors.BinaryFile
@@ -1701,7 +1702,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     If IsLink AndAlso ResourceTypeEditors.Audio.GetExtensionPriority(Path.GetExtension(AbsoluteLinkPathAndFileName)) > 0 Then
                         'Audio type editor says it can handle this extension - let it handle it.
                         TypeEditor = ResourceTypeEditors.Audio
-                    ElseIf IsLink AndAlso ValueType.Equals(GetType(Byte())) Then
+                    ElseIf IsLink AndAlso ValueType Is GetType(Byte()) Then
 
                         ' Bitmap and icons may be stored as a linked resource with byte array as the type.
                         ' Select the resource type editor using the extension of the file name in the link.
@@ -2112,7 +2113,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private Shared Function IsConvertibleFromToString(Value As Object, ValueTypeName As String, IsResXNullRef As Boolean) As Boolean
             Dim TC As TypeConverter = GetTypeConverter(Value, ValueTypeName, IsResXNullRef)
             If TC IsNot Nothing Then
-                If TC.GetType.Equals(GetType(Windows.Forms.CursorConverter)) Then
+                If TypeOf TC Is CursorConverter Then
                     'The CursorConverter lies to us - says it's convertible from/to string.  But this is only true from the
                     '  property sheet for the standard cursors that they support from the Windows Forms designer.  If we happen
                     '  upon a custom cursor in the resx file (possible but not likely), this would get us into trouble.
@@ -2704,7 +2705,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <returns>The new ResXDataNode instance</returns>
         Private Function NewResXDataNode(Name As String, Comment As String, Value As Object) As ResXDataNode
             Dim Node As ResXDataNode
-            If Value IsNot Nothing AndAlso Value.GetType().Equals(GetType(ResXFileRef)) Then
+            If Value IsNot Nothing AndAlso TypeOf Value Is ResXFileRef Then
                 Node = New ResXDataNode(Name, DirectCast(Value, ResXFileRef), AddressOf TypeNameConverter)
             Else
                 Node = New ResXDataNode(Name, Value, AddressOf TypeNameConverter)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorBinaryFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorBinaryFile.vb
@@ -112,8 +112,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <returns>The friendly size string.</returns>
         Public Overrides Function GetResourceFriendlySize(Resource As IResource) As String
             ValidateResourceValue(Resource, BinaryFileValueType)
-            Debug.Assert(Resource.GetValueType().Equals(BinaryFileValueType))
-            Debug.Assert(BinaryFileValueType.Equals(GetType(Byte())), "Need to change implementation - type of binary files has changed")
+            Debug.Assert(Resource.GetValueType() Is BinaryFileValueType)
+            Debug.Assert(BinaryFileValueType Is GetType(Byte()), "Need to change implementation - type of binary files has changed")
             Debug.Assert(Resource.IsLink)
 
             Return GetLinkedResourceFriendlySize(Resource)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorInternalBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorInternalBase.vb
@@ -112,7 +112,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 If ExpectedTypes IsNot Nothing AndAlso ExpectedTypes.Length > 0 Then
                     Dim MatchedAType As Boolean = False
                     For Each ExpectedType As Type In ExpectedTypes
-                        If ResourceValueType.Equals(ExpectedType) OrElse ResourceValueType.IsSubclassOf(ExpectedType) Then
+                        If ResourceValueType Is ExpectedType OrElse ResourceValueType.IsSubclassOf(ExpectedType) Then
                             MatchedAType = True
                             Exit For
                         End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorTextFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorTextFile.vb
@@ -240,8 +240,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Public Overrides Function GetResourceFriendlySize(Resource As IResource) As String
             ValidateResourceValue(Resource, TextFileValueType)
             Debug.Assert(Resource.IsLink)
-            Debug.Assert(Resource.GetValueType.Equals(TextFileValueType))
-            Debug.Assert(TextFileValueType.Equals(GetType(String)), "Type of text files has changed?")
+            Debug.Assert(Resource.GetValueType Is TextFileValueType)
+            Debug.Assert(TextFileValueType Is GetType(String), "Type of text files has changed?")
 
             Return GetLinkedResourceFriendlySize(Resource)
         End Function

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/SerializableEncodingConverter.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/SerializableEncodingConverter.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   type to a SerializableEncoding object using the specified context.
         ''' </summary>
         Public Overrides Function CanConvertFrom(Context As ITypeDescriptorContext, SourceType As Type) As Boolean
-            If SourceType.Equals(GetType(String)) Then
+            If SourceType Is GetType(String) Then
                 Return True
             End If
 
@@ -64,7 +64,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Public Overrides Function ConvertTo(Context As ITypeDescriptorContext, Culture As CultureInfo, Value As Object, DestinationType As Type) As Object
             Requires.NotNull(DestinationType, NameOf(DestinationType))
 
-            If DestinationType.Equals(GetType(String)) AndAlso TypeOf Value Is SerializableEncoding Then
+            If DestinationType Is GetType(String) AndAlso TypeOf Value Is SerializableEncoding Then
                 Dim SerializableEncoding As SerializableEncoding = DirectCast(Value, SerializableEncoding)
 
                 'Here we return the localized encoding name.  That's what actually shows up

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorCell.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorCell.vb
@@ -43,7 +43,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         Protected Overrides Function GetFormattedValue(value As Object, rowIndex As Integer, ByRef cellStyle As DataGridViewCellStyle, valueTypeConverter As TypeConverter, formattedValueTypeConverter As TypeConverter, context As DataGridViewDataErrorContexts) As Object
             If (context And DataGridViewDataErrorContexts.Display) <> 0 AndAlso
                 value IsNot Nothing AndAlso
-                value.GetType().Equals(GetType(VSDesigner.VSDesignerPackage.SerializableConnectionString)) Then
+                TypeOf value Is VSDesigner.VSDesignerPackage.SerializableConnectionString Then
                 'Begin
                 Return DirectCast(value, VSDesigner.VSDesignerPackage.SerializableConnectionString).ConnectionString
             Else

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorEditingControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorEditingControl.vb
@@ -113,7 +113,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         End Property
 
         Public Function GetFormattedValue(context As DataGridViewDataErrorContexts) As Object Implements IDataGridViewEditingControl.GetEditingControlFormattedValue
-            If (context And DataGridViewDataErrorContexts.Parsing) <> 0 AndAlso ValueType.Equals(GetType(SerializableConnectionString)) Then
+            If (context And DataGridViewDataErrorContexts.Parsing) <> 0 AndAlso ValueType Is GetType(SerializableConnectionString) Then
                 Dim scs As SerializableConnectionString = TryCast(Value, SerializableConnectionString)
                 If scs Is Nothing Then
                     scs = New SerializableConnectionString
@@ -263,7 +263,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
 
         Protected Overrides Function FormatValue(ValueToFormat As Object) As String
-            If ValueToFormat IsNot Nothing AndAlso ValueToFormat.GetType().Equals(GetType(SerializableConnectionString)) Then
+            If ValueToFormat IsNot Nothing AndAlso TypeOf ValueToFormat Is SerializableConnectionString Then
                 Return DirectCast(ValueToFormat, SerializableConnectionString).ConnectionString
             Else
                 Return SettingsValueSerializer.Serialize(ValueToFormat, System.Threading.Thread.CurrentThread.CurrentCulture)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettingInstance.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettingInstance.vb
@@ -659,7 +659,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             End Sub
 
             Public Overrides Function CanConvertFrom(context As ITypeDescriptorContext, type As Type) As Boolean
-                If GetType(String).Equals(type) Then
+                If type Is GetType(String) Then
                     Return True
                 Else
                     Return MyBase.CanConvertFrom(context, type)
@@ -667,7 +667,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             End Function
 
             Public Overrides Function CanConvertTo(context As ITypeDescriptorContext, type As Type) As Boolean
-                If GetType(String).Equals(type) Then
+                If type Is GetType(String) Then
                     Return True
                 Else
                     Return MyBase.CanConvertTo(context, type)
@@ -688,7 +688,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             End Function
 
             Public Overrides Function ConvertTo(context As ITypeDescriptorContext, culture As Globalization.CultureInfo, value As Object, destinationType As Type) As Object
-                If GetType(String).Equals(destinationType) Then
+                If destinationType Is GetType(String) Then
                     Dim instance As DesignTimeSettingInstance = Nothing
                     If context IsNot Nothing Then
                         instance = TryCast(context.Instance, DesignTimeSettingInstance)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/FakeCollectionEditor.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/FakeCollectionEditor.vb
@@ -61,8 +61,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Return Nothing
             End If
 
-            If value.GetType().Equals(GetType(StringCollection)) Then
-                Dim strCol As StringCollection = DirectCast(value, StringCollection)
+            Dim strCol = TryCast(value, StringCollection)
+            If strCol IsNot Nothing Then
                 Dim result(strCol.Count - 1) As String
                 strCol.CopyTo(result, 0)
                 Return result
@@ -79,8 +79,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Return Nothing
             End If
 
-            If value.GetType().Equals(GetType(String())) Then
-                Dim strings() As String = DirectCast(value, String())
+            Dim strings = TryCast(value, String())
+            If strings IsNot Nothing Then
                 Dim result As New StringCollection
                 result.AddRange(strings)
                 Return result

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsValueSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsValueSerializer.vb
@@ -99,7 +99,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         Private Shared Function SerializeImpl(value As Object, culture As Globalization.CultureInfo) As String
             If value Is Nothing Then
                 Return ""
-            ElseIf value.GetType().Equals(GetType(String)) Then
+            ElseIf TypeOf value Is String Then
                 Return DirectCast(value, String)
             Else
                 Dim prop As New SettingsProperty("") ' We don't care about the name of the setting!

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorHostControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorHostControl.vb
@@ -527,7 +527,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
 #Region "IServiceProvider implementation"
         Public Function IServiceProvider_GetService(serviceType As Type) As Object Implements IServiceProvider.GetService
-            If serviceType.Equals(GetType(IWindowsFormsEditorService)) Then
+            If serviceType Is GetType(IWindowsFormsEditorService) Then
                 Return Me
             Else
                 Return GetService(serviceType)


### PR DESCRIPTION
These are clearer to read and theoretically faster as they avoid calling the virtual `Equals` function.

Transformations:

1. `type1.Equals(type2)` ➡️ `type1 is type2`
2. `obj1.GetType() Is TypeOf(SomeType)` ➡️ TypeOf obj1 Is SomeType`