### PR TITLE
Don't dispose PropPageDesignerDocData when designer is closing

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerPanel.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerPanel.vb
@@ -170,13 +170,13 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 Return _customViewProvider
             End Get
             Set
-                If _customViewProvider Is value Then
+                If _customViewProvider Is Value Then
                     Exit Property
                 End If
 
                 'Close anything currently showing
                 CloseFrame()
-                _customViewProvider = value
+                _customViewProvider = Value
                 If Visible Then
                     ShowDesigner()
                 End If
@@ -797,13 +797,13 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 Return _tabTitle
             End Get
             Set
-                _tabTitle = value
+                _tabTitle = Value
 
                 ' We set Window.Text to be the page Title to help screen reader.
-                If String.IsNullOrEmpty(value) Then
+                If String.IsNullOrEmpty(Value) Then
                     Text = String.Empty
                 Else
-                    Text = My.Resources.Designer.GetString(My.Resources.Designer.APPDES_PageName, value)
+                    Text = My.Resources.Designer.GetString(My.Resources.Designer.APPDES_PageName, Value)
                 End If
 
                 _pageNameLabel.Text = Text
@@ -818,7 +818,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 Return _tabAutomationName
             End Get
             Set
-                _tabAutomationName = value
+                _tabAutomationName = Value
             End Set
         End Property
 

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerPanel.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerPanel.vb
@@ -275,6 +275,13 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
                         If DocData IsNot Nothing Then
                             ExistingDocDataPtr = Marshal.GetIUnknownForObject(DocData)
+                        Else
+                            ' See if there is doc data in the RDT
+                            Dim rdt As New Shell.RunningDocumentTable(_serviceProvider)
+                            Dim rdtInfo As Shell.RunningDocumentInfo = rdt.GetDocumentInfo(MkDocument)
+                            If rdtInfo.DocData IsNot Nothing Then
+                                ExistingDocDataPtr = Marshal.GetIUnknownForObject(rdtInfo.DocData)
+                            End If
                         End If
                         OleServiceProvider = CType(_serviceProvider.GetService(GetType(OLE.Interop.IServiceProvider)), OLE.Interop.IServiceProvider)
                         Debug.Assert(OleServiceProvider IsNot Nothing, "Unable to get OleServiceProvider")

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerDocData.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerDocData.vb
@@ -24,6 +24,8 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         Implements IVsPersistDocData2
         Implements OLE.Interop.IObjectWithSite
         Implements IVsTextBufferProvider
+        Implements IVsRunningDocTableEvents
+        Implements IVsRunningDocTableEvents4
 
         'Event support for IVsTextBufferDataEvents
         Public Delegate Sub LoadCompletedDelegate(Reload As Integer)
@@ -47,6 +49,9 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ' Dirty and readonly state
         Private _isReadOnly As Boolean
         Private _isDirty As Boolean
+
+        ' Cookie for RunningDocumentTable events
+        Private _rdtCookie As UInteger
 
         ''' <summary>
         ''' Constructor
@@ -215,6 +220,9 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         Public Function LoadDocData2(pszMkDocument As String) As Integer Implements IVsPersistDocData2.LoadDocData
             'Nothing to do here, no real file to load
             _mkDocument = pszMkDocument
+            ' Sign up for RDT events so we know when to dispose ourselves - there is no point doing this until we have the document moniker to compare to
+            Dim rdt As New Shell.RunningDocumentTable
+            _rdtCookie = rdt.Advise(DirectCast(Me, IVsRunningDocTableEvents))
             RaiseEvent OnLoadCompleted(0) 'FALSE == 0
         End Function
 
@@ -336,6 +344,12 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             If disposing Then
                 ' Dispose managed resources.
                 _baseProvider = Nothing
+
+                If _rdtCookie <> 0 Then
+                    Dim rdt As New Shell.RunningDocumentTable
+                    rdt.Unadvise(_rdtCookie)
+                End If
+
                 If _vsTextBuffer IsNot Nothing Then
                     ' Close IVsPersistDocData
                     Dim docData As IVsPersistDocData = TryCast(_vsTextBuffer, IVsPersistDocData)
@@ -351,7 +365,46 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             ' only the following code is executed.
 
         End Sub
+
 #End Region
+
+        Private Function OnBeforeFirstDocumentLock(pHier As IVsHierarchy, itemid As UInteger, pszMkDocument As String) As Integer Implements IVsRunningDocTableEvents4.OnBeforeFirstDocumentLock
+            Return VSConstants.S_OK
+        End Function
+
+        Private Function OnAfterSaveAll() As Integer Implements IVsRunningDocTableEvents4.OnAfterSaveAll
+            Return VSConstants.S_OK
+        End Function
+
+        Private Function OnAfterLastDocumentUnlock(pHier As IVsHierarchy, itemid As UInteger, pszMkDocument As String, fClosedWithoutSaving As Integer) As Integer Implements IVsRunningDocTableEvents4.OnAfterLastDocumentUnlock
+            If pszMkDocument.Equals(_mkDocument, StringComparison.OrdinalIgnoreCase) Then
+                Dispose(True)
+            End If
+        End Function
+
+        Private Function OnAfterFirstDocumentLock(docCookie As UInteger, dwRDTLockType As UInteger, dwReadLocksRemaining As UInteger, dwEditLocksRemaining As UInteger) As Integer Implements IVsRunningDocTableEvents.OnAfterFirstDocumentLock
+            Return VSConstants.S_OK
+        End Function
+
+        Private Function OnBeforeLastDocumentUnlock(docCookie As UInteger, dwRDTLockType As UInteger, dwReadLocksRemaining As UInteger, dwEditLocksRemaining As UInteger) As Integer Implements IVsRunningDocTableEvents.OnBeforeLastDocumentUnlock
+            Return VSConstants.S_OK
+        End Function
+
+        Private Function OnAfterSave(docCookie As UInteger) As Integer Implements IVsRunningDocTableEvents.OnAfterSave
+            Return VSConstants.S_OK
+        End Function
+
+        Private Function OnAfterAttributeChange(docCookie As UInteger, grfAttribs As UInteger) As Integer Implements IVsRunningDocTableEvents.OnAfterAttributeChange
+            Return VSConstants.S_OK
+        End Function
+
+        Private Function OnBeforeDocumentWindowShow(docCookie As UInteger, fFirstShow As Integer, pFrame As IVsWindowFrame) As Integer Implements IVsRunningDocTableEvents.OnBeforeDocumentWindowShow
+            Return VSConstants.S_OK
+        End Function
+
+        Private Function OnAfterDocumentWindowHide(docCookie As UInteger, pFrame As IVsWindowFrame) As Integer Implements IVsRunningDocTableEvents.OnAfterDocumentWindowHide
+            Return VSConstants.S_OK
+        End Function
 
     End Class
 

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerEditorFactory.vb
@@ -86,6 +86,8 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
 
                     If ExistingDocData Is Nothing Then
                         DocData = New PropPageDesignerDocData(_siteProvider)
+                    ElseIf TypeOf ExistingDocData Is PropPageDesignerDocData Then
+                        DocData = ExistingDocData
                     Else
                         Throw New COMException(My.Resources.Designer.DFX_IncompatibleBuffer, AppDesInterop.NativeMethods.VS_E_INCOMPATIBLEDOCDATA)
                     End If

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerEditorFactory.vb
@@ -122,6 +122,11 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                     DesignerLoader.Dispose()
                 End If
 
+                ' If we created the doc data then we should dispose it for a failure
+                If ExistingDocData Is Nothing Then
+                    DirectCast(DocData, PropPageDesignerDocData).Dispose()
+                End If
+
                 Throw New Exception(My.Resources.Designer.GetString(My.Resources.Designer.DFX_CreateEditorInstanceFailed_Ex, ex.Message))
             End Try
         End Sub

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerEditorFactory.vb
@@ -93,7 +93,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                     End If
 
                     DesignerLoader = CType(DesignerService.CreateDesignerLoader(GetType(PropPageDesignerLoader).AssemblyQualifiedName), PropPageDesignerLoader)
-                    DesignerLoader.InitializeEx(_siteProvider, Hierarchy, ItemId, DocData)
 
                     Dim OleProvider As IServiceProvider = CType(_siteProvider.GetService(GetType(IServiceProvider)), IServiceProvider)
                     Dim Designer As IVSMDDesigner = DesignerService.CreateDesigner(OleProvider, DesignerLoader)

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerLoader.vb
@@ -4,7 +4,6 @@ Imports System.ComponentModel.Design.Serialization
 Imports System.Diagnostics.CodeAnalysis
 
 Imports Microsoft.VisualStudio.Editors.AppDesCommon
-Imports Microsoft.VisualStudio.Shell.Interop
 
 Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
 
@@ -14,8 +13,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
     Public NotInheritable Class PropPageDesignerLoader
         Inherits BasicDesignerLoader
         Implements IDisposable
-
-        Private _punkDocData As Object
 
         ''' <summary>
         ''' This method is called immediately after the first time
@@ -34,30 +31,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 New DeferrableWindowPaneProviderService(LoaderHost))
             Debug.Assert(GetService(GetType(ComponentSerializationService)) IsNot Nothing,
                 "We just made the ComponentSerializationService service available.  Why isn't it there?")
-        End Sub
-
-
-        ''' <summary>
-        ''' This method is called to initialize the designer loader with the text
-        ''' buffer to read from and a service provider through which we
-        ''' can ask for services.
-        ''' </summary>
-        ''' <param name="ServiceProvider"></param>
-        ''' <param name="Hierarchy"></param>
-        ''' <param name="ItemId"></param>
-        ''' <param name="punkDocData"></param>
-        Public Sub InitializeEx(ServiceProvider As Shell.ServiceProvider, Hierarchy As IVsHierarchy, ItemId As UInteger, punkDocData As Object)
-
-            If punkDocData Is Nothing Then
-                Debug.Fail("Docdata must be supplied")
-                Throw New InvalidOperationException()
-            End If
-
-            Debug.Assert(TypeOf punkDocData Is PropPageDesignerDocData, "Unexpected docdata type")
-            If TypeOf punkDocData Is PropPageDesignerDocData Then
-                _punkDocData = punkDocData
-            End If
-
         End Sub
 
         ''' <summary>
@@ -110,11 +83,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="disposing">True if calling from Dispose()</param>
         Protected Overloads Sub Dispose(disposing As Boolean)
             If disposing Then
-                ' Dispose of managed resources.
-                Dim docData = TryCast(_punkDocData, PropPageDesignerDocData)
-                If docData IsNot Nothing Then
-                    docData.Dispose()
-                End If
                 'Remove our ComponentSerializationService
                 LoaderHost.RemoveService(GetType(ComponentSerializationService))
             End If

--- a/src/Microsoft.VisualStudio.AppDesigner/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.AppDesigner/PublicAPI.Shipped.txt
@@ -715,7 +715,6 @@ Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerEditorFactory.Ma
 Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerEditorFactory.New() -> Void
 Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerEditorFactory.SetSite(Site As Microsoft.VisualStudio.OLE.Interop.IServiceProvider) -> Integer
 Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerLoader
-Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerLoader.InitializeEx(ServiceProvider As Microsoft.VisualStudio.Shell.ServiceProvider, Hierarchy As Microsoft.VisualStudio.Shell.Interop.IVsHierarchy, ItemId As UInteger, punkDocData As Object) -> Void
 Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerLoader.New() -> Void
 Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerRootComponent
 Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerRootComponent.Hierarchy() -> Microsoft.VisualStudio.Shell.Interop.IVsHierarchy

--- a/src/Microsoft.VisualStudio.Editors/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Editors/PublicAPI.Shipped.txt
@@ -373,7 +373,6 @@ Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerEditorFactory.Ma
 Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerEditorFactory.New() -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerEditorFactory.SetSite(Site As Microsoft.VisualStudio.OLE.Interop.IServiceProvider) -> Integer (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerLoader (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerLoader.InitializeEx(ServiceProvider As Microsoft.VisualStudio.Shell.ServiceProvider, Hierarchy As Microsoft.VisualStudio.Shell.Interop.IVsHierarchy, ItemId As UInteger, punkDocData As Object) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerLoader.New() -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerRootComponent (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerRootComponent.Hierarchy() -> Microsoft.VisualStudio.Shell.Interop.IVsHierarchy (forwarded, contained in Microsoft.VisualStudio.AppDesigner)


### PR DESCRIPTION
Fixes #5723

A change was made to the shell to fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/684877 which means that while reopening document windows, all of the doc data are kept in the running document table (see code [here](https://devdiv.visualstudio.com/DevDiv/_git/VS?path=%2Fsrc%2Fenv%2Fmsenv%2Fcore%2Fvsshlsvc.cpp&version=GC6ff311afae3a6bfbd18cd01097c84fa8aa03f8e5&line=4107&lineEnd=4108&lineStartColumn=1&lineEndColumn=1&lineStyle=plain)). This broke the property pages because they always created a new doc data for each property page tab as its being created, but if the doc data was already in the RDT, that new one never got in there so not only was the new one orphaned (never initialized), worse the doc data that is in the RDT continued to be used by other components in Visual Studio but it had been disposed.

This fixes the issue by changing the `CreateDesigner` function to check for and re-use doc data in the RDT already, and makes the `PropPageDesignerDocData` take care of disposing itself when it is removed from the RDT.

There is a slight change to the public API here, removing a method that now has no function, but its easy enough to put that back as a no-op if anyone thinks its an issue.