### PR TITLE
Add basic dependencies to SWR file

### DIFF
--- a/setup/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles/CommonFiles.swr
+++ b/setup/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles/CommonFiles.swr
@@ -8,6 +8,14 @@ vs.localizedResources
                        title="Microsoft VisualStudio Managed Project System Common Files"
                        description="Microsoft VisualStudio ProjectSystem for C#/VB(Managed) Projects"
 
+vs.dependencies
+  vs.dependency id=Microsoft.NetCore.Component.DevelopmentTools
+                version=[$(Version),)
+  vs.dependency id=Microsoft.VisualStudio.ProjectSystem.Full
+                version=[$(Version),)
+  vs.dependency id=Microsoft.VisualStudio.Component.Roslyn.LanguageServices
+                version=[$(Version),)
+
 folder "InstallDir:MSBuild\Microsoft\VisualStudio\Managed"
   file source="$(VisualStudioXamlRulesDir)Microsoft.CSharp.DesignTime.targets"
   file source="$(VisualStudioXamlRulesDir)Microsoft.VisualBasic.DesignTime.targets"


### PR DESCRIPTION
Our VS setup authoring didn't express any dependencies, so this adds a basic set. In an ideal world this wouldn't be in the CommonFiles project but that one already had an SWR so I logged #5888 rather than hold things up by fighting with repotoolset today.