### PR TITLE
Reevaluate when global.json changes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -369,9 +369,16 @@
     </PropertyPageSchema>
   </ItemGroup>
 
-  <!-- List of external files that trigger design-time builds when they are modified -->
+  <!-- List of external files that trigger re-evaluation & design-time builds when they are modified -->
   <ItemGroup>
     <AdditionalDesignTimeBuildInput Include="$(ProjectAssetsFile)" />   <!-- NuGet assets file -->
+  </ItemGroup>
+
+  <!-- Find all potential locations of "global.json" starting from the Solution directory and walking backwards -->
+  <ItemGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true' and '$(SolutionDir)' != ''">
+    <_GlobalJsonStartingDir Include="$(SolutionDir)" />
+    <_PotentialContainingGlobalJsonDir Include="@(_GlobalJsonStartingDir->GetPathsOfAllDirectoriesAbove())" />
+    <AdditionalDesignTimeBuildInput Include="@(_PotentialContainingGlobalJsonDir->Combine('global.json'))" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/5847

CPS monitors and reevaluates when items added to `<AdditionalDesignTimeBuildInput>` are added, removed or deleted. Start monitoring global.json files starting from the solution directory and higher so that we can react to changes to it that affect MSBuild SDK resolution.

Note, this over-eagerly finds global.json files that may not influence the project, ie Given a solution structure like so:

```
C:\
C:\Folder\
C:\Folder\Solution\
C:\Folder\Solution\global.json
```
This will monitor for changes in `C:\`, `C:\Folder` and `C:\Folder\Solution` despite only `C:\Folder\Solution\global.json` ever infuencing SDK resolution. This is a limitation in MSBuild; there's no way to batch or filter the items inside evaluation and outside of a target, which is how `<AdditionalDesignTimeBuildInput>` items need to be produced.