### PR TITLE
Add Fast up-to-date the capability to detect project.assets.json

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
@@ -104,6 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             /// </list>
             /// <para>
             /// We need all <em>potential</em> paths for files which may start affecting build if they were to be added.
+            /// Any files not found on disk have MinValue dates.
             /// </para>
             /// </summary>
             /// <remarks>
@@ -112,12 +113,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             public IImmutableDictionary<string, DateTime> AdditionalDependentFileTimes { get; }
 
             /// <summary>
-            /// Gets the time at which the set of items in additionalDependentFileTimes changed (files added or removed).
+            /// Gets the time at which the set of items with non-<see cref="DateTime.MinValue"/> times
+            /// in <see cref="AdditionalDependentFileTimes"/> changed (files added or removed).
             /// </summary>
-            /// <remarks>
-            /// Additional dependent files are not required for compilation, but if present they might affect the compilation
-            /// output. e.g global.json, project.assets.json.
-            /// </remarks>
             public DateTime LastAdditionalDependentFileTimesChangedAtUtc { get; }
 
             private State()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
@@ -110,6 +110,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             /// The <see cref="DateTime"/> values here do not update dynamically.
             /// </remarks>
             public IImmutableDictionary<string, DateTime> AdditionalDependentFileTimes { get; }
+
+            /// <summary>
+            /// Gets the time at which the set of items in additionalDependentFileTimes changed (files added or removed).
+            /// </summary>
+            /// <remarks>
+            /// Additional dependent files are not required for compilation, but if present they might affect the compilation
+            /// output. e.g global.json, project.assets.json.
+            /// </remarks>
             public DateTime LastAdditionalDependentFileTimesChangedAtUtc { get; }
 
             private State()
@@ -200,10 +208,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 string? outputRelativeOrFullPath = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutDirProperty, msBuildProjectOutputPath);
                 string msBuildAllProjects = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildAllProjectsProperty, "");
 
-                var lastExistingAdditionalDependentFiles = AdditionalDependentFileTimes.Where(pair => pair.Value != DateTime.MinValue).Select(pair => pair.Key).ToImmutableHashSet();
+                var lastExistingAdditionalDependentFiles = AdditionalDependentFileTimes.Where(pair => pair.Value != default(DateTime)).Select(pair => pair.Key).ToImmutableHashSet();
                 IImmutableDictionary<string, DateTime> additionalDependentFileTimes = projectSnapshot.AdditionalDependentFileTimes;
 
-                var currentExistingAdditionalDependentFiles = additionalDependentFileTimes.Where(pair => pair.Value != DateTime.MinValue).Select(pair => pair.Key).ToImmutableHashSet();
+                var currentExistingAdditionalDependentFiles = additionalDependentFileTimes.Where(pair => pair.Value != default(DateTime)).Select(pair => pair.Key).ToImmutableHashSet();
                 bool AdditionalDependentFilesChanged = !lastExistingAdditionalDependentFiles.SetEquals(currentExistingAdditionalDependentFiles);
                 DateTime lastAdditionalDependentFileTimesChangedAtUtc = AdditionalDependentFilesChanged ? DateTime.UtcNow : LastAdditionalDependentFileTimesChangedAtUtc;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -164,11 +164,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return log.Fail("CopyAlwaysItemExists", "Item '{0}' has CopyToOutputDirectory set to 'Always', not up to date.", _configuredProject.UnconfiguredProject.MakeRooted(copyAlwaysItemPath));
             }
 
-
-            if (state.LastAdditionalDependentFileTimesChangedAtUtc > state.LastCheckedAtUtc)
-            {
-                return log.Fail("AdditionalDependentFiles", "Some additional dependent files are added or removed, not up to date.");
-            }
             return true;
         }
 
@@ -237,6 +232,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 if (earliestOutputTime < state.LastItemsChangedAtUtc)
                 {
                     return log.Fail("Outputs", "The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up to date.", state.LastItemsChangedAtUtc, earliestOutputPath, earliestOutputTime);
+                }
+
+                if (earliestOutputTime < state.LastAdditionalDependentFileTimesChangedAtUtc)
+                {
+                    return log.Fail("Outputs", "The set of AdditionalDependentFileTimes was changed more recently ({0}) than the earliest output '{1}' ({2}), not up to date.", state.LastAdditionalDependentFileTimesChangedAtUtc, earliestOutputPath, earliestOutputTime);
                 }
 
                 foreach ((string input, bool isRequired) in inputs)
@@ -648,6 +648,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             public void SetLastItemsChangedAtUtc(DateTime lastItemsChangedAtUtc)
             {
                 _check._state = _check._state.WithLastItemsChangedAtUtc(lastItemsChangedAtUtc);
+            }
+
+            public void SetLastAdditionalDependentFileTimesChangedAtUtc(DateTime lastAdditionalDependentFileTimesChangedAtUtc)
+            {
+                _check._state = _check._state.WithLastAdditionalDependentFilesChangedAtUtc(lastAdditionalDependentFileTimesChangedAtUtc);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -171,7 +171,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             }
 
 
-            if (state.AdditionalDependentFilesAddedOrRemoved)
+            if (state.LastAdditionalDependentFileTimesChangedAtUtc > state.LastCheckedAtUtc)
             {
                 return log.Fail("AdditionalDependentFiles", "Some additional dependent files are added or removed, not up to date.");
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -170,6 +170,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return log.Fail("CopyAlwaysItemExists", "Item '{0}' has CopyToOutputDirectory set to 'Always', not up to date.", _configuredProject.UnconfiguredProject.MakeRooted(copyAlwaysItemPath));
             }
 
+
+            if (state.AdditionalDependentFilesAddedOrRemoved)
+            {
+                return log.Fail("AdditionalDependentFiles", "Some additional dependent files are added or removed, not up to date.");
+            }
             return true;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -27,20 +27,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private const string DefaultSetName = "";
         private static readonly StringComparer s_setNameComparer = StringComparers.ItemNames;
 
-        private static ImmutableHashSet<string> ReferenceSchemas => ImmutableStringHashSet.EmptyOrdinal
+        private static ImmutableHashSet<string> ProjectPropertiesSchemas => ImmutableStringHashSet.EmptyOrdinal
+            .Add(ConfigurationGeneral.SchemaName)
             .Add(ResolvedAnalyzerReference.SchemaName)
-            .Add(ResolvedCompilationReference.SchemaName);
-
-        private static ImmutableHashSet<string> UpToDateSchemas => ImmutableStringHashSet.EmptyOrdinal
+            .Add(ResolvedCompilationReference.SchemaName)
             .Add(CopyUpToDateMarker.SchemaName)
             .Add(UpToDateCheckInput.SchemaName)
             .Add(UpToDateCheckOutput.SchemaName)
             .Add(UpToDateCheckBuilt.SchemaName);
-
-        private static ImmutableHashSet<string> ProjectPropertiesSchemas => ImmutableStringHashSet.EmptyOrdinal
-            .Add(ConfigurationGeneral.SchemaName)
-            .Union(ReferenceSchemas)
-            .Union(UpToDateSchemas);
 
         private static ImmutableHashSet<string> NonCompilationItemTypes => ImmutableHashSet<string>.Empty
             .WithComparer(StringComparers.ItemTypes)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -1177,11 +1177,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             };
 
             var lastAdditionalDependentFileTimesChanged = DateTime.UtcNow.AddMinutes(-4);
-            var itemChangeTime = DateTime.UtcNow.AddMinutes(-3);
-            var outputTime = DateTime.UtcNow.AddMinutes(-2);
-            var dependentTime = DateTime.UtcNow.AddMinutes(-1);
+            var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
+            var outputTime = DateTime.UtcNow.AddMinutes(-3);
+            var dependentTime = DateTime.UtcNow.AddMinutes(-2);
             // NOTE This delay is neeed to bypass lastAdditionalDependentFileTimesChangedAtUtc
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(0);
+            var lastCheckTime = DateTime.UtcNow.AddMinutes(-1);
 
             var dependentPath = @"C:\Dev\Solution\Project\Dependent";
             var outputPath = @"C:\Dev\Solution\Project\BuiltOutputPath1";
@@ -1209,11 +1209,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 [UpToDateCheckBuilt.SchemaName] = SimpleItems("Output")
             };
 
-            var lastAdditionalDependentFileTimesChanged = DateTime.UtcNow.AddMinutes(-4);
-            var itemChangeTime = DateTime.UtcNow.AddMinutes(-3);
-            var dependentTime = DateTime.UtcNow.AddMinutes(-2);
-            var outputTime = DateTime.UtcNow.AddMinutes(-1);
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(0);
+            var lastAdditionalDependentFileTimesChanged = DateTime.UtcNow.AddMinutes(-5);
+            var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
+            var dependentTime = DateTime.UtcNow.AddMinutes(-3);
+            var outputTime = DateTime.UtcNow.AddMinutes(-2);
+            var lastCheckTime = DateTime.UtcNow.AddMinutes(-1);
 
             var dependentPath = @"C:\Dev\Solution\Project\Dependent";
             var outputPath = @"C:\Dev\Solution\Project\Output";
@@ -1240,11 +1240,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 [UpToDateCheckBuilt.SchemaName] = SimpleItems("BuiltOutputPath1")
             };
 
-            var lastAdditionalDependentFileTimesChanged = DateTime.UtcNow.AddMinutes(-4);
-            var itemChangeTime = DateTime.UtcNow.AddMinutes(-3);
-            var dependentTime = DateTime.UtcNow.AddMinutes(-2);
-            var outputTime = DateTime.UtcNow.AddMinutes(-1);
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(0);
+            var lastAdditionalDependentFileTimesChanged = DateTime.UtcNow.AddMinutes(-5);
+            var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
+            var dependentTime = DateTime.UtcNow.AddMinutes(-3);
+            var outputTime = DateTime.UtcNow.AddMinutes(-2);
+            var lastCheckTime = DateTime.UtcNow.AddMinutes(-1);
 
             var dependentPath = @"C:\Dev\Solution\Project\Dependent";
             var outputPath = @"C:\Dev\Solution\Project\BuiltOutputPath1";

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -1100,10 +1100,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 [UpToDateCheckBuilt.SchemaName] = SimpleItems("Output")
             };
 
-            var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(-3);
+            var itemChangeTime = DateTime.UtcNow.AddMinutes(-3);
             var outputTime = DateTime.UtcNow.AddMinutes(-2);
             var dependentTime = DateTime.UtcNow.AddMinutes(-1);
+            // NOTE This delay is neeed to bypass lastAdditionalDependentFileTimesChangedAtUtc
+            var lastCheckTime = DateTime.UtcNow.AddMinutes(3);
 
             var dependentPath = @"C:\Dev\Solution\Project\Dependent";
             var outputPath = @"C:\Dev\Solution\Project\Output";
@@ -1133,7 +1134,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
             var dependentTime = DateTime.UtcNow.AddMinutes(-3);
             var outputTime = DateTime.UtcNow.AddMinutes(-2);
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(-1);
+            var lastCheckTime = DateTime.UtcNow.AddMinutes(3);
 
             var dependentPath = @"C:\Dev\Solution\Project\Dependent";
             var outputPath = @"C:\Dev\Solution\Project\Output";
@@ -1162,7 +1163,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
             var dependentTime = DateTime.UtcNow.AddMinutes(-3);
             var outputTime = DateTime.UtcNow.AddMinutes(-2);
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(-1);
+            var lastCheckTime = DateTime.UtcNow.AddMinutes(3);
 
             var dependentPath = @"C:\Dev\Solution\Project\Dependent";
             var outputPath = @"C:\Dev\Solution\Project\Output";

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -1100,11 +1100,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 [UpToDateCheckBuilt.SchemaName] = SimpleItems("BuiltOutputPath1")
             };
 
-            var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
-            var dependentTime = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(-3);
-            var lastAdditionalDependentFileTimesChanged = DateTime.UtcNow.AddMinutes(-2);
-            var outputTime = DateTime.UtcNow.AddMinutes(-1);
+            var itemChangeTime = DateTime.UtcNow.AddMinutes(-6);
+            var dependentTime = DateTime.UtcNow.AddMinutes(-5);
+            var lastCheckTime = DateTime.UtcNow.AddMinutes(-4);
+            var lastAdditionalDependentFileTimesChanged = DateTime.UtcNow.AddMinutes(-3);
+            var outputTime = DateTime.UtcNow.AddMinutes(-2);
 
             var dependentPath = @"C:\Dev\Solution\Project\Dependent";
             var outputPath = @"C:\Dev\Solution\Project\BuiltOutputPath1";
@@ -1124,7 +1124,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             // Remove dependentPath
             await SetupAsync(projectSnapshot: projectSnapshot);
 
-            lastAdditionalDependentFileTimesChanged = DateTime.UtcNow.AddMinutes(0);
+            lastAdditionalDependentFileTimesChanged = DateTime.UtcNow.AddMinutes(-1);
 
             _buildUpToDateCheck.TestAccess.SetLastItemsChangedAtUtc(itemChangeTime);
             _buildUpToDateCheck.TestAccess.SetLastAdditionalDependentFileTimesChangedAtUtc(lastAdditionalDependentFileTimesChanged);
@@ -1143,11 +1143,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 [UpToDateCheckBuilt.SchemaName] = SimpleItems("BuiltOutputPath1")
             };
 
-            var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(-3);
-            var outputTime = DateTime.UtcNow.AddMinutes(-2);
-            var dependentTime = DateTime.UtcNow.AddMinutes(-1);
-            var lastAdditionalDependentFileTimesChanged = DateTime.UtcNow.AddMinutes(0);
+            var itemChangeTime = DateTime.UtcNow.AddMinutes(-5);
+            var lastCheckTime = DateTime.UtcNow.AddMinutes(-4);
+            var outputTime = DateTime.UtcNow.AddMinutes(-3);
+            var dependentTime = DateTime.UtcNow.AddMinutes(-2);
+            var lastAdditionalDependentFileTimesChanged = DateTime.UtcNow.AddMinutes(-1);
 
             var dependentPath = @"C:\Dev\Solution\Project\Dependent";
             var outputPath = @"C:\Dev\Solution\Project\BuiltOutputPath1";

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -1101,9 +1101,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             };
 
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
-            var dependentTime = DateTime.UtcNow.AddMinutes(-3);
-            var outputTime = DateTime.UtcNow.AddMinutes(-2);
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(3);
+            var lastCheckTime = DateTime.UtcNow.AddMinutes(-3);
+            var dependentTime = DateTime.UtcNow.AddMinutes(-2);
+            var outputTime = DateTime.UtcNow.AddMinutes(-1);
 
             var dependentPath = @"C:\Dev\Solution\Project\Dependent";
             var outputPath = @"C:\Dev\Solution\Project\Output";
@@ -1116,9 +1116,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _fileSystem.AddFile(outputPath, outputTime);
             _buildUpToDateCheck.TestAccess.SetLastCheckedAtUtc(lastCheckTime);
             _buildUpToDateCheck.TestAccess.SetLastItemsChangedAtUtc(itemChangeTime);
-
-            await AssertUpToDateAsync(
-                $"No inputs are newer than earliest output '{outputPath}' ({outputTime.ToLocalTime()}).");
 
             // Remove dependentPath
             await SetupAsync(projectSnapshot: projectSnapshot);


### PR DESCRIPTION
Fixes #6006
Fixes [AB#1083953](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1083953)

The bug is that Fast up-to-date cannot detect when project.assets.json is deleted from the filesystem.
In case project.assets.json is missing FUTD will consider the project out of date.

This implementation take the output from Evaluation and keep a list (LastAdditionalDependentFileTimes) of the files in ApplicationDependentFileTimes that are present in the filesystem. In case projec.assets.json is deleted, then it compares the LastAdditionalDependentFileTimes with the current existing files.
In case FUTD is enabled, then it will check AdditionalDependentFilesAddedOrRemoved  to decide if the project is out of date or not.