### PR TITLE
Fast up-to-date convert relative path to absolute for item Analyzer in NetCore

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -318,7 +318,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 if (state.ResolvedAnalyzerReferencePaths.Count != 0)
                 {
                     log.Verbose("Adding " + ResolvedAnalyzerReference.SchemaName + " inputs:");
-                    foreach (string input in state.ResolvedAnalyzerReferencePaths)
+                    foreach (string input in state.ResolvedAnalyzerReferencePaths.Select(_configuredProject.UnconfiguredProject.MakeRooted))
                     {
                         log.Verbose("    '{0}'", input);
                         yield return (Path: input, IsRequired: true);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -604,13 +604,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var inputTime      = DateTime.UtcNow.AddMinutes(-2);
             var lastCheckTime  = DateTime.UtcNow.AddMinutes(-1);
 
-            _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\BuiltOutputPath1", outputTime);
-            _fileSystem.AddFile("Analyzer1ResolvedPath", inputTime);
+            var outputItem = "C:\\Dev\\Solution\\Project\\BuiltOutputPath1";
+            var analyzerItem = "C:\\Dev\\Solution\\Project\\Analyzer1ResolvedPath";
+
+            _fileSystem.AddFile(outputItem, outputTime);
+            _fileSystem.AddFile(analyzerItem, inputTime);
             _buildUpToDateCheck.TestAccess.SetLastCheckedAtUtc(lastCheckTime);
             _buildUpToDateCheck.TestAccess.SetLastItemsChangedAtUtc(itemChangeTime);
 
             await AssertNotUpToDateAsync(
-                $"Input 'Analyzer1ResolvedPath' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({outputTime.ToLocalTime()}), not up to date.",
+                $"Input '{analyzerItem}' is newer ({inputTime.ToLocalTime()}) than earliest output '{outputItem}' ({outputTime.ToLocalTime()}), not up to date.",
                 "Outputs");
         }
 


### PR DESCRIPTION
Fixes #4117 

This fixes the case when adding item Analyzer as a relative paths in in csproj