### PR TITLE
Remove COMReferences capability for .NET Core < 3.0

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -90,7 +90,6 @@
     -->
     <ProjectCapability Include="
                           AssemblyReferences;
-                          COMReferences;
                           ProjectReferences;
                           SharedProjectReferences;
                           WinRTReferences;
@@ -103,6 +102,9 @@
                           SupportAvailableItemName;
                           IntegratedConsoleDebugging;
                           PersistDesignTimeDataOutOfProject;" />
+
+    <!-- COM references are not supported in .NET Core before 3.0 -->
+    <ProjectCapability Include="COMReferences" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0')" />
 
     <!-- Settings page capability -->
     <ProjectCapability Include="AppSettings" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"/>


### PR DESCRIPTION
#5906 caused the "COM" reference manager page to appear for .NET Core projects before 3.0, which is not supported.