### PR TITLE
Rename the EnableCentralPackageVersions to ManagePackageVersionsCentr…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -21,7 +21,7 @@
                   ReadOnly="True"
                   Visible="False" />
 
-  <StringProperty Name="EnableCentralPackageVersions"
+  <StringProperty Name="ManagePackageVersionsCentrally"
                   ReadOnly="True"
                   Visible="False" />
 


### PR DESCRIPTION
…ally to avoid the conflict with already in use EnableCentralPackageVersions (https://github.com/microsoft/MSBuildSdks/tree/master/src/CentralPackageVersions).