### PR TITLE
Block rename in online scenarios

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsOnlineServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsOnlineServices.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    [ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    internal interface IVsOnlineServices
+    {
+        /// <summary>
+        /// Indicates whether or not the client is connected to VS Online.
+        /// </summary>
+        bool ConnectedToVSOnline { get; }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/Renamer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/Renamer.cs
@@ -30,6 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
         private readonly IRoslynServices _roslynServices;
         private readonly IWaitIndicator _waitService;
         private readonly IRefactorNotifyService _refactorNotifyService;
+        private readonly IVsOnlineServices _vsOnlineServices;
 
         [ImportingConstructor]
         internal Renamer(IUnconfiguredProjectVsServices projectVsServices,
@@ -40,7 +41,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                          IUserNotificationServices userNotificationServices,
                          IRoslynServices roslynServices,
                          IWaitIndicator waitService,
-                         IRefactorNotifyService refactorNotifyService)
+                         IRefactorNotifyService refactorNotifyService,
+                         IVsOnlineServices vsOnlineServices)
         {
             _projectVsServices = projectVsServices;
             _unconfiguredProjectTasksService = unconfiguredProjectTasksService;
@@ -51,6 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             _roslynServices = roslynServices;
             _waitService = waitService;
             _refactorNotifyService = refactorNotifyService;
+            _vsOnlineServices = vsOnlineServices;
         }
 
         public void HandleRename(string oldFilePath, string newFilePath)
@@ -66,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
         internal async Task HandleRenameAsync(string oldFilePath, string newFilePath)
         {
             // Do not offer to rename the file in VS Online scenarios.
-            if (Shell.KnownUIContexts.CloudEnvironmentConnectedContext.IsActive)
+            if (_vsOnlineServices.ConnectedToVSOnline)
             {
                 return;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/Renamer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/Renamer.cs
@@ -65,6 +65,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
 
         internal async Task HandleRenameAsync(string oldFilePath, string newFilePath)
         {
+            // Do not offer to rename the file in VS Online scenarios.
+            if (Shell.KnownUIContexts.CloudEnvironmentConnectedContext.IsActive)
+            {
+                return;
+            }
+
             // Do not offer to rename types if the user changes the file extensions
             if (!oldFilePath.EndsWith(Path.GetExtension(newFilePath), StringComparisons.Paths))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsOnlineServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsOnlineServices.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    [Export(typeof(IVsOnlineServices))]
+    internal class VsOnlineServices : IVsOnlineServices
+    {
+        public bool ConnectedToVSOnline => KnownUIContexts.CloudEnvironmentConnectedContext.IsActive;
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOnlineServicesFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOnlineServicesFactory.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.ProjectSystem.VS;
+using Moq;
+
+namespace Microsoft.VisualStudio.Mocks
+{
+    internal static class IVsOnlineServicesFactory
+    {
+        public static IVsOnlineServices Create(bool online)
+        {
+            var mock = new Mock<IVsOnlineServices>();
+
+            mock.SetupGet(s => s.ConnectedToVSOnline)
+                .Returns(online);
+
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/RenamerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/RenamerTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.Mocks;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices.CSharp;
 using Moq;
 using Xunit;
@@ -26,8 +27,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
         {
             var userNotificationServices = IUserNotificationServicesFactory.Create();
             var roslynServices = IRoslynServicesFactory.Implement(new CSharpSyntaxFactsService());
+            var vsOnlineServices = IVsOnlineServicesFactory.Create(online: false);
 
-            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.CSharp);
+            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.CSharp);
 
             Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Once);
             Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -49,8 +51,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
         {
             var userNotificationServices = IUserNotificationServicesFactory.Create();
             var roslynServices = IRoslynServicesFactory.Implement(new CSharpSyntaxFactsService());
+            var vsOnlineServices = IVsOnlineServicesFactory.Create(online: false);
 
-            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.CSharp).TimeoutAfter(TimeSpan.FromSeconds(1));
+            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.CSharp).TimeoutAfter(TimeSpan.FromSeconds(1));
+
+            Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Never);
+            Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            Mock.Get(roslynServices).Verify(h => h.ApplyChangesToSolution(It.IsAny<Workspace>(), It.IsAny<Solution>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Rename_Symbol_Should_ExitEarlyInVSOnlineAsync()
+        {
+            string sourceCode = "class Foo { }";
+            string oldFilePath = "Foo.cs";
+            string newFilePath = "Bar.cs";
+
+            var userNotificationServices = IUserNotificationServicesFactory.Create();
+            var roslynServices = IRoslynServicesFactory.Implement(new CSharpSyntaxFactsService());
+            var vsOnlineService = IVsOnlineServicesFactory.Create(online: true);
+
+            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineService, LanguageNames.CSharp);
 
             Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Never);
             Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/RenamerTestsBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/RenamerTestsBase.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                 });
         }
 
-        internal async Task RenameAsync(string sourceCode, string oldFilePath, string newFilePath, IUserNotificationServices userNotificationServices, IRoslynServices roslynServices, string language)
+        internal async Task RenameAsync(string sourceCode, string oldFilePath, string newFilePath, IUserNotificationServices userNotificationServices, IRoslynServices roslynServices, IVsOnlineServices vsOnlineServices, string language)
         {
             using var ws = new AdhocWorkspace();
             ws.AddSolution(InitializeWorkspace(ProjectId.CreateNewId(), newFilePath, sourceCode, language));
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
 
             var dte = IVsUIServiceFactory.Create<Shell.Interop.SDTE, EnvDTE.DTE>(null!);
 
-            var renamer = new Renamer(projectServices, unconfiguredProjectTasksService, ws, dte, environmentOptionsFactory, userNotificationServices, roslynServices, waitIndicator, refactorNotifyService);
+            var renamer = new Renamer(projectServices, unconfiguredProjectTasksService, ws, dte, environmentOptionsFactory, userNotificationServices, roslynServices, waitIndicator, refactorNotifyService, vsOnlineServices);
             await renamer.HandleRenameAsync(oldFilePath, newFilePath)
                          .TimeoutAfter(TimeSpan.FromSeconds(1));
         }


### PR DESCRIPTION
We've gotten reports that renaming a file in Solution Explorer in VS Online scenarios causes VS to crash. I haven't been able to reproduce the issue, but it is conceivable that the server is trying to show the rename dialog and things are going sideways at that point. Until we can make this work properly we should block off the scenario and not even try to rename the file.

Fixes [AB#1063020](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1063020).