### PR TITLE
Import tree display order

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
             IActiveConfiguredProjectSubscriptionService projectSubscriptionService,
             IUnconfiguredProjectTasksService unconfiguredProjectTasksService,
             UnconfiguredProject unconfiguredProject)
-            : base(threadingService, unconfiguredProject)
+            : base(threadingService, unconfiguredProject, useDisplayOrdering: true)
         {
             _projectSubscriptionService = projectSubscriptionService;
             _unconfiguredProjectTasksService = unconfiguredProjectTasksService;
@@ -222,10 +222,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                                     }
                                 }
 
-                                var observedCaptions = new HashSet<string>(
-                                    tree.Children.Select(node => node.Caption),
-                                    StringComparer.OrdinalIgnoreCase);
-
                                 for (int displayOrder = 0; displayOrder < imports.Count; displayOrder++)
                                 {
                                     IProjectImportSnapshot import = imports[displayOrder];
@@ -236,11 +232,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                                         ProjectTreeFlags flags = isImplicit ? s_projectImportImplicitFlags : s_projectImportFlags;
                                         ProjectImageMoniker icon = isImplicit ? s_nodeImplicitIcon : s_nodeIcon;
                                         string caption = Path.GetFileName(import.ProjectPath);
-
-                                        // Skip nodes with duplicate captions
-                                        // TODO remove this once we enable DisplayOrder for the subtree, as that supports duplicate captions
-                                        if (!observedCaptions.Add(caption))
-                                            continue;
 
                                         IProjectTree2 newChild = NewTree(
                                             caption,


### PR DESCRIPTION
Fixes #5711.
Fixes #5754.

This PR shows imports in the correct order, and allows duplicate imports to appear side-by-side in the tree.

Since https://dev.azure.com/devdiv/DevDiv/_git/CPS/pullrequest/220752, CPS allows root graft tree providers (like the import tree) to opt-in to `IProjectTree2.DisplayOrder` support.

### Before (alphabetical order)

![image](https://user-images.githubusercontent.com/350947/72522107-f9871300-38b0-11ea-8d4b-1afa3226a548.png)

### After (evaluation order)

![image](https://user-images.githubusercontent.com/350947/72521979-b2991d80-38b0-11ea-9dbf-7cb149974f2e.png)

---

~This PR is blocked until the following PRs are merged:~

- [x] https://github.com/dotnet/project-system/pull/5774
- [x] https://dev.azure.com/devdiv/DevDiv/_git/CPS/pullrequest/221941
- [x] https://dev.azure.com/devdiv/DevDiv/_git/CPS/pullrequest/221943

~This PR is blocked until we have an insertion of CPS with the above fixes.~