### PR TITLE
IVsShellUtilitiesHelper cleanup

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsShellUtilitiesHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsShellUtilitiesHelper.cs
@@ -10,10 +10,13 @@ namespace Microsoft.VisualStudio.Shell.Interop
     internal interface IVsShellUtilitiesHelper
     {
         /// <summary>
-        /// Returns the version of VS as defined by VSVSAPROPID_ProductSemanticVersion with the trailing sem version stripped, or null on failure. 
+        /// Returns the version of VS as defined by <see cref="VSAPropID.VSAPROPID_ProductSemanticVersion"/> with the trailing sem version stripped, or <see langword="null"/> on failure.
         /// </summary>
         Task<Version?> GetVSVersionAsync(IVsService<IVsAppId> vsAppIdService);
 
+        /// <summary>
+        /// Returns the local app data folder as defined by <see cref="__VSSPROPID4.VSSPROPID_LocalAppDataDir"/>.
+        /// </summary>
         Task<string?> GetLocalAppDataFolderAsync(IVsService<IVsShell> vsShellService);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsShellUtilitiesHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsShellUtilitiesHelper.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Interop;
 
 namespace Microsoft.VisualStudio.Shell.Interop
 {
-    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    [ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IVsShellUtilitiesHelper
     {
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsShellUtilitiesHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsShellUtilitiesHelper.cs
@@ -2,11 +2,14 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Composition;
+using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.VS;
 using Microsoft.VisualStudio.ProjectSystem.VS.Interop;
 
 namespace Microsoft.VisualStudio.Shell.Interop
 {
+    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IVsShellUtilitiesHelper
     {
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsShellUtilitiesHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsShellUtilitiesHelper.cs
@@ -58,9 +58,9 @@ namespace Microsoft.VisualStudio.Shell.Interop
 
             Assumes.Present(shell);
 
-            if (ErrorHandler.Succeeded(shell.GetProperty((int)__VSSPROPID4.VSSPROPID_LocalAppDataDir, out object objDataFolder)) && objDataFolder is string appDataFolder)
+            if (ErrorHandler.Succeeded(shell.GetProperty((int)__VSSPROPID4.VSSPROPID_LocalAppDataDir, out object value)))
             {
-                return appDataFolder;
+                return value as string;
             }
 
             return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsShellUtilitiesHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsShellUtilitiesHelper.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Interop;
 namespace Microsoft.VisualStudio.Shell.Interop
 {
     /// <summary>
-    /// Wrapper for VsShellUtilities to allow for testing.
+    /// Wrapper for <see cref="VsShellUtilities"/> to allow for testing.
     /// </summary>
     [Export(typeof(IVsShellUtilitiesHelper))]
     internal class VsShellUtilitiesHelper : IVsShellUtilitiesHelper
@@ -23,9 +23,6 @@ namespace Microsoft.VisualStudio.Shell.Interop
             _threadingService = threadingService;
         }
 
-        /// <summary>
-        /// <see cref="IVsShellUtilitiesHelper.GetVSVersionAsync"/>
-        /// </summary>
         public async Task<Version?> GetVSVersionAsync(IVsService<IVsAppId> vsAppIdService)
         {
             await _threadingService.SwitchToUIThread();


### PR DESCRIPTION
For a brief moment in time I was looking to extend this interface and its implementation to provide the VS installation directory. But it didn't quite do what I wanted.

Pulled these cleanup commits out to their own branch.