### PR TITLE
Opt the PropPageDesignerEditorFactory out of PLM

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.VisualStudio.Editors
     ProvideMenuResource("Menus.ctmenu", 30),
     ProvideEditorFactory(GetType(ApplicationDesigner.ApplicationDesignerEditorFactory), 1300, True, TrustLevel:=__VSEDITORTRUSTLEVEL.ETL_AlwaysTrusted),
     ProvideEditorFactory(GetType(SettingsDesigner.SettingsDesignerEditorFactory), 1200, True, TrustLevel:=__VSEDITORTRUSTLEVEL.ETL_AlwaysTrusted, CommonPhysicalViewAttributes:=3),
-    ProvideEditorFactory(GetType(PropPageDesigner.PropPageDesignerEditorFactory), 1400, True, TrustLevel:=__VSEDITORTRUSTLEVEL.ETL_AlwaysTrusted),
+    ProvideEditorFactory(GetType(PropPageDesigner.PropPageDesignerEditorFactory), 1400, False, TrustLevel:=__VSEDITORTRUSTLEVEL.ETL_AlwaysTrusted),
     ProvideEditorFactory(GetType(ResourceEditor.ResourceEditorFactory), 1100, True, TrustLevel:=__VSEDITORTRUSTLEVEL.ETL_AlwaysTrusted, CommonPhysicalViewAttributes:=3),
     ProvideKeyBindingTable(Constants.MenuConstants.GUID_SETTINGSDESIGNER_CommandUIString, 1200, AllowNavKeyBinding:=False),
     ProvideKeyBindingTable(Constants.MenuConstants.GUID_RESXEditorCommandUIString, 1100, AllowNavKeyBinding:=False),


### PR DESCRIPTION
Fixes #5858

This is a short term solution to fix the regression for 16.5 where the Debug -> [Project] Properties menu item shows a blank screen. The real fix for this will be #5317.

Whats happening is that the Application tab initializes and then switches to the Debug page, but when the OutputType property is read to initialize the Application table it sets some data flowing through the system including a version-only update of ProjectRuleSource, which gets to the WorkspaceContext, and that triggers operation progress. It happens just in time for the Debug editor factory to be asked to initialize, which sees that operation progress has started, so gets the PLM window frame, which it can't deal with, and bombs out.

The change itself should be safe enough because the only thing that requests the PropPageDesignerEditorFactory is the ApplicationDesignerEditorFactory and that is opted-in so it will wait for the initial Intellisense stage to finish because any PropPageDesignerEditorFactory is requested.