### PR TITLE
Display import tree items in correct order

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProjectTypeCapabilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProjectTypeCapabilities.cs
@@ -16,6 +16,7 @@ namespace Microsoft.VisualStudio.Packaging
                                       ProjectCapability.PreserveFormatting + "; " +
                                       ProjectCapability.ProjectConfigurationsDeclaredDimensions + "; " +
                                       ProjectCapability.LanguageService + "; " +
+                                      ProjectCapability.SortByDisplayOrder + "; " + // Respect IProjectTree2.DisplayOrder
                                       ProjectCapability.DotNet;
 
         /// <summary>
@@ -23,7 +24,6 @@ namespace Microsoft.VisualStudio.Packaging
         /// </summary>
         public const string FSharp = Default + "; " +
                                      ProjectCapability.FSharp + "; " +
-                                     ProjectCapability.SortByDisplayOrder + "; " +
                                      ProjectCapability.EditableDisplayOrder;
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProjectTypeCapabilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProjectTypeCapabilities.cs
@@ -16,7 +16,6 @@ namespace Microsoft.VisualStudio.Packaging
                                       ProjectCapability.PreserveFormatting + "; " +
                                       ProjectCapability.ProjectConfigurationsDeclaredDimensions + "; " +
                                       ProjectCapability.LanguageService + "; " +
-                                      ProjectCapability.SortByDisplayOrder + "; " + // Respect IProjectTree2.DisplayOrder
                                       ProjectCapability.DotNet;
 
         /// <summary>
@@ -24,6 +23,7 @@ namespace Microsoft.VisualStudio.Packaging
         /// </summary>
         public const string FSharp = Default + "; " +
                                      ProjectCapability.FSharp + "; " +
+                                     ProjectCapability.SortByDisplayOrder + "; " +
                                      ProjectCapability.EditableDisplayOrder;
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProjectTypeCapabilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProjectTypeCapabilities.cs
@@ -21,7 +21,10 @@ namespace Microsoft.VisualStudio.Packaging
         /// <summary>
         ///     Represents F#'s set of capabilities that are always present.
         /// </summary>
-        public const string FSharp = Default + "; " + ProjectCapability.FSharp + "; " + ProjectCapability.SortByDisplayOrder;
+        public const string FSharp = Default + "; " +
+                                     ProjectCapability.FSharp + "; " +
+                                     ProjectCapability.SortByDisplayOrder + "; " +
+                                     ProjectCapability.EditableDisplayOrder;
 
         /// <summary>
         ///     Represents C#'s set of capabilities that are always present.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemAboveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemAboveCommand.cs
@@ -9,7 +9,7 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
     [ProjectCommand(CommandGroup.ManagedProjectSystemOrder, ManagedProjectSystemOrderCommandId.AddExistingItemAbove)]
-    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder + " & " + ProjectCapability.EditableDisplayOrder)]
     internal class AddExistingItemAboveCommand : AbstractAddItemCommand
     {
         private readonly IAddItemDialogService _addItemDialogService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemBelowCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemBelowCommand.cs
@@ -9,7 +9,7 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
     [ProjectCommand(CommandGroup.ManagedProjectSystemOrder, ManagedProjectSystemOrderCommandId.AddExistingItemBelow)]
-    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder + " & " + ProjectCapability.EditableDisplayOrder)]
     internal class AddExistingItemBelowCommand : AbstractAddItemCommand
     {
         private readonly IAddItemDialogService _addItemDialogService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemCommand.cs
@@ -9,7 +9,7 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
     [ProjectCommand(CommandGroup.VisualStudioStandard97, (long)VSConstants.VSStd97CmdID.AddExistingItem)]
-    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder + " & " + ProjectCapability.EditableDisplayOrder)]
     [Order(5000)]
     internal class AddExistingItemCommand : AbstractAddItemCommand
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemAboveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemAboveCommand.cs
@@ -9,7 +9,7 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
     [ProjectCommand(CommandGroup.ManagedProjectSystemOrder, ManagedProjectSystemOrderCommandId.AddNewItemAbove)]
-    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder + " & " + ProjectCapability.EditableDisplayOrder)]
     internal class AddNewItemAboveCommand : AbstractAddItemCommand
     {
         private readonly IAddItemDialogService _addItemDialogService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemBelowCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemBelowCommand.cs
@@ -9,7 +9,7 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
     [ProjectCommand(CommandGroup.ManagedProjectSystemOrder, ManagedProjectSystemOrderCommandId.AddNewItemBelow)]
-    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder + " & " + ProjectCapability.EditableDisplayOrder)]
     internal class AddNewItemBelowCommand : AbstractAddItemCommand
     {
         private readonly IAddItemDialogService _addItemDialogService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemCommand.cs
@@ -9,7 +9,7 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
     [ProjectCommand(CommandGroup.VisualStudioStandard97, (long)VSConstants.VSStd97CmdID.AddNewItem)]
-    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder + " & " + ProjectCapability.EditableDisplayOrder)]
     [Order(5000)]
     internal class AddNewItemCommand : AbstractAddItemCommand
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommand.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.Shell;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
     [ProjectCommand(CommandGroup.FSharpProject, FSharpProjectCommandId.MoveDown)]
-    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder + " & " + ProjectCapability.EditableDisplayOrder)]
     internal class MoveDownCommand : AbstractMoveCommand
     {
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommand.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.Shell;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
     [ProjectCommand(CommandGroup.FSharpProject, FSharpProjectCommandId.MoveUp)]
-    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder + " & " + ProjectCapability.EditableDisplayOrder)]
     internal class MoveUpCommand : AbstractMoveCommand
     {
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
     [Export(typeof(IProjectChangeHintReceiver))]
     [Export(typeof(OrderAddItemHintReceiver))]
     [ProjectChangeHintKind(ProjectChangeFileSystemEntityHint.AddedFileAsString)]
-    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder + " & " + ProjectCapability.EditableDisplayOrder)]
     internal class OrderAddItemHintReceiver : IProjectChangeHintReceiver
     {
         private readonly IProjectAccessor _accessor;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/PasteOrdering.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/PasteOrdering.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
     /// </summary>
     [Export(typeof(IPasteDataObjectProcessor))]
     [Export(typeof(IPasteHandler))]
-    [AppliesTo(ProjectCapabilities.SortByDisplayOrder)]
+    [AppliesTo(ProjectCapabilities.SortByDisplayOrder + " & " + ProjectCapability.EditableDisplayOrder)]
     [Order(OrderPrecedence)]
     internal class PasteOrdering : IPasteHandler, IPasteDataObjectProcessor
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderSource.cs
@@ -9,10 +9,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
 {
     /// <summary>
     /// Setup the dataflow for a provider that updates solution tree item properties with 
-    /// display order metadata derived from IOrderedSourceItemsDataSourceService
+    /// display order metadata derived from <see cref="IOrderedSourceItemsDataSourceService"/>.
     /// </summary>
     [Export(typeof(IProjectTreePropertiesProviderDataSource))]
-    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder + " & " + ProjectCapability.EditableDisplayOrder)]
     internal class TreeItemOrderPropertyProviderSource : ChainedProjectValueDataSourceBase<IProjectTreePropertiesProvider>, IProjectTreePropertiesProviderDataSource
     {
         private readonly UnconfiguredProject _project;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -82,6 +82,12 @@
     <ProjectCapability Include="LaunchProfiles" />
     <ProjectCapability Include="NoGeneralDependentFileIcon"/>
     <!--
+      We want the tree to respect IProjectTree2.DisplayOrder when it is set.
+      This is different to capability EditableDisplayOrder, used by F# for example, which
+      allows the user to manipulate display order values.
+    -->
+    <ProjectCapability Include="SortByDisplayOrder"/>
+    <!--
       List of capabilities below is adding back common capabilities defined in imported targets.
       We disabled them with the property DefineCommonCapabilities=false to get rid of default
       References capability, but everything else we want back.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -82,12 +82,6 @@
     <ProjectCapability Include="LaunchProfiles" />
     <ProjectCapability Include="NoGeneralDependentFileIcon"/>
     <!--
-      We want the tree to respect IProjectTree2.DisplayOrder when it is set.
-      This is different to capability EditableDisplayOrder, used by F# for example, which
-      allows the user to manipulate display order values.
-    -->
-    <ProjectCapability Include="SortByDisplayOrder"/>
-    <!--
       List of capabilities below is adding back common capabilities defined in imported targets.
       We disabled them with the property DefineCommonCapabilities=false to get rid of default
       References capability, but everything else we want back.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
@@ -37,7 +37,21 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public const string ProjectConfigurationsDeclaredDimensions = ProjectCapabilities.ProjectConfigurationsDeclaredDimensions;
         public const string LanguageService = nameof(LanguageService);
         public const string DotNetLanguageService = DotNet + " & " + LanguageService;
+        
+        /// <summary>
+        /// Instructs CPS to order tree items according to the <see cref="IProjectTree2.DisplayOrder"/> property first.
+        /// This is in addition to the default ordering by <see cref="ProjectTreeFlags.Common.BubbleUp"/>, then by
+        /// <see cref="ProjectTreeFlags.Common.Folder"/> or <see cref="ProjectTreeFlags.Common.VirtualFolder"/>, and finally
+        /// alphabetical.
+        /// </summary>
         public const string SortByDisplayOrder = ProjectCapabilities.SortByDisplayOrder;
+        
+        /// <summary>
+        /// Enables commands and behaviour that allows reordering items in the tree.
+        /// Used by F# projects, for which item order is significant to compilation.
+        /// </summary>
+        public const string EditableDisplayOrder = nameof(EditableDisplayOrder);
+        
         public const string DotNet = ".NET";
         public const string WindowsForms = nameof(WindowsForms);
         public const string WPF = nameof(WPF);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -220,6 +220,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                                     }
                                 }
 
+                                var observedCaptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
                                 for (int displayOrder = 0; displayOrder < imports.Count; displayOrder++)
                                 {
                                     IProjectImportSnapshot import = imports[displayOrder];
@@ -229,9 +231,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                                         bool isImplicit = _importPathCheck.IsImplicit(import.ProjectPath);
                                         ProjectTreeFlags flags = isImplicit ? s_projectImportImplicitFlags : s_projectImportFlags;
                                         ProjectImageMoniker icon = isImplicit ? s_nodeImplicitIcon : s_nodeIcon;
+                                        string caption = Path.GetFileName(import.ProjectPath);
+
+                                        // Skip nodes with duplicate captions
+                                        // TODO remove this once we enable DisplayOrder for the subtree, as that supports duplicate captions
+                                        if (!observedCaptions.Add(caption))
+                                            continue;
 
                                         IProjectTree2 newChild = NewTree(
-                                            Path.GetFileName(import.ProjectPath),
+                                            caption,
                                             filePath: import.ProjectPath,
                                             flags: flags,
                                             icon: icon,


### PR DESCRIPTION
Fixes #5711. 
Relates to #5754.
Relates to #5702.

Previously, import tree items would always be displayed in alphabetical order. With this change, their tree order reflects the actual order they are evaluated in. This is helpful when tracing the value of a given property, for example.

For CPS to respect the `IProjectTree2.DisplayOrder` property, the `SortByDisplayOrder` capability must be present. This was only used in F# projects before where it controlled both the display and manipulation of item order. Consequently a new `EditableDisplayOrder` capability has been added which covers the manipulation component, and has been added to F#-specific commands/exports.

### Before

Alphabetical:

![image](https://user-images.githubusercontent.com/350947/70905889-2d281080-2059-11ea-812e-09a6f9aabb33.png)

### After

In evaluation order:

![image](https://user-images.githubusercontent.com/350947/70905914-3b762c80-2059-11ea-84f5-b5d77c1111f1.png)
