### PR TITLE
Fix fast up-to-date check to detect app.config

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -421,7 +421,11 @@
       <UpToDateCheckBuilt Condition="'$(_DebugSymbolsProduced)'=='true' and '$(SkipCopyingSymbolsToOutputDirectory)' != 'true' and '$(CopyOutputSymbolsToOutputDirectory)' != 'false'" Include="@(_DebugSymbolsOutputPath)"/>
 
       <!-- app.config -->
-      <UpToDateCheckBuilt Condition=" '@(AppConfigWithTargetPath)' != '' " Include="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Original="@(AppConfigWithTargetPath)"/>
+      <!-- The property AppConfig, created in PrepareForBuild, is used instead of AppConfigWithTargetPath because GenerateSupportedRuntime
+           rewrites AppConfigWithTargetPath to point to the intermediate filename. This is needed because Fast up-to-date needs to compare
+           the timestamp of the source filename (AppConfig) with destination filename. 
+           https://github.com/microsoft/msbuild/blob/64c8e4a18e7cf7f064fbad304ea7ed877cdaa0a1/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1109-L1122 -->
+      <UpToDateCheckBuilt Condition=" '@(AppConfigWithTargetPath)' != '' " Include="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Original="$(AppConfig)"/>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This fixes https://github.com/dotnet/project-system/issues/5918
App.config was not taking into consideration in FUTD. The issue is that App.config was using the intermediate filename as a source.

This fix enables FUTD to check App.config.
The item AppConfigWithTargetPath now gets the application configuration filename from the property  AppConfig.
