### PR TITLE
Compare visible attribute ignoring the case of the strings.

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/MiscellaneousRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/MiscellaneousRuleTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
             {
                 var visibleAttribute = element.Attribute("Visible");
 
-                if (visibleAttribute != null && visibleAttribute.Value.Equals("false", StringComparison.Ordinal))
+                if (visibleAttribute != null && visibleAttribute.Value.Equals("false", StringComparison.OrdinalIgnoreCase))
                 {
                     Assert.Null(element.Attribute("DisplayName"));
                     Assert.Null(element.Attribute("Description"));


### PR DESCRIPTION
Found this bug while reviewing the file with @drewnoakes 😄.