### PR TITLE
Fix compile warning

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
@@ -281,7 +281,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                 If Not obj Is PropertyControlData.MissingProperty Then
                     If Not obj Is PropertyControlData.Indeterminate Then
-                        bRegisterForCOM = If(CType(obj, String) = "", False, CType(obj, Boolean))
+                        bRegisterForCOM = CType(obj, String) IsNot "" AndAlso CType(obj, Boolean)
                     End If
 
                     chkRegisterForCOM.Checked = bRegisterForCOM


### PR DESCRIPTION
This is an automated codefix for IDE0075 _Visual Basic Conditional expression can be simplified_.

This started appearing in the output window during build.