### PR TITLE
Hide Reference Manager -> Extensions tab

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -19,9 +19,11 @@
 
     <!--This property sets the default output types supported by the project system.-->
     <SupportedOutputTypes Condition="'$(SupportedOutputTypes)' == ''">Exe;WinExe;Library</SupportedOutputTypes>
-
     <SuppressOutOfDateMessageOnBuild Condition="'$(SuppressOutOfDateMessageOnBuild)' == ''">true</SuppressOutOfDateMessageOnBuild>
-
+    
+    <!-- When using SDK-style projects, opt out of AssemblyFolderEx ("Extensions") tab under Assemblies category in Reference Manager -->
+    <AssemblyReferenceTabs Condition="'$(AssemblyReferenceTabs)' == '' And '$(UsingMicrosoftNETSdk)' == 'true'">TAB_ASSEMBLY_FRAMEWORK</AssemblyReferenceTabs>
+    
     <!-- Tells CPS which target to run for the Package solution build type -->
     <PackageAction Condition="'$(PackageAction)' == ''">Pack</PackageAction>
   </PropertyGroup>


### PR DESCRIPTION
[AssemblyFoldersEx](https://docs.microsoft.com/en-us/visualstudio/msbuild/registering-extensions-of-the-dotnet-framework?view=vs-2019) [isn't supported in SDK-based projects](https://github.com/dotnet/sdk/issues/994) and is always empty. This hides the tab when using SDK-based projects.