### PR TITLE
Use missing folder icon when Properties is missing from disk

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/AppDesignerFolderProjectImageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/AppDesignerFolderProjectImageProvider.cs
@@ -21,9 +21,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging
         {
             Requires.NotNullOrEmpty(key, nameof(key));
 
-            return key == ProjectImageKey.AppDesignerFolder ?
-                KnownMonikers.Property.ToProjectSystemType() :
-                null;
+            switch (key)
+            {
+                case ProjectImageKey.AppDesignerFolder:
+                case ProjectImageKey.ExpandedAppDesignerFolder:
+                    return KnownMonikers.Property.ToProjectSystemType();
+
+                case ProjectImageKey.MissingAppDesignerFolder:
+                    return KnownMonikers.FolderOffline.ToProjectSystemType();
+            };
+
+            return null;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/ProjectImageKey.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/ProjectImageKey.cs
@@ -23,8 +23,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging
         public const string SharedItemsImportFile = nameof(SharedItemsImportFile);
 
         /// <summary>
-        ///     Represents the image key for the AppDesigner folder (called "Properties" in C# and "My Project" in VB).
+        ///     Represents the image key for the AppDesigner folder (called "Properties" in C# and "My Project" in VB) when it is closed.
         /// </summary>
         public const string AppDesignerFolder = nameof(AppDesignerFolder);
+
+        /// <summary>
+        ///     Represents the image key for the AppDesigner folder (called "Properties" in C# and "My Project" in VB) when it is expanded.
+        /// </summary>
+        public const string ExpandedAppDesignerFolder = nameof(ExpandedAppDesignerFolder);
+
+        /// <summary>
+        ///     Represents the image key for the AppDesigner folder (called "Properties" in C# and "My Project" in VB) when it is missing from disk.
+        /// </summary>
+        public const string MissingAppDesignerFolder = nameof(MissingAppDesignerFolder);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/AbstractSpecialFolderProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/AbstractSpecialFolderProjectTreePropertiesProvider.cs
@@ -25,6 +25,16 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public abstract string FolderImageKey { get; }
 
         /// <summary>
+        ///     Gets the image key that represents the image that will be applied to the special folder when expanded.
+        /// </summary>
+        public abstract string ExpandedFolderImageKey { get; }
+
+        /// <summary>
+        ///     Gets the image key that represents the image that will be applied to the special folder when the folder is missing from disk.
+        /// </summary>
+        public abstract string MissingFolderImageKey { get; }
+
+        /// <summary>
         ///     Gets the default flags that will be applied to the special folder.
         /// </summary>
         public abstract ProjectTreeFlags FolderFlags { get; }
@@ -82,14 +92,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             propertyValues.Flags = propertyValues.Flags.Union(FolderFlags);
 
-            // Avoid overwriting icon if the image provider didn't provide one
-            ProjectImageMoniker? icon = _imageProvider.GetProjectImage(FolderImageKey);
+            bool isMissing = propertyValues.Flags.IsMissingOnDisk();
 
-            if (icon != null)
-            {
-                propertyValues.Icon = icon;
-                propertyValues.ExpandedIcon = icon;
-            }
+            ProjectImageMoniker? icon = _imageProvider.GetProjectImage(isMissing ? MissingFolderImageKey : FolderImageKey);
+            ProjectImageMoniker? expandedIcon = _imageProvider.GetProjectImage(isMissing ? MissingFolderImageKey : ExpandedFolderImageKey);
+
+            // Avoid overwriting icon if the image provider didn't provide one
+            propertyValues.Icon = icon ?? propertyValues.Icon;
+            propertyValues.ExpandedIcon = expandedIcon ?? propertyValues.ExpandedIcon;
         }
 
         private static void ApplySpecialFolderItemProperties(IProjectTreeCustomizablePropertyValues propertyValues)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/AppDesignerFolderProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/AppDesignerFolderProjectTreePropertiesProvider.cs
@@ -46,6 +46,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree
             get { return ProjectImageKey.AppDesignerFolder; }
         }
 
+        public override string ExpandedFolderImageKey
+        {
+            get { return ProjectImageKey.ExpandedAppDesignerFolder; }
+        }
+
+        public override string MissingFolderImageKey
+        {
+            get { return ProjectImageKey.MissingAppDesignerFolder; }
+        }
+
         public ICollection<string> ProjectPropertiesRules
         {
             get { return AppDesigner.SchemaNameArray; }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/AppDesignerFolderProjectTreePropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/AppDesignerFolderProjectTreePropertiesProviderTests.cs
@@ -317,6 +317,50 @@ Root (flags: {ProjectRoot})
         [Theory]
         [InlineData(@"
 Root (flags: {ProjectRoot})
+    Properties (flags: {FileSystemEntity Folder})
+        Folder (flags: {FileSystemEntity Folder})
+", @"
+Root (flags: {ProjectRoot})
+    Properties (flags: {FileSystemEntity Folder AppDesignerFolder BubbleUp}), Icon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 1}
+        Folder (flags: {FileSystemEntity Folder})
+")]
+        public void ChangePropertyValues_TreeWithAppDesignerFolder_SetsIconToAppDesignerFolder(string input, string expected)
+        {
+            var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
+            var imageProvider = IProjectImageProviderFactory.ImplementGetProjectImage(ProjectImageKey.AppDesignerFolder, new ProjectImageMoniker(new Guid("AE27A6B0-E345-4288-96DF-5EAF394EE369"), 1));
+            var propertiesProvider = CreateInstance(imageProvider, designerService);
+
+            var inputTree = ProjectTreeParser.Parse(input);
+            var expectedTree = ProjectTreeParser.Parse(expected);
+
+            Verify(propertiesProvider, expectedTree, inputTree);
+        }
+
+        [Theory]
+        [InlineData(@"
+Root (flags: {ProjectRoot})
+    Properties (flags: {FileSystemEntity Folder})
+        Folder (flags: {FileSystemEntity Folder})
+", @"
+Root (flags: {ProjectRoot})
+    Properties (flags: {FileSystemEntity Folder AppDesignerFolder BubbleUp}), ExpandedIcon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 1}
+        Folder (flags: {FileSystemEntity Folder})
+")]
+        public void ChangePropertyValues_TreeWithAppDesignerFolder_SetsExpandedIconToExpandedAppDesignerFolder(string input, string expected)
+        {
+            var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
+            var imageProvider = IProjectImageProviderFactory.ImplementGetProjectImage(ProjectImageKey.ExpandedAppDesignerFolder, new ProjectImageMoniker(new Guid("AE27A6B0-E345-4288-96DF-5EAF394EE369"), 1));
+            var propertiesProvider = CreateInstance(imageProvider, designerService);
+
+            var inputTree = ProjectTreeParser.Parse(input);
+            var expectedTree = ProjectTreeParser.Parse(expected);
+
+            Verify(propertiesProvider, expectedTree, inputTree);
+        }
+
+        [Theory]
+        [InlineData(@"
+Root (flags: {ProjectRoot})
     Properties (flags: {Folder})
         Folder (flags: {Folder})
 ", @"
@@ -324,10 +368,10 @@ Root (flags: {ProjectRoot})
     Properties (flags: {Folder AppDesignerFolder BubbleUp}), Icon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 1}, ExpandedIcon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 1}
         Folder (flags: {Folder})
 ")]
-        public void ChangePropertyValues_TreeWithAppDesignerFolder_SetsIconAndExpandedIconToAppDesignerFolder(string input, string expected)
+        public void ChangePropertyValues_TreeWithMissingAppDesignerFolder_SetsIconAndExpandedIconToMissingAppDesignerFolder(string input, string expected)
         {
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
-            var imageProvider = IProjectImageProviderFactory.ImplementGetProjectImage(ProjectImageKey.AppDesignerFolder, new ProjectImageMoniker(new Guid("AE27A6B0-E345-4288-96DF-5EAF394EE369"), 1));
+            var imageProvider = IProjectImageProviderFactory.ImplementGetProjectImage(ProjectImageKey.MissingAppDesignerFolder, new ProjectImageMoniker(new Guid("AE27A6B0-E345-4288-96DF-5EAF394EE369"), 1));
             var propertiesProvider = CreateInstance(imageProvider, designerService);
 
             var inputTree = ProjectTreeParser.Parse(input);


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/216

When the properties folder is explicitly included in the project when globs are turned off and source files are included from under it, or when explicitly included in the project via `<Folder Include="Properties" />` and its missing from disk, use the missing folder icon to make it obvious as to why Add/Open Folder in File Explorer don't work.

Also made it easier for https://github.com/dotnet/project-system/issues/5803 to be implemented by plumbing out the expanded folder case.

Adding a specific missing folder icon for the App Designer is being tracked by: https://github.com/dotnet/project-system/issues/5803.