### PR TITLE
Consider existing child captions when preventing duplicates

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -220,7 +220,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                                     }
                                 }
 
-                                var observedCaptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                                var observedCaptions = new HashSet<string>(
+                                    tree.Children.Select(node => node.Caption),
+                                    StringComparer.OrdinalIgnoreCase);
 
                                 for (int displayOrder = 0; displayOrder < imports.Count; displayOrder++)
                                 {


### PR DESCRIPTION
Improves the workaround for #5711 added in #5736.

Longer term we'll want to enable display order within the tree so that items with duplicate captions appear correctly. Without that, the tree is misleading. For example, an ASP.NET Core project has four sibling `Sdk.props` files:

![image](https://user-images.githubusercontent.com/350947/71646904-24feef00-2d42-11ea-941d-5e41b8d8c08c.png)
