### PR TITLE
Add help text to Executable path watermark.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
@@ -182,7 +182,8 @@
                 VerticalAlignment="Center"
                 Text="{Binding Path=ExecutablePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 Visibility="{Binding Path=SupportsExecutable, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
-                AutomationProperties.Name="{x:Static Member=local:PropertyPageResources.Executable}"/>
+                AutomationProperties.Name="{x:Static Member=local:PropertyPageResources.Executable}"
+                AutomationProperties.HelpText="{x:Static Member=local:PropertyPageResources.ExecutablePathWatermark}"/>
             <Button
                 Grid.Row="2"
                 Grid.Column="2"


### PR DESCRIPTION
Found another text box without a help text, follows #5802.
Note: no localization needed.

Before:
![image](https://user-images.githubusercontent.com/8518253/73779304-64ee3300-4741-11ea-8bf7-6339ddf09845.png)

After:
![image](https://user-images.githubusercontent.com/8518253/73779242-4b4ceb80-4741-11ea-8736-e56947e95d6c.png)
