### PR TITLE
Open import files using primary editor

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/ProjectImports/ImportTreeCommandGroupHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/ProjectImports/ImportTreeCommandGroupHandler.cs
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.ProjectImports
                     try
                     {
                         // Open the document.
-                        Guid logicalView = IsOpenWithCommand(commandId) ? LOGVIEWID_UserChooseView : LOGVIEWID.Code_guid;
+                        Guid logicalView = IsOpenWithCommand(commandId) ? LOGVIEWID_UserChooseView : LOGVIEWID.Primary_guid;
                         IntPtr docData = IntPtr.Zero;
 
                         ErrorHandler.ThrowOnFailure(


### PR DESCRIPTION
All project systems use primary editor as the default editor for "Open". This has no observable change, but is just done for correctness.