### PR TITLE
Display ManifestExplanationLabel as a label

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.Designer.vb
@@ -31,7 +31,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Friend WithEvents TargetFrameworkLabel As System.Windows.Forms.Label
         Friend WithEvents AutoGenerateBindingRedirects As System.Windows.Forms.CheckBox
         Friend WithEvents overarchingLayoutPanel As System.Windows.Forms.TableLayoutPanel
-        Friend WithEvents ManifestExplanationLabel As System.Windows.Forms.TextBox
+        Friend WithEvents ManifestExplanationLabel As System.Windows.Forms.Label
         Friend WithEvents iconTableLayoutPanel As System.Windows.Forms.TableLayoutPanel
 
         <System.Diagnostics.DebuggerStepThrough()> Private Sub InitializeComponent()
@@ -53,7 +53,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.iconTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
             Me.ResourcesLabel = New System.Windows.Forms.Label()
             Me.IconRadioButton = New System.Windows.Forms.RadioButton()
-            Me.ManifestExplanationLabel = New System.Windows.Forms.TextBox()
+            Me.ManifestExplanationLabel = New System.Windows.Forms.Label()
             Me.ApplicationIconLabel = New System.Windows.Forms.Label()
             Me.ApplicationIcon = New System.Windows.Forms.ComboBox()
             Me.AppIconBrowse = New System.Windows.Forms.Button()
@@ -195,7 +195,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.ManifestExplanationLabel.BorderStyle = System.Windows.Forms.BorderStyle.None
             resources.ApplyResources(Me.ManifestExplanationLabel, "ManifestExplanationLabel")
             Me.ManifestExplanationLabel.Name = "ManifestExplanationLabel"
-            Me.ManifestExplanationLabel.ReadOnly = True
             '
             'ApplicationIconLabel
             '


### PR DESCRIPTION
The ManifestExplanationLabel is the two-line text below the Icon and manifest radio button. Currently, it's a text box with the label appearance. This affects the accessibility of the UI: there is a tab stop in it (when it shouldn't since it's not interactable) and a screen reader might confuse it as a text input.

**Before:**
![before](https://user-images.githubusercontent.com/8518253/72400487-365ed880-36fe-11ea-8dc2-04cf4b7503ab.PNG)

**After:**
![after](https://user-images.githubusercontent.com/8518253/72400498-3f4faa00-36fe-11ea-9424-17dbc52eeef2.PNG)

By changing the text box to a label, it does not focus nor look intereractive. Also, the position and size remain the same.

Work item tracked in https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1049278
