### PR TITLE
Up-to-date check considers AdditionalDependentFileTime items

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -390,7 +390,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     foreach (string input in upToDateCheckInputItems.Select(_configuredProject.UnconfiguredProject.MakeRooted))
                     {
                         log.Verbose("    '{0}'", input);
-                        yield return (input, true);
+                        yield return (Path: input, IsRequired: true);
                     }
                 }
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectSnapshot2Factory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectSnapshot2Factory.cs
@@ -8,11 +8,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class IProjectSnapshot2Factory
     {
-        public static IProjectSnapshot2 CreateEmpty()
+        public static IProjectSnapshot2 Create(
+            IImmutableDictionary<string, DateTime>? dependentFileTimes = null)
         {
             var mock = new Mock<IProjectSnapshot2>();
+
             mock.Setup(s => s.AdditionalDependentFileTimes)
-                .Returns(ImmutableDictionary<string, DateTime>.Empty);
+                .Returns(dependentFileTimes ?? ImmutableDictionary<string, DateTime>.Empty);
 
             return mock.Object;
         }
@@ -26,7 +28,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 .Returns(fileTimes);
 
             return mock.Object;
-
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/PackageRestoreProgressTrackerInstanceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/PackageRestoreProgressTrackerInstanceTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             var currentTimestamp = DateTime.Now;
 
             var restoreData = new RestoreData(projectAssetsFile, currentTimestamp);
-            var snapshot = IProjectSnapshot2Factory.CreateEmpty();
+            var snapshot = IProjectSnapshot2Factory.Create();
 
             var result = await OnRestoreCompleted(snapshot, restoreData);
 
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         public async Task OnRestoreCompleted_WhenRestoreFailed_IsUpToDate()
         {
             var restoreData = new RestoreData(string.Empty, DateTime.MinValue, succeeded: false);
-            var snapshot = IProjectSnapshot2Factory.CreateEmpty();
+            var snapshot = IProjectSnapshot2Factory.Create();
 
             var result = await OnRestoreCompleted(snapshot, restoreData);
 


### PR DESCRIPTION
Fixes #5846.

Builds on top of #5849.

This change teaches the fast up-to-date check to also consider `IProjectSnapshot.AdditionalDependentFileTimes`. This required a new subscription to `ProjectSource`, and plumbing the values through the state object.

Also, this introduces a class of input that is "not required". Specifically, potential paths to files which are probed for are not required, as those paths are speculative catch-alls. Previously a missing input would cause the project to be considered out-of-date. That behaviour is preserved for all except these new `AdditionalDependentFileTimes` items.