### PR TITLE
Respect "RestoreProjectStyle"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -81,6 +81,8 @@
     <ProjectCapability Include="ProjectImportsTree" />
     <ProjectCapability Include="LaunchProfiles" />
     <ProjectCapability Include="NoGeneralDependentFileIcon"/>
+    <ProjectCapability Include="PackageReferences" Condition="'$(RestoreProjectStyle)' == 'PackageReference'"/>
+    
     <!--
       List of capabilities below is adding back common capabilities defined in imported targets.
       We disabled them with the property DefineCommonCapabilities=false to get rid of default
@@ -90,7 +92,6 @@
                           AssemblyReferences;
                           COMReferences;
                           ProjectReferences;
-                          PackageReferences;
                           SharedProjectReferences;
                           WinRTReferences;
                           OutputGroups;


### PR DESCRIPTION
Certain projects in http://github.com/dotnet/runtime "turn off" package restore via <RestoreProjectStyle>Unknown</RestoreProjectStyle>: https://github.com/dotnet/runtime/blob/86bfd8d46b3817e2a027b23d829cd0d035cd8ad6/eng/restore/repoRestore.targets#L4.

This causes us to nominate to NuGet, only for it to fail to produce an assets file. This causes us to never complete operation progress resulting in https://developercommunity.visualstudio.com/content/problem/884350/intellisense-waiting-forever-dialog-in-dotnetrunti.html.

Turn off PackageReferences support if is not PackageReference based.

This works quite well, and can be changed dynamically and does the right thing.