### PR TITLE
Remove LastFileWriteTime

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -24,7 +24,6 @@ namespace Microsoft.VisualStudio.IO
         void WriteAllText(string path, string content);
         void WriteAllText(string path, string content, Encoding encoding);
         void WriteAllBytes(string path, byte[] bytes);
-        DateTime LastFileWriteTime(string path);
         DateTime LastFileWriteTimeUtc(string path);
         long FileLength(string filename);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
@@ -58,11 +58,6 @@ namespace Microsoft.VisualStudio.IO
             File.WriteAllBytes(path, bytes);
         }
 
-        public DateTime LastFileWriteTime(string path)
-        {
-            return File.GetLastWriteTime(path);
-        }
-
         public DateTime LastFileWriteTimeUtc(string path)
         {
             return File.GetLastWriteTimeUtc(path);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public ITaskDelayScheduler FileChangeScheduler { get; protected set; }
 
         // Tracks when we last read or wrote to the file. Prevents picking up needless changes
-        protected DateTime LastSettingsFileSyncTime { get; set; }
+        protected DateTime LastSettingsFileSyncTimeUtc { get; set; }
 
         protected const int WaitForFirstSnapshotDelayMillis = 5000;
 
@@ -354,7 +354,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             string fileName = await GetLaunchSettingsFilePathAsync();
 
-            return !_fileSystem.FileExists(fileName) || _fileSystem.LastFileWriteTime(fileName) != LastSettingsFileSyncTime;
+            return !_fileSystem.FileExists(fileName) || _fileSystem.LastFileWriteTimeUtc(fileName) != LastSettingsFileSyncTimeUtc;
         }
 
         /// <summary>
@@ -453,7 +453,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             }
 
             // Remember the time we are sync'd to
-            LastSettingsFileSyncTime = _fileSystem.LastFileWriteTime(fileName);
+            LastSettingsFileSyncTimeUtc = _fileSystem.LastFileWriteTimeUtc(fileName);
             return launchSettingsData;
         }
 
@@ -508,7 +508,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 _fileSystem.WriteAllText(fileName, jsonString);
 
                 // Update the last write time
-                LastSettingsFileSyncTime = _fileSystem.LastFileWriteTime(fileName);
+                LastSettingsFileSyncTimeUtc = _fileSystem.LastFileWriteTimeUtc(fileName);
             }
             finally
             {
@@ -593,7 +593,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
                 // Only do something if the file is truly different than what we synced. Here, we want to
                 // throttle.
-                if (!_fileSystem.FileExists(fileName) || _fileSystem.LastFileWriteTime(fileName) != LastSettingsFileSyncTime)
+                if (!_fileSystem.FileExists(fileName) || _fileSystem.LastFileWriteTimeUtc(fileName) != LastSettingsFileSyncTimeUtc)
                 {
                     return FileChangeScheduler.ScheduleAsyncTask(token =>
                     {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -221,11 +221,6 @@ namespace Microsoft.VisualStudio.IO
             }
         }
 
-        public DateTime LastFileWriteTime(string path)
-        {
-            return Files[path].LastWriteTimeUtc.ToLocalTime();
-        }
-
         public DateTime LastFileWriteTimeUtc(string path)
         {
             return Files[path].LastWriteTimeUtc;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -266,7 +266,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             moqFS.WriteAllText(provider.LaunchSettingsFile, JsonString1);
 
             Assert.True(await provider.SettingsFileHasChangedAsyncTest());
-            provider.LastSettingsFileSyncTimeTest = moqFS.LastFileWriteTime(provider.LaunchSettingsFile);
+            provider.LastSettingsFileSyncTimeTest = moqFS.LastFileWriteTimeUtc(provider.LaunchSettingsFile);
             Assert.False(await provider.SettingsFileHasChangedAsyncTest());
         }
 
@@ -373,7 +373,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             await provider.SaveSettingsToDiskAsyncTest(testSettings.Object);
 
             // Last Write time should be set
-            Assert.Equal(moqFS.LastFileWriteTime(provider.LaunchSettingsFile), provider.LastSettingsFileSyncTimeTest);
+            Assert.Equal(moqFS.LastFileWriteTimeUtc(provider.LaunchSettingsFile), provider.LastSettingsFileSyncTimeTest);
 
             // Check disk contents
             Assert.Equal(JsonStringWithWebSettings, moqFS.ReadAllText(provider.LaunchSettingsFile), ignoreLineEndingDifferences: true);
@@ -425,7 +425,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             // Write new file, but set the timestamp to match
             moqFS.WriteAllText(provider.LaunchSettingsFile, JsonStringWithWebSettings);
-            provider.LastSettingsFileSyncTimeTest = moqFS.LastFileWriteTime(provider.LaunchSettingsFile);
+            provider.LastSettingsFileSyncTimeTest = moqFS.LastFileWriteTimeUtc(provider.LaunchSettingsFile);
             Assert.Equal(provider.LaunchSettingsFile_ChangedTest(), Task.CompletedTask);
             AssertEx.CollectionLength(provider.CurrentSnapshot.Profiles, 4);
 
@@ -902,7 +902,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public Task SaveSettingsToDiskAsyncTest(ILaunchSettings curSettings) { return SaveSettingsToDiskAsync(curSettings); }
         public Task UpdateAndSaveSettingsInternalAsyncTest(ILaunchSettings curSettings, bool persistToDisk) { return UpdateAndSaveSettingsInternalAsync(curSettings, persistToDisk); }
 
-        public DateTime LastSettingsFileSyncTimeTest { get { return LastSettingsFileSyncTime; } set { LastSettingsFileSyncTime = value; } }
+        public DateTime LastSettingsFileSyncTimeTest { get { return LastSettingsFileSyncTimeUtc; } set { LastSettingsFileSyncTimeUtc = value; } }
         public Task UpdateProfilesAsyncTest(string? activeProfile) { return UpdateProfilesAsync(activeProfile); }
         public void SetIgnoreFileChanges(bool value) { IgnoreFileChanges = value; }
         public Task<bool> SettingsFileHasChangedAsyncTest() { return SettingsFileHasChangedAsync(); }


### PR DESCRIPTION
We shouldn't be using local time to determine file write times, as clocks can change while VS is open.