### PR TITLE
Don't require analyzers to be in evaluation data

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AnalyzerRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AnalyzerRuleHandler.cs
@@ -34,6 +34,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         public override ImageMoniker ImplicitIcon => ManagedImageMonikers.CodeInformationPrivate;
 
+        protected override bool ResolvedItemRequiresEvaluatedItem => false;
+
         public override IDependencyModel CreateRootDependencyNode() => s_rootModel;
 
         protected override IDependencyModel CreateDependencyModel(


### PR DESCRIPTION
Fixes #5418.

The dependency node receives both evaluation (unresolved) data and design-time build (resolved) data. Both sources provide data about the same items and must be correlated and combined.

A while ago the dependency node changed to disallow adding items to the tree that appear _only_ in design-time build results. This broke the Analyzers node as analyzers are not available during evaluation (see #4782).

This change allows specific rules to opt out of the restriction, doing so only for analyzer items.