### PR TITLE
Enable new dependencies tree context menus

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -117,8 +117,8 @@
     <PackageReference Update="Microsoft.Test.Apex.VisualStudio"                                       Version="16.3.29003.189" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.5.493-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.5.493-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.6.78-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.6.78-pre" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="3.2.0-beta4-19359-03" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/DependenciesContextMenuProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/DependenciesContextMenuProvider.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
+{
+    /// <summary>
+    /// Provides context menus for nodes in the dependencies tree.
+    /// </summary>
+    [Export(typeof(IProjectItemContextMenuProvider))]
+    [AppliesTo(ProjectCapability.DependenciesTree)]
+    [Order(ProjectSystem.Order.Default)]
+    internal class DependenciesContextMenuProvider : IProjectItemContextMenuProvider
+    {
+        private static class Menus
+        {
+            public const int IDM_VS_CTXT_REFERENCEROOT              = 0x0450;
+            public const int IDM_VS_CTXT_REFERENCE                  = 0x0451;
+            public const int IDM_VS_CTXT_DEPENDENCYTARGET           = 0X04A0; // Target framework group node
+            public const int IDM_VS_CTXT_REFERENCE_GROUP            = 0X04A1; // Assembly reference group
+            public const int IDM_VS_CTXT_PACKAGEREFERENCE_GROUP     = 0x04A2;
+            public const int IDM_VS_CTXT_PACKAGEREFERENCE           = 0x04A3;
+            public const int IDM_VS_CTXT_COMREFERENCE_GROUP         = 0x04A4;
+            public const int IDM_VS_CTXT_COMREFERENCE               = 0x04A5;
+            public const int IDM_VS_CTXT_PROJECTREFERENCE_GROUP     = 0x04A6;
+            public const int IDM_VS_CTXT_PROJECTREFERENCE           = 0x04A7;
+            public const int IDM_VS_CTXT_SHAREDPROJECTREFERENCE     = 0x04A8;
+            public const int IDM_VS_CTXT_FRAMEWORKREFERENCE_GROUP   = 0x04A9;
+            public const int IDM_VS_CTXT_FRAMEWORKREFERENCE         = 0x04AA;
+            public const int IDM_VS_CTXT_ANALYZERREFERENCE_GROUP    = 0x04AB;
+            public const int IDM_VS_CTXT_ANALYZERREFERENCE          = 0x04AC;
+            public const int IDM_VS_CTXT_SDKREFERENCE_GROUP         = 0x04AD;
+            public const int IDM_VS_CTXT_SDKREFERENCE               = 0x04AE;
+        }
+
+        public bool TryGetContextMenu(IProjectTree projectItem, out Guid menuCommandGuid, out int menuCommandId)
+        {
+            Requires.NotNull(projectItem, nameof(projectItem));
+
+            if (projectItem.Flags.Contains(DependencyTreeFlags.DependenciesRootNode))
+            {
+                menuCommandId = Menus.IDM_VS_CTXT_REFERENCEROOT;
+            }
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.TargetNode))
+            {
+                menuCommandId = Menus.IDM_VS_CTXT_DEPENDENCYTARGET;
+            }
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.AssemblySubTreeRootNode))
+            {
+                menuCommandId = Menus.IDM_VS_CTXT_REFERENCE_GROUP;
+            }
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.AssemblyDependency))
+            {
+                menuCommandId = Menus.IDM_VS_CTXT_REFERENCE;
+            }
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.NuGetSubTreeRootNode))
+            {
+                menuCommandId = Menus.IDM_VS_CTXT_PACKAGEREFERENCE_GROUP;
+            }
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.NuGetDependency))
+            {
+                menuCommandId = Menus.IDM_VS_CTXT_PACKAGEREFERENCE;
+            }
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.ComSubTreeRootNode))
+            {
+                menuCommandId = Menus.IDM_VS_CTXT_COMREFERENCE_GROUP;
+            }
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.ComDependency))
+            {
+                menuCommandId = Menus.IDM_VS_CTXT_COMREFERENCE;
+            }
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.ProjectSubTreeRootNode))
+            {
+                menuCommandId = Menus.IDM_VS_CTXT_PROJECTREFERENCE_GROUP;
+            }
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.ProjectDependency))
+            {
+                menuCommandId = Menus.IDM_VS_CTXT_PROJECTREFERENCE;
+            }
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.SharedProjectDependency))
+            {
+                menuCommandId = Menus.IDM_VS_CTXT_SHAREDPROJECTREFERENCE;
+            }
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.AnalyzerSubTreeRootNode))
+            {
+                menuCommandId = Menus.IDM_VS_CTXT_ANALYZERREFERENCE_GROUP;
+            }
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.AnalyzerDependency))
+            {
+                menuCommandId = Menus.IDM_VS_CTXT_ANALYZERREFERENCE;
+            }
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.FrameworkSubTreeRootNode))
+            {
+                menuCommandId = Menus.IDM_VS_CTXT_FRAMEWORKREFERENCE_GROUP;
+            }
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.FrameworkDependency))
+            {
+                menuCommandId = Menus.IDM_VS_CTXT_FRAMEWORKREFERENCE;
+            }
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.SdkSubTreeRootNode))
+            {
+                menuCommandId = Menus.IDM_VS_CTXT_SDKREFERENCE_GROUP;
+            }
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.SdkDependency))
+            {
+                menuCommandId = Menus.IDM_VS_CTXT_SDKREFERENCE;
+            }
+            else
+            {
+                menuCommandGuid = default;
+                menuCommandId = default;
+                return false;
+            }
+
+            menuCommandGuid = VSConstants.CMDSETID.ShellMainMenu_guid;
+            return true;
+        }
+
+        public bool TryGetMixedItemsContextMenu(IEnumerable<IProjectTree> projectItems, out Guid menuCommandGuid, out int menuCommandId)
+        {
+            Requires.NotNull(projectItems, nameof(projectItems));
+
+            menuCommandGuid = default;
+            menuCommandId = default;
+
+            // If there are multiple items, and any item is a group node, suppress the context menu altogether
+
+            int count = 0;
+            bool containsProhibited = false;
+
+            foreach (IProjectTree item in projectItems)
+            {
+                count++;
+
+                if (!containsProhibited)
+                {
+                    // TODO when CPS inserts, use ContainsAny here instead
+                    if (item.Flags.Contains(DependencyTreeFlags.SubTreeRootNode) ||
+                        item.Flags.Contains(DependencyTreeFlags.TargetNode) ||
+                        item.Flags.Contains(DependencyTreeFlags.DependenciesRootNode))
+                    {
+                        containsProhibited = true;
+                    }
+                }
+
+                if (containsProhibited && count > 1)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/HideAddReferenceCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/HideAddReferenceCommand.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.Threading;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
 {
     /// <summary>
-    /// Suppresses the "Add Reference..." command in various menus.
+    /// Hides the "Add Reference..." command in various menus.
     /// </summary>
     /// <remarks>
     /// All places that previously had this command should now feature <c>IDG_VS_CTXT_REFERENCEMANAGEMENT</c>
@@ -17,11 +17,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
     [ProjectCommand(VSConstants.CMDSETID.StandardCommandSet2K_string, (long)VSConstants.VSStd2KCmdID.ADDREFERENCE)]
     [AppliesTo(ProjectCapability.DependenciesTree)]
     [Order(ProjectSystem.Order.Default)]
-    internal sealed class SuppressAddReferenceCommand : AbstractSingleNodeProjectCommand
+    internal sealed class HideAddReferenceCommand : AbstractSingleNodeProjectCommand
     {
         protected override Task<CommandStatusResult> GetCommandStatusAsync(IProjectTree node, bool focused, string? commandText, CommandStatus progressiveStatus)
         {
-            return GetCommandStatusResult.Suppressed;
+            progressiveStatus |= CommandStatus.Invisible;
+            return GetCommandStatusResult.Handled(commandText, progressiveStatus);
         }
 
         protected override Task<bool> TryHandleCommandAsync(IProjectTree node, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/ReferenceManagerCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/ReferenceManagerCommandHandler.cs
@@ -27,9 +27,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
         [ImportingConstructor]
         public ReferenceManagerCommandHandler(UnconfiguredProject unconfiguredProject, IReferencesUI referencesUI)
         {
-            Requires.NotNull(unconfiguredProject, nameof(unconfiguredProject));
-            Requires.NotNull(referencesUI, nameof(referencesUI));
-
             _unconfiguredProject = unconfiguredProject;
             _referencesUI = referencesUI;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/ReferenceManagerCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/ReferenceManagerCommandHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
         public const int CmdidAddComReference            = 0x201;
         public const int CmdidAddProjectReference        = 0x202;
         public const int CmdidAddSharedProjectReference  = 0x203;
-        public const int CmdidAddWinRTReference          = 0x204;
+        public const int CmdidAddSdkReference          = 0x204;
 
         private readonly UnconfiguredProject _unconfiguredProject;
         private readonly IReferencesUI _referencesUI;
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
                 CmdidAddComReference           => _unconfiguredProject.Capabilities.AppliesTo(ProjectCapabilities.ComReferences),
                 CmdidAddProjectReference       => _unconfiguredProject.Capabilities.AppliesTo(ProjectCapabilities.ProjectReferences),
                 CmdidAddSharedProjectReference => _unconfiguredProject.Capabilities.AppliesTo(ProjectCapabilities.SharedProjectReferences),
-                CmdidAddWinRTReference         => _unconfiguredProject.Capabilities.AppliesTo(ProjectCapabilities.WinRTReferences) && _unconfiguredProject.Capabilities.AppliesTo(ProjectCapabilities.SdkReferences),
+                CmdidAddSdkReference           => _unconfiguredProject.Capabilities.AppliesTo(ProjectCapabilities.WinRTReferences) && _unconfiguredProject.Capabilities.AppliesTo(ProjectCapabilities.SdkReferences),
                 _ => false
             };
 
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
                 CmdidAddComReference           => VSConstants.ComReferenceProvider_Guid,
                 CmdidAddProjectReference       => VSConstants.ProjectReferenceProvider_Guid,
                 CmdidAddSharedProjectReference => VSConstants.SharedProjectReferenceProvider_Guid,
-                CmdidAddWinRTReference         => VSConstants.PlatformReferenceProvider_Guid,
+                CmdidAddSdkReference           => VSConstants.PlatformReferenceProvider_Guid,
                 _ => Guid.Empty
             };
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/ReferenceManagerCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/ReferenceManagerCommandHandler.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.References;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
+{
+    /// <summary>
+    /// Enables commands for launching Reference Manager at a specific page.
+    /// </summary>
+    [ExportCommandGroup(VSConstants.CMDSETID.StandardCommandSet16_string)]
+    [AppliesTo(ProjectCapability.DependenciesTree)]
+    [Order(ProjectSystem.Order.Default)]
+    internal sealed class ReferenceManagerCommandHandler : ICommandGroupHandler
+    {
+        public const int CmdidAddAssemblyReference       = 0x200;
+        public const int CmdidAddComReference            = 0x201;
+        public const int CmdidAddProjectReference        = 0x202;
+        public const int CmdidAddSharedProjectReference  = 0x203;
+        public const int CmdidAddWinRTReference          = 0x204;
+
+        private readonly UnconfiguredProject _unconfiguredProject;
+        private readonly IReferencesUI _referencesUI;
+
+        [ImportingConstructor]
+        public ReferenceManagerCommandHandler(UnconfiguredProject unconfiguredProject, IReferencesUI referencesUI)
+        {
+            Requires.NotNull(unconfiguredProject, nameof(unconfiguredProject));
+            Requires.NotNull(referencesUI, nameof(referencesUI));
+
+            _unconfiguredProject = unconfiguredProject;
+            _referencesUI = referencesUI;
+        }
+
+        public CommandStatusResult GetCommandStatus(IImmutableSet<IProjectTree> items, long commandId, bool focused, string? commandText, CommandStatus status)
+        {
+            bool enable = commandId switch
+            {
+                CmdidAddAssemblyReference      => _unconfiguredProject.Capabilities.AppliesTo(ProjectCapabilities.AssemblyReferences),
+                CmdidAddComReference           => _unconfiguredProject.Capabilities.AppliesTo(ProjectCapabilities.ComReferences),
+                CmdidAddProjectReference       => _unconfiguredProject.Capabilities.AppliesTo(ProjectCapabilities.ProjectReferences),
+                CmdidAddSharedProjectReference => _unconfiguredProject.Capabilities.AppliesTo(ProjectCapabilities.SharedProjectReferences),
+                CmdidAddWinRTReference         => _unconfiguredProject.Capabilities.AppliesTo(ProjectCapabilities.WinRTReferences) && _unconfiguredProject.Capabilities.AppliesTo(ProjectCapabilities.SdkReferences),
+                _ => false
+            };
+
+            if (enable)
+            {
+                status &= ~CommandStatus.Invisible;
+                status |= CommandStatus.Enabled | CommandStatus.Supported;
+                return new CommandStatusResult(handled: true, commandText, status);
+            }
+
+            return CommandStatusResult.Unhandled;
+        }
+
+        public bool TryHandleCommand(IImmutableSet<IProjectTree> items, long commandId, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
+        {
+            Guid guid = commandId switch
+            {
+                CmdidAddAssemblyReference      => VSConstants.AssemblyReferenceProvider_Guid,
+                CmdidAddComReference           => VSConstants.ComReferenceProvider_Guid,
+                CmdidAddProjectReference       => VSConstants.ProjectReferenceProvider_Guid,
+                CmdidAddSharedProjectReference => VSConstants.SharedProjectReferenceProvider_Guid,
+                CmdidAddWinRTReference         => VSConstants.PlatformReferenceProvider_Guid,
+                _ => Guid.Empty
+            };
+
+            // Other known provider GUIDs:
+            //
+            // - VSConstants.FileReferenceProvider_Guid
+            // - VSConstants.ConnectedServiceInstanceReferenceProvider_Guid
+
+            if (guid != Guid.Empty)
+            {
+                _referencesUI.ShowReferenceManagerDialog(guid);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/ReferenceManagerCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/ReferenceManagerCommandHandler.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
             _referencesUI = referencesUI;
         }
 
-        public CommandStatusResult GetCommandStatus(IImmutableSet<IProjectTree> items, long commandId, bool focused, string? commandText, CommandStatus status)
+        public CommandStatusResult GetCommandStatus(IImmutableSet<IProjectTree> items, long commandId, bool focused, string? commandText, CommandStatus progressiveStatus)
         {
             bool enable = commandId switch
             {
@@ -48,9 +48,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
 
             if (enable)
             {
-                status &= ~CommandStatus.Invisible;
-                status |= CommandStatus.Enabled | CommandStatus.Supported;
-                return new CommandStatusResult(handled: true, commandText, status);
+                progressiveStatus &= ~CommandStatus.Invisible;
+                progressiveStatus |= CommandStatus.Enabled | CommandStatus.Supported;
+                return new CommandStatusResult(handled: true, commandText, progressiveStatus);
             }
 
             return CommandStatusResult.Unhandled;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/SuppressAddReferenceCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/SuppressAddReferenceCommand.cs
@@ -8,25 +8,20 @@ using Microsoft.VisualStudio.Threading;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
 {
     /// <summary>
-    /// Suppresses the "Add Reference..." command in specific dependencies tree context menus.
+    /// Suppresses the "Add Reference..." command in various menus.
     /// </summary>
+    /// <remarks>
+    /// All places that previously had this command should now feature <c>IDG_VS_CTXT_REFERENCEMANAGEMENT</c>
+    /// which includes specific "Add ___ Reference..." commands, including "Add Assembly Reference...".
+    /// </remarks>
     [ProjectCommand(VSConstants.CMDSETID.StandardCommandSet2K_string, (long)VSConstants.VSStd2KCmdID.ADDREFERENCE)]
     [AppliesTo(ProjectCapability.DependenciesTree)]
     [Order(ProjectSystem.Order.Default)]
     internal sealed class SuppressAddReferenceCommand : AbstractSingleNodeProjectCommand
     {
-        // TODO once CPS inserts, use this field along with ContainsAny
-//      private static readonly ProjectTreeFlags s_hideAddReferenceForFlags = DependencyTreeFlags.DependenciesRootNode + DependencyTreeFlags.TargetNode;
-
         protected override Task<CommandStatusResult> GetCommandStatusAsync(IProjectTree node, bool focused, string? commandText, CommandStatus progressiveStatus)
         {
-//          if (node.Flags.ContainsAny(s_hideAddReferenceForFlags))
-            if (node.Flags.Contains(DependencyTreeFlags.DependenciesRootNode) || node.Flags.Contains(DependencyTreeFlags.TargetNode))
-            {
-                return GetCommandStatusResult.Suppressed;
-            }
-
-            return GetCommandStatusResult.Unhandled;
+            return GetCommandStatusResult.Suppressed;
         }
 
         protected override Task<bool> TryHandleCommandAsync(IProjectTree node, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/SuppressAddReferenceCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/SuppressAddReferenceCommand.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Input;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
+{
+    /// <summary>
+    /// Suppresses the "Add Reference..." command in specific dependencies tree context menus.
+    /// </summary>
+    [ProjectCommand(VSConstants.CMDSETID.StandardCommandSet2K_string, (long)VSConstants.VSStd2KCmdID.ADDREFERENCE)]
+    [AppliesTo(ProjectCapability.DependenciesTree)]
+    [Order(ProjectSystem.Order.Default)]
+    internal sealed class SuppressAddReferenceCommand : AbstractSingleNodeProjectCommand
+    {
+        // TODO once CPS inserts, use this field along with ContainsAny
+//      private static readonly ProjectTreeFlags s_hideAddReferenceForFlags = DependencyTreeFlags.DependenciesRootNode + DependencyTreeFlags.TargetNode;
+
+        protected override Task<CommandStatusResult> GetCommandStatusAsync(IProjectTree node, bool focused, string? commandText, CommandStatus progressiveStatus)
+        {
+//          if (node.Flags.ContainsAny(s_hideAddReferenceForFlags))
+            if (node.Flags.Contains(DependencyTreeFlags.DependenciesRootNode) || node.Flags.Contains(DependencyTreeFlags.TargetNode))
+            {
+                return GetCommandStatusResult.Suppressed;
+            }
+
+            return GetCommandStatusResult.Unhandled;
+        }
+
+        protected override Task<bool> TryHandleCommandAsync(IProjectTree node, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
+        {
+            return TaskResult.False;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/SuppressObjectBrowserForPackageReferenceCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/SuppressObjectBrowserForPackageReferenceCommand.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Threading;
 
-namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
 {
     /// <summary>
     /// Suppresses the "Open in Object Browser" command for NuGet packages.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProvider.cs
@@ -106,7 +106,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
                 return _orderedMap.TryGetValue(propertyContext.ItemName, out displayOrder);
             }
 
-            return propertyContext.Metadata.TryGetValue(FullPathProperty, out string fullPath) &&
+            return propertyContext.Metadata != null &&
+                propertyContext.Metadata.TryGetValue(FullPathProperty, out string fullPath) &&
                 _orderedMap.TryGetValue(fullPath, out displayOrder);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/ProjectImports/ImportTreeCommandGroupHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/ProjectImports/ImportTreeCommandGroupHandler.cs
@@ -52,12 +52,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.ProjectImports
 
         protected abstract bool IsOpenWithCommand(long commandId);
 
-        public Task<CommandStatusResult> GetCommandStatusAsync(IImmutableSet<IProjectTree> items, long commandId, bool focused, string? commandText, CommandStatus status)
+        public Task<CommandStatusResult> GetCommandStatusAsync(IImmutableSet<IProjectTree> items, long commandId, bool focused, string? commandText, CommandStatus progressiveStatus)
         {
             if (IsOpenCommand(commandId) && items.All(CanOpenFile))
             {
-                status |= CommandStatus.Enabled | CommandStatus.Supported;
-                return new CommandStatusResult(true, commandText, status).AsTask();
+                progressiveStatus |= CommandStatus.Enabled | CommandStatus.Supported;
+                return new CommandStatusResult(true, commandText, progressiveStatus).AsTask();
             }
 
             return CommandStatusResult.Unhandled.AsTask();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Input/AbstractSingleNodeProjectCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Input/AbstractSingleNodeProjectCommand.cs
@@ -13,10 +13,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Input
     /// </summary>
     internal abstract class AbstractSingleNodeProjectCommand : AbstractProjectCommand
     {
-        protected AbstractSingleNodeProjectCommand()
-        {
-        }
-
         protected sealed override Task<CommandStatusResult> GetCommandStatusAsync(IImmutableSet<IProjectTree> nodes, bool focused, string? commandText, CommandStatus progressiveStatus)
         {
             if (nodes.Count == 1)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Input/GetCommandStatusResult.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Input/GetCommandStatusResult.cs
@@ -10,9 +10,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Input
 
         public static Task<CommandStatusResult> Suppressed { get; } = Task.FromResult(new CommandStatusResult(handled: true, null, CommandStatus.NotSupported | CommandStatus.Invisible));
 
-        public static Task<CommandStatusResult> Handled(string? commandText, CommandStatus status)
+        public static Task<CommandStatusResult> Handled(string? commandText, CommandStatus progressiveStatus)
         {
-            return new CommandStatusResult(true, commandText, status | CommandStatus.Supported).AsTask();
+            return new CommandStatusResult(true, commandText, progressiveStatus | CommandStatus.Supported).AsTask();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeFlags.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeFlags.cs
@@ -12,11 +12,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     /// </remarks>
     public static class DependencyTreeFlags
     {
+        internal static readonly ProjectTreeFlags DependenciesRootNode = ProjectTreeFlags.Create("DependenciesRootNode");
+        internal static readonly ProjectTreeFlags DependenciesGroupNode = ProjectTreeFlags.Create("DependenciesGroupNode");
+
         internal static readonly ProjectTreeFlags DependenciesRootNodeFlags
                 = ProjectTreeFlags.Create(ProjectTreeFlags.Common.BubbleUp)
                 + ProjectTreeFlags.Create(ProjectTreeFlags.Common.ReferencesFolder)
                 + ProjectTreeFlags.Create(ProjectTreeFlags.Common.VirtualFolder)
-                + ProjectTreeFlags.Create("DependenciesRootNode");
+                + DependenciesRootNode;
 
         /// <summary>
         /// The set of flags common to all Reference nodes.
@@ -88,33 +91,44 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 + GenericDependency;
 
         internal static readonly ProjectTreeFlags TargetNode = ProjectTreeFlags.Create("TargetNode");
-        internal static readonly ProjectTreeFlags SubTreeRootNode = ProjectTreeFlags.Create(ProjectTreeFlags.Common.VirtualFolder) +
-                                                                    ProjectTreeFlags.Create(ProjectTreeFlags.Common.ReferencesFolder);
+        
+        internal static readonly ProjectTreeFlags SubTreeRootNode = ProjectTreeFlags.Create("SubTreeRootNode");
 
+        internal static readonly ProjectTreeFlags SubTreeRootNodeFlags
+                = ProjectTreeFlags.Create(ProjectTreeFlags.Common.VirtualFolder)
+                + SubTreeRootNode;
 
+        internal static readonly ProjectTreeFlags AnalyzerSubTreeRootNode = ProjectTreeFlags.Create("AnalyzerSubTreeRootNode");
         internal static readonly ProjectTreeFlags AnalyzerDependency = ProjectTreeFlags.Create("AnalyzerDependency");
 
+        internal static readonly ProjectTreeFlags AssemblySubTreeRootNode = ProjectTreeFlags.Create("AssemblySubTreeRootNode");
         internal static readonly ProjectTreeFlags AssemblyDependency = ProjectTreeFlags.Create("AssemblyDependency");
 
+        internal static readonly ProjectTreeFlags ComSubTreeRootNode = ProjectTreeFlags.Create("ComSubTreeRootNode");
         internal static readonly ProjectTreeFlags ComDependency = ProjectTreeFlags.Create("ComDependency");
 
+        internal static readonly ProjectTreeFlags NuGetSubTreeRootNode = ProjectTreeFlags.Create("NuGetSubTreeRootNode");
         internal static readonly ProjectTreeFlags NuGetDependency = ProjectTreeFlags.Create("NuGetDependency");
         internal static readonly ProjectTreeFlags NuGetPackageDependency = ProjectTreeFlags.Create("NuGetPackageDependency");
         internal static readonly ProjectTreeFlags FrameworkAssembliesNode = ProjectTreeFlags.Create("FrameworkAssembliesNode");
         internal static readonly ProjectTreeFlags FxAssemblyDependency = ProjectTreeFlags.Create("FxAssemblyDependency");
 
+        internal static readonly ProjectTreeFlags FrameworkSubTreeRootNode = ProjectTreeFlags.Create("FrameworkSubTreeRootNode");
         internal static readonly ProjectTreeFlags FrameworkDependency = ProjectTreeFlags.Create("FrameworkDependency");
 
+        internal static readonly ProjectTreeFlags ProjectSubTreeRootNode = ProjectTreeFlags.Create("ProjectSubTreeRootNode");
         internal static readonly ProjectTreeFlags ProjectDependency = ProjectTreeFlags.Create("ProjectDependency");
+        internal static readonly ProjectTreeFlags SharedProjectDependency = ProjectTreeFlags.Create("SharedProjectDependency");
 
         internal static readonly ProjectTreeFlags SharedProjectFlags
-                = ProjectTreeFlags.Create("SharedProjectDependency")
+                = SharedProjectDependency
                 + ProjectTreeFlags.Create(ProjectTreeFlags.Common.SharedProjectImportReference);
 
         internal static readonly ProjectTreeFlags Diagnostic = ProjectTreeFlags.Create("Diagnostic");
         internal static readonly ProjectTreeFlags ErrorDiagnostic = ProjectTreeFlags.Create("ErrorDiagnostic");
         internal static readonly ProjectTreeFlags WarningDiagnostic = ProjectTreeFlags.Create("WarningDiagnostic");
 
+        internal static readonly ProjectTreeFlags SdkSubTreeRootNode = ProjectTreeFlags.Create("SdkSubTreeRootNode");
         internal static readonly ProjectTreeFlags SdkDependency = ProjectTreeFlags.Create("SdkDependency");
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/SubTreeRootDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/SubTreeRootDependencyModel.cs
@@ -11,11 +11,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
         public SubTreeRootDependencyModel(
             string providerType,
             string name,
-            DependencyIconSet iconSet)
+            DependencyIconSet iconSet,
+            ProjectTreeFlags flags)
             : base(
                 name,
                 originalItemSpec: name,
-                flags: DependencyTreeFlags.SubTreeRootNode,
+                flags: flags + DependencyTreeFlags.SubTreeRootNodeFlags,
                 isResolved: true,
                 isImplicit: false,
                 properties: null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AnalyzerRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AnalyzerRuleHandler.cs
@@ -23,7 +23,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 icon: KnownMonikers.CodeInformation,
                 expandedIcon: KnownMonikers.CodeInformation,
                 unresolvedIcon: ManagedImageMonikers.CodeInformationWarning,
-                unresolvedExpandedIcon: ManagedImageMonikers.CodeInformationWarning));
+                unresolvedExpandedIcon: ManagedImageMonikers.CodeInformationWarning),
+            DependencyTreeFlags.AnalyzerSubTreeRootNode);
 
         public AnalyzerRuleHandler()
             : base(AnalyzerReference.SchemaName, ResolvedAnalyzerReference.SchemaName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AssemblyRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AssemblyRuleHandler.cs
@@ -23,7 +23,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 icon: KnownMonikers.Reference,
                 expandedIcon: KnownMonikers.Reference,
                 unresolvedIcon: KnownMonikers.ReferenceWarning,
-                unresolvedExpandedIcon: KnownMonikers.ReferenceWarning));
+                unresolvedExpandedIcon: KnownMonikers.ReferenceWarning),
+            DependencyTreeFlags.AssemblySubTreeRootNode);
 
         public AssemblyRuleHandler()
             : base(AssemblyReference.SchemaName, ResolvedAssemblyReference.SchemaName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ComRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ComRuleHandler.cs
@@ -22,7 +22,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 icon: ManagedImageMonikers.Component,
                 expandedIcon: ManagedImageMonikers.Component,
                 unresolvedIcon: ManagedImageMonikers.ComponentWarning,
-                unresolvedExpandedIcon: ManagedImageMonikers.ComponentWarning));
+                unresolvedExpandedIcon: ManagedImageMonikers.ComponentWarning),
+            DependencyTreeFlags.ComSubTreeRootNode);
 
         public ComRuleHandler()
             : base(ComReference.SchemaName, ResolvedCOMReference.SchemaName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/FrameworkRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/FrameworkRuleHandler.cs
@@ -22,7 +22,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 icon: ManagedImageMonikers.Framework,
                 expandedIcon: ManagedImageMonikers.Framework,
                 unresolvedIcon: ManagedImageMonikers.FrameworkWarning,
-                unresolvedExpandedIcon: ManagedImageMonikers.FrameworkWarning));
+                unresolvedExpandedIcon: ManagedImageMonikers.FrameworkWarning),
+            DependencyTreeFlags.FrameworkSubTreeRootNode);
 
         public FrameworkRuleHandler()
             : base(FrameworkReference.SchemaName, ResolvedFrameworkReference.SchemaName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -23,7 +23,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 icon: ManagedImageMonikers.NuGetGrey,
                 expandedIcon: ManagedImageMonikers.NuGetGrey,
                 unresolvedIcon: ManagedImageMonikers.NuGetGreyWarning,
-                unresolvedExpandedIcon: ManagedImageMonikers.NuGetGreyWarning));
+                unresolvedExpandedIcon: ManagedImageMonikers.NuGetGreyWarning),
+            DependencyTreeFlags.NuGetSubTreeRootNode);
 
         private readonly ITargetFrameworkProvider _targetFrameworkProvider;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ProjectRuleHandler.cs
@@ -29,7 +29,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 icon: KnownMonikers.Application,
                 expandedIcon: KnownMonikers.Application,
                 unresolvedIcon: ManagedImageMonikers.ApplicationWarning,
-                unresolvedExpandedIcon: ManagedImageMonikers.ApplicationWarning));
+                unresolvedExpandedIcon: ManagedImageMonikers.ApplicationWarning),
+            DependencyTreeFlags.ProjectSubTreeRootNode);
 
         public override string ProviderType => ProviderTypeString;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/SdkRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/SdkRuleHandler.cs
@@ -23,7 +23,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 icon: ManagedImageMonikers.Sdk,
                 expandedIcon: ManagedImageMonikers.Sdk,
                 unresolvedIcon: ManagedImageMonikers.SdkWarning,
-                unresolvedExpandedIcon: ManagedImageMonikers.SdkWarning));
+                unresolvedExpandedIcon: ManagedImageMonikers.SdkWarning),
+            DependencyTreeFlags.SdkSubTreeRootNode);
 
         public SdkRuleHandler()
             : base(SdkReference.SchemaName, ResolvedSdkReference.SchemaName)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SubTreeRootDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SubTreeRootDependencyModelTests.cs
@@ -20,7 +20,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var model = new SubTreeRootDependencyModel(
                 "myProvider",
                 "myRoot",
-                iconSet);
+                iconSet,
+                ProjectTreeFlags.AlwaysCopyable);
 
             Assert.Equal("myProvider", model.ProviderType);
             Assert.Equal("myRoot", model.Path);
@@ -31,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.AboutBox, model.ExpandedIcon);
             Assert.Equal(KnownMonikers.AbsolutePosition, model.UnresolvedIcon);
             Assert.Equal(KnownMonikers.AbsolutePosition, model.UnresolvedExpandedIcon);
-            Assert.Equal(DependencyTreeFlags.SubTreeRootNode, model.Flags);
+            Assert.Equal(ProjectTreeFlags.AlwaysCopyable + DependencyTreeFlags.SubTreeRootNodeFlags, model.Flags);
         }
     }
 }


### PR DESCRIPTION
Fixes #5922.

- Opts in new menus for dependencies tree items
- Suppresses the old "Add Reference" command 
- Wires up behaviour for new "Add * Reference" commands to launch Reference Manager at the correct page

### Menu for 'Dependencies' node

![image](https://user-images.githubusercontent.com/350947/75836569-67ae7780-5e16-11ea-92f6-9b941be86497.png)

Note that the NuGet team will be modifying package-related items here too.

### Menu for 'Assemblies' group node

![image](https://user-images.githubusercontent.com/350947/75843693-d9db8800-5e27-11ea-9060-ac2e33241b7d.png)

### Menu for 'COM' group node

![image](https://user-images.githubusercontent.com/350947/75836356-c1fb0880-5e15-11ea-8e93-33e7208b425d.png)

### Menu for 'Projects' group node

![image](https://user-images.githubusercontent.com/350947/75836257-6892d980-5e15-11ea-8cc6-41a342365f70.png)

### Menu for 'SDKs' group node

### Main "Project" menu

![image](https://user-images.githubusercontent.com/350947/75835764-e0f89b00-5e13-11ea-9d48-96ee60467188.png)

### Project | Add context sum-menu

![image](https://user-images.githubusercontent.com/350947/75835802-fff72d00-5e13-11ea-9510-408396c275a0.png)

### Note

- 'Analyzers', 'Frameworks' and 'Packages' nodes have empty context menus, though they may be added to in future if needed. NuGet will almost certainly be adding the the 'Packages' context menu.
- Target framework nodes (for multi-targeting projects) currently display the same as the 'Dependencies' node itself. We may wish to suppress commands from these menus as they currently apply to all target frameworks. This will require coordination with the NuGet team.
- Requires https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/231736