### PR TITLE
Change nullablility of IVsXXService interfaces

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
@@ -48,10 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             await _projectVsServices.ThreadingService.SwitchToUIThread();
 
-            DTE2? dte = _dte.Value;
-            Assumes.Present(dte);
-
-            string templateFilePath = ((Solution2)dte.Solution).GetProjectItemTemplate(templateFile, templateLanguage);
+            string templateFilePath = ((Solution2)_dte.Value.Solution).GetProjectItemTemplate(templateFile, templateLanguage);
 
             if (templateFilePath != null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
@@ -198,8 +198,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 // The debugger needs to be called on the UI thread
                 await ThreadingService.SwitchToUIThread();
 
-                IVsDebugger4? shellDebugger = await _vsDebuggerService.GetValueAsync();
-                Assumes.Present(shellDebugger);
+                IVsDebugger4 shellDebugger = await _vsDebuggerService.GetValueAsync();
                 var launchResults = new VsDebugTargetProcessInfo[launchSettingsNative.Length];
                 shellDebugger.LaunchDebugTargets4((uint)launchSettingsNative.Length, launchSettingsNative, launchResults);
                 return launchResults;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/RemoteDebuggerAuthenticationService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/RemoteDebuggerAuthenticationService.cs
@@ -47,10 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 extraFlags |= provider.AdditionalRemoteDiscoveryDialogFlags;
             }
 
-            IVsDebugRemoteDiscoveryUI? remoteDiscoveryUIService = _remoteDiscoveryUIService.Value;
-            Assumes.Present(remoteDiscoveryUIService);
-
-            if (ErrorHandler.Succeeded(remoteDiscoveryUIService.SelectRemoteInstanceViaDlg(remoteDebugMachine, currentPortSupplier, extraFlags, out string remoteMachine, out Guid portSupplier)))
+            if (ErrorHandler.Succeeded(_remoteDiscoveryUIService.Value.SelectRemoteInstanceViaDlg(remoteDebugMachine, currentPortSupplier, extraFlags, out string remoteMachine, out Guid portSupplier)))
             {
                 remoteDebugMachine = remoteMachine;
                 remoteAuthenticationProvider = AuthenticationProviders.FirstOrDefaultValue(p => p.AuthenticationModeGuid.Equals(portSupplier));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -73,9 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             bool isDebuggable = await _launchProviders.Value.IsDebuggableAsync();
 
-            IVsStartupProjectsListService? startupProjectsListService = await _startupProjectsListService.GetValueAsync();
-
-            Assumes.Present(startupProjectsListService);
+            IVsStartupProjectsListService startupProjectsListService = await _startupProjectsListService.GetValueAsync();
 
             if (isDebuggable)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DteEnvironmentOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DteEnvironmentOptions.cs
@@ -23,10 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public T GetOption<T>(string category, string page, string option, T defaultValue)
         {
-            DTE2? dte = _dte.Value;
-            Assumes.Present(dte);
-
-            EnvDTE.Properties? properties = dte.Properties[category, page];
+            EnvDTE.Properties? properties = _dte.Value.Properties[category, page];
 
             if (properties != null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsService`1.cs
@@ -15,7 +15,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     ///     The type of the service to retrieve and return from <see cref="GetValueAsync"/>.
     /// </typeparam>
     [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
-    internal interface IVsService<T> where T : class
+    internal interface IVsService<T> 
+        where T : class?
     {
         /// <summary>
         ///     Gets the service object associated with <typeparamref name="T"/>.
@@ -37,6 +38,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// <exception cref="OperationCanceledException">
         ///     The result is awaited and <paramref name="cancellationToken"/> is cancelled.
         /// </exception>
-        Task<T?> GetValueAsync(CancellationToken cancellationToken = default);
+        Task<T> GetValueAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsService`2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsService`2.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IVsService<TService, TInterface> : IVsService<TInterface>
         where TService : class
-        where TInterface : class
+        where TInterface : class?
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsUIService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsUIService`1.cs
@@ -12,7 +12,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     ///     The type of the service to retrieve and return from <see cref="Value"/>.
     /// </typeparam>
     [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
-    internal interface IVsUIService<T> where T : class
+    internal interface IVsUIService<T> 
+        where T : class?
     {
         /// <summary>
         ///     Gets the service object associated with <typeparamref name="T"/>.
@@ -24,6 +25,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         ///     The service <see cref="object"/> associated with <typeparamref name="T"/>;
         ///     otherwise, <see langword="null"/> if it is not present.
         /// </value>
-        T? Value { get; }
+        T Value { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsUIService`2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsUIService`2.cs
@@ -16,7 +16,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IVsUIService<TService, TInterface> : IVsUIService<TInterface>
         where TService : class
-        where TInterface : class
+        where TInterface : class?
+
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractAddItemCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractAddItemCommandHandler.cs
@@ -52,8 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
             if (nodes.Count == 1 && _addItemDialogService.CanAddNewOrExistingItemTo(nodes.First()) && TryGetTemplateDetails(commandId, out TemplateDetails? result))
             {
-                IVsShell? vsShell = _vsShell.Value;
-                Assumes.Present(vsShell);
+                IVsShell vsShell = _vsShell.Value;
 
                 // Look up the resources from each package to get the strings to pass to the Add Item dialog.
                 // These strings must match what is used in the template exactly, including localized versions. Rather than relying on

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
@@ -70,7 +70,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             if (_buildManager == null)
             {
                 _buildManager = await _vsSolutionBuildManagerService.GetValueAsync();
-                Assumes.Present(_buildManager);
 
                 // Register for solution build events.
                 _buildManager.AdviseUpdateSolutionEvents(this, out _solutionEventsCookie);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/StartupProjectHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/StartupProjectHelper.cs
@@ -37,19 +37,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         /// </summary>
         public ImmutableArray<T> GetExportFromDotNetStartupProjects<T>(string capabilityMatch) where T : class
         {
-            DTE? dte = _dte.Value;
-            Assumes.Present(dte);
-
-            if (dte.Solution.SolutionBuild.StartupProjects is Array startupProjects && startupProjects.Length > 0)
+            if (_dte.Value.Solution.SolutionBuild.StartupProjects is Array startupProjects && startupProjects.Length > 0)
             {
-                IVsSolution? solution = _solution.Value;
-                Assumes.Present(solution);
-
                 var results = PooledArray<T>.GetInstance();
 
                 foreach (string projectName in startupProjects)
                 {
-                    solution.GetProjectOfUniqueName(projectName, out IVsHierarchy hier);
+                    _solution.Value.GetProjectOfUniqueName(projectName, out IVsHierarchy hier);
 
                     if (hier != null && hier.IsCapabilityMatch(capabilityMatch))
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowPaneProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowPaneProvider.cs
@@ -14,11 +14,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
         private static readonly Guid s_projectOutputWindowPaneGuid = new Guid("{A18568CC-CA90-4AEE-9D14-A7E9D753B544}");
 
         private readonly IProjectThreadingService _threadingService;
-        private readonly IVsUIService<IVsOutputWindow> _outputWindow;
+        private readonly IVsUIService<IVsOutputWindow?> _outputWindow;
         private readonly AsyncLazy<IVsOutputWindowPane?> _outputWindowPane;
 
         [ImportingConstructor]
-        public ProjectOutputWindowPaneProvider(IProjectThreadingService threadingService, IVsUIService<SVsOutputWindow, IVsOutputWindow> outputWindow)
+        public ProjectOutputWindowPaneProvider(IProjectThreadingService threadingService, IVsUIService<SVsOutputWindow, IVsOutputWindow?> outputWindow)
         {
             _threadingService = threadingService;
             _outputWindow = outputWindow;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
@@ -58,20 +58,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             await _joinableTaskContext.Factory.SwitchToMainThreadAsync(cancellationToken);
 
-            ISettingsManager? settingsManager = _settingsManager.Value;
-            Assumes.Present(settingsManager);
-
-            return settingsManager.GetValueOrDefault(name, defaultValue);
+            return _settingsManager.Value.GetValueOrDefault(name, defaultValue);
         }
 
         private async Task SetSettingValueAsync(string name, object value, CancellationToken cancellationToken)
         {
             await _joinableTaskContext.Factory.SwitchToMainThreadAsync(cancellationToken);
 
-            ISettingsManager? settingsManager = _settingsManager.Value;
-            Assumes.Present(settingsManager);
-
-            await settingsManager.SetValueAsync(name, value, isMachineLocal: false);
+            await _settingsManager.Value.SetValueAsync(name, value, isMachineLocal: false);
         }
 
         private bool IsEnvironmentVariableEnabled(string variable, ref bool? result)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Refactor/VisualStudioRefactorNotifyService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Refactor/VisualStudioRefactorNotifyService.cs
@@ -82,10 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Refactor
 
         private Project? TryGetProjectFromPath(string projectPath)
         {
-            DTE? dte = _dte.Value;
-            Assumes.NotNull(dte);
-
-            foreach (Project project in dte.Solution.Projects)
+            foreach (Project project in _dte.Value.Solution.Projects)
             {
                 string? fullName;
                 try
@@ -109,10 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Refactor
 
         private IVsHierarchy? TryGetIVsHierarchy(Project project)
         {
-            IVsSolution? solution = _solution.Value;
-            Assumes.Present(solution);
-
-            if (solution.GetProjectOfUniqueName(project.UniqueName, out IVsHierarchy projectHierarchy) == HResult.OK)
+            if (_solution.Value.GetProjectOfUniqueName(project.UniqueName, out IVsHierarchy projectHierarchy) == HResult.OK)
             {
                 return projectHierarchy;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/Renamer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/Renamer.cs
@@ -145,11 +145,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
 
                 IEnumerable<ProjectChanges> changes = renamedSolution.GetChanges(solution).GetProjectChanges();
 
-                DTE? dte = _dte.Value;
-
-                Assumes.Present(dte);
-
-                using var _ = UndoScope.Create(dte, renameOperationName);
+                using var _ = UndoScope.Create(_dte.Value, renameOperationName);
 
                 // Notify other VS features that symbol is about to be renamed
                 NotifyBeforeRename(newName, rqName, changes);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
@@ -91,8 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         {
             DesignTimeInputs designTimeInputs = input.Value;
 
-            IVsAsyncFileChangeEx? vsAsyncFileChangeEx = await _fileChangeService.GetValueAsync();
-            Assumes.Present(vsAsyncFileChangeEx);
+            IVsAsyncFileChangeEx vsAsyncFileChangeEx = await _fileChangeService.GetValueAsync();
 
             // we don't care about the difference between types of inputs, so we just construct one hashset for fast comparisons later
             var allFiles = new HashSet<string>(StringComparers.Paths);
@@ -154,8 +153,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                         // Wait for any processing to finish so we don't fight over the cookies 🍪
                         await _actionBlock.Completion;
 
-                        IVsAsyncFileChangeEx? vsAsyncFileChangeEx = await _fileChangeService.GetValueAsync();
-                        Assumes.Present(vsAsyncFileChangeEx);
+                        IVsAsyncFileChangeEx vsAsyncFileChangeEx = await _fileChangeService.GetValueAsync();
 
                         // Unsubscribe from all files
                         foreach (uint cookie in _fileWatcherCookies.Values)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/ProjectImports/ImportTreeCommandGroupHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/ProjectImports/ImportTreeCommandGroupHandler.cs
@@ -76,15 +76,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.ProjectImports
 
             void OpenItems()
             {
-                IVsUIShellOpenDocument? uiShellOpenDocument = _uiShellOpenDocument.Value;
-                Assumes.Present(uiShellOpenDocument);
-
-                IOleServiceProvider? oleServiceProvider = _oleServiceProvider.Value;
-                Assumes.Present(oleServiceProvider);
-
-                IVsExternalFilesManager? externalFilesManager = _externalFilesManager.Value;
-                Assumes.Present(externalFilesManager);
-
                 Assumes.NotNull(_configuredProject.UnconfiguredProject.Services.HostObject);
                 var hierarchy = (IVsUIHierarchy)_configuredProject.UnconfiguredProject.Services.HostObject;
                 var rdt = new RunningDocumentTable(_serviceProvider);
@@ -102,7 +93,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.ProjectImports
                         IntPtr docData = IntPtr.Zero;
 
                         ErrorHandler.ThrowOnFailure(
-                            uiShellOpenDocument!.OpenStandardEditor(
+                            _uiShellOpenDocument.Value.OpenStandardEditor(
                                 (uint)__VSOSEFLAGS.OSE_ChooseBestStdEditor,
                                 item.FilePath,
                                 ref logicalView,
@@ -110,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.ProjectImports
                                 hierarchy,
                                 item.GetHierarchyId(),
                                 docData,
-                                oleServiceProvider,
+                                _oleServiceProvider.Value,
                                 out windowFrame));
 
                         RunningDocumentInfo rdtInfo = rdt.GetDocumentInfo(item.FilePath);
@@ -126,7 +117,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.ProjectImports
 
                         // Detach the document from this project.
                         // Ignore failure. It may be that we've already transferred the item to Miscellaneous Files.
-                        externalFilesManager!.TransferDocument(item.FilePath, item.FilePath, windowFrame);
+                        _externalFilesManager.Value.TransferDocument(item.FilePath, item.FilePath, windowFrame);
 
                         // Show the document window
                         if (windowFrame != null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/AddItemDialogService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/AddItemDialogService.cs
@@ -15,10 +15,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UI
     {
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
         private readonly IPhysicalProjectTree _projectTree;
-        private readonly IVsUIService<IVsAddProjectItemDlg> _addProjectItemDialog;
+        private readonly IVsUIService<IVsAddProjectItemDlg?> _addProjectItemDialog;
 
         [ImportingConstructor]
-        public AddItemDialogService(IUnconfiguredProjectVsServices unconfiguredProjectVsServices, IPhysicalProjectTree projectTree, IVsUIService<SVsAddProjectItemDlg, IVsAddProjectItemDlg> addProjectItemDialog)
+        public AddItemDialogService(IUnconfiguredProjectVsServices unconfiguredProjectVsServices, IPhysicalProjectTree projectTree, IVsUIService<SVsAddProjectItemDlg, IVsAddProjectItemDlg?> addProjectItemDialog)
         {
             _projectVsServices = unconfiguredProjectVsServices;
             _projectTree = projectTree;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetector.cs
@@ -95,7 +95,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             VisualStudioVersion = await _shellUtilitiesHelper.Value.GetVSVersionAsync(_vsAppIdService);
 
             _vsSolution = await _vsSolutionService.GetValueAsync();
-            Assumes.Present(_vsSolution);
 
             Verify.HResult(_vsSolution.AdviseSolutionEvents(this, out _solutionCookie));
 
@@ -183,8 +182,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 return false;
             }
 
-            ISettingsManager? settings = await _settingsManagerService.GetValueAsync();
-            Assumes.Present(settings);
+            ISettingsManager settings = await _settingsManagerService.GetValueAsync();
 
             return settings.GetValueOrDefault<bool>(UsePreviewSdkSettingKey);
         }
@@ -271,20 +269,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 // Only want to warn once per solution
                 CompatibilityLevelWarnedForCurrentSolution = compatLevel;
 
-                IVsUIShell? uiShell = await _vsUIShellService.GetValueAsync();
-                Assumes.Present(uiShell);
-
+                IVsUIShell uiShell = await _vsUIShellService.GetValueAsync();
                 uiShell.GetAppName(out string caption);
 
                 if (compatLevel == CompatibilityLevel.Supported)
                 {
                     // Get current dontShowAgain value
-                    ISettingsManager? settingsManager = await _settingsManagerService.GetValueAsync();
-                    bool suppressPrompt = false;
-                    if (settingsManager != null)
-                    {
-                        suppressPrompt = settingsManager.GetValueOrDefault(SuppressDotNewCoreWarningKey, defaultValue: false);
-                    }
+                    ISettingsManager settingsManager = await _settingsManagerService.GetValueAsync();
+                    bool suppressPrompt = settingsManager.GetValueOrDefault(SuppressDotNewCoreWarningKey, defaultValue: false);
 
                     if (compatData.OpenSupportedPreviewMessage is null && isPreviewSDKInUse)
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsService`1.cs
@@ -16,9 +16,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     ///     Provides an implementation of <see cref="IVsService{T}"/> that calls into Visual Studio's <see cref="IAsyncServiceProvider"/>.
     /// </summary>
     [Export(typeof(IVsService<>))]
-    internal class VsService<T> : IVsService<T> where T : class
+    internal class VsService<T> : IVsService<T>
+        where T : class?
     {
-        private readonly AsyncLazy<T?> _value;
+        private readonly AsyncLazy<T> _value;
 
         [ImportingConstructor]
         public VsService([Import(typeof(SAsyncServiceProvider))]IAsyncServiceProvider serviceProvider, JoinableTaskContext joinableTaskContext)
@@ -26,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             Requires.NotNull(serviceProvider, nameof(serviceProvider));
             Requires.NotNull(joinableTaskContext, nameof(joinableTaskContext));
 
-            _value = new AsyncLazy<T?>(async () =>
+            _value = new AsyncLazy<T>(async () =>
             {
                 // If the service request requires a package load, GetServiceAsync will 
                 // happily do that on a background thread.
@@ -36,12 +37,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 // via blocking RPC for STA objects when we cast explicitly to the type
                 await joinableTaskContext.Factory.SwitchToMainThreadAsync();
 
-                return (T?)iunknown;
+                return (T)iunknown;
 
             }, joinableTaskContext.Factory);
         }
 
-        public Task<T?> GetValueAsync(CancellationToken cancellationToken = default)
+        public Task<T> GetValueAsync(CancellationToken cancellationToken = default)
         {
             return _value.GetValueAsync(cancellationToken);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsService`2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsService`2.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     [Export(typeof(IVsService<,>))]
     internal class VsService<TService, TInterface> : VsService<TInterface>, IVsService<TService, TInterface>
         where TService : class
-        where TInterface : class
+        where TInterface : class?
     {
         [ImportingConstructor]
         public VsService([Import(typeof(SAsyncServiceProvider))]IAsyncServiceProvider serviceProvider, JoinableTaskContext joinableTaskContext)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
@@ -37,10 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             await _threadingService.SwitchToUIThread(cancellationToken);
 
-            IVsSolution? solution = _solution.Value;
-            Assumes.Present(solution);
-
-            Verify.HResult(solution.AdviseSolutionEvents(this, out _cookie));
+            Verify.HResult(_solution.Value.AdviseSolutionEvents(this, out _cookie));
         }
 
         protected override async Task DisposeCoreAsync(bool initialized)
@@ -51,10 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 {
                     await _threadingService.SwitchToUIThread();
 
-                    IVsSolution? solution = _solution.Value;
-                    Assumes.Present(solution);
-
-                    Verify.HResult(solution.UnadviseSolutionEvents(_cookie));
+                    Verify.HResult(_solution.Value.UnadviseSolutionEvents(_cookie));
 
                     _cookie = VSConstants.VSCOOKIE_NIL;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsUIService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsUIService`1.cs
@@ -14,7 +14,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     ///     Provides an implementation of <see cref="IVsUIService{T}"/> that calls into Visual Studio's <see cref="IServiceProvider"/>.
     /// </summary>
     [Export(typeof(IVsUIService<>))]
-    internal class VsUIService<T> : IVsUIService<T> where T : class
+    internal class VsUIService<T> : IVsUIService<T>
+        where T : class?
     {
         private readonly Lazy<T> _value;
         private readonly JoinableTaskContext _joinableTaskContext;
@@ -29,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             _joinableTaskContext = joinableTaskContext;
         }
 
-        public T? Value
+        public T Value
         {
             get
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsUIService`2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsUIService`2.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     [Export(typeof(IVsUIService<,>))]
     internal class VsUIService<TService, TInterface> : VsUIService<TInterface>, IVsUIService<TService, TInterface>
         where TService : class
-        where TInterface : class
+        where TInterface : class?
     {
         [ImportingConstructor]
         public VsUIService([Import(typeof(SVsServiceProvider))]IServiceProvider serviceProvider, JoinableTaskContext joinableTaskContext)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitIndicator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitIndicator.cs
@@ -112,10 +112,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
 
         private IWaitContext StartWait(string title, string message, bool allowCancel)
         {
-            IVsThreadedWaitDialogFactory? vsThreadedWaitDialogFactory = _waitDialogFactoryService.Value;
-            Assumes.Present(vsThreadedWaitDialogFactory);
-
-            return new VisualStudioWaitContext(vsThreadedWaitDialogFactory, title, message, allowCancel);
+            return new VisualStudioWaitContext(_waitDialogFactoryService.Value, title, message, allowCancel);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsShellUtilitiesHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsShellUtilitiesHelper.cs
@@ -27,9 +27,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
         {
             await _threadingService.SwitchToUIThread();
 
-            IVsAppId? vsAppId = await vsAppIdService.GetValueAsync();
-
-            Assumes.Present(vsAppId);
+            IVsAppId vsAppId = await vsAppIdService.GetValueAsync();
 
             if (ErrorHandler.Succeeded(vsAppId.GetProperty((int)VSAPropID.VSAPROPID_ProductSemanticVersion, out object oVersion)) &&
                 oVersion is string semVersion)
@@ -54,9 +52,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
         {
             await _threadingService.SwitchToUIThread();
 
-            IVsShell? shell = await vsShellService.GetValueAsync();
-
-            Assumes.Present(shell);
+            IVsShell shell = await vsShellService.GetValueAsync();
 
             if (ErrorHandler.Succeeded(shell.GetProperty((int)__VSSPROPID4.VSSPROPID_LocalAppDataDir, out object value)))
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsServiceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsServiceFactory.cs
@@ -16,7 +16,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             return mock.Object;
         }
 
-        public static IVsService<TService, TInterface> Create<TService, TInterface>(TInterface? value) where TService : class where TInterface : class
+        public static IVsService<TService, TInterface> Create<TService, TInterface>(TInterface value) 
+            where TService : class where TInterface : class?
         {
             var mock = new Mock<IVsService<TService, TInterface>>();
             mock.Setup(s => s.GetValueAsync(It.IsAny<CancellationToken>()))

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsUIServiceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsUIServiceFactory.cs
@@ -15,7 +15,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             return mock.Object;
         }
 
-        public static IVsUIService<TService, TInterface> Create<TService, TInterface>(TInterface? value) where TService : class where TInterface : class
+        public static IVsUIService<TService, TInterface> Create<TService, TInterface>(TInterface value) where TService : class 
+            where TInterface : class?
         {
             var mock = new Mock<IVsUIService<TService, TInterface>>();
             mock.SetupGet(s => s.Value)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
@@ -181,9 +181,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             IActiveConfiguredProjectSubscriptionService? projectSubscriptionService = null,
             ActiveConfiguredProject<DebuggerLaunchProviders>? launchProviders = null)
         {
+
             var instance = new StartupProjectRegistrar(
                 null!,
-                IVsServiceFactory.Create<SVsStartupProjectsListService, IVsStartupProjectsListService>(vsStartupProjectsListService),
+                IVsServiceFactory.Create<SVsStartupProjectsListService, IVsStartupProjectsListService>(vsStartupProjectsListService!),
                 threadingService ?? IProjectThreadingServiceFactory.Create(),
                 projectGuidService ?? ISafeProjectGuidServiceFactory.ImplementGetProjectGuidAsync(Guid.NewGuid()),
                 projectSubscriptionService ?? IActiveConfiguredProjectSubscriptionServiceFactory.Create(),

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommandTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommandTests.cs
@@ -14,13 +14,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         [Fact]
         public void Constructor_NullAsUnconfiguredProject_ThrowsArgumentNull()
         {
-            Assert.Throws<ArgumentNullException>(() => CreateInstanceCore(null!, IProjectThreadingServiceFactory.Create(), IVsServiceFactory.Create<SVsSolutionBuildManager, IVsSolutionBuildManager2>(null), CreateGeneratePackageOnBuildPropertyProvider()));
+            Assert.Throws<ArgumentNullException>(() => CreateInstanceCore(null!, IProjectThreadingServiceFactory.Create(), IVsServiceFactory.Create<SVsSolutionBuildManager, IVsSolutionBuildManager2>(null!), CreateGeneratePackageOnBuildPropertyProvider()));
         }
 
         [Fact]
         public void Constructor_NullAsProjectThreadingServiceFactory_ThrowsArgumentNull()
         {
-            Assert.Throws<ArgumentNullException>(() => CreateInstanceCore(UnconfiguredProjectFactory.Create(), null!, IVsServiceFactory.Create<SVsSolutionBuildManager, IVsSolutionBuildManager2>(null), CreateGeneratePackageOnBuildPropertyProvider()));
+            Assert.Throws<ArgumentNullException>(() => CreateInstanceCore(UnconfiguredProjectFactory.Create(), null!, IVsServiceFactory.Create<SVsSolutionBuildManager, IVsSolutionBuildManager2>(null!), CreateGeneratePackageOnBuildPropertyProvider()));
         }
 
         [Fact]
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         [Fact]
         public void Constructor_NullAsGeneratePackageOnBuildPropertyProvider_ThrowsArgumentNull()
         {
-            Assert.Throws<ArgumentNullException>(() => CreateInstanceCore(UnconfiguredProjectFactory.Create(), IProjectThreadingServiceFactory.Create(), IVsServiceFactory.Create<SVsSolutionBuildManager, IVsSolutionBuildManager2>(null), null!));
+            Assert.Throws<ArgumentNullException>(() => CreateInstanceCore(UnconfiguredProjectFactory.Create(), IProjectThreadingServiceFactory.Create(), IVsServiceFactory.Create<SVsSolutionBuildManager, IVsSolutionBuildManager2>(null!), null!));
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryTests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             projectVsServices ??= IUnconfiguredProjectVsServicesFactory.Create();
             projectContextHost ??= IActiveWorkspaceProjectContextHostFactory.Create();
 
-            return new VsContainedLanguageComponentsFactory(IVsServiceFactory.Create<SAsyncServiceProvider, IOleAsyncServiceProvider>(serviceProvider),
+            return new VsContainedLanguageComponentsFactory(IVsServiceFactory.Create<SAsyncServiceProvider, IOleAsyncServiceProvider>(serviceProvider!),
                                                             projectVsServices,
                                                             projectContextHost);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Logging/ProjectOutputWindowPaneProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Logging/ProjectOutputWindowPaneProviderTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
         {
             threadingService ??= IProjectThreadingServiceFactory.Create();
 
-            var outputWindowService = IVsUIServiceFactory.Create<SVsOutputWindow, IVsOutputWindow>(outputWindow);
+            var outputWindowService = IVsUIServiceFactory.Create<SVsOutputWindow, IVsOutputWindow?>(outputWindow);
 
             return new ProjectOutputWindowPaneProvider(threadingService, outputWindowService);
         }


### PR DESCRIPTION
This changes the nullability of IVsXXServices interfaces to be determined by the importer of the service. Instead of:

``` C#
IVsUIService<IVsOutputWindow> outputWindow = ...

if (outputWindow.Value != null
{

}

```

and:

``` C#
IVsUIService<IVsOutputWindow> outputWindow = ...
Assumes.Present(outputWindow.Value);
```

We now move to:

``` C#
IVsUIService<IVsOutputWindow?> outputWindow = ...

if (outputWindow.Value != null
{
...
}
```

and:

``` C#
IVsUIService<IVsOutputWindow> outputWindow = ...
outputWindow.Value.ActivatePane(..)
```