### PR TITLE
Add launch profiles for VS Online

### DIFF
--- a/setup/ProjectSystemSetup/Properties/launchSettings.json
+++ b/setup/ProjectSystemSetup/Properties/launchSettings.json
@@ -35,6 +35,28 @@
         "COMPlus_ZapDisable": "1"
       },
       "nativeDebugging": true
+    },
+    "Start VS Online Server": {
+      "commandName": "Executable",
+      "executablePath": "$(DevEnvDir)devenv.exe",
+      "commandLineArgs": "<path_to_folder_or_solution> /rootsuffix $(VSSDKTargetPlatformRegRootSuffix) /server",
+      "environmentVariables": {
+        "VisualBasicDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.VisualBasic.DesignTime.targets",
+        "FSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.FSharp.DesignTime.targets",
+        "CSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.CSharp.DesignTime.targets",
+        "PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED": "1"
+      }
+    },
+    "Start VS Online Client": {
+      "commandName": "Executable",
+      "executablePath": "$(DevEnvDir)devenv.exe",
+      "commandLineArgs": "/rootsuffix $(VSSDKTargetPlatformRegRootSuffix) /client \"vsls:?workspaceId=<workspace_ID>&remoteJoin=true\"",
+      "environmentVariables": {
+        "VisualBasicDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.VisualBasic.DesignTime.targets",
+        "FSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.FSharp.DesignTime.targets",
+        "CSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.CSharp.DesignTime.targets",
+        "PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED": "1"
+      }
     }
   }
 }


### PR DESCRIPTION
Add launch profiles to make it a little easier to debug VS Online scenarios.

The server profile requires that you fill in a path to a folder or solution for the server to open when it launches, and the the client profile requires that you fill in the "workspace ID" of the server to connect to.

Note that the order of parameters is important. The solution/folder to open, if any, must always be the first argument to devenv.exe (both in local and online scenarios). "/rootsuffix" needs to be the first switch if you wish to debug an experimental instance. The VS Online-specific switches come after those.

Also note that the /server and /client switches seem to be incompatible with /log, or at least I could never find an order that allowed both to work properly.