### PR TITLE
Fix project instance leak

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -24,10 +24,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         /// <summary>
-        /// For each target framework in <paramref name="changes"/>, applies the corresponding
-        /// <see cref="IDependenciesChanges"/> to <paramref name="previousSnapshot"/> in order to produce
-        /// and return an updated <see cref="DependenciesSnapshot"/> object.
-        /// If no changes are made, <paramref name="previousSnapshot"/> is returned unmodified.
+        /// Updates the <see cref="TargetedDependenciesSnapshot"/> corresponding to <paramref name="changedTargetFramework"/>,
+        /// returning either:
+        /// <list type="bullet">
+        ///   <item>An updated <see cref="DependenciesSnapshot"/> object, or</item>
+        ///   <item>the immutable <paramref name="previousSnapshot"/> if no changes were made.</item>
+        /// </list>
         /// </summary>
         /// <remarks>
         /// As part of the update, each <see cref="IDependenciesSnapshotFilter"/> in <paramref name="snapshotFilters"/>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             string projectPath,
             DependenciesSnapshot previousSnapshot,
             ITargetFramework changedTargetFramework,
-            IDependenciesChanges changes,
+            IDependenciesChanges? changes,
             IProjectCatalogSnapshot? catalogs,
             ImmutableArray<ITargetFramework> targetFrameworks,
             ITargetFramework? activeTargetFramework,
@@ -51,7 +51,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Requires.NotNullOrWhiteSpace(projectPath, nameof(projectPath));
             Requires.NotNull(previousSnapshot, nameof(previousSnapshot));
             Requires.NotNull(changedTargetFramework, nameof(changedTargetFramework));
-            Requires.NotNull(changes, nameof(changes));
             Requires.Argument(!snapshotFilters.IsDefault, nameof(snapshotFilters), "Cannot be default.");
             Requires.NotNull(subTreeProviderByProviderType, nameof(subTreeProviderByProviderType));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public static TargetedDependenciesSnapshot FromChanges(
             string projectPath,
             TargetedDependenciesSnapshot previousSnapshot,
-            IDependenciesChanges changes,
+            IDependenciesChanges? changes,
             IProjectCatalogSnapshot? catalogs,
             ImmutableArray<IDependenciesSnapshotFilter> snapshotFilters,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviderByProviderType,
@@ -37,7 +37,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         {
             Requires.NotNullOrWhiteSpace(projectPath, nameof(projectPath));
             Requires.NotNull(previousSnapshot, nameof(previousSnapshot));
-            Requires.NotNull(changes, nameof(changes));
             Requires.Argument(!snapshotFilters.IsDefault, nameof(snapshotFilters), "Cannot be default.");
             Requires.NotNull(subTreeProviderByProviderType, nameof(subTreeProviderByProviderType));
 
@@ -47,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             var worldBuilder = previousSnapshot.DependenciesWorld.ToBuilder();
 
-            if (changes.RemovedNodes.Count != 0)
+            if (changes != null && changes.RemovedNodes.Count != 0)
             {
                 var context = new RemoveDependencyContext(worldBuilder);
 
@@ -57,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 }
             }
 
-            if (changes.AddedNodes.Count != 0)
+            if (changes != null && changes.AddedNodes.Count != 0)
             {
                 var context = new AddDependencyContext(worldBuilder);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -294,7 +294,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         private void UpdateDependenciesSnapshot(
             ITargetFramework changedTargetFramework,
-            IDependenciesChanges changes,
+            IDependenciesChanges? changes,
             IProjectCatalogSnapshot? catalogs,
             ImmutableArray<ITargetFramework> targetFrameworks,
             ITargetFramework? activeTargetFramework,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -132,11 +132,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             IDependenciesChanges? changes = changesBuilder.TryBuildChanges();
 
-            if (changes != null)
-            {
-                // Notify subscribers of a change in dependency data
-                RaiseDependenciesChanged(targetFrameworkToUpdate, changes, currentAggregateContext, catalogSnapshot);
-            }
+            // Notify subscribers of a change in dependency data.
+            // NOTE even if changes is null, it's possible the catalog has changed. If we don't take the newer
+            // catalog we end up retaining a reference to an old catalog, which in turn retains an old project
+            // instance which can be very large.
+            RaiseDependenciesChanged(targetFrameworkToUpdate, changes, currentAggregateContext, catalogSnapshot);
 
             // Record all the rules that have occurred
             _treeTelemetryService.ObserveTargetFrameworkRules(targetFrameworkToUpdate, projectUpdate.ProjectChanges.Keys);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriberBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriberBase.cs
@@ -157,7 +157,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             return Task.CompletedTask;
         }
 
-        protected void RaiseDependenciesChanged(ITargetFramework targetFramework, IDependenciesChanges changes, AggregateCrossTargetProjectContext currentAggregateContext, IProjectCatalogSnapshot catalogSnapshot)
+        protected void RaiseDependenciesChanged(ITargetFramework targetFramework, IDependenciesChanges? changes, AggregateCrossTargetProjectContext currentAggregateContext, IProjectCatalogSnapshot catalogSnapshot)
         {
             DependenciesChanged?.Invoke(
                 this,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/IDependencyCrossTargetSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/IDependencyCrossTargetSubscriber.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             ImmutableArray<ITargetFramework> targetFrameworks,
             ITargetFramework activeTarget,
             ITargetFramework changedTargetFramework,
-            IDependenciesChanges changes,
+            IDependenciesChanges? changes,
             IProjectCatalogSnapshot catalogs)
         {
             Requires.Argument(!targetFrameworks.IsDefaultOrEmpty, nameof(targetFrameworks), "Must not be default or empty.");
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         public IProjectCatalogSnapshot Catalogs { get; }
 
-        public IDependenciesChanges Changes { get; }
+        public IDependenciesChanges? Changes { get; }
 
         public ITargetFramework ChangedTargetFramework { get; }
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/AssertEx.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/AssertEx.cs
@@ -23,30 +23,5 @@ namespace Xunit
         {
             CollectionLength(collection.Cast<object>(), expectedCount);
         }
-
-        public static void SequenceEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual)
-        {
-            using IEnumerator<T> expectedEnumerator = expected.GetEnumerator();
-            using IEnumerator<T> actualEnumerator = actual.GetEnumerator();
-
-            while (true)
-            {
-                bool nextExpected = expectedEnumerator.MoveNext();
-                bool nextActual = actualEnumerator.MoveNext();
-
-                if (nextExpected && nextActual)
-                {
-                    Assert.Equal(expectedEnumerator.Current, actualEnumerator.Current);
-                }
-                else if (!nextExpected && !nextActual)
-                {
-                    return;
-                }
-                else
-                {
-                    throw new XunitException("Sequences have different lengths");
-                }
-            }
-        }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/AssertEx.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/AssertEx.cs
@@ -23,5 +23,30 @@ namespace Xunit
         {
             CollectionLength(collection.Cast<object>(), expectedCount);
         }
+
+        public static void SequenceSame<T>(IEnumerable<T> expected, IEnumerable<T> actual) where T : class
+        {
+            using IEnumerator<T> expectedEnumerator = expected.GetEnumerator();
+            using IEnumerator<T> actualEnumerator = actual.GetEnumerator();
+
+            while (true)
+            {
+                bool nextExpected = expectedEnumerator.MoveNext();
+                bool nextActual = actualEnumerator.MoveNext();
+
+                if (nextExpected && nextActual)
+                {
+                    Assert.Same(expectedEnumerator.Current, actualEnumerator.Current);
+                }
+                else if (!nextExpected && !nextActual)
+                {
+                    return;
+                }
+                else
+                {
+                    throw new XunitException("Sequences have different lengths");
+                }
+            }
+        }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/AssertEx.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/AssertEx.cs
@@ -7,7 +7,7 @@ using Xunit.Sdk;
 
 namespace Xunit
 {
-    public static class AssertEx
+    internal static class AssertEx
     {
         public static void CollectionLength<T>(IEnumerable<T> collection, int expectedCount)
         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VisualBasic/VisualBasicNamespaceImportsListTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VisualBasic/VisualBasicNamespaceImportsListTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
 
                 list.OnNamespaceImportChanged(projectVersionedValue);
 
-                AssertEx.SequenceEqual(expected, list);
+                Assert.Equal(expected, list);
             }
 
             return;


### PR DESCRIPTION
Fixes #5836 and impacts #4474.

The first few commits are some clean-up. The main change is in 5778c199ad907fe9217b8d79dd00892a4efdde1e:

> A project subscription (evaluation or design-time build) can update in such a way that produces no change to the dependencies tree.
> 
> Previously, when no tree changes were observed we would not trigger an update. This, however, meant that we held a transitive reference to the project instance (via the catalog collection).
> 
> This change ensures we always accept updates to other fields (not just catalogs) regardless of whether `IDependencyModel` changes were made or not.