### PR TITLE
Fix annotation warning

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -347,16 +346,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// IDeployedProjectItemMappingProvider
         /// Implemented so that we can map URL's back to local file item paths
         /// </summary>
-        public bool TryGetProjectItemPathFromDeployedPath(string deployedPath, [NotNullWhen(true)] out string? localPath)
+        public bool TryGetProjectItemPathFromDeployedPath(string deployedPath, out string? localPath)
         {
             // Just delegate to the last provider. It needs to figure out how best to map the items
-            localPath = null;
             if (LastLaunchProvider is IDeployedProjectItemMappingProvider deployedItemMapper)
             {
                 return deployedItemMapper.TryGetProjectItemPathFromDeployedPath(deployedPath, out localPath);
             }
 
             // Return false to allow normal processing
+            localPath = null;
             return false;
         }
     }


### PR DESCRIPTION
`TryGetProjectItemPathFromDeployedPath` can output `null` when returning `true`.