### PR TITLE
Nominate for restore when project references change

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/RestoreHasher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/RestoreHasher.cs
@@ -21,6 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             {
                 AppendProperty(hasher, nameof(framework.TargetFrameworkMoniker), framework.TargetFrameworkMoniker);
                 AppendFrameworkProperties(hasher, framework);
+                AppendReferences(hasher, framework.ProjectReferences);
                 AppendReferences(hasher, framework.PackageReferences);
                 AppendReferences(hasher, framework.FrameworkReferences);
                 AppendReferences(hasher, framework.PackageDownloads);


### PR DESCRIPTION
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1075169

We weren't nominating ProjectReferences because they weren't factored in the hash.