### PR TITLE
Import tree treats NuGet props/targets as read only

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/LinqExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/LinqExtensions.cs
@@ -85,5 +85,22 @@ namespace Microsoft.VisualStudio
                 }
             }
         }
+
+        /// <summary>
+        /// Specialisation of <see cref="System.Linq.Enumerable.Any{TSource}(IEnumerable{TSource})"/>
+        /// that avoids allocation when the sequence is statically known to be an array.
+        /// </summary>
+        public static bool Any<T>(this T[] array, Func<T, bool> predicate)
+        {
+            foreach (T item in array)
+            {
+                if (predicate(item))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -114,6 +114,10 @@
                   ReadOnly="True"
                   Visible="False" />
 
+  <StringProperty Name="NuGetPackageFolders"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <StringProperty Name="OneAppCapabilities"
                   Visible="False" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.ImplicitProjectCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.ImplicitProjectCheck.cs
@@ -13,6 +13,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
             private readonly string? _programFiles64;
             private readonly string? _vsInstallationDirectory;
 
+            private string[] _nuGetPackageFolders = Array.Empty<string>();
+            private string? _nuGetPackageFoldersString;
+
             /// <summary>
             /// Gets and sets the <c>MSBuildProjectExtensionsPath</c> property value for this project.
             /// Project files under this folder are considered implicit.
@@ -21,6 +24,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
             /// Example value: <c>"C:\repos\MySolution\MyProject\obj\"</c>
             /// </remarks>
             public string? ProjectExtensionsPath { get; set; }
+
+            /// <summary>
+            /// Gets and sets the paths found in the <c>NuGetPackageFolders</c> property value for this project.
+            /// Project files under any of these folders are considered implicit.
+            /// </summary>
+            /// <remarks>
+            /// Example value: <c>"C:\Users\myusername\.nuget\;D:\LocalNuGetCache\"</c>
+            /// </remarks>
+            public string NuGetPackageFolders
+            {
+                set
+                {
+                    if (!string.Equals(_nuGetPackageFoldersString, value, StringComparisons.Paths))
+                    {
+                        _nuGetPackageFoldersString = value;
+                        _nuGetPackageFolders = value.Split(';');
+                    }
+                }
+            }
 
             public ImplicitProjectCheck()
             {
@@ -61,6 +83,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                     || importPath.StartsWith(_programFiles86, StringComparisons.Paths)
                     || importPath.StartsWith(_windows, StringComparisons.Paths)
                     || (ProjectExtensionsPath != null && importPath.StartsWith(ProjectExtensionsPath, StringComparisons.Paths))
+                    || _nuGetPackageFolders.Any(nugetFolder => importPath.StartsWith(nugetFolder, StringComparisons.Paths))
                     || (_vsInstallationDirectory != null && importPath.StartsWith(_vsInstallationDirectory, StringComparisons.Paths));
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.ImplicitProjectCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.ImplicitProjectCheck.cs
@@ -60,8 +60,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                 return (_programFiles64 != null && importPath.StartsWith(_programFiles64, StringComparisons.Paths))
                     || importPath.StartsWith(_programFiles86, StringComparisons.Paths)
                     || importPath.StartsWith(_windows, StringComparisons.Paths)
-                    || (ProjectExtensionsPath != null && importPath.StartsWith(ProjectExtensionsPath, StringComparisons.Paths)
-                    || (_vsInstallationDirectory != null && importPath.StartsWith(_vsInstallationDirectory, StringComparisons.Paths)));
+                    || (ProjectExtensionsPath != null && importPath.StartsWith(ProjectExtensionsPath, StringComparisons.Paths))
+                    || (_vsInstallationDirectory != null && importPath.StartsWith(_vsInstallationDirectory, StringComparisons.Paths));
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -180,10 +180,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
 
                         void SyncTree(IProjectVersionedValue<ValueTuple<IProjectImportTreeSnapshot, IProjectSubscriptionUpdate>> e)
                         {
-                            if (e.Value.Item2.CurrentState.TryGetValue(ConfigurationGeneral.SchemaName, out IProjectRuleSnapshot snapshot) &&
-                                snapshot.Properties.TryGetValue(ConfigurationGeneral.MSBuildProjectExtensionsPathProperty, out string projectExtensionsPath))
+                            if (e.Value.Item2.CurrentState.TryGetValue(ConfigurationGeneral.SchemaName, out IProjectRuleSnapshot snapshot))
                             {
-                                _importPathCheck.ProjectExtensionsPath = projectExtensionsPath;
+                                if (snapshot.Properties.TryGetValue(ConfigurationGeneral.MSBuildProjectExtensionsPathProperty, out string projectExtensionsPath))
+                                {
+                                    _importPathCheck.ProjectExtensionsPath = projectExtensionsPath;
+                                }
+
+                                if (snapshot.Properties.TryGetValue(ConfigurationGeneral.NuGetPackageFoldersProperty, out string nuGetPackageFolders))
+                                {
+                                    _importPathCheck.NuGetPackageFolders = nuGetPackageFolders;
+                                }
                             }
 
                             _ = SubmitTreeUpdateAsync(


### PR DESCRIPTION
Fixes #5928.