### PR TITLE
Adding OutDir property for msbuild.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -127,6 +127,9 @@
   <StringProperty Name="OutputPath"
                   DisplayName="Output Path" />
 
+  <StringProperty Name="OutDir"
+                  DisplayName="Output Directory" />
+
   <EnumProperty Name="OutputType"
                 DisplayName="Output Type" >
     <EnumValue Name="Library"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.cs.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Ikona aplikace</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|OutDir|DisplayName">
+        <source>Output Directory</source>
+        <target state="new">Output Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkIdentifier|DisplayName">
         <source>Target Framework Identifier</source>
         <target state="translated">Identifikátor cílové architektury</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.de.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Anwendungssymbol</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|OutDir|DisplayName">
+        <source>Output Directory</source>
+        <target state="new">Output Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkIdentifier|DisplayName">
         <source>Target Framework Identifier</source>
         <target state="translated">Zielframeworkbezeichner</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.es.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Icono de aplicación</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|OutDir|DisplayName">
+        <source>Output Directory</source>
+        <target state="new">Output Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkIdentifier|DisplayName">
         <source>Target Framework Identifier</source>
         <target state="translated">Identificador de la plataforma de destino</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.fr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Icône d'application</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|OutDir|DisplayName">
+        <source>Output Directory</source>
+        <target state="new">Output Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkIdentifier|DisplayName">
         <source>Target Framework Identifier</source>
         <target state="translated">Identificateur du Framework cible</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.it.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Icona dell'applicazione</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|OutDir|DisplayName">
+        <source>Output Directory</source>
+        <target state="new">Output Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkIdentifier|DisplayName">
         <source>Target Framework Identifier</source>
         <target state="translated">Identificatore framework di destinazione</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ja.xlf
@@ -27,6 +27,11 @@
         <target state="translated">アプリケーション アイコン</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|OutDir|DisplayName">
+        <source>Output Directory</source>
+        <target state="new">Output Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkIdentifier|DisplayName">
         <source>Target Framework Identifier</source>
         <target state="translated">ターゲット フレームワーク ID</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ko.xlf
@@ -27,6 +27,11 @@
         <target state="translated">애플리케이션 아이콘</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|OutDir|DisplayName">
+        <source>Output Directory</source>
+        <target state="new">Output Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkIdentifier|DisplayName">
         <source>Target Framework Identifier</source>
         <target state="translated">대상 프레임워크 식별자</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.pl.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Ikona aplikacji</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|OutDir|DisplayName">
+        <source>Output Directory</source>
+        <target state="new">Output Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkIdentifier|DisplayName">
         <source>Target Framework Identifier</source>
         <target state="translated">Identyfikator platformy docelowej</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Ícone do Aplicativo</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|OutDir|DisplayName">
+        <source>Output Directory</source>
+        <target state="new">Output Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkIdentifier|DisplayName">
         <source>Target Framework Identifier</source>
         <target state="translated">Identificador de Estrutura de Destino</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ru.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Значок приложения</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|OutDir|DisplayName">
+        <source>Output Directory</source>
+        <target state="new">Output Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkIdentifier|DisplayName">
         <source>Target Framework Identifier</source>
         <target state="translated">Идентификатор целевой платформы</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.tr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Uygulama Simgesi</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|OutDir|DisplayName">
+        <source>Output Directory</source>
+        <target state="new">Output Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkIdentifier|DisplayName">
         <source>Target Framework Identifier</source>
         <target state="translated">Hedef Çerçeve Tanımlayıcısı</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="translated">应用程序图标</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|OutDir|DisplayName">
+        <source>Output Directory</source>
+        <target state="new">Output Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkIdentifier|DisplayName">
         <source>Target Framework Identifier</source>
         <target state="translated">目标框架标识符</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="translated">應用程式圖示</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|OutDir|DisplayName">
+        <source>Output Directory</source>
+        <target state="new">Output Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkIdentifier|DisplayName">
         <source>Target Framework Identifier</source>
         <target state="translated">目標 Framework 識別碼</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
@@ -169,7 +169,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 string? msBuildProjectFullPath = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, MSBuildProjectFullPath);
                 string? msBuildProjectDirectory = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectDirectoryProperty, MSBuildProjectDirectory);
-                string? outputRelativeOrFullPath = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputPathProperty, OutputRelativeOrFullPath);
+                string? msBuildProjectOutputPath = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputPathProperty, OutputRelativeOrFullPath);
+                string? outputRelativeOrFullPath = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutDirProperty, msBuildProjectOutputPath);
                 string msBuildAllProjects = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildAllProjectsProperty, "");
 
                 // The first item in this semicolon-separated list of project files will always be the one


### PR DESCRIPTION
Fixes #4737.

outputRelativeOrFullPath was using the legacy property OutPath.
OutDir is used instead to fix the fast up-to-date check.
