### PR TITLE
Cache flags applied to configuration nodes in dependencies tree

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/TargetDependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/TargetDependencyViewModel.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Immutable;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
@@ -8,13 +10,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal sealed class TargetDependencyViewModel : IDependencyViewModel
     {
+        private static ImmutableDictionary<string, ProjectTreeFlags> s_configurationFlags = ImmutableDictionary<string, ProjectTreeFlags>.Empty.WithComparers(StringComparer.Ordinal);
+
         private readonly bool _hasUnresolvedDependency;
 
         public TargetDependencyViewModel(ITargetFramework targetFramework, bool hasReachableVisibleUnresolvedDependency)
         {
             Caption = targetFramework.FriendlyName;
-            Flags = DependencyTreeFlags.DependencyConfigurationGroup.Add($"$TFM:{targetFramework.FullName}");
+            Flags = GetCachedFlags(targetFramework);
             _hasUnresolvedDependency = hasReachableVisibleUnresolvedDependency;
+
+            static ProjectTreeFlags GetCachedFlags(ITargetFramework targetFramework)
+            {
+                return ImmutableInterlocked.GetOrAdd(
+                    ref s_configurationFlags,
+                    targetFramework.FullName,
+                    fullName => DependencyTreeFlags.DependencyConfigurationGroup.Add($"$TFM:{fullName}"));
+            }
         }
 
         public string Caption { get; }


### PR DESCRIPTION
Prevents creating new `String`/`ImmutableHashSet<string>` instances to back `ProjectTreeFlags` instances on every project update.