### PR TITLE
Add 'Nullable' option to the build property page

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.Designer.vb
@@ -94,6 +94,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.errorsAndWarningsLabel = New System.Windows.Forms.Label()
             Me.lblSGenOption = New System.Windows.Forms.Label()
             Me.cboSGenOption = New System.Windows.Forms.ComboBox()
+            Me.lblNullable = New System.Windows.Forms.Label()
+            Me.cboNullable = New System.Windows.Forms.ComboBox()
             Me.overarchingTableLayoutPanel.SuspendLayout()
             Me.outputTableLayoutPanel.SuspendLayout()
             Me.generalHeaderTableLayoutPanel.SuspendLayout()
@@ -237,36 +239,38 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'overarchingTableLayoutPanel
             '
             resources.ApplyResources(Me.overarchingTableLayoutPanel, "overarchingTableLayoutPanel")
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.outputTableLayoutPanel, 0, 15)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.outputTableLayoutPanel, 0, 16)
             Me.overarchingTableLayoutPanel.Controls.Add(Me.generalHeaderTableLayoutPanel, 0, 0)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.treatWarningsAsErrorsTableLayoutPanel, 0, 11)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.errorsAndWarningsTableLayoutPanel, 0, 8)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.chkRegisterForCOM, 0, 18)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.chkXMLDocumentationFile, 0, 17)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.txtXMLDocumentationFile, 1, 17)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.btnOutputPathBrowse, 2, 16)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.txtOutputPath, 1, 16)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.lblOutputPath, 0, 16)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.rbWarningSpecific, 0, 14)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.txtSpecificWarnings, 1, 14)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.rbWarningAll, 0, 13)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.rbWarningNone, 0, 12)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.txtSupressWarnings, 1, 10)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.lblSupressWarnings, 0, 10)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.cboWarningLevel, 1, 9)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.lblWarningLevel, 0, 9)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.treatWarningsAsErrorsTableLayoutPanel, 0, 12)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.errorsAndWarningsTableLayoutPanel, 0, 9)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.chkRegisterForCOM, 0, 19)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.chkXMLDocumentationFile, 0, 18)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.txtXMLDocumentationFile, 1, 18)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.btnOutputPathBrowse, 2, 17)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.txtOutputPath, 1, 17)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.lblOutputPath, 0, 17)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.rbWarningSpecific, 0, 15)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.txtSpecificWarnings, 1, 15)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.rbWarningAll, 0, 14)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.rbWarningNone, 0, 13)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.txtSupressWarnings, 1, 11)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.lblSupressWarnings, 0, 11)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.cboWarningLevel, 1, 10)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.lblWarningLevel, 0, 10)
             Me.overarchingTableLayoutPanel.Controls.Add(Me.cboPlatformTarget, 1, 4)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.chkOptimizeCode, 0, 7)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.chkAllowUnsafeCode, 0, 6)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.chkPrefer32Bit, 0, 5)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.chkOptimizeCode, 0, 8)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.chkAllowUnsafeCode, 0, 7)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.chkPrefer32Bit, 0, 6)
             Me.overarchingTableLayoutPanel.Controls.Add(Me.chkDefineTrace, 0, 3)
             Me.overarchingTableLayoutPanel.Controls.Add(Me.chkDefineDebug, 0, 2)
             Me.overarchingTableLayoutPanel.Controls.Add(Me.txtConditionalCompilationSymbols, 1, 1)
             Me.overarchingTableLayoutPanel.Controls.Add(Me.lblConditionalCompilationSymbols, 0, 1)
             Me.overarchingTableLayoutPanel.Controls.Add(Me.lblPlatformTarget, 0, 4)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.lblSGenOption, 0, 19)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.cboSGenOption, 1, 19)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.btnAdvanced, 2, 20)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.lblSGenOption, 0, 20)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.cboSGenOption, 1, 20)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.btnAdvanced, 2, 21)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.lblNullable, 0, 5)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.cboNullable, 1, 5)
             Me.overarchingTableLayoutPanel.Name = "overarchingTableLayoutPanel"
             '
             'outputTableLayoutPanel
@@ -361,6 +365,18 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.cboSGenOption.FormattingEnabled = True
             Me.cboSGenOption.Name = "cboSGenOption"
             '
+            'lblNullable
+            '
+            resources.ApplyResources(Me.lblNullable, "lblNullable")
+            Me.lblNullable.Name = "lblNullable"
+            '
+            'cboNullable
+            '
+            resources.ApplyResources(Me.cboNullable, "cboNullable")
+            Me.cboNullable.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
+            Me.cboNullable.FormattingEnabled = True
+            Me.cboNullable.Name = "cboNullable"
+            '
             'BuildPropPage
             '
             resources.ApplyResources(Me, "$this")
@@ -382,6 +398,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         End Sub
 
+        Friend WithEvents lblNullable As Windows.Forms.Label
+        Friend WithEvents cboNullable As Windows.Forms.ComboBox
     End Class
 
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
@@ -211,7 +211,7 @@
     <value>3, 0, 0, 0</value>
   </data>
   <data name="outputLineLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>491, 1</value>
+    <value>544, 1</value>
   </data>
   <data name="outputLineLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -259,7 +259,7 @@
     <value>1</value>
   </data>
   <data name="outputTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 377</value>
+    <value>0, 404</value>
   </data>
   <data name="outputTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -268,7 +268,7 @@
     <value>1</value>
   </data>
   <data name="outputTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>539, 13</value>
+    <value>592, 13</value>
   </data>
   <data name="outputTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -307,7 +307,7 @@
     <value>3, 0, 0, 0</value>
   </data>
   <data name="generalLineLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>489, 1</value>
+    <value>542, 1</value>
   </data>
   <data name="generalLineLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -367,7 +367,7 @@
     <value>1</value>
   </data>
   <data name="generalHeaderTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>539, 13</value>
+    <value>592, 13</value>
   </data>
   <data name="generalHeaderTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -406,7 +406,7 @@
     <value>3, 0, 0, 0</value>
   </data>
   <data name="treatWarningsAsErrorsLineLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>413, 1</value>
+    <value>466, 1</value>
   </data>
   <data name="treatWarningsAsErrorsLineLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -457,7 +457,7 @@
     <value>1</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 279</value>
+    <value>0, 306</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -466,7 +466,7 @@
     <value>1</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>539, 13</value>
+    <value>592, 13</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -505,7 +505,7 @@
     <value>3, 0, 0, 0</value>
   </data>
   <data name="errorsAndWarningsLineLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>433, 1</value>
+    <value>486, 1</value>
   </data>
   <data name="errorsAndWarningsLineLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -556,7 +556,7 @@
     <value>1</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 197</value>
+    <value>0, 224</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -565,7 +565,7 @@
     <value>1</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>539, 13</value>
+    <value>592, 13</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -592,7 +592,7 @@
     <value>True</value>
   </data>
   <data name="chkRegisterForCOM.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 456</value>
+    <value>23, 483</value>
   </data>
   <data name="chkRegisterForCOM.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 3</value>
@@ -625,7 +625,7 @@
     <value>True</value>
   </data>
   <data name="chkXMLDocumentationFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 431</value>
+    <value>23, 458</value>
   </data>
   <data name="chkXMLDocumentationFile.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 3</value>
@@ -651,11 +651,14 @@
   <data name="&gt;&gt;chkXMLDocumentationFile.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="txtXMLDocumentationFile.AccessibleName" xml:space="preserve">
+    <value>XML Document File Path</value>
+  </data>
   <data name="txtXMLDocumentationFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
   <data name="txtXMLDocumentationFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>184, 430</value>
+    <value>184, 457</value>
   </data>
   <data name="txtXMLDocumentationFile.Size" type="System.Drawing.Size, System.Drawing">
     <value>274, 20</value>
@@ -682,13 +685,13 @@
     <value>True</value>
   </data>
   <data name="btnOutputPathBrowse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>464, 401</value>
+    <value>464, 428</value>
   </data>
   <data name="btnOutputPathBrowse.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 11, 0, 3</value>
   </data>
   <data name="btnOutputPathBrowse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>128, 23</value>
   </data>
   <data name="btnOutputPathBrowse.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -712,7 +715,7 @@
     <value>Left, Right</value>
   </data>
   <data name="txtOutputPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>184, 402</value>
+    <value>184, 429</value>
   </data>
   <data name="txtOutputPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 11, 3, 3</value>
@@ -742,7 +745,7 @@
     <value>True</value>
   </data>
   <data name="lblOutputPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 406</value>
+    <value>20, 433</value>
   </data>
   <data name="lblOutputPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>20, 11, 3, 3</value>
@@ -775,7 +778,7 @@
     <value>True</value>
   </data>
   <data name="rbWarningSpecific.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 349</value>
+    <value>23, 376</value>
   </data>
   <data name="rbWarningSpecific.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 11</value>
@@ -801,11 +804,14 @@
   <data name="&gt;&gt;rbWarningSpecific.ZOrder" xml:space="preserve">
     <value>10</value>
   </data>
+  <data name="txtSpecificWarnings.AccessibleName" xml:space="preserve">
+    <value>Specific Warnings To Treat As Errors</value>
+  </data>
   <data name="txtSpecificWarnings.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
   <data name="txtSpecificWarnings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>184, 351</value>
+    <value>184, 378</value>
   </data>
   <data name="txtSpecificWarnings.Size" type="System.Drawing.Size, System.Drawing">
     <value>274, 20</value>
@@ -832,7 +838,7 @@
     <value>True</value>
   </data>
   <data name="rbWarningAll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 326</value>
+    <value>23, 353</value>
   </data>
   <data name="rbWarningAll.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 3</value>
@@ -865,7 +871,7 @@
     <value>True</value>
   </data>
   <data name="rbWarningNone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 303</value>
+    <value>23, 330</value>
   </data>
   <data name="rbWarningNone.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 11, 3, 3</value>
@@ -895,7 +901,7 @@
     <value>Left, Right</value>
   </data>
   <data name="txtSupressWarnings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>184, 248</value>
+    <value>184, 275</value>
   </data>
   <data name="txtSupressWarnings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 11</value>
@@ -925,7 +931,7 @@
     <value>True</value>
   </data>
   <data name="lblSupressWarnings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 251</value>
+    <value>20, 278</value>
   </data>
   <data name="lblSupressWarnings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>20, 3, 3, 11</value>
@@ -970,7 +976,7 @@
     <value>4</value>
   </data>
   <data name="cboWarningLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>184, 221</value>
+    <value>184, 248</value>
   </data>
   <data name="cboWarningLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 11, 3, 3</value>
@@ -1000,7 +1006,7 @@
     <value>True</value>
   </data>
   <data name="lblWarningLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 225</value>
+    <value>20, 252</value>
   </data>
   <data name="lblWarningLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>20, 11, 3, 3</value>
@@ -1057,7 +1063,7 @@
     <value>True</value>
   </data>
   <data name="chkOptimizeCode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 169</value>
+    <value>23, 196</value>
   </data>
   <data name="chkOptimizeCode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 11</value>
@@ -1090,7 +1096,7 @@
     <value>True</value>
   </data>
   <data name="chkAllowUnsafeCode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 146</value>
+    <value>23, 173</value>
   </data>
   <data name="chkAllowUnsafeCode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 3</value>
@@ -1123,7 +1129,7 @@
     <value>True</value>
   </data>
   <data name="chkPrefer32Bit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 123</value>
+    <value>23, 150</value>
   </data>
   <data name="chkPrefer32Bit.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 3</value>
@@ -1222,7 +1228,7 @@
     <value>True</value>
   </data>
   <data name="lblSGenOption.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 483</value>
+    <value>20, 510</value>
   </data>
   <data name="lblSGenOption.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>20, 3, 3, 3</value>
@@ -1252,7 +1258,7 @@
     <value>Left</value>
   </data>
   <data name="cboSGenOption.Location" type="System.Drawing.Point, System.Drawing">
-    <value>184, 479</value>
+    <value>184, 506</value>
   </data>
   <data name="cboSGenOption.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>125, 0</value>
@@ -1282,13 +1288,13 @@
     <value>True</value>
   </data>
   <data name="btnAdvanced.Location" type="System.Drawing.Point, System.Drawing">
-    <value>464, 507</value>
+    <value>464, 533</value>
   </data>
   <data name="btnAdvanced.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 0, 0</value>
   </data>
   <data name="btnAdvanced.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>128, 17</value>
   </data>
   <data name="btnAdvanced.TabIndex" type="System.Int32, mscorlib">
     <value>29</value>
@@ -1308,6 +1314,66 @@
   <data name="&gt;&gt;btnAdvanced.ZOrder" xml:space="preserve">
     <value>29</value>
   </data>
+  <data name="lblNullable.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="lblNullable.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblNullable.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblNullable.Location" type="System.Drawing.Point, System.Drawing">
+    <value>20, 127</value>
+  </data>
+  <data name="lblNullable.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>20, 3, 3, 3</value>
+  </data>
+  <data name="lblNullable.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 13</value>
+  </data>
+  <data name="lblNullable.TabIndex" type="System.Int32, mscorlib">
+    <value>32</value>
+  </data>
+  <data name="lblNullable.Text" xml:space="preserve">
+    <value>Nulla&amp;ble:</value>
+  </data>
+  <data name="&gt;&gt;lblNullable.Name" xml:space="preserve">
+    <value>lblNullable</value>
+  </data>
+  <data name="&gt;&gt;lblNullable.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblNullable.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;lblNullable.ZOrder" xml:space="preserve">
+    <value>30</value>
+  </data>
+  <data name="cboNullable.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="cboNullable.Location" type="System.Drawing.Point, System.Drawing">
+    <value>184, 123</value>
+  </data>
+  <data name="cboNullable.Size" type="System.Drawing.Size, System.Drawing">
+    <value>125, 21</value>
+  </data>
+  <data name="cboNullable.TabIndex" type="System.Int32, mscorlib">
+    <value>33</value>
+  </data>
+  <data name="&gt;&gt;cboNullable.Name" xml:space="preserve">
+    <value>cboNullable</value>
+  </data>
+  <data name="&gt;&gt;cboNullable.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cboNullable.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;cboNullable.ZOrder" xml:space="preserve">
+    <value>31</value>
+  </data>
   <data name="overarchingTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
@@ -1315,10 +1381,10 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="overarchingTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
-    <value>18</value>
+    <value>22</value>
   </data>
   <data name="overarchingTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>539, 531</value>
+    <value>592, 550</value>
   </data>
   <data name="overarchingTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1336,7 +1402,7 @@
     <value>0</value>
   </data>
   <data name="overarchingTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="outputTableLayoutPanel" Row="15" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="generalHeaderTableLayoutPanel" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="treatWarningsAsErrorsTableLayoutPanel" Row="11" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="errorsAndWarningsTableLayoutPanel" Row="8" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkRegisterForCOM" Row="18" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkXMLDocumentationFile" Row="17" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtXMLDocumentationFile" Row="17" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="btnOutputPathBrowse" Row="16" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="txtOutputPath" Row="16" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblOutputPath" Row="16" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="rbWarningSpecific" Row="14" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtSpecificWarnings" Row="14" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="rbWarningAll" Row="13" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="rbWarningNone" Row="12" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="txtSupressWarnings" Row="10" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblSupressWarnings" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cboWarningLevel" Row="9" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblWarningLevel" Row="9" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cboPlatformTarget" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="chkOptimizeCode" Row="7" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkAllowUnsafeCode" Row="6" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkPrefer32Bit" Row="5" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkDefineTrace" Row="3" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkDefineDebug" Row="2" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="txtConditionalCompilationSymbols" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblConditionalCompilationSymbols" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblPlatformTarget" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblSGenOption" Row="19" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cboSGenOption" Row="19" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="btnAdvanced" Row="20" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Autosize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="outputTableLayoutPanel" Row="16" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="generalHeaderTableLayoutPanel" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="treatWarningsAsErrorsTableLayoutPanel" Row="12" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="errorsAndWarningsTableLayoutPanel" Row="9" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkRegisterForCOM" Row="19" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkXMLDocumentationFile" Row="18" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtXMLDocumentationFile" Row="18" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="btnOutputPathBrowse" Row="17" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="txtOutputPath" Row="17" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblOutputPath" Row="17" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="rbWarningSpecific" Row="15" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtSpecificWarnings" Row="15" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="rbWarningAll" Row="14" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="rbWarningNone" Row="13" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="txtSupressWarnings" Row="11" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblSupressWarnings" Row="11" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cboWarningLevel" Row="10" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblWarningLevel" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cboPlatformTarget" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="chkOptimizeCode" Row="8" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkAllowUnsafeCode" Row="7" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkPrefer32Bit" Row="6" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkDefineTrace" Row="3" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkDefineDebug" Row="2" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="txtConditionalCompilationSymbols" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblConditionalCompilationSymbols" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblPlatformTarget" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblSGenOption" Row="20" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cboSGenOption" Row="20" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="btnAdvanced" Row="21" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lblNullable" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cboNullable" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="chkDefineDebug.Location" type="System.Drawing.Point, System.Drawing">
     <value>23, 50</value>
@@ -1365,9 +1431,9 @@
   <data name="&gt;&gt;chkDefineDebug.ZOrder" xml:space="preserve">
     <value>23</value>
   </data>
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
-  </data>
+  </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
@@ -1375,18 +1441,12 @@
     <value>True</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>539, 536</value>
+    <value>592, 550</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>BuildPropPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase, Microsoft.VisualStudio.AppDesigner, Version=42.42.42.42, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="txtSpecificWarnings.AccessibleName" xml:space="preserve">
-    <value>Specific Warnings To Treat As Errors</value>
-  </data>
-  <data name="txtXMLDocumentationFile.AccessibleName" xml:space="preserve">
-    <value>XML Document File Path</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
@@ -218,10 +218,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Dim version As Decimal
             Dim supportNullable = String.IsNullOrEmpty(value) OrElse (Decimal.TryParse(value, version) AndAlso version >= 8D)
 
-            If Not supportNullable Then
-                lblNullable.Visible = False
-                cboNullable.Visible = False
-            End If
+            EnableControl(lblNullable, supportNullable)
+            EnableControl(cboNullable, supportNullable)
         End Sub
 
         Private Function ShouldEnableRegisterForCOM() As Boolean

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
@@ -87,7 +87,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         VsProjPropId80.VBPROJPROPID_GenerateSerializationAssemblies, "GenerateSerializationAssemblies", cboSGenOption, New Control() {lblSGenOption}),
                      New PropertyControlData(VsProjPropId110.VBPROJPROPID_Prefer32Bit, "Prefer32Bit", chkPrefer32Bit, AddressOf Prefer32BitSet, AddressOf Prefer32BitGet),
                      New PropertyControlData(1, "Nullable", cboNullable, AddressOf NullableSet, AddressOf NullableGet, ControlDataFlags.None, New Control() {lblNullable}),
-                     New PropertyControlData(CSharpProjPropId.CSPROJPROPID_LanguageVersion, "LanguageVersion", Nothing, ControlDataFlags.None)
+                     New PropertyControlData(CSharpProjPropId.CSPROJPROPID_LanguageVersion, "LanguageVersion", Nothing, AddressOf LanguageVersionSet, Nothing, ControlDataFlags.None, Nothing)
                      }
                 End If
                 Return m_ControlData
@@ -221,6 +221,15 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             EnableControl(lblNullable, supportNullable)
             EnableControl(cboNullable, supportNullable)
         End Sub
+
+        Private Function LanguageVersionSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
+            If Not m_fInsideInit AndAlso Not InsideInternalUpdate Then
+                ' Changes to the LanguageVersion may affect whether nullable is enabled
+                RefreshVisibleStatusForNullable()
+            End If
+
+            Return True
+        End Function
 
         Private Function ShouldEnableRegisterForCOM() As Boolean
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
@@ -46,6 +46,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             'Opt out of page scaling since we're using AutoScaleMode
             PageRequiresScaling = False
+
+            cboNullable.Items.AddRange(New Object() {
+                New ComboItem("disable", My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_BuildSettings_Nullable_Disable),
+                New ComboItem("enable", My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_BuildSettings_Nullable_Enable),
+                New ComboItem("warnings", My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_BuildSettings_Nullable_Warnings),
+                New ComboItem("annotations", My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_BuildSettings_Nullable_Annotations)})
         End Sub
 
 
@@ -79,7 +85,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                      New PropertyControlData(VsProjPropId110.VBPROJPROPID_OutputTypeEx, "OutputTypeEx", Nothing, AddressOf OutputTypeSet, Nothing),
                      New SingleConfigPropertyControlData(SingleConfigPropertyControlData.Configs.Release,
                         VsProjPropId80.VBPROJPROPID_GenerateSerializationAssemblies, "GenerateSerializationAssemblies", cboSGenOption, New Control() {lblSGenOption}),
-                     New PropertyControlData(VsProjPropId110.VBPROJPROPID_Prefer32Bit, "Prefer32Bit", chkPrefer32Bit, AddressOf Prefer32BitSet, AddressOf Prefer32BitGet)
+                     New PropertyControlData(VsProjPropId110.VBPROJPROPID_Prefer32Bit, "Prefer32Bit", chkPrefer32Bit, AddressOf Prefer32BitSet, AddressOf Prefer32BitGet),
+                     New PropertyControlData(1, "Nullable", cboNullable, AddressOf NullableSet, AddressOf NullableGet, ControlDataFlags.None, New Control() {lblNullable}),
+                     New PropertyControlData(CSharpProjPropId.CSPROJPROPID_LanguageVersion, "LanguageVersion", Nothing, ControlDataFlags.None)
                      }
                 End If
                 Return m_ControlData
@@ -159,11 +167,61 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             rbWarningSpecific.Enabled = rbWarningAll.Enabled
 
             RefreshEnabledStatusForPrefer32Bit(chkPrefer32Bit)
-
+            RefreshVisibleStatusForNullable()
         End Sub
 
         Private Sub AdvancedButton_Click(sender As Object, e As EventArgs) Handles btnAdvanced.Click
             ShowChildPage(My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_AdvancedBuildSettings_Title, GetType(AdvBuildSettingsPropPage), HelpKeywords.CSProjPropAdvancedCompile)
+        End Sub
+
+        Private Function NullableSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
+            If (Not (PropertyControlData.IsSpecialValue(value))) Then
+                Dim stValue As String = CType(value, String)
+                If Not String.IsNullOrEmpty(stValue) Then
+                    SelectComboItem(cboNullable, stValue)
+                Else
+                    cboNullable.SelectedIndex = 0 ' Zero is the (disabled) entry in the list
+                End If
+                Return True
+            Else
+                cboNullable.SelectedIndex = -1 ' Indeterminate state
+            End If
+        End Function
+
+        Private Function NullableGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
+            Dim item As ComboItem = CType(CType(control, ComboBox).SelectedItem, ComboItem)
+            If item IsNot Nothing Then
+                value = item.Value
+                Return True
+            Else
+                Return False ' Indeterminate
+            End If
+        End Function
+
+        Private Shared Sub SelectComboItem(control As ComboBox, value As String)
+            For Each entry As ComboItem In control.Items
+                If entry.Value = value Then
+                    control.SelectedItem = entry
+                    Exit For
+                End If
+            Next
+        End Sub
+
+        Private Sub RefreshVisibleStatusForNullable()
+            Dim pcd = GetPropertyControlData("LanguageVersion")
+            Dim value = TryCast(pcd.GetPropertyValueNative(pcd.ExtendedPropertiesObjects), String)
+
+            ' If the project doesn't specify a LangVersion property, one is determined based upon TargetFramework.
+            ' For new target frameworks such as netcoreapp3.1 that support C# 8 and Nullable Reference Types, the
+            ' LangVersion property is not set. For target frameworks which do not support C# 8 by default (such as
+            ' net472) LangVersion is set to a string such as "7.3"
+            Dim version As Decimal
+            Dim supportNullable = String.IsNullOrEmpty(value) OrElse (Decimal.TryParse(value, version) AndAlso version >= 8D)
+
+            If Not supportNullable Then
+                lblNullable.Visible = False
+                cboNullable.Visible = False
+            End If
         End Sub
 
         Private Function ShouldEnableRegisterForCOM() As Boolean
@@ -1052,6 +1110,45 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 #End Region
 
+        Private Class ComboItem
+
+            ''' <summary>
+            ''' Stores the property value
+            ''' </summary>
+            Private ReadOnly _value As String
+
+            ''' <summary>
+            ''' Stores the display name
+            ''' </summary>
+            Private ReadOnly _displayName As String
+
+            ''' <summary>
+            ''' Constructor that uses the provided value and display name
+            ''' </summary>
+            Friend Sub New(value As String, displayName As String)
+
+                _value = value
+                _displayName = displayName
+
+            End Sub
+
+            ''' <summary>
+            ''' Gets the value
+            ''' </summary>
+            Public ReadOnly Property Value As String
+                Get
+                    Return _value
+                End Get
+            End Property
+
+            ''' <summary>
+            ''' Use the display name for the string display
+            ''' </summary>
+            Public Overrides Function ToString() As String
+                Return _displayName
+            End Function
+
+        End Class
     End Class
 
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">S&amp;ymboly podmíněné kompilace:</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblNullable.Text">
+        <source>Nulla&amp;ble:</source>
+        <target state="new">Nulla&amp;ble:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Výstup</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">&amp;Symbole für bedingte Kompilierung:</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblNullable.Text">
+        <source>Nulla&amp;ble:</source>
+        <target state="new">Nulla&amp;ble:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Ausgabe</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Sí&amp;mbolos de compilación condicional:</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblNullable.Text">
+        <source>Nulla&amp;ble:</source>
+        <target state="new">Nulla&amp;ble:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Salida</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">S&amp;ymboles de compilation conditionnelle :</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblNullable.Text">
+        <source>Nulla&amp;ble:</source>
+        <target state="new">Nulla&amp;ble:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Sortie</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Sim&amp;boli di compilazione condizionale:</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblNullable.Text">
+        <source>Nulla&amp;ble:</source>
+        <target state="new">Nulla&amp;ble:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Output</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">条件付きコンパイル シンボル(&amp;Y):</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblNullable.Text">
+        <source>Nulla&amp;ble:</source>
+        <target state="new">Nulla&amp;ble:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">出力</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">조건부 컴파일 기호(&amp;Y):</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblNullable.Text">
+        <source>Nulla&amp;ble:</source>
+        <target state="new">Nulla&amp;ble:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">출력</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">S&amp;ymbole kompilacji warunkowej:</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblNullable.Text">
+        <source>Nulla&amp;ble:</source>
+        <target state="new">Nulla&amp;ble:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Wyjściowe</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">S&amp;ímbolos de compilação condicional:</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblNullable.Text">
+        <source>Nulla&amp;ble:</source>
+        <target state="new">Nulla&amp;ble:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Saída</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Обознач&amp;ения условной компиляции:</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblNullable.Text">
+        <source>Nulla&amp;ble:</source>
+        <target state="new">Nulla&amp;ble:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Выходные данные</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Koşullu derleme s&amp;embolleri:</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblNullable.Text">
+        <source>Nulla&amp;ble:</source>
+        <target state="new">Nulla&amp;ble:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Çıkış</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">条件编译和符号(&amp;Y):</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblNullable.Text">
+        <source>Nulla&amp;ble:</source>
+        <target state="new">Nulla&amp;ble:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">输出</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">條件式編譯符號(&amp;Y):</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblNullable.Text">
+        <source>Nulla&amp;ble:</source>
+        <target state="new">Nulla&amp;ble:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">輸出</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.Designer.vb
@@ -993,6 +993,42 @@ Namespace My.Resources
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Annotations.
+        '''</summary>
+        Friend Shared ReadOnly Property PPG_BuildSettings_Nullable_Annotations() As String
+            Get
+                Return ResourceManager.GetString("PPG_BuildSettings_Nullable_Annotations", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Disable.
+        '''</summary>
+        Friend Shared ReadOnly Property PPG_BuildSettings_Nullable_Disable() As String
+            Get
+                Return ResourceManager.GetString("PPG_BuildSettings_Nullable_Disable", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Enable.
+        '''</summary>
+        Friend Shared ReadOnly Property PPG_BuildSettings_Nullable_Enable() As String
+            Get
+                Return ResourceManager.GetString("PPG_BuildSettings_Nullable_Enable", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Warnings.
+        '''</summary>
+        Friend Shared ReadOnly Property PPG_BuildSettings_Nullable_Warnings() As String
+            Get
+                Return ResourceManager.GetString("PPG_BuildSettings_Nullable_Warnings", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Build.
         '''</summary>
         Friend Shared ReadOnly Property PPG_BuildTitle() As String
@@ -2835,7 +2871,7 @@ Namespace My.Resources
                 Return ResourceManager.GetString("PropPage_ImportedNamespacesTitle", resourceCulture)
             End Get
         End Property
-
+        
         '''<summary>
         '''  Looks up a localized string similar to &quot;Invalid characters in file path.&quot;.
         '''</summary>
@@ -2844,7 +2880,7 @@ Namespace My.Resources
                 Return ResourceManager.GetString("PropPage_InvalidCharactersInFilePath", resourceCulture)
             End Get
         End Property
-
+        
         '''<summary>
         '''  Looks up a localized string similar to The URL is invalid. Please enter a valid URL like &quot;http://www.microsoft.com/&quot;.
         '''</summary>

--- a/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.resx
+++ b/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.resx
@@ -1970,6 +1970,18 @@ Do you want to update the value in the .settings file?</value>
   <data name="PPG_AdvancedBuildSettings_DebugInfo_Portable" xml:space="preserve">
     <value>Portable</value>
   </data>
+  <data name="PPG_BuildSettings_Nullable_Disable" xml:space="preserve">
+    <value>Disable</value>
+  </data>
+  <data name="PPG_BuildSettings_Nullable_Enable" xml:space="preserve">
+    <value>Enable</value>
+  </data>
+  <data name="PPG_BuildSettings_Nullable_Warnings" xml:space="preserve">
+    <value>Warnings</value>
+  </data>
+  <data name="PPG_BuildSettings_Nullable_Annotations" xml:space="preserve">
+    <value>Annotations</value>
+  </data>
   <data name="BlockedResx" xml:space="preserve">
     <value>Unable to load '{0}' because it is not trusted.</value>
     <comment>{0} is resx file name that is blocked</comment>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.cs.xlf
@@ -7,6 +7,26 @@
         <target state="translated">Všechny soubory</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Annotations">
+        <source>Annotations</source>
+        <target state="new">Annotations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Disable">
+        <source>Disable</source>
+        <target state="new">Disable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Enable">
+        <source>Enable</source>
+        <target state="new">Enable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Warnings">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PPG_PropertyPageControlName">
         <source>Property Page</source>
         <target state="translated">Stránka vlastností</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.de.xlf
@@ -7,6 +7,26 @@
         <target state="translated">Alle Dateien</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Annotations">
+        <source>Annotations</source>
+        <target state="new">Annotations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Disable">
+        <source>Disable</source>
+        <target state="new">Disable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Enable">
+        <source>Enable</source>
+        <target state="new">Enable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Warnings">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PPG_PropertyPageControlName">
         <source>Property Page</source>
         <target state="translated">Eigenschaftenseite</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.es.xlf
@@ -7,6 +7,26 @@
         <target state="translated">Todos los archivos</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Annotations">
+        <source>Annotations</source>
+        <target state="new">Annotations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Disable">
+        <source>Disable</source>
+        <target state="new">Disable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Enable">
+        <source>Enable</source>
+        <target state="new">Enable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Warnings">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PPG_PropertyPageControlName">
         <source>Property Page</source>
         <target state="translated">Página de propiedades</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.fr.xlf
@@ -7,6 +7,26 @@
         <target state="translated">Tous les fichiers</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Annotations">
+        <source>Annotations</source>
+        <target state="new">Annotations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Disable">
+        <source>Disable</source>
+        <target state="new">Disable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Enable">
+        <source>Enable</source>
+        <target state="new">Enable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Warnings">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PPG_PropertyPageControlName">
         <source>Property Page</source>
         <target state="translated">Page de propriétés</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.it.xlf
@@ -7,6 +7,26 @@
         <target state="translated">Tutti i file</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Annotations">
+        <source>Annotations</source>
+        <target state="new">Annotations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Disable">
+        <source>Disable</source>
+        <target state="new">Disable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Enable">
+        <source>Enable</source>
+        <target state="new">Enable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Warnings">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PPG_PropertyPageControlName">
         <source>Property Page</source>
         <target state="translated">Pagina delle proprietà</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ja.xlf
@@ -7,6 +7,26 @@
         <target state="translated">すべてのファイル</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Annotations">
+        <source>Annotations</source>
+        <target state="new">Annotations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Disable">
+        <source>Disable</source>
+        <target state="new">Disable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Enable">
+        <source>Enable</source>
+        <target state="new">Enable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Warnings">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PPG_PropertyPageControlName">
         <source>Property Page</source>
         <target state="translated">プロパティ ページ</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ko.xlf
@@ -7,6 +7,26 @@
         <target state="translated">모든 파일</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Annotations">
+        <source>Annotations</source>
+        <target state="new">Annotations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Disable">
+        <source>Disable</source>
+        <target state="new">Disable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Enable">
+        <source>Enable</source>
+        <target state="new">Enable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Warnings">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PPG_PropertyPageControlName">
         <source>Property Page</source>
         <target state="translated">속성 페이지</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pl.xlf
@@ -7,6 +7,26 @@
         <target state="translated">Wszystkie pliki</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Annotations">
+        <source>Annotations</source>
+        <target state="new">Annotations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Disable">
+        <source>Disable</source>
+        <target state="new">Disable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Enable">
+        <source>Enable</source>
+        <target state="new">Enable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Warnings">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PPG_PropertyPageControlName">
         <source>Property Page</source>
         <target state="translated">Strona właściwości</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pt-BR.xlf
@@ -7,6 +7,26 @@
         <target state="translated">Todos os Arquivos</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Annotations">
+        <source>Annotations</source>
+        <target state="new">Annotations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Disable">
+        <source>Disable</source>
+        <target state="new">Disable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Enable">
+        <source>Enable</source>
+        <target state="new">Enable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Warnings">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PPG_PropertyPageControlName">
         <source>Property Page</source>
         <target state="translated">Página de Propriedades</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ru.xlf
@@ -7,6 +7,26 @@
         <target state="translated">Все файлы</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Annotations">
+        <source>Annotations</source>
+        <target state="new">Annotations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Disable">
+        <source>Disable</source>
+        <target state="new">Disable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Enable">
+        <source>Enable</source>
+        <target state="new">Enable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Warnings">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PPG_PropertyPageControlName">
         <source>Property Page</source>
         <target state="translated">Страница свойств</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.tr.xlf
@@ -7,6 +7,26 @@
         <target state="translated">Tüm Dosyalar</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Annotations">
+        <source>Annotations</source>
+        <target state="new">Annotations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Disable">
+        <source>Disable</source>
+        <target state="new">Disable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Enable">
+        <source>Enable</source>
+        <target state="new">Enable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Warnings">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PPG_PropertyPageControlName">
         <source>Property Page</source>
         <target state="translated">Özellik Sayfası</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hans.xlf
@@ -7,6 +7,26 @@
         <target state="translated">所有文件</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Annotations">
+        <source>Annotations</source>
+        <target state="new">Annotations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Disable">
+        <source>Disable</source>
+        <target state="new">Disable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Enable">
+        <source>Enable</source>
+        <target state="new">Enable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Warnings">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PPG_PropertyPageControlName">
         <source>Property Page</source>
         <target state="translated">属性页</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hant.xlf
@@ -7,6 +7,26 @@
         <target state="translated">所有檔案</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Annotations">
+        <source>Annotations</source>
+        <target state="new">Annotations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Disable">
+        <source>Disable</source>
+        <target state="new">Disable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Enable">
+        <source>Enable</source>
+        <target state="new">Enable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PPG_BuildSettings_Nullable_Warnings">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PPG_PropertyPageControlName">
         <source>Property Page</source>
         <target state="translated">屬性頁</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
@@ -125,14 +125,15 @@
   <StringProperty Name="NoWarn"
                   Visible="False" />
 
-  <BoolProperty Name="NullableReferenceTypes"
-                Visible="False">
-    <BoolProperty.DataSource>
+  <StringProperty Name="Nullable"
+                  Visible="False">
+    <StringProperty.DataSource>
       <DataSource HasConfigurationCondition="False"
+                  PersistedName="Nullable"
                   Persistence="ProjectFile"
                   SourceOfDefaultValue="AfterContext" />
-    </BoolProperty.DataSource>
-  </BoolProperty>
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <BoolProperty Name="Optimize"
                 Visible="False" />


### PR DESCRIPTION
Fixes #4058.

This option is only available when the language version is 8.0 or greater.

---

### netcoreapp3.1 (LangVersion 8)

![image](https://user-images.githubusercontent.com/350947/72721113-71b24900-3bcf-11ea-9ac3-2737380ba1e9.png)

The dropdown has the following options:

![image](https://user-images.githubusercontent.com/350947/72721168-87c00980-3bcf-11ea-92e4-8e8d7488fe56.png)

---

### net48 (LangVersion 7.3)

The nullable control is disabled:

![image](https://user-images.githubusercontent.com/350947/72770664-a9aea000-3c52-11ea-95c7-dec54933481f.png)

