### PR TITLE
Ban initialize methods in OnceInitializedOnceDisposedXXX

### DIFF
--- a/src/Common/BannedSymbols.txt
+++ b/src/Common/BannedSymbols.txt
@@ -78,3 +78,6 @@ T:Microsoft.VisualStudio.Shell.ThreadHelper;Import JoinableTaskContext if inside
 
 T:Microsoft.VisualStudio.ProjectSystem.Properties.StandardRuleDataflowLinkOptions;Use DataflowOption.WithRuleNames to avoid boilerplate initialization
 T:System.Threading.Tasks.Dataflow.DataflowLinkOptions;Use DataflowOption.PropagateCompletion to avoid boilerplate initialization
+
+M:Microsoft.VisualStudio.ProjectSystem.OnceInitializedOnceDisposed.Initialize();Did you mean EnsureInitialized?
+M:Microsoft.VisualStudio.ProjectSystem.OnceInitializedOnceDisposedAsync.InitializeCoreAsync(System.Threading.CancellationToken);Did you mean InitializeAsync(CancellationToken)?


### PR DESCRIPTION
To avoid double-initializing, you are meant to call EnsureInitialized/InitializedAsync.

Note, until https://github.com/dotnet/roslyn-analyzers/issues/3295 is fixed, this doesn't cover much - but will do if we pick up a new version of the analyzers with that bug fixed.

I ran into this when fixing https://github.com/dotnet/project-system/pull/5890.