### PR TITLE
WIP Changed table layout panel in BuildPropPage

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
@@ -1318,7 +1318,7 @@
     <value>18</value>
   </data>
   <data name="overarchingTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>539, 531</value>
+    <value>539, 800</value>
   </data>
   <data name="overarchingTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>


### PR DESCRIPTION
Fixes 'Advanced' button not displaying properly. Apparently, #5636 still had the button truncated.

DO NOT MERGE