### PR TITLE
Register referenced "Shared Projects"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProjectTypeCapabilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProjectTypeCapabilities.cs
@@ -29,11 +29,15 @@ namespace Microsoft.VisualStudio.Packaging
         /// <summary>
         ///     Represents C#'s set of capabilities that are always present.
         /// </summary>
-        public const string CSharp = Default + "; " + ProjectCapability.CSharp;
+        public const string CSharp = Default + "; " +
+                                     ProjectCapability.CSharp + "; " + 
+                                     ProjectCapabilities.SharedImports;
 
         /// <summary>
         ///     Represents Visual Basic's set of capabilities that are always present.
         /// </summary>
-        public const string VisualBasic = Default + "; " + ProjectCapability.VisualBasic;
+        public const string VisualBasic = Default + "; " + 
+                                          ProjectCapability.VisualBasic + "; " + 
+                                          ProjectCapabilities.SharedImports;
     }
 }


### PR DESCRIPTION
We were not registering "Shared Projects" with IVsSharedMSBuildFilesManagerHierarchy, which is hidden behind the "SharedImports" capability (not to be confused with "SharedProjectReferences"), this led to:

- Context switcher was broken
- Reference Manager didn't think that any Shared Projects were referenced

This fixes:

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/508624
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/792775
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/972385
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/979565
https://developercommunity.visualstudio.com/content/problem/606555/the-code-editor-project-selector-switches-back-to.html
https://developercommunity.visualstudio.com/content/problem/130875/console-net-core-2-app-still-not-showing-reference.html
https://developercommunity.visualstudio.com/content/problem/328798/cannot-remove-a-shared-project-reference-from-net.html
https://developercommunity.visualstudio.com/content/problem/728261/-vshpropid7vshpropid-shareditemcontexthierarchy-is.html
https://github.com/dotnet/project-system/issues/1391
https://github.com/dotnet/project-system/issues/2916

This needs to be a fixed capability because CPS calls the registration once during IVsParentProject.OpenChildren and will never call it again.