### PR TITLE
Add/remove source file only when link metadata changes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
@@ -182,7 +182,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                 // that aren't traditional items, but are just command-line args we took from
                 // the compiler and converted them to look like items.
 
-                // We Remove then Add changed items to pick up the Linked metadata
                 foreach (string includePath in difference.ChangedItems)
                 {
                     UpdateInContextIfPresent(includePath, previousMetadata, currentMetadata, isActiveContext, logger);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
@@ -96,17 +96,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         ///     <para>
         ///         -or-
         ///     </para>
-        ///     <paramref name="metadata" /> is <see langword="null"/>.
+        ///     <paramref name="previousMetadata" /> is <see langword="null"/>.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="currentMetadata" /> is <see langword="null"/>.
         ///     <para>
         ///         -or-
         ///     </para>
         ///     <paramref name="logger" /> is <see langword="null"/>.
         /// </exception>
-        public void ApplyProjectEvaluation(IComparable version, IProjectChangeDiff difference, IImmutableDictionary<string, IImmutableDictionary<string, string>> metadata, bool isActiveContext, IProjectLogger logger)
+        public void ApplyProjectEvaluation(IComparable version, IProjectChangeDiff difference, IImmutableDictionary<string, IImmutableDictionary<string, string>> previousMetadata, IImmutableDictionary<string, IImmutableDictionary<string, string>> currentMetadata, bool isActiveContext, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(difference, nameof(difference));
-            Requires.NotNull(metadata, nameof(metadata));
+            Requires.NotNull(previousMetadata, nameof(previousMetadata));
+            Requires.NotNull(currentMetadata, nameof(currentMetadata));
             Requires.NotNull(logger, nameof(logger));
 
             if (!difference.AnyChanges)
@@ -116,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             difference = HandlerServices.NormalizeRenames(difference);
             EnqueueProjectEvaluation(version, difference);
 
-            ApplyChangesToContext(difference, metadata, renamedItems, isActiveContext, logger);
+            ApplyChangesToContext(difference, previousMetadata, currentMetadata, renamedItems, isActiveContext, logger, evaluation: true);
         }
 
         /// <summary>
@@ -147,7 +152,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             difference = HandlerServices.NormalizeRenames(difference);
             difference = ResolveProjectBuildConflicts(version, difference);
 
-            ApplyChangesToContext(difference, ImmutableStringDictionary<IImmutableDictionary<string, string>>.EmptyOrdinal, renamedItems, isActiveContext, logger);
+            ApplyChangesToContext(difference, ImmutableStringDictionary<IImmutableDictionary<string, string>>.EmptyOrdinal, ImmutableStringDictionary<IImmutableDictionary<string, string>>.EmptyOrdinal, renamedItems, isActiveContext, logger, evaluation: false);
         }
 
         protected abstract void AddToContext(string fullPath, IImmutableDictionary<string, string> metadata, bool isActiveContext, IProjectLogger logger);
@@ -158,7 +163,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         {
         }
 
-        private void ApplyChangesToContext(IProjectChangeDiff difference, IImmutableDictionary<string, IImmutableDictionary<string, string>> metadata, IImmutableDictionary<string, string> renamedItems, bool isActiveContext, IProjectLogger logger)
+        private void ApplyChangesToContext(IProjectChangeDiff difference, IImmutableDictionary<string, IImmutableDictionary<string, string>> previousMetadata, IImmutableDictionary<string, IImmutableDictionary<string, string>> currentMetadata, IImmutableDictionary<string, string> renamedItems, bool isActiveContext, IProjectLogger logger, bool evaluation)
         {
             foreach (string includePath in difference.RemovedItems)
             {
@@ -167,14 +172,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             foreach (string includePath in difference.AddedItems)
             {
-                AddToContextIfNotPresent(includePath, metadata, isActiveContext, logger);
+                AddToContextIfNotPresent(includePath, currentMetadata, isActiveContext, logger);
             }
 
-            // We Remove then Add changed items to pick up the Linked metadata
-            foreach (string includePath in difference.ChangedItems)
-            {
-                RemoveFromContextIfPresent(includePath, logger);
-                AddToContextIfNotPresent(includePath, metadata, isActiveContext, logger);
+            if (evaluation)
+            {   // No need to look at metadata for design-time builds, the items that come from
+                // that aren't traditional items, but are just command-line args we took from
+                // the compiler and converted them to look like items.
+
+                // We Remove then Add changed items to pick up the Linked metadata
+                foreach (string includePath in difference.ChangedItems)
+                {
+                    RemoveFromContextIfPresent(includePath, logger);
+                    AddToContextIfNotPresent(includePath, currentMetadata, isActiveContext, logger);
+                }
             }
 
             // Wait for all context changed to be propagated first before handling rename

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CompileItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CompileItemHandler.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             VerifyInitialized();
 
-            ApplyProjectEvaluation(version, projectChange.Difference, projectChange.After.Items, isActiveContext, logger);
+            ApplyProjectEvaluation(version, projectChange.Difference, projectChange.Before.Items, projectChange.After.Items, isActiveContext, logger);
         }
 
         public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CompileItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CompileItemHandler.cs
@@ -90,9 +90,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         protected override void UpdateInContext(string fullPath, IImmutableDictionary<string, string> previousMetadata, IImmutableDictionary<string, string> currentMetadata, bool isActiveContext, IProjectLogger logger)
         {
-            logger.WriteLine("Removing and then re-adding source file '{0}' to metadata changes", fullPath);
-            RemoveFromContext(fullPath, logger);
-            AddToContext(fullPath, currentMetadata, isActiveContext, logger);
+            if (LinkMetadataChanged(previousMetadata, currentMetadata))
+            {
+                logger.WriteLine("Removing and then re-adding source file '{0}' to <Link> metadata changes", fullPath);
+                RemoveFromContext(fullPath, logger);
+                AddToContext(fullPath, currentMetadata, isActiveContext, logger);
+            }
+        }
+
+        private bool LinkMetadataChanged(IImmutableDictionary<string, string> previousMetadata, IImmutableDictionary<string, string> currentMetadata)
+        {
+            string previousLink = previousMetadata.GetValueOrDefault(Compile.LinkProperty, string.Empty);
+            string currentLink = currentMetadata.GetValueOrDefault(Compile.LinkProperty, string.Empty);
+
+            return previousLink != currentLink;
         }
 
         protected override void HandleItemRename(string fullPathBefore, string fullPathAfter, IProjectLogger logger)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CompileItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CompileItemHandler.cs
@@ -88,6 +88,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Context.RemoveSourceFile(fullPath);
         }
 
+        protected override void UpdateInContext(string fullPath, IImmutableDictionary<string, string> previousMetadata, IImmutableDictionary<string, string> currentMetadata, bool isActiveContext, IProjectLogger logger)
+        {
+            logger.WriteLine("Removing and then re-adding source file '{0}' to metadata changes", fullPath);
+            RemoveFromContext(fullPath, logger);
+            AddToContext(fullPath, currentMetadata, isActiveContext, logger);
+        }
+
         protected override void HandleItemRename(string fullPathBefore, string fullPathAfter, IProjectLogger logger)
         {
             logger.WriteLine("Handling rename of source file '{0}' to {1}", fullPathBefore, fullPathAfter);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.EvaluationCommandLineHandler.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.EvaluationCommandLineHandler.cs
@@ -32,6 +32,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             {
                 Files.Remove(fullPath);
             }
+
+            protected override void UpdateInContext(string fullPath, IImmutableDictionary<string, string> previousMetadata, IImmutableDictionary<string, string> currentMetadata, bool isActiveContext, IProjectLogger logger)
+            {
+                RemoveFromContext(fullPath, logger);
+                AddToContext(fullPath, currentMetadata, isActiveContext, logger);
+            }
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             
             Assert.Throws<ArgumentNullException>(() =>
             {
-                handler.ApplyProjectEvaluation(null!, difference, metadata, true, logger);
+                handler.ApplyProjectEvaluation(null!, difference, metadata, metadata, true, logger);
             });
         }
 
@@ -36,22 +36,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                handler.ApplyProjectEvaluation(version, null!, metadata, true, logger);
+                handler.ApplyProjectEvaluation(version, null!, metadata, metadata, true, logger);
             });
         }
 
         [Fact]
-        public void ApplyProjectEvaluation_NullAsMetadata_ThrowsArgumentNull()
+        public void ApplyProjectEvaluation_NullAsPreviousMetadata_ThrowsArgumentNull()
         {
             var handler = CreateInstance();
 
             var version = 1;
             var difference = IProjectChangeDiffFactory.Create();
+            var currentMetadata = ImmutableDictionary<string, IImmutableDictionary<string, string>>.Empty;
             var logger = IProjectLoggerFactory.Create();
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                handler.ApplyProjectEvaluation(version, difference, null!, true, logger);
+                handler.ApplyProjectEvaluation(version, difference, null!, currentMetadata, true, logger);
+            });
+        }
+
+        [Fact]
+        public void ApplyProjectEvaluation_NullAsCurrentMetadata_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+
+            var version = 1;
+            var difference = IProjectChangeDiffFactory.Create();
+            var previousMetadata = ImmutableDictionary<string, IImmutableDictionary<string, string>>.Empty;
+            var logger = IProjectLoggerFactory.Create();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                handler.ApplyProjectEvaluation(version, difference, previousMetadata, null!, true, logger);
             });
         }
 
@@ -66,7 +83,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             
             Assert.Throws<ArgumentNullException>(() =>
             {
-                handler.ApplyProjectEvaluation(version, difference, metadata, true, null!);
+                handler.ApplyProjectEvaluation(version, difference, metadata, metadata, true, null!);
             });
         }
 
@@ -445,10 +462,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         private static void ApplyProjectEvaluation(AbstractEvaluationCommandLineHandler handler, IComparable version, IProjectChangeDiff difference, IImmutableDictionary<string, IImmutableDictionary<string, string>>? metadata = null)
         {
             metadata ??= ImmutableDictionary<string, IImmutableDictionary<string, string>>.Empty;
+            var previousMetadata = ImmutableDictionary<string, IImmutableDictionary<string, string>>.Empty; 
             bool isActiveContext = true;
             var logger = IProjectLoggerFactory.Create();
 
-            handler.ApplyProjectEvaluation(version, difference, metadata, isActiveContext, logger);
+            handler.ApplyProjectEvaluation(version, difference, previousMetadata, metadata, isActiveContext, logger);
         }
 
         private static void ApplyProjectBuild(AbstractEvaluationCommandLineHandler handler, IComparable version, IProjectChangeDiff difference)


### PR DESCRIPTION
Fixes: #5259

The first two commits are boilerplate that are required to plumb through the "previous" metadata for an item, https://github.com/dotnet/project-system/commit/8f43fd75561ab075b9fdc21497179f589eade765 actually fixes the bug.