### PR TITLE
Property page tidying

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -566,17 +566,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             get
             {
                 return LazyInitializer.EnsureInitialized(ref _newProfileCommand, () =>
-                 new DelegateCommand(state =>
-                 {
-                     var dialog = new GetProfileNameDialog(Project.Services.ExportProvider.GetExportedValue<SVsServiceProvider>(),
-                                                            ProjectThreadingService,
-                                                            GetNewProfileName(),
-                                                            IsNewProfileNameValid);
-                     if (dialog.ShowModal() == true)
-                     {
-                         CreateProfile(dialog.ProfileName, ProfileCommandNames.Executable);
-                     }
-                 }));
+                    new DelegateCommand(state =>
+                    {
+                        var dialog = new GetProfileNameDialog(Project.Services.ExportProvider.GetExportedValue<SVsServiceProvider>(),
+                                                               ProjectThreadingService,
+                                                               GetNewProfileName(),
+                                                               IsNewProfileNameValid);
+                        if (dialog.ShowModal() == true)
+                        {
+                            CreateProfile(dialog.ProfileName, ProfileCommandNames.Executable);
+                        }
+                    }));
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
         /// <summary>
         /// This is here so that we can clear the in-memory status of the active profile if it has been edited. This is
-        /// so that the profile, and hence the users customizations, will be saved to disk
+        /// so that the profile, and hence the user's customizations, will be saved to disk
         /// </summary>
         private void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ExecutableLaunchSettingsUIProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ExecutableLaunchSettingsUIProvider.cs
@@ -14,41 +14,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
     [Order(Order.Lowest)] // Lowest priority to allow this to be overridden
     internal class ExecutableLaunchSettingsUIProvider : ILaunchSettingsUIProvider
     {
-        /// <summary>
-        /// Required to control the MEF scope
-        /// </summary>
         [ImportingConstructor]
-        public ExecutableLaunchSettingsUIProvider(UnconfiguredProject uncProject)
+        public ExecutableLaunchSettingsUIProvider(UnconfiguredProject _) // force MEF scope
         {
         }
 
-        /// <summary>
-        /// The name of the command that is written to the launchSettings.json file
-        /// </summary>
         public string CommandName => LaunchSettingsProvider.RunExecutableCommandName;
 
-        /// <summary>
-        /// The name to display in the dropdown for this command
-        /// </summary>
         public string FriendlyName => PropertyPageResources.ProfileKindExecutableName;
 
-        /// <summary>
-        /// Launch url is not supported
-        /// </summary>
         public bool ShouldEnableProperty(string propertyName)
         {
+            // Launch url is not supported
             return !string.Equals(propertyName, UIProfilePropertyName.LaunchUrl, StringComparisons.UIPropertyNames);
         }
 
-        /// <summary>
-        /// No custom UI
-        /// </summary>
+        /// <inheritdoc />
+        /// <remarks>This implementation does not provide any UI.</remarks>
         public UserControl? CustomUI => null;
 
-        /// <summary>
-        /// Called when the selected profile changes to a profile which matches this command. curSettings will contain 
-        /// the current values from the page, and activeProfile will point to the active one.
-        /// </summary>
         public void ProfileSelected(IWritableLaunchSettings curSettings)
         {
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ExecutableLaunchSettingsUIProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ExecutableLaunchSettingsUIProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
     /// </summary>
     [Export(typeof(ILaunchSettingsUIProvider))]
     [AppliesTo(ProjectCapability.LaunchProfiles)]
-    [Order(Order.Lowest)]              // Lowest priority to allow this to be overridden
+    [Order(Order.Lowest)] // Lowest priority to allow this to be overridden
     internal class ExecutableLaunchSettingsUIProvider : ILaunchSettingsUIProvider
     {
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ProjectLaunchSettingsUIProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ProjectLaunchSettingsUIProvider.cs
@@ -14,42 +14,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
     [Order(Order.Lowest)]              // Lowest priority to allow this to be overridden
     internal class ProjectLaunchSettingsUIProvider : ILaunchSettingsUIProvider
     {
-        /// <summary>
-        /// Required to control the MEF scope
-        /// </summary>
         [ImportingConstructor]
-        public ProjectLaunchSettingsUIProvider(UnconfiguredProject uncProject)
+        public ProjectLaunchSettingsUIProvider(UnconfiguredProject _) // force MEF scope
         {
         }
 
-        /// <summary>
-        /// The name of the command that is written to the launchSettings.json file
-        /// </summary>
         public string CommandName => LaunchSettingsProvider.RunProjectCommandName;
 
-        /// <summary>
-        /// The name to display in the dropdown for this command
-        /// </summary>
         public string FriendlyName => PropertyPageResources.ProfileKindProjectName;
 
-        /// <summary>
-        /// Disable the executable and launch url controls
-        /// </summary>
         public bool ShouldEnableProperty(string propertyName)
         {
+            // Disable the executable and launch url controls
             return !string.Equals(propertyName, UIProfilePropertyName.Executable, StringComparisons.UIPropertyNames) &&
                    !string.Equals(propertyName, UIProfilePropertyName.LaunchUrl, StringComparisons.UIPropertyNames);
         }
 
-        /// <summary>
-        /// No custom UI
-        /// </summary>
+        /// <inheritdoc />
+        /// <remarks>This implementation does not provide any UI.</remarks>
         public UserControl? CustomUI => null;
 
-        /// <summary>
-        /// Called when the selected profile changes to a profile which matches this command. curSettings will contain 
-        /// the current values from the page, and activeProfile will point to the active one.
-        /// </summary>
         public void ProfileSelected(IWritableLaunchSettings curSettings)
         {
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ProjectLaunchSettingsUIProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ProjectLaunchSettingsUIProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
     /// </summary>
     [Export(typeof(ILaunchSettingsUIProvider))]
     [AppliesTo(ProjectCapability.LaunchProfiles)]
-    [Order(0)]              // Lowest priority to allow this to be overridden
+    [Order(Order.Lowest)]              // Lowest priority to allow this to be overridden
     internal class ProjectLaunchSettingsUIProvider : ILaunchSettingsUIProvider
     {
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ProjectLaunchSettingsUIProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ProjectLaunchSettingsUIProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
     /// </summary>
     [Export(typeof(ILaunchSettingsUIProvider))]
     [AppliesTo(ProjectCapability.LaunchProfiles)]
-    [Order(Order.Lowest)]              // Lowest priority to allow this to be overridden
+    [Order(Order.Lowest)] // Lowest priority to allow this to be overridden
     internal class ProjectLaunchSettingsUIProvider : ILaunchSettingsUIProvider
     {
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
@@ -53,8 +53,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
         }
 
+#pragma warning disable CA1822 // Can be made static
         [Obsolete("This property is not used by the project system.")]
-        public List<IVsBrowseObjectContext>? ContextObjects { get; private set; }
+        public List<IVsBrowseObjectContext>? ContextObjects => null;
+#pragma warning restore CA1822
 
         /// <summary>
         /// IPropertyPage

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageControl.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageControl.cs
@@ -45,7 +45,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             IsDirty = false;
             ViewModel = viewModel;
             ViewModel.PropertyChanged += ViewModel_PropertyChanged;
-            ViewModel.ParentControl = this;
             _ignoreEvents = false;
         }
 
@@ -59,7 +58,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
             // Let the view model know we are done.
             ViewModel.ViewModelDetached();
-            ViewModel.ParentControl = null;
             ViewModel = null;
             _ignoreEvents = false;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageViewModel.cs
@@ -11,7 +11,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         public event PropertyChangedEventHandler? PropertyChanged;
 
         public UnconfiguredProject? Project { get; set; }
-        public PropertyPageControl? ParentControl { get; set; }
 
         /// <summary>
         /// Since calls to ignore events can be nested, a downstream call could change the outer 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageViewModel.cs
@@ -72,23 +72,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             return OnPropertyChanged(ref propertyRef, value, suppressInvalidation: false, propertyName: propertyName);
         }
 
-        protected void SetBooleanProperty(ref bool property, string value, bool defaultValue, bool invert = false)
-        {
-            if (!string.IsNullOrEmpty(value))
-            {
-                property = bool.Parse(value);
-
-                if (invert)
-                {
-                    property = !property;
-                }
-            }
-            else
-            {
-                property = defaultValue;
-            }
-        }
-
         /// <summary>
         /// Override to do cleanup
         /// </summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/NameValuePair.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/NameValuePair.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
                 string? error = null;
                 HasValidationError = false;
 
-                if (propertyName.Equals("Name", StringComparisons.UIPropertyNames))
+                if (propertyName.Equals(nameof(Name), StringComparisons.UIPropertyNames))
                 {
                     if (IsNamePropertyEmpty())
                     {
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
                         HasValidationError = IsValuePropertyEmpty();
                     }
                 }
-                else if (propertyName.Equals("Value", StringComparisons.UIPropertyNames))
+                else if (propertyName.Equals(nameof(Value), StringComparisons.UIPropertyNames))
                 {
                     if (string.IsNullOrWhiteSpace(Value))
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsUIProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsUIProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         string CommandName { get; }
 
         /// <summary>
-        /// The user-friendly name of this this launch provider.
+        /// The user-friendly name of this this launch provider, to show in the drop down.
         /// </summary>
         string FriendlyName { get; }
 


### PR DESCRIPTION
Part 1 of 2 ahead of remote-debugging support for the property pages. Part 2 is annotations, and is more involved as `DebugPageViewModel` was difficult to annotate.