### PR TITLE
remove extra spaces in project platforms configuration

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
@@ -141,7 +141,7 @@ namespace Microsoft.VisualStudio.Build
             bool valueFound = false;
             foreach (string value in GetPropertyValues(evaluatedPropertyValue, delimiter))
             {
-                if (!string.Equals(value, valueToRemove, StringComparisons.PropertyValues))
+                if (!string.Equals(value, valueToRemove.Replace(" ", ""), StringComparisons.PropertyValues))
                 {
                     if (newValue.Length != 0)
                     {


### PR DESCRIPTION
this fixes the case when 'Any CPU' instead of 'AnyCPU'

https://github.com/dotnet/project-system/issues/2745