### PR TITLE
Add an "Edit Project File" command for VS Online scenarios

### DIFF
--- a/ProjectSystem.sln
+++ b/ProjectSystem.sln
@@ -41,6 +41,10 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "docs", "docs\docs.shproj", 
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Microsoft.VisualStudio.ProjectSystem.Managed.TestServices", "tests\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.shproj", "{02578366-DFA9-4827-93F7-08E2AE5CE6A4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client", "src\Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client\Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.csproj", "{90F64FB6-87AA-4841-A272-AD363608E17B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests", "tests\Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests.csproj", "{857E59F7-3FE9-4A12-A841-DFC4707C0DE5}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		tests\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.projitems*{02578366-dfa9-4827-93f7-08e2ae5ce6a4}*SharedItemsImports = 13
@@ -107,6 +111,14 @@ Global
 		{C16993CC-6063-4447-AE16-BE671AFDE08A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C16993CC-6063-4447-AE16-BE671AFDE08A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C16993CC-6063-4447-AE16-BE671AFDE08A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{90F64FB6-87AA-4841-A272-AD363608E17B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90F64FB6-87AA-4841-A272-AD363608E17B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90F64FB6-87AA-4841-A272-AD363608E17B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90F64FB6-87AA-4841-A272-AD363608E17B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{857E59F7-3FE9-4A12-A841-DFC4707C0DE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{857E59F7-3FE9-4A12-A841-DFC4707C0DE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{857E59F7-3FE9-4A12-A841-DFC4707C0DE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{857E59F7-3FE9-4A12-A841-DFC4707C0DE5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -126,6 +138,8 @@ Global
 		{892500A5-BF6B-4FD5-A7B9-5EEA20EB775F} = {7349958E-C619-481F-BB2A-8A4CA2E349D9}
 		{C16993CC-6063-4447-AE16-BE671AFDE08A} = {7349958E-C619-481F-BB2A-8A4CA2E349D9}
 		{02578366-DFA9-4827-93F7-08E2AE5CE6A4} = {7349958E-C619-481F-BB2A-8A4CA2E349D9}
+		{90F64FB6-87AA-4841-A272-AD363608E17B} = {1FF0293B-6808-4BB1-8370-1FE222986654}
+		{857E59F7-3FE9-4A12-A841-DFC4707C0DE5} = {7349958E-C619-481F-BB2A-8A4CA2E349D9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6B652C28-D1FD-4885-A0CA-4704C54E78E7}

--- a/build/ci/SignToolData.json
+++ b/build/ci/SignToolData.json
@@ -7,7 +7,9 @@
         "bin/Dlls/Microsoft.VisualStudio.ProjectSystem.Managed.dll",
         "bin/Dlls/*/Microsoft.VisualStudio.ProjectSystem.Managed.resources.dll",
         "bin/Dlls/Microsoft.VisualStudio.ProjectSystem.Managed.VS.dll",
-        "bin/Dlls/*/Microsoft.VisualStudio.ProjectSystem.Managed.VS.resources.dll"
+        "bin/Dlls/*/Microsoft.VisualStudio.ProjectSystem.Managed.VS.resources.dll",
+        "bin/Dlls/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.dll",
+        "bin/Dlls/*/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.resources.dll"
       ]
     },
     {

--- a/build/import/HostAgnostic.props
+++ b/build/import/HostAgnostic.props
@@ -62,8 +62,6 @@
     <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" />
     <PackageReference Include="StreamJsonRpc" />
 
-    <PackageReference Include="Microsoft.ServiceHub.Framework" />
-
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsUnitTestProject)' == 'true'" >

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -47,9 +47,10 @@
     <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces"                             Version="1.1.4322" />
     <PackageReference Update="Microsoft.VisualStudio.Diagnostics.PerformanceProvider"                 Version="16.0.28226-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.GraphModel"                                      Version="16.0.28226-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="16.5.29508.29" />
+    <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="16.5.29722.127" />
     <PackageReference Update="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime"                 Version="14.3.26930"/>
     <PackageReference Update="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50727" />
+    <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="16.5.32-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Telemetry"                                       Version="16.0.4-master" />
     <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.9.0"                         Version="9.0.30729" />
     <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.10.0"                        Version="10.0.30319" />
@@ -57,9 +58,9 @@
     <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime"             Version="12.1.30328" />
     <PackageReference Update="Microsoft.VisualStudio.Settings.15.0"                                   Version="15.8.28010" />
     <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="1.16.30" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.15.0"                                      Version="16.4.29318.21" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.15.0"                                      Version="16.5.29726.04" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Design"                                    Version="16.0.28316-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Framework"                                 Version="16.4.29318.21" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Framework"                                 Version="16.5.29726.04" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.9.0"                               Version="9.0.30730" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.10.0"                              Version="10.0.30320" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.11.0"                              Version="11.0.61031" />
@@ -70,12 +71,13 @@
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.7.DesignTime"                   Version="15.7.1" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.8.DesignTime"                   Version="15.8.1" />
     <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="8.0.0-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="16.5.124-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="16.5.124-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="16.4.29318.188-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="16.5.126" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="16.5.126" />
+    <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="16.5.29726.04" />
     <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="15.5.31" />
     <PackageReference Update="Microsoft.VisualStudio.VSHelp"                                          Version="16.0.28321-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.WCFReference.Interop"                            Version="9.1.26606-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Workspace.VSIntegration"                         Version="16.3.43" />
     <PackageReference Update="Microsoft.VisualStudio.XmlEditor"                                       Version="16.0.28321-alpha" />
     <PackageReference Update="Microsoft.VSDesigner"                                                   Version="16.0.28321-alpha" />
     <PackageReference Update="VsWebSite.Interop"                                                      Version="8.0.0-alpha"/>
@@ -89,7 +91,7 @@
     <PackageReference Update="EnvDTE"                                                                 Version="8.0.1" />
     <PackageReference Update="EnvDTE80"                                                               Version="8.0.1" />
     <PackageReference Update="EnvDTE90"                                                               Version="9.0.1" />
-    <PackageReference Update="StreamJsonRpc"                                                          Version="2.2.17-alpha" />
+    <PackageReference Update="StreamJsonRpc"                                                          Version="2.3.81" />
     
     <!-- Avoid double-writes, can remove when https://github.com/NuGet/Home/issues/8343 is fixed -->
     <PackageReference Include="VSSDK.DTE"                                                             Version="7.0.4"                           ExcludeAssets="All" />
@@ -103,12 +105,6 @@
          resolved". By explicitly bringing in the dependency we ensure that the proper 
          version of the assembly is available. -->
     <PackageReference Update="System.Threading.Tasks.Dataflow"                                        Version="4.9.0" />
-
-    <!-- Microsoft.VisualStudio.Shell.15.0 v16.4.29318.21 (and possibly other packages)
-         depend on Microsoft.ServiceHub.Framework v2.0.72. However, that version of the
-         package isn't available on the feeds we have access to. Here we force a slightly
-         newer version that *is* available.-->
-    <PackageReference Update="Microsoft.ServiceHub.Framework"                                         Version="2.0.84" />
 
     <!-- VS Editor APIs -->
     <PackageReference Update="Microsoft.VisualStudio.CoreUtility"                                     Version="16.0.467" />

--- a/setup/ProjectSystemSetup/AssemblyRedirects.cs
+++ b/setup/ProjectSystemSetup/AssemblyRedirects.cs
@@ -7,3 +7,4 @@ using Microsoft.VisualStudio;
 // via the Roslyn Insertion tool when it consumes artifacts\Debug\DevDivInsertionFiles\DependentAssemblyVersions.csv.
 [assembly: ProvideCodeBaseBindingRedirection("Microsoft.VisualStudio.ProjectSystem.Managed")]
 [assembly: ProvideCodeBaseBindingRedirection("Microsoft.VisualStudio.ProjectSystem.Managed.VS")]
+[assembly: ProvideCodeBaseBindingRedirection("Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client")]

--- a/setup/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/setup/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -23,6 +23,11 @@
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;GetCopyToOutputDirectoryItems;SatelliteDllsProjectOutputGroup;PkgdefProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client\Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.csproj">
+      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;GetCopyToOutputDirectoryItems;SatelliteDllsProjectOutputGroup;PkgdefProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj">
       <Name>Microsoft.VisualStudio.ProjectSystem.Managed</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;GetCopyToOutputDirectoryItems;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>

--- a/setup/ProjectSystemSetup/source.extension.vsixmanifest
+++ b/setup/ProjectSystemSetup/source.extension.vsixmanifest
@@ -22,8 +22,10 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="Microsoft.VisualStudio.ProjectSystem.Managed" Path="|Microsoft.VisualStudio.ProjectSystem.Managed|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="Microsoft.VisualStudio.ProjectSystem.Managed.VS" Path="|Microsoft.VisualStudio.ProjectSystem.Managed.VS|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client" Path="|Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="ProjectSelectors.pkgdef" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="Microsoft.VisualStudio.ProjectSystem.Managed.VS" Path="|Microsoft.VisualStudio.ProjectSystem.Managed.VS;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client" Path="|Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client;PkgdefProjectOutputGroup|" />
   </Assets>
 </PackageManifest>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/CloudEnvironment.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/CloudEnvironment.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio
+{
+    internal static class CloudEnvironment
+    {
+        public const string LiveShareSolutionView = "LiveShareSolutionView";
+
+        public static readonly Guid SolutionViewProjectGuid = new Guid("F9806588-A88E-4429-8BFD-228795DB3894");
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/CloudEnvironment.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/CloudEnvironment.cs
@@ -4,10 +4,20 @@ using System;
 
 namespace Microsoft.VisualStudio
 {
+    /// <summary>
+    /// Specifies various constant values needed in the cloud environment.
+    /// </summary>
     internal static class CloudEnvironment
     {
+        /// <summary>
+        /// Name of the Solution Explorer view responsible for showing the contents of a
+        /// solution (as opposed to the contents of a folder).
+        /// </summary>
         public const string LiveShareSolutionView = "LiveShareSolutionView";
 
+        /// <summary>
+        /// Guid indicating that the selected node in Solution Explorer is a project.
+        /// </summary>
         public static readonly Guid SolutionViewProjectGuid = new Guid("F9806588-A88E-4429-8BFD-228795DB3894");
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Input/CommandGroup.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Input/CommandGroup.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.Input
+{
+    internal static class CommandGroup
+    {
+        public const string ManagedProjectSystemClientProjectCommandSet = "{28C12D02-11CB-437D-B84D-9CEA7A5333A3}";
+
+        public static readonly Guid ManagedProjectSystemClientProjectCommandSetGuid = Guid.Parse(ManagedProjectSystemClientProjectCommandSet);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Input/CommandGroup.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Input/CommandGroup.cs
@@ -4,6 +4,9 @@ using System;
 
 namespace Microsoft.VisualStudio.Input
 {
+    /// <summary>
+    /// Specifies the command groups handled in this project.
+    /// </summary>
     internal static class CommandGroup
     {
         public const string ManagedProjectSystemClientProjectCommandSet = "{28C12D02-11CB-437D-B84D-9CEA7A5333A3}";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Input/ManagedProjectSystemClientProjectCommandIds.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Input/ManagedProjectSystemClientProjectCommandIds.cs
@@ -2,6 +2,9 @@
 
 namespace Microsoft.VisualStudio.Input
 {
+    /// <summary>
+    /// Specifies the IDs of commands related to managed project files.
+    /// </summary>
     internal static class ManagedProjectSystemClientProjectCommandIds
     {
         public const int EditProjectFile = 0x0100;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Input/ManagedProjectSystemClientProjectCommandIds.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Input/ManagedProjectSystemClientProjectCommandIds.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.Input
+{
+    internal static class ManagedProjectSystemClientProjectCommandIds
+    {
+        public const int EditProjectFile = 0x0100;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Menus.vsct
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Menus.vsct
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CommandTable xmlns="http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <!--  This is the file that defines the actual layout and type of the commands.
+        It is divided in different sections (e.g. command definition, command
+        placement, ...), with each defining a specific set of properties.
+        See the comment before each section for more details about how to
+        use it. -->
+
+  <!--  The VSCT compiler (the tool that translates this file into the binary
+        format that VisualStudio will consume) has the ability to run a preprocessor
+        on the vsct file; this preprocessor is (usually) the C++ preprocessor, so
+        it is possible to define includes and macros with the same syntax used
+        in C++ files. Using this ability of the compiler here, we include some files
+        defining some of the constants that we will use inside the file. -->
+
+  <!--This is the file that defines the IDs for all the commands exposed by VisualStudio. -->
+  <Extern href="stdidcmd.h" />
+
+  <!--This header contains the command ids for the menus provided by the shell. -->
+  <Extern href="vsshlids.h" />
+
+  <!--Definition of some VSCT specific constants. In this sample we use it for the IDs inside the guidOfficeIcon group. -->
+  <!--<Extern href="msobtnid.h" xmlns="http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable" />-->
+
+  <Commands package="PackageGuidString">
+
+    <Groups>
+      <Group guid="guidManagedProjectSystemClientProjectCommandSet" id="groupidEditProjectFile" priority="0x0900">
+        <Parent guid="guidWorkspaceExplorerToolWindowPackageCmdSet" id="idmWSE_ContextMenu"/>
+      </Group>
+    </Groups>
+
+    <Buttons>
+      <Button guid="guidManagedProjectSystemClientProjectCommandSet" id="cmdidEditProjectFile" priority="0x0100" type="Button">
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <Strings>
+          <ButtonText>Edit Project File</ButtonText>
+          <CommandName>SolutionExplorer.Project.Edit</CommandName>
+          <CanonicalName>SolutionExplorer.Project.Edit</CanonicalName>
+          <LocCanonicalName>SolutionExplorer.Project.Edit</LocCanonicalName>
+        </Strings>
+      </Button>
+    </Buttons>
+  
+  </Commands>
+
+  <CommandPlacements>
+
+    <CommandPlacement guid="guidManagedProjectSystemClientProjectCommandSet" id="cmdidEditProjectFile" priority="0x0100">
+      <Parent guid="guidManagedProjectSystemClientProjectCommandSet" id="groupidEditProjectFile" />
+    </CommandPlacement>
+  
+  </CommandPlacements>
+
+  <Symbols>
+    <!-- This is our managed package guid. -->
+    <GuidSymbol name="PackageGuidString" value="{AE74FDFC-B9CE-4948-9E2F-F443B5BE8D37}" />
+  
+    <!-- Guid and IDs for our commands and groups -->
+    <GuidSymbol name="guidManagedProjectSystemClientProjectCommandSet" value="{28C12D02-11CB-437D-B84D-9CEA7A5333A3}">
+      <IDSymbol name="cmdidEditProjectFile" value="0x0100" />
+      <IDSymbol name="groupidEditProjectFile" value="0x0101" />
+    </GuidSymbol>
+
+    <!-- Guid and IDs copied from Microsoft.VisualStudio.Workspace.VSIntegration -->
+    <GuidSymbol name="guidWorkspaceExplorerToolWindowPackageCmdSet" value="{cfb400f1-5c60-4f3c-856e-180d28def0b7}">
+      <IDSymbol name="idmWSE_ContextMenu" value="0x0002"/>
+    </GuidSymbol>
+  </Symbols>
+
+</CommandTable>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.csproj
@@ -1,0 +1,36 @@
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\build\import\VisualStudio.props" />
+  <PropertyGroup>
+    <RootNamespace>Microsoft.VisualStudio</RootNamespace>
+    
+    <!-- VSIX -->
+    <GeneratePkgDefFile>true</GeneratePkgDefFile>
+    <CreateVsixContainer>false</CreateVsixContainer>
+    
+    <!-- Nuget -->
+    <IsPackable>true</IsPackable>
+    <Description>Microsoft VisualStudio ProjectSystem for Managed Languages Project hosts that interact with VisualStudio interfaces.</Description>
+    <Summary>Microsoft VisualStudio Managed Project System VS Components</Summary>
+    <PackageTags>Roslyn Managed Project System VisualStudio</PackageTags>
+    <NoWarn>$(NoWarn);NU5125</NoWarn>    
+  </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.RpcContracts" />
+    <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" />
+  </ItemGroup>
+  <ItemGroup>
+    <VSCTCompile Include="Menus.vsct">
+      <ResourceName>Menus.ctmenu</ResourceName>
+      <SubType>Designer</SubType>
+    </VSCTCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Packaging/ManagedProjectSystemClientPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Packaging/ManagedProjectSystemClientPackage.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.Packaging
+{
+    [Guid(PackageGuid)]
+    [PackageRegistration(AllowsBackgroundLoading = true, RegisterUsing = RegistrationMethod.CodeBase, UseManagedResourcesOnly = true)]
+    [ProvideMenuResource("Menus.ctmenu", 1)]
+    internal sealed class ManagedProjectSystemClientPackage : AsyncPackage
+    {
+        public const string PackageGuid = "AE74FDFC-B9CE-4948-9E2F-F443B5BE8D37";
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeCommandHandler.cs
@@ -17,12 +17,12 @@ namespace Microsoft.VisualStudio.SolutionExplorer
     /// Extends the Solution Explorer in cloud-connected scenarios by handling commands
     /// for nodes representing managed projects.
     /// </summary>
-    internal class ProjectNodeExtenderCommandHandler : IWorkspaceCommandHandler
+    internal class ProjectNodeCommandHandler : IWorkspaceCommandHandler
     {
         private readonly JoinableTaskContext _taskContext;
         private readonly IServiceProvider _serviceProvider;
 
-        public ProjectNodeExtenderCommandHandler(JoinableTaskContext taskContext, IServiceProvider serviceProvider)
+        public ProjectNodeCommandHandler(JoinableTaskContext taskContext, IServiceProvider serviceProvider)
         {
             _taskContext = taskContext;
             _serviceProvider = serviceProvider;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeExtender.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeExtender.cs
@@ -9,10 +9,21 @@ using Microsoft.VisualStudio.Workspace.VSIntegration.UI;
 
 namespace Microsoft.VisualStudio.SolutionExplorer
 {
+    /// <summary>
+    /// Extends the Solution Explorer in cloud-connected scenarios by adding command
+    /// handlers for nodes representing managed projects.
+    /// </summary>
     [ExportNodeExtender(CloudEnvironment.LiveShareSolutionView)]
     internal sealed class ProjectNodeExtender : INodeExtender
     {
+        /// <summary>
+        /// The shared command handler for all nodes representing managed projects.
+        /// </summary>
         private readonly IWorkspaceCommandHandler _commandHandler;
+
+        /// <summary>
+        /// Extensions for the set of supported projects.
+        /// </summary>
         private static readonly string[] s_supportedProjectExtensions = new[] { ".csproj", ".vbproj" };
 
         [ImportingConstructor]
@@ -28,6 +39,10 @@ namespace Microsoft.VisualStudio.SolutionExplorer
             return null;
         }
 
+        /// <summary>
+        /// Provides our <see cref="IWorkspaceCommandHandler"/> for nodes representing
+        /// managed projects.
+        /// </summary>
         public IWorkspaceCommandHandler? ProvideCommandHandler(WorkspaceVisualNodeBase parentNode)
         {
             if (NodeRepresentsAManagedProject(parentNode))
@@ -38,6 +53,21 @@ namespace Microsoft.VisualStudio.SolutionExplorer
             return null;
         }
 
+        /// <summary>
+        /// <para>
+        /// This is a bit of a hack. There currently isn't a good way to determine if the
+        /// <paramref name="node"/> represents a project backed by the managed project
+        /// system. In the interests of getting something working, here we check if the
+        /// Solution Explorer thinks the node is a project and then check that it has a
+        /// supported extension.
+        /// </para>
+        /// <para>
+        /// The _right_ way to do this probably involves getting the project GUID from the
+        /// node and then running that throught the Project API to determine if the project
+        /// has the appropriate capabilities. At the moment there's no good way to
+        /// achieve that first step, however.
+        /// </para>
+        /// </summary>
         private static bool NodeRepresentsAManagedProject(WorkspaceVisualNodeBase node)
         {
             return node != null

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeExtender.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeExtender.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.SolutionExplorer
             JoinableTaskContext taskContext,
             [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider)
         {
-            _commandHandler = new ProjectNodeExtenderCommandHandler(taskContext, serviceProvider);
+            _commandHandler = new ProjectNodeCommandHandler(taskContext, serviceProvider);
         }
 
         public IChildrenSource? ProvideChildren(WorkspaceVisualNodeBase parentNode)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeExtender.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeExtender.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Workspace.VSIntegration.UI;
+
+namespace Microsoft.VisualStudio.SolutionExplorer
+{
+    [ExportNodeExtender(CloudEnvironment.LiveShareSolutionView)]
+    internal sealed class ProjectNodeExtender : INodeExtender
+    {
+        private readonly IWorkspaceCommandHandler _commandHandler;
+        private static readonly string[] s_supportedProjectExtensions = new[] { ".csproj", ".vbproj" };
+
+        [ImportingConstructor]
+        public ProjectNodeExtender(
+            JoinableTaskContext taskContext,
+            [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider)
+        {
+            _commandHandler = new ProjectNodeExtenderCommandHandler(taskContext, serviceProvider);
+        }
+
+        public IChildrenSource? ProvideChildren(WorkspaceVisualNodeBase parentNode)
+        {
+            return null;
+        }
+
+        public IWorkspaceCommandHandler? ProvideCommandHandler(WorkspaceVisualNodeBase parentNode)
+        {
+            if (NodeRepresentsAManagedProject(parentNode))
+            {
+                return _commandHandler;
+            }
+
+            return null;
+        }
+
+        private static bool NodeRepresentsAManagedProject(WorkspaceVisualNodeBase node)
+        {
+            return node != null
+                && node.VSSelectionMoniker != null
+                && node.VSSelectionKind == CloudEnvironment.SolutionViewProjectGuid
+                && node.NodeMoniker != null
+                && s_supportedProjectExtensions.Any(extension => node.NodeMoniker.EndsWith(extension, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeExtenderCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeExtenderCommandHandler.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.Input;
+using Microsoft.VisualStudio.ProjectSystem.VS;
+using Microsoft.VisualStudio.RpcContracts.OpenDocument;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Workspace.VSIntegration.UI;
+
+namespace Microsoft.VisualStudio.SolutionExplorer
+{
+    internal class ProjectNodeExtenderCommandHandler : IWorkspaceCommandHandler
+    {
+        private readonly JoinableTaskContext _taskContext;
+        private readonly IServiceProvider _serviceProvider;
+
+        public ProjectNodeExtenderCommandHandler(JoinableTaskContext taskContext, IServiceProvider serviceProvider)
+        {
+            _taskContext = taskContext;
+            _serviceProvider = serviceProvider;
+        }
+
+        public int Priority => 2000;
+
+        public bool IgnoreOnMultiselect => true;
+
+        public int Exec(List<WorkspaceVisualNodeBase> selection, Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
+        {
+            if (pguidCmdGroup == CommandGroup.ManagedProjectSystemClientProjectCommandSetGuid)
+            {
+                var nCmdIDInt = (int)nCmdID;
+
+                switch (nCmdIDInt)
+                {
+                    case ManagedProjectSystemClientProjectCommandIds.EditProjectFile:
+                        OpenFile(selection.SingleOrDefault());
+
+                        return HResult.OK;
+                }
+            }
+
+            return HResult.Ole.Cmd.NotSupported;
+        }
+
+        public bool QueryStatus(List<WorkspaceVisualNodeBase> selection, Guid pguidCmdGroup, uint nCmdID, ref uint cmdf, ref string customTitle)
+        {
+            bool handled = false;
+
+            if (pguidCmdGroup == CommandGroup.ManagedProjectSystemClientProjectCommandSetGuid)
+            {
+                var nCmdIDInt = (int)nCmdID;
+
+                switch (nCmdIDInt)
+                {
+                    case ManagedProjectSystemClientProjectCommandIds.EditProjectFile:
+                        cmdf = (uint)(OLE.Interop.OLECMDF.OLECMDF_ENABLED | OLE.Interop.OLECMDF.OLECMDF_SUPPORTED);
+                        handled = true;
+                        break;
+                }
+            }
+
+            return handled;
+        }
+        private void OpenFile(WorkspaceVisualNodeBase node)
+        {
+            if (node == null
+                || string.IsNullOrEmpty(node.NodeMoniker))
+            {
+                return;
+            }
+
+            _taskContext.Factory.RunAsync(async () =>
+            {
+                var serviceContainer = _serviceProvider.GetService<SVsBrokeredServiceContainer, IBrokeredServiceContainer>();
+                var serviceBroker = serviceContainer.GetFullAccessServiceBroker();
+
+                var openDocumentService = await serviceBroker.GetProxyAsync<IOpenDocumentService>(VisualStudioServices.VS2019_4.OpenDocumentService);
+
+                try
+                {
+                    await openDocumentService.OpenDocumentAsync(node.NodeMoniker, cancellationToken: default);
+                }
+                finally
+                {
+                    (openDocumentService as IDisposable)?.Dispose();
+                }
+            });
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeExtenderCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeExtenderCommandHandler.cs
@@ -13,6 +13,10 @@ using Microsoft.VisualStudio.Workspace.VSIntegration.UI;
 
 namespace Microsoft.VisualStudio.SolutionExplorer
 {
+    /// <summary>
+    /// Extends the Solution Explorer in cloud-connected scenarios by handling commands
+    /// for nodes representing managed projects.
+    /// </summary>
     internal class ProjectNodeExtenderCommandHandler : IWorkspaceCommandHandler
     {
         private readonly JoinableTaskContext _taskContext;
@@ -24,8 +28,15 @@ namespace Microsoft.VisualStudio.SolutionExplorer
             _serviceProvider = serviceProvider;
         }
 
+        /// <summary>
+        /// The command handlers priority. If there are multiple handlers for a given node
+        /// then they are called in order of decreasing priority.
+        /// </summary>
         public int Priority => 2000;
 
+        /// <summary>
+        /// Whether or not this handler should be ignored when multiple nodes are selected.
+        /// </summary>
         public bool IgnoreOnMultiselect => true;
 
         public int Exec(List<WorkspaceVisualNodeBase> selection, Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
@@ -65,6 +76,11 @@ namespace Microsoft.VisualStudio.SolutionExplorer
 
             return handled;
         }
+
+        /// <summary>
+        /// Handles opening the file associated with the given <paramref name="node"/>.
+        /// </summary>
+        /// <param name="node"></param>
         private void OpenFile(WorkspaceVisualNodeBase node)
         {
             if (node == null

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.cs.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../Menus.vsct">
+    <body>
+      <trans-unit id="cmdidEditProjectFile|ButtonText">
+        <source>Edit Project File</source>
+        <target state="new">Edit Project File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|CommandName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|LocCanonicalName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.de.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../Menus.vsct">
+    <body>
+      <trans-unit id="cmdidEditProjectFile|ButtonText">
+        <source>Edit Project File</source>
+        <target state="new">Edit Project File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|CommandName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|LocCanonicalName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.es.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../Menus.vsct">
+    <body>
+      <trans-unit id="cmdidEditProjectFile|ButtonText">
+        <source>Edit Project File</source>
+        <target state="new">Edit Project File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|CommandName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|LocCanonicalName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.fr.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../Menus.vsct">
+    <body>
+      <trans-unit id="cmdidEditProjectFile|ButtonText">
+        <source>Edit Project File</source>
+        <target state="new">Edit Project File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|CommandName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|LocCanonicalName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.it.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../Menus.vsct">
+    <body>
+      <trans-unit id="cmdidEditProjectFile|ButtonText">
+        <source>Edit Project File</source>
+        <target state="new">Edit Project File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|CommandName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|LocCanonicalName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.ja.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../Menus.vsct">
+    <body>
+      <trans-unit id="cmdidEditProjectFile|ButtonText">
+        <source>Edit Project File</source>
+        <target state="new">Edit Project File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|CommandName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|LocCanonicalName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.ko.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../Menus.vsct">
+    <body>
+      <trans-unit id="cmdidEditProjectFile|ButtonText">
+        <source>Edit Project File</source>
+        <target state="new">Edit Project File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|CommandName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|LocCanonicalName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.pl.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../Menus.vsct">
+    <body>
+      <trans-unit id="cmdidEditProjectFile|ButtonText">
+        <source>Edit Project File</source>
+        <target state="new">Edit Project File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|CommandName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|LocCanonicalName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.pt-BR.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../Menus.vsct">
+    <body>
+      <trans-unit id="cmdidEditProjectFile|ButtonText">
+        <source>Edit Project File</source>
+        <target state="new">Edit Project File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|CommandName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|LocCanonicalName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.ru.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../Menus.vsct">
+    <body>
+      <trans-unit id="cmdidEditProjectFile|ButtonText">
+        <source>Edit Project File</source>
+        <target state="new">Edit Project File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|CommandName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|LocCanonicalName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.tr.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../Menus.vsct">
+    <body>
+      <trans-unit id="cmdidEditProjectFile|ButtonText">
+        <source>Edit Project File</source>
+        <target state="new">Edit Project File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|CommandName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|LocCanonicalName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.zh-Hans.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Menus.vsct">
+    <body>
+      <trans-unit id="cmdidEditProjectFile|ButtonText">
+        <source>Edit Project File</source>
+        <target state="new">Edit Project File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|CommandName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|LocCanonicalName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/Menus.vsct.zh-Hant.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Menus.vsct">
+    <body>
+      <trans-unit id="cmdidEditProjectFile|ButtonText">
+        <source>Edit Project File</source>
+        <target state="new">Edit Project File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|CommandName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidEditProjectFile|LocCanonicalName">
+        <source>SolutionExplorer.Project.Edit</source>
+        <target state="new">SolutionExplorer.Project.Edit</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/tests/DeployTestDependencies/DeployTestDependencies.csproj
+++ b/tests/DeployTestDependencies/DeployTestDependencies.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="..\..\src\Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.vbproj" />
     <ProjectReference Include="..\..\src\Microsoft.VisualStudio.Editors\Microsoft.VisualStudio.Editors.vbproj" />
     <ProjectReference Include="..\..\src\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client\Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests.csproj
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests.csproj
@@ -1,0 +1,11 @@
+﻿ <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\build\import\VisualStudio.props" />
+  <PropertyGroup>
+    <RootNamespace>Microsoft.VisualStudio</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client\Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests/Mocks/INodeContainerFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests/Mocks/INodeContainerFactory.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Workspace.VSIntegration.UI;
+using Moq;
+
+namespace Microsoft.VisualStudio.Mocks
+{
+    internal static class INodeContainerFactory
+    {
+        public static INodeContainer Implement()
+        {
+            var mock = new Mock<INodeContainer>();
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests/Mocks/IServiceProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests/Mocks/IServiceProviderFactory.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Moq;
+
+namespace Microsoft.VisualStudio
+{
+    internal static class IServiceProviderFactory
+    {
+        public static IServiceProvider ImplementGetService(Func<Type, object?> func)
+        {
+            var mock = new Mock<IServiceProvider>();
+            mock.Setup<object?>(sp => sp.GetService(It.IsAny<Type>()))
+                .Returns(func);
+
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests/Mocks/WorkspaceVisualNodeBaseFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests/Mocks/WorkspaceVisualNodeBaseFactory.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Workspace.VSIntegration.UI;
+
+namespace Microsoft.VisualStudio.Mocks
+{
+    internal static class WorkspaceVisualNodeBaseFactory
+    {
+        public static WorkspaceVisualNodeBase Implement(
+            Guid? selectionKind = null,
+            string? nodeMoniker = null,
+            string? selectionMoniker = null)
+        {
+            return new TestWorkspaceVisualNode(
+                INodeContainerFactory.Implement(),
+                selectionKind ?? Guid.Empty,
+                nodeMoniker ?? string.Empty,
+                selectionMoniker ?? string.Empty);
+        }
+
+        private class TestWorkspaceVisualNode : WorkspaceVisualNodeBase
+        {
+            public TestWorkspaceVisualNode(INodeContainer container,
+                Guid selectionKind,
+                string nodeMoniker,
+                string selectionMoniker)
+                : base(container)
+            {
+                VSSelectionKind = selectionKind;
+                NodeMoniker = nodeMoniker;
+                VSSelectionMoniker = selectionMoniker;
+            }
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests/SolutionExplorer/ProjectNodeCommandHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests/SolutionExplorer/ProjectNodeCommandHandlerTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.SolutionExplorer
 {
-    public class ProjectNodeExtenderCommandHandlerTests
+    public class ProjectNodeCommandHandlerTests
     {
         [Fact]
         public void WhenCommandSetIsWrong_QueryStatusReturnsFalse()
@@ -101,14 +101,14 @@ namespace Microsoft.VisualStudio.SolutionExplorer
 #pragma warning restore VSSDK005 // Avoid instantiating JoinableTaskContext
         }
 
-        private static ProjectNodeExtenderCommandHandler CreateCommandHandler()
+        private static ProjectNodeCommandHandler CreateCommandHandler()
         {
-            return new ProjectNodeExtenderCommandHandler(
+            return new ProjectNodeCommandHandler(
                 GetJoinableTaskContext(),
                 IServiceProviderFactory.ImplementGetService(t => null));
         }
 
-        private static bool RunQueryStatus(Guid commandSet, uint commandId, ProjectNodeExtenderCommandHandler commandHandler, ref uint commandFlags)
+        private static bool RunQueryStatus(Guid commandSet, uint commandId, ProjectNodeCommandHandler commandHandler, ref uint commandFlags)
         {
             var selectedNodes = new List<WorkspaceVisualNodeBase>();
             string customTitle = string.Empty;
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.SolutionExplorer
             return result;
         }
 
-        private static int RunExec(Guid commandSet, uint commandId, ProjectNodeExtenderCommandHandler commandHandler)
+        private static int RunExec(Guid commandSet, uint commandId, ProjectNodeCommandHandler commandHandler)
         {
             var selectedNodes = new List<WorkspaceVisualNodeBase>();
             var result = commandHandler.Exec(selection: selectedNodes, commandSet, commandId, (uint)OLECMDEXECOPT.OLECMDEXECOPT_DODEFAULT, IntPtr.Zero, IntPtr.Zero);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests/SolutionExplorer/ProjectNodeExtenderCommandHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests/SolutionExplorer/ProjectNodeExtenderCommandHandlerTests.cs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.Input;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.ProjectSystem.VS;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Workspace.VSIntegration.UI;
+using Xunit;
+
+namespace Microsoft.VisualStudio.SolutionExplorer
+{
+    public class ProjectNodeExtenderCommandHandlerTests
+    {
+        [Fact]
+        public void WhenCommandSetIsWrong_QueryStatusReturnsFalse()
+        {
+            Guid commandSet = Guid.Parse("{4D4BC677-DF3C-490A-97AB-47F92F19E83B}");
+            uint commandId = ManagedProjectSystemClientProjectCommandIds.EditProjectFile;
+
+            var commandHandler = CreateCommandHandler();
+            uint commandFlags = 0;
+            var result = RunQueryStatus(commandSet, commandId, commandHandler, ref commandFlags);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void WhenCommandIdIsWrong_QueryStatusReturnsFalse()
+        {
+            Guid commandSet = CommandGroup.ManagedProjectSystemClientProjectCommandSetGuid;
+            uint commandId = 0xFFFF;
+
+            var commandHandler = CreateCommandHandler();
+            uint commandFlags = 0;
+            var result = RunQueryStatus(commandSet, commandId, commandHandler, ref commandFlags);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void WhenCommandIsEditProjectFile_QueryStatusReturnsTrue()
+        {
+            Guid commandSet = CommandGroup.ManagedProjectSystemClientProjectCommandSetGuid;
+            uint commandId = ManagedProjectSystemClientProjectCommandIds.EditProjectFile;
+
+            var commandHandler = CreateCommandHandler();
+            uint commandFlags = 0;
+            var result = RunQueryStatus(commandSet, commandId, commandHandler, ref commandFlags);
+
+            Assert.True(result);
+            Assert.Equal(expected: (uint)(OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED), actual: commandFlags);
+        }
+
+        [Fact]
+        public void WhenCommandSetIsWrong_ExecReturnsNotSupported()
+        {
+            Guid commandSet = Guid.Parse("{4D4BC677-DF3C-490A-97AB-47F92F19E83B}");
+            uint commandId = ManagedProjectSystemClientProjectCommandIds.EditProjectFile;
+
+            var commandHandler = CreateCommandHandler();
+            var result = RunExec(commandSet, commandId, commandHandler);
+
+            Assert.Equal(expected: (int)HResult.Ole.Cmd.NotSupported, actual: result);
+        }
+
+        [Fact]
+        public void WhenCommandIdIsWrong_ExecReturnsNotSupported()
+        {
+            Guid commandSet = CommandGroup.ManagedProjectSystemClientProjectCommandSetGuid;
+            uint commandId = 0xFFFF;
+
+            var commandHandler = CreateCommandHandler();
+
+            var selectedNodes = new List<WorkspaceVisualNodeBase>();
+            var result = commandHandler.Exec(selection: selectedNodes, commandSet, commandId, (uint)OLECMDEXECOPT.OLECMDEXECOPT_DODEFAULT, IntPtr.Zero, IntPtr.Zero);
+
+            Assert.Equal(expected: (int)HResult.Ole.Cmd.NotSupported, actual: result);
+        }
+
+        [Fact]
+        public void WhenCommandIsEditProjectFile_ExecReturnsOK()
+        {
+            Guid commandSet = CommandGroup.ManagedProjectSystemClientProjectCommandSetGuid;
+            uint commandId = ManagedProjectSystemClientProjectCommandIds.EditProjectFile;
+
+            var commandHandler = CreateCommandHandler();
+
+            var selectedNodes = new List<WorkspaceVisualNodeBase>();
+
+            var result = commandHandler.Exec(selection: selectedNodes, commandSet, commandId, (uint)OLECMDEXECOPT.OLECMDEXECOPT_DODEFAULT, IntPtr.Zero, IntPtr.Zero);
+
+            Assert.Equal(expected: (int)HResult.OK, actual: result);
+        }
+
+        private static JoinableTaskContext GetJoinableTaskContext()
+        {
+#pragma warning disable VSSDK005 // Avoid instantiating JoinableTaskContext
+            return new Threading.JoinableTaskContext();
+#pragma warning restore VSSDK005 // Avoid instantiating JoinableTaskContext
+        }
+
+        private static ProjectNodeExtenderCommandHandler CreateCommandHandler()
+        {
+            return new ProjectNodeExtenderCommandHandler(
+                GetJoinableTaskContext(),
+                IServiceProviderFactory.ImplementGetService(t => null));
+        }
+
+        private static bool RunQueryStatus(Guid commandSet, uint commandId, ProjectNodeExtenderCommandHandler commandHandler, ref uint commandFlags)
+        {
+            var selectedNodes = new List<WorkspaceVisualNodeBase>();
+            string customTitle = string.Empty;
+            var result = commandHandler.QueryStatus(selection: selectedNodes, commandSet, commandId, ref commandFlags, ref customTitle);
+            return result;
+        }
+
+        private static int RunExec(Guid commandSet, uint commandId, ProjectNodeExtenderCommandHandler commandHandler)
+        {
+            var selectedNodes = new List<WorkspaceVisualNodeBase>();
+            var result = commandHandler.Exec(selection: selectedNodes, commandSet, commandId, (uint)OLECMDEXECOPT.OLECMDEXECOPT_DODEFAULT, IntPtr.Zero, IntPtr.Zero);
+            return result;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests/SolutionExplorer/ProjectNodeExtenderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.UnitTests/SolutionExplorer/ProjectNodeExtenderTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Net.NetworkInformation;
+using EnvDTE;
+using Microsoft.VisualStudio.Mocks;
+using Microsoft.VisualStudio.Threading;
+using Xunit;
+
+namespace Microsoft.VisualStudio.SolutionExplorer
+{
+    public class ProjectNodeExtenderTests
+    {
+        [Fact]
+        public void WhenNodeIsNull_NoCommandHandlerIsReturned()
+        {
+            var extender = new ProjectNodeExtender(GetJoinableTaskContext(), IServiceProviderFactory.ImplementGetService(t => null));
+
+            var commandHandler = extender.ProvideCommandHandler(null!);
+
+            Assert.Null(commandHandler);
+        }
+
+        [Fact]
+        public void WhenSelectionKindIsWrong_NoCommandHandlerIsReturned()
+        {
+            var extender = new ProjectNodeExtender(GetJoinableTaskContext(), IServiceProviderFactory.ImplementGetService(t => null));
+            var node = WorkspaceVisualNodeBaseFactory.Implement(
+                selectionKind: Guid.Parse("{95D7E5E9-08FA-40FB-9010-2CCEEC6D54C1}"),
+                nodeMoniker: "Test.csproj",
+                selectionMoniker: "Test.csproj");
+
+            var commandHandler = extender.ProvideCommandHandler(node);
+
+            Assert.Null(commandHandler);
+        }
+
+        [Fact]
+        public void WhenExtensionIsWrong_NoCommandHandlerIsReturned()
+        {
+            var extender = new ProjectNodeExtender(GetJoinableTaskContext(), IServiceProviderFactory.ImplementGetService(t => null));
+            var node = WorkspaceVisualNodeBaseFactory.Implement(
+                selectionKind: CloudEnvironment.SolutionViewProjectGuid,
+                nodeMoniker: "Test.notMyProj",
+                selectionMoniker: "Test.notMyProj");
+
+            var commandHandler = extender.ProvideCommandHandler(node);
+
+            Assert.Null(commandHandler);
+        }
+
+        [Fact]
+        public void WhenNodeRepresentsAManagedProject_ACommandHandlerIsReturned()
+        {
+            var extender = new ProjectNodeExtender(GetJoinableTaskContext(), IServiceProviderFactory.ImplementGetService(t => null));
+            var node = WorkspaceVisualNodeBaseFactory.Implement(
+                selectionKind: CloudEnvironment.SolutionViewProjectGuid,
+                nodeMoniker: "Test.csproj",
+                selectionMoniker: "Test.csproj");
+
+            var commandHandler = extender.ProvideCommandHandler(node);
+
+            Assert.NotNull(commandHandler);
+        }
+
+        private JoinableTaskContext GetJoinableTaskContext()
+        {
+#pragma warning disable VSSDK005 // Avoid instantiating JoinableTaskContext
+            return new JoinableTaskContext();
+#pragma warning restore VSSDK005 // Avoid instantiating JoinableTaskContext
+        }
+    }
+}


### PR DESCRIPTION
This change adds a basic "Edit Project File" command to the context menu when right-clicking on a project node in Solution Explorer in VS Online scenarios. The project file then opens in the XML editor.

The primary purpose of this change is to unblock dogfood scenarios in the immediate future and it is *not* an optimal implementation of this feature. Notably, it has the following deficiencies:

1. Ideally we would re-use the existing "Edit Project File" command and place it on the context menu rather than creating a whole new command that does the exact same thing. However, much still needs to be figured out about the setup authoring for the VS Online client and that will undoubtedly lead to many other components being refactored. When that happens I don't want to run the risk of the existing "Edit Project File" command disappearing from the client and breaking this feature--better we have two copies of this command on the client than none.
2. The logic for identifying the project nodes is sketchy. Ideally we would get the project's GUID from the node and run that through the new Project API to check if it is indeed a managed project _and_ has the appropriate capabilities. However, getting the GUID is not straightforward. For the time being we must be content to check the file extension.
3. This doesn't necessarily play nice with the existing code we have for editing the project file. There may be bugs we haven't run into yet.
4. This change opens the project file, but due to https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1040697 the file will be read-only. There's nothing we can do about that at the moment so I'm not going to hold the change.