### PR TITLE
Mark ProjectImport's with FileSystemEntity

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
             ProjectTreeFlags.Common.VirtualFolder |
             ProjectTreeFlags.Common.DisableAddItemFolder);
 
-        private static readonly ProjectTreeFlags s_projectImportFlags = ProjectImport | ProjectTreeFlags.FileOnDisk;
+        private static readonly ProjectTreeFlags s_projectImportFlags = ProjectImport | ProjectTreeFlags.FileOnDisk | ProjectTreeFlags.FileSystemEntity;
         private static readonly ProjectTreeFlags s_projectImportImplicitFlags = s_projectImportFlags + ProjectImportImplicit;
 
         private readonly ImplicitProjectCheck _importPathCheck = new ImplicitProjectCheck();


### PR DESCRIPTION
Project imports were being marked with FileOnDisk, but not FileSystemEntity which is the base between FileOnDisk and Folder. This enables the "Copy Full Path" command but there is additional work needed to make the command actually execute which is being tracked by https://github.com/dotnet/project-system/issues/102.