### PR TITLE
Create GitHub Action to post PRs to teams

### DIFF
--- a/.github/workflows/post-to-teams.yml
+++ b/.github/workflows/post-to-teams.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on: 
+  pull_request:
+    types: [opened, reopened]
+  
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+# github.event is one of these: https://developer.github.com/v3/activity/events/types/#pullrequestevent
+# allowed values on github.event.pull_request come from here: https://developer.github.com/v3/pulls/
+
+    steps:
+      - name: Microsoft Teams (Generic)
+        uses: aliencube/microsoft-teams-actions@v0.7.0
+        with:
+          # Incoming webhook URI to Microsoft Teams
+          webhook_uri: https://outlook.office.com/webhook/4ba7372f-2799-4677-89f0-7a1aaea3706c@72f988bf-86f1-41af-91ab-2d7cd011db47/IncomingWebhook/574a9caf099746e480b30f29d5dfadc2/9dbc0cfc-eab3-42c9-838a-4879bef6875e
+          # Message title
+          title: "PR opened: ${{ github.event.pull_request.title }}"
+          # Message summary
+          summary: "You can view the PR here: ${{ github.event.pull_request.html_url }}"
+          # Message text
+          #text: # optional, default is 
+          # Message theme color
+          #theme_color: # optional, default is 
+          # JSON array for message sections
+          #sections: # optional, default is 
+          # JSON array for message actions
+          #actions: # optional, default is 


### PR DESCRIPTION
Trying this out, will tweak content over time. Should be more reliable than the twitter app we use now.