### PR TITLE
Tidy dependency tree flags

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/DependenciesContextMenuProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/DependenciesContextMenuProvider.cs
@@ -43,11 +43,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
             {
                 menuCommandId = Menus.IDM_VS_CTXT_REFERENCEROOT;
             }
-            else if (projectItem.Flags.Contains(DependencyTreeFlags.TargetNode))
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.DependencyTargetFrameworkGroup))
             {
                 menuCommandId = Menus.IDM_VS_CTXT_DEPENDENCYTARGET;
             }
-            else if (projectItem.Flags.Contains(DependencyTreeFlags.AssemblySubTreeRootNode))
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.AssemblyDependencyGroup))
             {
                 menuCommandId = Menus.IDM_VS_CTXT_REFERENCE_GROUP;
             }
@@ -55,15 +55,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
             {
                 menuCommandId = Menus.IDM_VS_CTXT_REFERENCE;
             }
-            else if (projectItem.Flags.Contains(DependencyTreeFlags.NuGetSubTreeRootNode))
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.PackageDependencyGroup))
             {
                 menuCommandId = Menus.IDM_VS_CTXT_PACKAGEREFERENCE_GROUP;
             }
-            else if (projectItem.Flags.Contains(DependencyTreeFlags.NuGetDependency))
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.PackageDependency))
             {
                 menuCommandId = Menus.IDM_VS_CTXT_PACKAGEREFERENCE;
             }
-            else if (projectItem.Flags.Contains(DependencyTreeFlags.ComSubTreeRootNode))
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.ComDependencyGroup))
             {
                 menuCommandId = Menus.IDM_VS_CTXT_COMREFERENCE_GROUP;
             }
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
             {
                 menuCommandId = Menus.IDM_VS_CTXT_COMREFERENCE;
             }
-            else if (projectItem.Flags.Contains(DependencyTreeFlags.ProjectSubTreeRootNode))
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.ProjectDependencyGroup))
             {
                 menuCommandId = Menus.IDM_VS_CTXT_PROJECTREFERENCE_GROUP;
             }
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
             {
                 menuCommandId = Menus.IDM_VS_CTXT_SHAREDPROJECTREFERENCE;
             }
-            else if (projectItem.Flags.Contains(DependencyTreeFlags.AnalyzerSubTreeRootNode))
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.AnalyzerDependencyGroup))
             {
                 menuCommandId = Menus.IDM_VS_CTXT_ANALYZERREFERENCE_GROUP;
             }
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
             {
                 menuCommandId = Menus.IDM_VS_CTXT_ANALYZERREFERENCE;
             }
-            else if (projectItem.Flags.Contains(DependencyTreeFlags.FrameworkSubTreeRootNode))
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.FrameworkDependencyGroup))
             {
                 menuCommandId = Menus.IDM_VS_CTXT_FRAMEWORKREFERENCE_GROUP;
             }
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
             {
                 menuCommandId = Menus.IDM_VS_CTXT_FRAMEWORKREFERENCE;
             }
-            else if (projectItem.Flags.Contains(DependencyTreeFlags.SdkSubTreeRootNode))
+            else if (projectItem.Flags.Contains(DependencyTreeFlags.SdkDependencyGroup))
             {
                 menuCommandId = Menus.IDM_VS_CTXT_SDKREFERENCE_GROUP;
             }
@@ -137,8 +137,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
                 if (!containsProhibited)
                 {
                     // TODO when CPS inserts, use ContainsAny here instead
-                    if (item.Flags.Contains(DependencyTreeFlags.SubTreeRootNode) ||
-                        item.Flags.Contains(DependencyTreeFlags.TargetNode) ||
+                    if (item.Flags.Contains(DependencyTreeFlags.DependencyGroup) ||
+                        item.Flags.Contains(DependencyTreeFlags.DependencyTargetFrameworkGroup) ||
                         item.Flags.Contains(DependencyTreeFlags.DependenciesRootNode))
                     {
                         containsProhibited = true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/SuppressObjectBrowserForPackageReferenceCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/SuppressObjectBrowserForPackageReferenceCommand.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
     {
         protected override Task<CommandStatusResult> GetCommandStatusAsync(IProjectTree node, bool focused, string? commandText, CommandStatus progressiveStatus)
         {
-            if (node.Flags.Contains(DependencyTreeFlags.NuGetPackageDependency))
+            if (node.Flags.Contains(DependencyTreeFlags.PackageDependency))
             {
                 return GetCommandStatusResult.Suppressed;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectTreeExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectTreeExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         /// <summary>
-        /// Finds a tree node by it's flags. If there many nodes that satisfy flags, returns first.
+        /// Finds a tree node by its flags. If there many nodes that satisfy flags, returns first.
         /// </summary>
         internal static IProjectTree? GetSubTreeNode(this IProjectTree self, ProjectTreeFlags flags)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Unshipped.txt
@@ -71,7 +71,6 @@ static Microsoft.VisualStudio.ProjectSystem.VS.ManagedImageMonikers.SharedProjec
 static Microsoft.VisualStudio.ProjectSystem.VS.ManagedImageMonikers.TargetFile.get -> Microsoft.VisualStudio.Imaging.Interop.ImageMoniker
 static Microsoft.VisualStudio.ProjectSystem.VS.ManagedImageMonikers.TargetFilePrivate.get -> Microsoft.VisualStudio.Imaging.Interop.ImageMoniker
 static Microsoft.VisualStudio.ProjectSystem.VS.ManagedImageMonikers.WarningSmall.get -> Microsoft.VisualStudio.Imaging.Interop.ImageMoniker
-static readonly Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.DependencyTreeFlags.BaseReferenceFlags -> Microsoft.VisualStudio.ProjectSystem.ProjectTreeFlags
 static readonly Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.DependencyTreeFlags.DependencyFlags -> Microsoft.VisualStudio.ProjectSystem.ProjectTreeFlags
 static readonly Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.DependencyTreeFlags.ResolvedDependencyFlags -> Microsoft.VisualStudio.ProjectSystem.ProjectTreeFlags
 static readonly Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.DependencyTreeFlags.ShowEmptyProviderRootNode -> Microsoft.VisualStudio.ProjectSystem.ProjectTreeFlags

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -190,7 +190,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             // Get the list of shared import nodes.
             IEnumerable<IProjectTree> sharedImportNodes = nodes.Where(node =>
-                    node.Flags.Contains(DependencyTreeFlags.SharedProjectFlags));
+                    node.Flags.Contains(DependencyTreeFlags.SharedProjectDependency));
 
             // Get the list of normal reference Item Nodes (this excludes any shared import nodes).
             IEnumerable<IProjectTree> referenceItemNodes = nodes.Except(sharedImportNodes);
@@ -363,7 +363,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     Caption = Resources.DependenciesNodeName,
                     Icon = ManagedImageMonikers.ReferenceGroup.ToProjectSystemType(),
                     ExpandedIcon = ManagedImageMonikers.ReferenceGroup.ToProjectSystemType(),
-                    Flags = DependencyTreeFlags.DependenciesRootNodeFlags
+                    Flags = ProjectTreeFlags.Create(ProjectTreeFlags.Common.BubbleUp)
+                          + ProjectTreeFlags.Create(ProjectTreeFlags.Common.ReferencesFolder)
+                          + ProjectTreeFlags.Create(ProjectTreeFlags.Common.VirtualFolder)
+                          + DependencyTreeFlags.DependenciesRootNode
                 };
 
                 // Allow property providers to perform customization.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -161,9 +161,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return null;
             }
 
-            IProjectTree? dependenciesNode = root.Flags.Contains(DependencyTreeFlags.DependenciesRootNodeFlags)
+            IProjectTree? dependenciesNode = root.Flags.Contains(DependencyTreeFlags.DependenciesRootNode)
                 ? root
-                : root.GetSubTreeNode(DependencyTreeFlags.DependenciesRootNodeFlags);
+                : root.GetSubTreeNode(DependencyTreeFlags.DependenciesRootNode);
 
             return dependenciesNode?.GetSelfAndDescendentsBreadthFirst()
                 .FirstOrDefault((node, p) => string.Equals(node.FilePath, p, StringComparisons.Paths), path);
@@ -386,7 +386,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 // For IProjectTree remove ProjectTreeFlags.Common.Reference flag, otherwise CPS would fail to
                 // map this node to graph node and GraphProvider would be never called.
                 // Only IProjectItemTree can have this flag
-                filteredFlags = filteredFlags.Except(DependencyTreeFlags.BaseReferenceFlags);
+                filteredFlags = filteredFlags.Except(ProjectTreeFlags.Reference);
 
                 return _treeServices.CreateTree(
                     caption: viewModel.Caption,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeFlags.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeFlags.cs
@@ -12,38 +12,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     /// </remarks>
     public static class DependencyTreeFlags
     {
+        /// <summary>
+        /// Identifies the root "Dependencies" node of the dependencies tree. This flag should exist on only one node in a project.
+        /// </summary>
         internal static readonly ProjectTreeFlags DependenciesRootNode = ProjectTreeFlags.Create("DependenciesRootNode");
-        internal static readonly ProjectTreeFlags DependenciesGroupNode = ProjectTreeFlags.Create("DependenciesGroupNode");
-
-        internal static readonly ProjectTreeFlags DependenciesRootNodeFlags
-                = ProjectTreeFlags.Create(ProjectTreeFlags.Common.BubbleUp)
-                + ProjectTreeFlags.Create(ProjectTreeFlags.Common.ReferencesFolder)
-                + ProjectTreeFlags.Create(ProjectTreeFlags.Common.VirtualFolder)
-                + DependenciesRootNode;
-
-        /// <summary>
-        /// The set of flags common to all Reference nodes.
-        /// </summary>
-        public static readonly ProjectTreeFlags BaseReferenceFlags
-                = ProjectTreeFlags.Create(ProjectTreeFlags.Common.Reference);
-
-        /// <summary>
-        /// The set of flags to assign to unresolved Reference nodes.
-        /// </summary>
-        /// <remarks>
-        /// Contains <see cref="ProjectTreeFlags.Common.BrokenReference"/> which stops
-        /// <c>IGraphProvider</c> APIs from being called for that node.
-        /// </remarks>
-        internal static readonly ProjectTreeFlags UnresolvedReferenceFlags
-                = BaseReferenceFlags
-                + ProjectTreeFlags.Create(ProjectTreeFlags.Common.BrokenReference);
-
-        /// <summary>
-        /// The set of flags to assign to resolved Reference nodes.
-        /// </summary>
-        internal static readonly ProjectTreeFlags ResolvedReferenceFlags
-                = BaseReferenceFlags
-                + ProjectTreeFlags.Create(ProjectTreeFlags.Common.ResolvedReference);
 
         internal static readonly ProjectTreeFlags GenericDependency = ProjectTreeFlags.Create("GenericDependency");
 
@@ -60,6 +32,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         public static readonly ProjectTreeFlags SupportsHierarchy = ProjectTreeFlags.Create("SupportsHierarchy");
 
+        /// <summary>
+        /// If a dependency is not visible and has this flag, then an empty group node may be displayed for the dependency's provider type.
+        /// </summary>
         public static readonly ProjectTreeFlags ShowEmptyProviderRootNode = ProjectTreeFlags.Create("ShowEmptyProviderRootNode");
 
         /// <summary>
@@ -69,8 +44,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         public static readonly ProjectTreeFlags DependencyFlags
                 = ProjectTreeFlags.Create("Dependency")
-                + ProjectTreeFlags.Create(ProjectTreeFlags.Common.VirtualFolder)
-                + ProjectTreeFlags.Create(ProjectTreeFlags.Common.BubbleUp)
+                + ProjectTreeFlags.VirtualFolder
+                + ProjectTreeFlags.BubbleUp
                 + SupportsRuleProperties
                 + SupportsRemove;
 
@@ -80,53 +55,61 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public static readonly ProjectTreeFlags UnresolvedDependencyFlags = Unresolved + DependencyFlags;
         public static readonly ProjectTreeFlags ResolvedDependencyFlags = Resolved + DependencyFlags;
 
+        /// <summary>
+        /// The set of flags to assign to unresolved Reference nodes.
+        /// </summary>
+        /// <remarks>
+        /// Contains <see cref="ProjectTreeFlags.Common.BrokenReference"/> which stops
+        /// <c>IGraphProvider</c> APIs from being called for that node.
+        /// </remarks>
         internal static readonly ProjectTreeFlags GenericUnresolvedDependencyFlags
-                = UnresolvedDependencyFlags
-                + UnresolvedReferenceFlags
+                = ProjectTreeFlags.Reference
+                + ProjectTreeFlags.BrokenReference 
+                + UnresolvedDependencyFlags
                 + GenericDependency;
 
+        /// <summary>
+        /// The set of flags to assign to resolved Reference nodes.
+        /// </summary>
         internal static readonly ProjectTreeFlags GenericResolvedDependencyFlags
-                = ResolvedDependencyFlags
-                + ResolvedReferenceFlags
+                = ProjectTreeFlags.Reference
+                + ProjectTreeFlags.ResolvedReference
+                + ResolvedDependencyFlags
                 + GenericDependency;
 
-        internal static readonly ProjectTreeFlags TargetNode = ProjectTreeFlags.Create("TargetNode");
+        internal static readonly ProjectTreeFlags DependencyTargetFrameworkGroup = ProjectTreeFlags.Create("DependencyTargetFrameworkGroup");
         
-        internal static readonly ProjectTreeFlags SubTreeRootNode = ProjectTreeFlags.Create("SubTreeRootNode");
+        /// <summary>
+        /// Present on nodes that group dependencies of a given provider (e.g. "Packages", "Assemblies", ...).
+        /// </summary>
+        internal static readonly ProjectTreeFlags DependencyGroup = ProjectTreeFlags.Create("DependencyGroup");
 
-        internal static readonly ProjectTreeFlags SubTreeRootNodeFlags
-                = ProjectTreeFlags.Create(ProjectTreeFlags.Common.VirtualFolder)
-                + SubTreeRootNode;
-
-        internal static readonly ProjectTreeFlags AnalyzerSubTreeRootNode = ProjectTreeFlags.Create("AnalyzerSubTreeRootNode");
+        internal static readonly ProjectTreeFlags AnalyzerDependencyGroup = ProjectTreeFlags.Create("AnalyzerDependencyGroup");
         internal static readonly ProjectTreeFlags AnalyzerDependency = ProjectTreeFlags.Create("AnalyzerDependency");
 
-        internal static readonly ProjectTreeFlags AssemblySubTreeRootNode = ProjectTreeFlags.Create("AssemblySubTreeRootNode");
+        internal static readonly ProjectTreeFlags AssemblyDependencyGroup = ProjectTreeFlags.Create("AssemblyDependencyGroup");
         internal static readonly ProjectTreeFlags AssemblyDependency = ProjectTreeFlags.Create("AssemblyDependency");
 
-        internal static readonly ProjectTreeFlags ComSubTreeRootNode = ProjectTreeFlags.Create("ComSubTreeRootNode");
+        internal static readonly ProjectTreeFlags ComDependencyGroup = ProjectTreeFlags.Create("ComDependencyGroup");
         internal static readonly ProjectTreeFlags ComDependency = ProjectTreeFlags.Create("ComDependency");
 
-        internal static readonly ProjectTreeFlags NuGetSubTreeRootNode = ProjectTreeFlags.Create("NuGetSubTreeRootNode");
-        internal static readonly ProjectTreeFlags NuGetDependency = ProjectTreeFlags.Create("NuGetDependency");
-        internal static readonly ProjectTreeFlags NuGetPackageDependency = ProjectTreeFlags.Create("NuGetPackageDependency");
+        internal static readonly ProjectTreeFlags PackageDependencyGroup = ProjectTreeFlags.Create("PackageDependencyGroup");
+        internal static readonly ProjectTreeFlags PackageDependency = ProjectTreeFlags.Create("PackageDependency");
+        internal static readonly ProjectTreeFlags PackageUnknownDependency = ProjectTreeFlags.Create("PackageUnknownDependency");
+        internal static readonly ProjectTreeFlags PackageAssemblyDependency = ProjectTreeFlags.Create("PackageAssemblyDependency");
+        internal static readonly ProjectTreeFlags PackageAnalyzerDependency = ProjectTreeFlags.Create("PackageAnalyzerDependency");
+        internal static readonly ProjectTreeFlags PackageDiagnostic = ProjectTreeFlags.Create("PackageDiagnostic");
+        internal static readonly ProjectTreeFlags PackageErrorDiagnostic = ProjectTreeFlags.Create("PackageErrorDiagnostic");
+        internal static readonly ProjectTreeFlags PackageWarningDiagnostic = ProjectTreeFlags.Create("PackageWarningDiagnostic");
 
-        internal static readonly ProjectTreeFlags FrameworkSubTreeRootNode = ProjectTreeFlags.Create("FrameworkSubTreeRootNode");
+        internal static readonly ProjectTreeFlags FrameworkDependencyGroup = ProjectTreeFlags.Create("FrameworkDependencyGroup");
         internal static readonly ProjectTreeFlags FrameworkDependency = ProjectTreeFlags.Create("FrameworkDependency");
 
-        internal static readonly ProjectTreeFlags ProjectSubTreeRootNode = ProjectTreeFlags.Create("ProjectSubTreeRootNode");
+        internal static readonly ProjectTreeFlags ProjectDependencyGroup = ProjectTreeFlags.Create("ProjectDependencyGroup");
         internal static readonly ProjectTreeFlags ProjectDependency = ProjectTreeFlags.Create("ProjectDependency");
-        internal static readonly ProjectTreeFlags SharedProjectDependency = ProjectTreeFlags.Create("SharedProjectDependency");
+        internal static readonly ProjectTreeFlags SharedProjectDependency = ProjectTreeFlags.SharedProjectImportReference;
 
-        internal static readonly ProjectTreeFlags SharedProjectFlags
-                = SharedProjectDependency
-                + ProjectTreeFlags.Create(ProjectTreeFlags.Common.SharedProjectImportReference);
-
-        internal static readonly ProjectTreeFlags Diagnostic = ProjectTreeFlags.Create("Diagnostic");
-        internal static readonly ProjectTreeFlags ErrorDiagnostic = ProjectTreeFlags.Create("ErrorDiagnostic");
-        internal static readonly ProjectTreeFlags WarningDiagnostic = ProjectTreeFlags.Create("WarningDiagnostic");
-
-        internal static readonly ProjectTreeFlags SdkSubTreeRootNode = ProjectTreeFlags.Create("SdkSubTreeRootNode");
+        internal static readonly ProjectTreeFlags SdkDependencyGroup = ProjectTreeFlags.Create("SdkDependencyGroup");
         internal static readonly ProjectTreeFlags SdkDependency = ProjectTreeFlags.Create("SdkDependency");
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IProjectDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IProjectDependenciesSubTreeProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         string ProviderType { get; }
 
         /// <summary>
-        /// Returns the root node for this provider's dependency nodes.
+        /// Returns the root (group) node for this provider's dependency nodes.
         /// </summary>
         /// <remarks>
         /// Despite the method's name, implementations may return the same instance for repeated

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/DependencyGroupModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/DependencyGroupModel.cs
@@ -2,13 +2,16 @@
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
-    internal class SubTreeRootDependencyModel : DependencyModel
+    /// <summary>
+    /// Represents a node that groups dependencies from a given provider.
+    /// </summary>
+    internal class DependencyGroupModel : DependencyModel
     {
         public override string ProviderType { get; }
 
         public override DependencyIconSet IconSet { get; }
 
-        public SubTreeRootDependencyModel(
+        public DependencyGroupModel(
             string providerType,
             string name,
             DependencyIconSet iconSet,
@@ -16,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             : base(
                 name,
                 originalItemSpec: name,
-                flags: flags + DependencyTreeFlags.SubTreeRootNodeFlags,
+                flags: flags + ProjectTreeFlags.VirtualFolder + DependencyTreeFlags.DependencyGroup,
                 isResolved: true,
                 isImplicit: false,
                 properties: null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModel.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class PackageAnalyzerAssemblyDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.NuGetDependency);
+        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.PackageAnalyzerDependency);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
             icon: KnownMonikers.CodeInformation,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageAssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageAssemblyDependencyModel.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class PackageAssemblyDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.NuGetDependency);
+        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.PackageAssemblyDependency);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
             icon: KnownMonikers.Reference,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageDependencyModel.cs
@@ -9,8 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
     internal class PackageDependencyModel : DependencyModel
     {
         private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
-            add: DependencyTreeFlags.NuGetDependency +
-                 DependencyTreeFlags.NuGetPackageDependency +
+            add: DependencyTreeFlags.PackageDependency +
                  DependencyTreeFlags.SupportsHierarchy);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageDiagnosticDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageDiagnosticDependencyModel.cs
@@ -5,24 +5,22 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.Ru
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
-    internal enum DiagnosticMessageSeverity
+    internal enum PackageDiagnosticMessageSeverity
     {
         Info,
         Warning,
         Error,
     }
 
-    internal class DiagnosticDependencyModel : DependencyModel
+    internal class PackageDiagnosticDependencyModel : DependencyModel
     {
         private static readonly ProjectTreeFlags s_errorFlags = new DependencyFlagCache(
-            add: DependencyTreeFlags.NuGetDependency +
-                 DependencyTreeFlags.Diagnostic +
-                 DependencyTreeFlags.ErrorDiagnostic).Get(isResolved: false, isImplicit: false);
+            add: DependencyTreeFlags.PackageDiagnostic +
+                 DependencyTreeFlags.PackageErrorDiagnostic).Get(isResolved: false, isImplicit: false);
 
         private static readonly ProjectTreeFlags s_warningFlags = new DependencyFlagCache(
-            add: DependencyTreeFlags.NuGetDependency +
-                 DependencyTreeFlags.Diagnostic +
-                 DependencyTreeFlags.WarningDiagnostic).Get(isResolved: false, isImplicit: false);
+            add: DependencyTreeFlags.PackageDiagnostic +
+                 DependencyTreeFlags.PackageWarningDiagnostic).Get(isResolved: false, isImplicit: false);
 
         private static readonly DependencyIconSet s_errorIconSet = new DependencyIconSet(
             icon: ManagedImageMonikers.ErrorSmall,
@@ -36,23 +34,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             unresolvedIcon: ManagedImageMonikers.WarningSmall,
             unresolvedExpandedIcon: ManagedImageMonikers.WarningSmall);
 
-        private readonly DiagnosticMessageSeverity _severity;
+        private readonly PackageDiagnosticMessageSeverity _severity;
 
-        public override DependencyIconSet IconSet => _severity == DiagnosticMessageSeverity.Error
+        public override DependencyIconSet IconSet => _severity == PackageDiagnosticMessageSeverity.Error
             ? s_errorIconSet
             : s_warningIconSet;
 
         public override string Name { get; }
 
-        public override int Priority => _severity == DiagnosticMessageSeverity.Error
+        public override int Priority => _severity == PackageDiagnosticMessageSeverity.Error
             ? GraphNodePriority.DiagnosticsError
             : GraphNodePriority.DiagnosticsWarning;
 
         public override string ProviderType => PackageRuleHandler.ProviderTypeString;
 
-        public DiagnosticDependencyModel(
+        public PackageDiagnosticDependencyModel(
             string originalItemSpec,
-            DiagnosticMessageSeverity severity,
+            PackageDiagnosticMessageSeverity severity,
             string code,
             string message,
             bool isVisible,
@@ -60,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             : base(
                 originalItemSpec,
                 originalItemSpec,
-                flags: severity == DiagnosticMessageSeverity.Error
+                flags: severity == PackageDiagnosticMessageSeverity.Error
                     ? s_errorFlags
                     : s_warningFlags,
                 isResolved: false,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageUnknownDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageUnknownDependencyModel.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class PackageUnknownDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.NuGetDependency);
+        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.PackageUnknownDependency);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
             icon: KnownMonikers.QuestionMark,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
     {
         private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
             add: DependencyTreeFlags.ProjectDependency +
-                 DependencyTreeFlags.SharedProjectFlags,
+                 DependencyTreeFlags.SharedProjectDependency,
             remove: DependencyTreeFlags.SupportsRuleProperties);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/TargetDependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/TargetDependencyViewModel.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
         public TargetDependencyViewModel(TargetedDependenciesSnapshot snapshot)
         {
             Caption = snapshot.TargetFramework.FriendlyName;
-            Flags = DependencyTreeFlags.TargetNode.Add($"$TFM:{snapshot.TargetFramework.FullName}");
+            Flags = DependencyTreeFlags.DependencyTargetFrameworkGroup.Add($"$TFM:{snapshot.TargetFramework.FullName}");
             _hasUnresolvedDependency = snapshot.HasReachableVisibleUnresolvedDependency;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                 && !dependency.Implicit                                               // explicit
                 && dependency.Resolved                                                // resolved
                 && dependency.Flags.Contains(DependencyTreeFlags.GenericDependency)   // generic dependency
-                && !dependency.Flags.Contains(DependencyTreeFlags.SharedProjectFlags) // except for shared projects
+                && !dependency.Flags.Contains(DependencyTreeFlags.SharedProjectDependency) // except for shared projects
                 && !projectItemSpecs.Contains(dependency.OriginalItemSpec)            // is not a known item spec
                 && subTreeProviderByProviderType.TryGetValue(dependency.ProviderType, out IProjectDependenciesSubTreeProvider provider)
                 && provider is IProjectDependenciesSubTreeProviderInternal internalProvider)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                     return;
                 }
             }
-            else if (dependency.Flags.Contains(DependencyTreeFlags.NuGetPackageDependency) && dependency.Resolved)
+            else if (dependency.Flags.Contains(DependencyTreeFlags.PackageDependency) && dependency.Resolved)
             {
                 // This is a resolved package dependency.
                 //
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
         {
             if (dependency.TopLevel &&
                 dependency.Resolved &&
-                dependency.Flags.Contains(DependencyTreeFlags.NuGetPackageDependency))
+                dependency.Flags.Contains(DependencyTreeFlags.PackageDependency))
             {
                 // This is a package dependency.
                 //

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/UnresolvedProjectReferenceSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/UnresolvedProjectReferenceSnapshotFilter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             if (dependency.TopLevel
                 && dependency.Resolved
                 && dependency.Flags.Contains(DependencyTreeFlags.ProjectDependency)
-                && !dependency.Flags.Contains(DependencyTreeFlags.SharedProjectFlags))
+                && !dependency.Flags.Contains(DependencyTreeFlags.SharedProjectDependency))
             {
                 TargetedDependenciesSnapshot? snapshot = _aggregateSnapshotProvider.GetSnapshot(dependency);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 
             IEnumerable<string> sharedFolderProjectPaths = sharedFolders.Value.Select(sf => sf.ProjectPath);
             var currentSharedImportNodePaths = targetedSnapshot.TopLevelDependencies
-                .Where(x => x.Flags.Contains(DependencyTreeFlags.SharedProjectFlags))
+                .Where(x => x.Flags.Contains(DependencyTreeFlags.SharedProjectDependency))
                 .Select(x => x.Path)
                 .ToList();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AnalyzerRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AnalyzerRuleHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     {
         public const string ProviderTypeString = "AnalyzerDependency";
 
-        private static readonly SubTreeRootDependencyModel s_rootModel = new SubTreeRootDependencyModel(
+        private static readonly DependencyGroupModel s_groupModel = new DependencyGroupModel(
             ProviderTypeString,
             Resources.AnalyzersNodeName,
             new DependencyIconSet(
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 expandedIcon: KnownMonikers.CodeInformation,
                 unresolvedIcon: ManagedImageMonikers.CodeInformationWarning,
                 unresolvedExpandedIcon: ManagedImageMonikers.CodeInformationWarning),
-            DependencyTreeFlags.AnalyzerSubTreeRootNode);
+            DependencyTreeFlags.AnalyzerDependencyGroup);
 
         public AnalyzerRuleHandler()
             : base(AnalyzerReference.SchemaName, ResolvedAnalyzerReference.SchemaName)
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         protected override bool ResolvedItemRequiresEvaluatedItem => false;
 
-        public override IDependencyModel CreateRootDependencyNode() => s_rootModel;
+        public override IDependencyModel CreateRootDependencyNode() => s_groupModel;
 
         protected override IDependencyModel CreateDependencyModel(
             string path,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AssemblyRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AssemblyRuleHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     {
         public const string ProviderTypeString = "AssemblyDependency";
 
-        private static readonly SubTreeRootDependencyModel s_rootModel = new SubTreeRootDependencyModel(
+        private static readonly DependencyGroupModel s_groupModel = new DependencyGroupModel(
             ProviderTypeString,
             Resources.AssembliesNodeName,
             new DependencyIconSet(
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 expandedIcon: KnownMonikers.Reference,
                 unresolvedIcon: KnownMonikers.ReferenceWarning,
                 unresolvedExpandedIcon: KnownMonikers.ReferenceWarning),
-            DependencyTreeFlags.AssemblySubTreeRootNode);
+            DependencyTreeFlags.AssemblyDependencyGroup);
 
         public AssemblyRuleHandler()
             : base(AssemblyReference.SchemaName, ResolvedAssemblyReference.SchemaName)
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         public override ImageMoniker ImplicitIcon => ManagedImageMonikers.ReferencePrivate;
 
-        public override IDependencyModel CreateRootDependencyNode() => s_rootModel;
+        public override IDependencyModel CreateRootDependencyNode() => s_groupModel;
 
         protected override IDependencyModel CreateDependencyModel(
             string path,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ComRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ComRuleHandler.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     {
         public const string ProviderTypeString = "ComDependency";
 
-        private static readonly SubTreeRootDependencyModel s_rootModel = new SubTreeRootDependencyModel(
+        private static readonly DependencyGroupModel s_groupModel = new DependencyGroupModel(
             ProviderTypeString,
             Resources.ComNodeName,
             new DependencyIconSet(
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 expandedIcon: ManagedImageMonikers.Component,
                 unresolvedIcon: ManagedImageMonikers.ComponentWarning,
                 unresolvedExpandedIcon: ManagedImageMonikers.ComponentWarning),
-            DependencyTreeFlags.ComSubTreeRootNode);
+            DependencyTreeFlags.ComDependencyGroup);
 
         public ComRuleHandler()
             : base(ComReference.SchemaName, ResolvedCOMReference.SchemaName)
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         public override ImageMoniker ImplicitIcon => ManagedImageMonikers.ComponentPrivate;
 
-        public override IDependencyModel CreateRootDependencyNode() => s_rootModel;
+        public override IDependencyModel CreateRootDependencyNode() => s_groupModel;
 
         protected override IDependencyModel CreateDependencyModel(
             string path,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/FrameworkRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/FrameworkRuleHandler.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     {
         public const string ProviderTypeString = "FrameworkDependency";
 
-        private static readonly SubTreeRootDependencyModel s_rootModel = new SubTreeRootDependencyModel(
+        private static readonly DependencyGroupModel s_groupModel = new DependencyGroupModel(
             ProviderTypeString,
             Resources.FrameworkNodeName,
             new DependencyIconSet(
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 expandedIcon: ManagedImageMonikers.Framework,
                 unresolvedIcon: ManagedImageMonikers.FrameworkWarning,
                 unresolvedExpandedIcon: ManagedImageMonikers.FrameworkWarning),
-            DependencyTreeFlags.FrameworkSubTreeRootNode);
+            DependencyTreeFlags.FrameworkDependencyGroup);
 
         public FrameworkRuleHandler()
             : base(FrameworkReference.SchemaName, ResolvedFrameworkReference.SchemaName)
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         public override ImageMoniker ImplicitIcon => ManagedImageMonikers.FrameworkPrivate;
 
-        public override IDependencyModel CreateRootDependencyNode() => s_rootModel;
+        public override IDependencyModel CreateRootDependencyNode() => s_groupModel;
 
         protected override IDependencyModel CreateDependencyModel(
             string path,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
@@ -163,9 +163,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                             Properties,
                             dependenciesIDs: GetDependencyItemSpecs());
                     case DependencyType.Diagnostic:
-                        return new DiagnosticDependencyModel(
+                        return new PackageDiagnosticDependencyModel(
                             OriginalItemSpec,
-                            severity: Properties.GetEnumProperty<DiagnosticMessageSeverity>(ProjectItemMetadata.Severity) ?? DiagnosticMessageSeverity.Info,
+                            severity: Properties.GetEnumProperty<PackageDiagnosticMessageSeverity>(ProjectItemMetadata.Severity) ?? PackageDiagnosticMessageSeverity.Info,
                             code: Properties.GetStringProperty(ProjectItemMetadata.DiagnosticCode) ?? string.Empty,
                             Name,
                             isVisible: true,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     {
         public const string ProviderTypeString = "NuGetDependency";
 
-        private static readonly SubTreeRootDependencyModel s_rootModel = new SubTreeRootDependencyModel(
+        private static readonly DependencyGroupModel s_groupModel = new DependencyGroupModel(
             ProviderTypeString,
             Resources.PackagesNodeName,
             new DependencyIconSet(
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 expandedIcon: ManagedImageMonikers.NuGetGrey,
                 unresolvedIcon: ManagedImageMonikers.NuGetGreyWarning,
                 unresolvedExpandedIcon: ManagedImageMonikers.NuGetGreyWarning),
-            DependencyTreeFlags.NuGetSubTreeRootNode);
+            DependencyTreeFlags.PackageDependencyGroup);
 
         private readonly ITargetFrameworkProvider _targetFrameworkProvider;
 
@@ -103,6 +103,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             }
         }
 
-        public override IDependencyModel CreateRootDependencyNode() => s_rootModel;
+        public override IDependencyModel CreateRootDependencyNode() => s_groupModel;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ProjectRuleHandler.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     {
         public const string ProviderTypeString = "ProjectDependency";
 
-        private static readonly SubTreeRootDependencyModel s_rootModel = new SubTreeRootDependencyModel(
+        private static readonly DependencyGroupModel s_groupModel = new DependencyGroupModel(
             ProviderTypeString,
             Resources.ProjectsNodeName,
             new DependencyIconSet(
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 expandedIcon: KnownMonikers.Application,
                 unresolvedIcon: ManagedImageMonikers.ApplicationWarning,
                 unresolvedExpandedIcon: ManagedImageMonikers.ApplicationWarning),
-            DependencyTreeFlags.ProjectSubTreeRootNode);
+            DependencyTreeFlags.ProjectDependencyGroup);
 
         public override string ProviderType => ProviderTypeString;
 
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             }
         }
 
-        public override IDependencyModel CreateRootDependencyNode() => s_rootModel;
+        public override IDependencyModel CreateRootDependencyNode() => s_groupModel;
 
         protected override IDependencyModel CreateDependencyModel(
             string path,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/SdkRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/SdkRuleHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     {
         public const string ProviderTypeString = "SdkDependency";
 
-        private static readonly SubTreeRootDependencyModel s_rootModel = new SubTreeRootDependencyModel(
+        private static readonly DependencyGroupModel s_groupModel = new DependencyGroupModel(
             ProviderTypeString,
             Resources.SdkNodeName,
             new DependencyIconSet(
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 expandedIcon: ManagedImageMonikers.Sdk,
                 unresolvedIcon: ManagedImageMonikers.SdkWarning,
                 unresolvedExpandedIcon: ManagedImageMonikers.SdkWarning),
-            DependencyTreeFlags.SdkSubTreeRootNode);
+            DependencyTreeFlags.SdkDependencyGroup);
 
         public SdkRuleHandler()
             : base(SdkReference.SchemaName, ResolvedSdkReference.SchemaName)
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         public override ImageMoniker ImplicitIcon => ManagedImageMonikers.SdkPrivate;
 
-        public override IDependencyModel CreateRootDependencyNode() => s_rootModel;
+        public override IDependencyModel CreateRootDependencyNode() => s_groupModel;
 
         protected override IDependencyModel CreateDependencyModel(
             string path,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(targetFramework.FullName, result.Caption);
             Assert.Equal(KnownMonikers.Library, result.Icon);
             Assert.Equal(KnownMonikers.Library, result.ExpandedIcon);
-            Assert.True(result.Flags.Contains(DependencyTreeFlags.TargetNode));
+            Assert.True(result.Flags.Contains(DependencyTreeFlags.DependencyTargetFrameworkGroup));
             Assert.True(result.Flags.Contains("$TFM:tFm1"));
         }
 
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(targetFramework.FullName, result.Caption);
             Assert.Equal(ManagedImageMonikers.LibraryWarning, result.Icon);
             Assert.Equal(ManagedImageMonikers.LibraryWarning, result.ExpandedIcon);
-            Assert.True(result.Flags.Contains(DependencyTreeFlags.TargetNode));
+            Assert.True(result.Flags.Contains(DependencyTreeFlags.DependencyTargetFrameworkGroup));
             Assert.True(result.Flags.Contains("$TFM:tFm1"));
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModelTests.cs
@@ -14,9 +14,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             var properties = ImmutableStringDictionary<string>.EmptyOrdinal.Add("myProp", "myVal");
 
-            var model = new DiagnosticDependencyModel(
+            var model = new PackageDiagnosticDependencyModel(
                 "myOriginalItemSpec",
-                DiagnosticMessageSeverity.Error,
+                PackageDiagnosticMessageSeverity.Error,
                 "nu1002",
                 "myMessage",
                 isVisible: true,
@@ -40,9 +40,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.ErrorSmall, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.ErrorSmall, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.NuGetDependency +
-                DependencyTreeFlags.Diagnostic +
-                DependencyTreeFlags.ErrorDiagnostic +
+                DependencyTreeFlags.PackageDiagnostic +
+                DependencyTreeFlags.PackageErrorDiagnostic +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
         }
@@ -52,9 +51,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             var properties = ImmutableStringDictionary<string>.EmptyOrdinal.Add("myProp", "myVal");
 
-            var model = new DiagnosticDependencyModel(
+            var model = new PackageDiagnosticDependencyModel(
                  "myOriginalItemSpec",
-                 DiagnosticMessageSeverity.Warning,
+                 PackageDiagnosticMessageSeverity.Warning,
                  "nu1002",
                  "myMessage",
                  isVisible: true,
@@ -78,9 +77,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.WarningSmall, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.WarningSmall, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.NuGetDependency +
-                DependencyTreeFlags.Diagnostic +
-                DependencyTreeFlags.WarningDiagnostic +
+                DependencyTreeFlags.PackageDiagnostic +
+                DependencyTreeFlags.PackageWarningDiagnostic +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModelTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedExpandedIcon);
             AssertEx.CollectionLength(model.DependencyIDs, 2);
             Assert.Equal(
-                DependencyTreeFlags.NuGetDependency +
+                DependencyTreeFlags.PackageAnalyzerDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
         }
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedExpandedIcon);
             AssertEx.CollectionLength(model.DependencyIDs, 2);
             Assert.Equal(
-                DependencyTreeFlags.NuGetDependency +
+                DependencyTreeFlags.PackageAnalyzerDependency +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAssemblyDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAssemblyDependencyModelTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedExpandedIcon);
             AssertEx.CollectionLength(model.DependencyIDs, 2);
             Assert.Equal(
-                DependencyTreeFlags.NuGetDependency +
+                DependencyTreeFlags.PackageAssemblyDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
         }
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedExpandedIcon);
             AssertEx.CollectionLength(model.DependencyIDs, 2);
             Assert.Equal(
-                DependencyTreeFlags.NuGetDependency +
+                DependencyTreeFlags.PackageAssemblyDependency +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModelTests.cs
@@ -47,8 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedExpandedIcon);
             AssertEx.CollectionLength(model.DependencyIDs, 2);
             Assert.Equal(
-                DependencyTreeFlags.NuGetDependency +
-                DependencyTreeFlags.NuGetPackageDependency +
+                DependencyTreeFlags.PackageDependency +
                 DependencyTreeFlags.SupportsHierarchy +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
@@ -92,8 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedExpandedIcon);
             AssertEx.CollectionLength(model.DependencyIDs, 2);
             Assert.Equal(
-                DependencyTreeFlags.NuGetDependency +
-                DependencyTreeFlags.NuGetPackageDependency +
+                DependencyTreeFlags.PackageDependency +
                 DependencyTreeFlags.SupportsHierarchy +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
@@ -137,8 +135,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedExpandedIcon);
             AssertEx.CollectionLength(model.DependencyIDs, 2);
             Assert.Equal(
-                DependencyTreeFlags.NuGetDependency +
-                DependencyTreeFlags.NuGetPackageDependency +
+                DependencyTreeFlags.PackageDependency +
                 DependencyTreeFlags.SupportsHierarchy +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageUnknownDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageUnknownDependencyModelTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.QuestionMark, model.UnresolvedExpandedIcon);
             AssertEx.CollectionLength(model.DependencyIDs, 2);
             Assert.Equal(
-                DependencyTreeFlags.NuGetDependency +
+                DependencyTreeFlags.PackageUnknownDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SharedProjectDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SharedProjectDependencyModelTests.cs
@@ -36,11 +36,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.SharedProject, model.ExpandedIcon);
             Assert.Equal(ManagedImageMonikers.SharedProjectWarning, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.SharedProjectWarning, model.UnresolvedExpandedIcon);
-            Assert.True(model.Flags.Contains(DependencyTreeFlags.SharedProjectFlags));
+            Assert.True(model.Flags.Contains(DependencyTreeFlags.SharedProjectDependency));
             Assert.False(model.Flags.Contains(DependencyTreeFlags.SupportsRuleProperties));
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
-                DependencyTreeFlags.SharedProjectFlags +
+                DependencyTreeFlags.SharedProjectDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRuleProperties,
                 model.Flags);
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.SharedProjectWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
-                DependencyTreeFlags.SharedProjectFlags +
+                DependencyTreeFlags.SharedProjectDependency +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRuleProperties,
                 model.Flags);
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.SharedProjectWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
-                DependencyTreeFlags.SharedProjectFlags +
+                DependencyTreeFlags.SharedProjectDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRuleProperties -
                 DependencyTreeFlags.SupportsRemove,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SubTreeRootDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SubTreeRootDependencyModelTests.cs
@@ -17,11 +17,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 unresolvedIcon: KnownMonikers.AbsolutePosition,
                 unresolvedExpandedIcon: KnownMonikers.AbsolutePosition);
 
-            var model = new SubTreeRootDependencyModel(
+            var flag = ProjectTreeFlags.Create("Foo");
+
+            var model = new DependencyGroupModel(
                 "myProvider",
                 "myRoot",
                 iconSet,
-                ProjectTreeFlags.AlwaysCopyable);
+                flag);
 
             Assert.Equal("myProvider", model.ProviderType);
             Assert.Equal("myRoot", model.Path);
@@ -32,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.AboutBox, model.ExpandedIcon);
             Assert.Equal(KnownMonikers.AbsolutePosition, model.UnresolvedIcon);
             Assert.Equal(KnownMonikers.AbsolutePosition, model.UnresolvedExpandedIcon);
-            Assert.Equal(ProjectTreeFlags.AlwaysCopyable + DependencyTreeFlags.SubTreeRootNodeFlags, model.Flags);
+            Assert.Equal(flag + ProjectTreeFlags.VirtualFolder + DependencyTreeFlags.DependencyGroup, model.Flags);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 Implicit = true,
                 Visible = true,
                 Priority = 3,
-                Flags = DependencyTreeFlags.DependencyFlags.Union(DependencyTreeFlags.GenericDependency),
+                Flags = DependencyTreeFlags.GenericDependency,
                 Icon = KnownMonikers.Path,
                 ExpandedIcon = KnownMonikers.PathIcon,
                 UnresolvedIcon = KnownMonikers.PathListBox,
@@ -118,8 +118,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Assert.True(dependency.BrowseObjectProperties.ContainsKey("prop1"));
             Assert.Single(dependency.DependencyIDs);
             Assert.Equal("Tfm1\\xxx\\otherid", dependency.DependencyIDs[0]);
-            Assert.True(dependency.Flags.Contains(DependencyTreeFlags.Resolved));
-            Assert.True(dependency.Flags.Contains(DependencyTreeFlags.DependencyFlags));
+            Assert.Equal(DependencyTreeFlags.Resolved + DependencyTreeFlags.GenericDependency, dependency.Flags);
         }
 
         [Theory]
@@ -157,16 +156,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             var dependencyModel = new TestDependencyModel { ProviderType = "providerType", Id = "someId" };
 
             var dependency = new Dependency(dependencyModel, new TargetFramework("tfm1"), @"C:\Foo\Project.csproj");
+            var flags = ProjectTreeFlags.Create("TestFlag");
 
             var newDependency = dependency.SetProperties(
                 caption: "newcaption",
                 resolved: true,
-                flags: DependencyTreeFlags.BaseReferenceFlags,
+                flags: flags,
                 dependencyIDs: ImmutableArray.Create("aaa"));
 
             Assert.Equal("newcaption", newDependency.Caption);
             Assert.True(newDependency.Resolved);
-            Assert.True(newDependency.Flags.Equals(DependencyTreeFlags.BaseReferenceFlags));
+            Assert.True(newDependency.Flags.Equals(flags));
             Assert.Single(newDependency.DependencyIDs);
             Assert.Equal("aaa", newDependency.DependencyIDs[0]);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 new TestDependency
                 {
                     ClonePropertiesFrom = _acceptable,
-                    Flags = DependencyTreeFlags.SharedProjectFlags
+                    Flags = DependencyTreeFlags.SharedProjectDependency
                 },
                 projectItemSpecs: ImmutableHashSet<string>.Empty);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 Id = Dependency.GetID(targetFramework, PackageRuleHandler.ProviderTypeString, sdkName),
                 Resolved = true,
                 DependencyIDs = dependencyIDs,
-                Flags = DependencyTreeFlags.NuGetPackageDependency
+                Flags = DependencyTreeFlags.PackageDependency
             };
 
             var worldBuilder = new IDependency[] { sdkDependency, packageDependency }.ToImmutableDictionary(d => d.Id).ToBuilder();
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             {
                 Id = Dependency.GetID(targetFramework, PackageRuleHandler.ProviderTypeString, sdkName),
                 Resolved = false,
-                Flags = DependencyTreeFlags.NuGetPackageDependency
+                Flags = DependencyTreeFlags.PackageDependency
             };
 
             var worldBuilder = new IDependency[] { sdkDependency, packageDependency }.ToImmutableDictionary(d => d.Id).ToBuilder();
@@ -132,14 +132,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 Id = Dependency.GetID(targetFramework, SdkRuleHandler.ProviderTypeString, packageName),
                 TopLevel = false,
                 Resolved = true,
-                Flags = DependencyTreeFlags.NuGetPackageDependency.Union(DependencyTreeFlags.Unresolved) // to see if unresolved is fixed
+                Flags = DependencyTreeFlags.PackageDependency.Union(DependencyTreeFlags.Unresolved) // to see if unresolved is fixed
             };
 
             var packageDependency = new TestDependency
             {
                 Id = "packageId",
                 Name = packageName,
-                Flags = DependencyTreeFlags.NuGetPackageDependency,
+                Flags = DependencyTreeFlags.PackageDependency,
                 TopLevel = true,
                 Resolved = true,
                 DependencyIDs = dependencyIDs
@@ -190,7 +190,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             {
                 Id = "packageId",
                 Name = packageName,
-                Flags = DependencyTreeFlags.NuGetPackageDependency,
+                Flags = DependencyTreeFlags.PackageDependency,
                 TopLevel = true,
                 Resolved = true
             };

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnresolvedProjectReferenceSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnresolvedProjectReferenceSnapshotFilterTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             AssertNoChange(new TestDependency
             {
                 ClonePropertiesFrom = acceptable,
-                Flags = DependencyTreeFlags.ProjectDependency.Union(DependencyTreeFlags.SharedProjectFlags)
+                Flags = DependencyTreeFlags.ProjectDependency.Union(DependencyTreeFlags.SharedProjectDependency)
             });
 
             return;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/DependenciesTreeViewProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/DependenciesTreeViewProviderTests.cs
@@ -606,7 +606,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.TreeView
             var dependenciesRoot = new TestProjectTree
             {
                 Caption = "MyDependencies",
-                Flags = DependencyTreeFlags.DependenciesRootNodeFlags,
+                Flags = DependencyTreeFlags.DependenciesRootNode,
                 Children =
                 {
                     new TestProjectTree
@@ -667,7 +667,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.TreeView
             var dependenciesRoot = new TestProjectTree
             {
                 Caption = "MyDependencies",
-                Flags = DependencyTreeFlags.DependenciesRootNodeFlags,
+                Flags = DependencyTreeFlags.DependenciesRootNode,
                 Children =
                 {
                     new TestProjectTree
@@ -732,7 +732,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.TreeView
                     new TestProjectTree
                     {
                         Caption = "MyDependencies",
-                        Flags = DependencyTreeFlags.DependenciesRootNodeFlags,
+                        Flags = DependencyTreeFlags.DependenciesRootNode,
                         Children =
                         {
                             new TestProjectTree


### PR DESCRIPTION
- Renaming of dependency 'root' nodes to 'group' nodes.
- Renaming of 'NuGet packages' to 'packages'.
- Removal of public 'BaseReferenceFlags' item, which is unused across index.
- Inline a few aggregate flags.
- Remove general 'NuGetDependency' flag in favour of more specific alternatives.
- Clarify diagnostics as relating to packages.