### PR TITLE
Add new file system methods for getting file write times

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -163,25 +162,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 
             return new RestoreData(
                 restoreInfo.ProjectAssetsFilePath,
-                GetLastWriteTimeUtc(restoreInfo.ProjectAssetsFilePath), succeeded: succeeded);
-        }
-
-        private DateTime GetLastWriteTimeUtc(string path)
-        {
-            Assumes.NotNullOrEmpty(path);
-
-            try
-            {
-                return _fileSystem.LastFileWriteTimeUtc(path);
-            }
-            catch (IOException)
-            {
-            }
-            catch (UnauthorizedAccessException)
-            {
-            }
-
-            return DateTime.MinValue;
+                _fileSystem.GetLastFileWriteTimeOrMinValueUtc(restoreInfo.ProjectAssetsFilePath), succeeded: succeeded);
         }
 
         public Task LoadAsync()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.cs
@@ -282,28 +282,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
         private bool CompilationNeeded(HashSet<string> files, string outputFileName)
         {
-            if (!_fileSystem.FileExists(outputFileName))
+            if (!_fileSystem.TryGetLastFileWriteTimeUtc(outputFileName, out DateTime? outputDateTime))
+                return true; // File does not exist
+            
+            foreach (string file in files)
             {
-                return true;
+                DateTime fileDateTime = _fileSystem.GetLastFileWriteTimeOrMinValueUtc(file);
+                if (fileDateTime > outputDateTime)
+                    return true;
             }
-
-            try
-            {
-                DateTime outputDateTime = _fileSystem.LastFileWriteTimeUtc(outputFileName);
-
-                foreach (string file in files)
-                {
-                    DateTime fileDateTime = _fileSystem.LastFileWriteTimeUtc(file);
-                    if (fileDateTime > outputDateTime)
-                        return true;
-                }
-            }
-            // if we can't read the file time of the output file, then we presumably can't compile to it either, so returning false is appropriate.
-            // if we can't read the file time of an input file, then we presumably can't read from it to compile either, so returning false is appropriate
-            catch (IOException)
-            { }
-            catch (UnauthorizedAccessException)
-            { }
 
             return false;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Web/RemoteCacheFile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Web/RemoteCacheFile.cs
@@ -26,8 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
 
         public bool CacheFileIsStale()
         {
-            return !_fileSystem.FileExists(_cacheFilePath) ||
-                   _fileSystem.LastFileWriteTimeUtc(_cacheFilePath).Add(_cacheExpiration) < DateTime.UtcNow;
+            return _fileSystem.GetLastFileWriteTimeOrMinValueUtc(_cacheFilePath).Add(_cacheExpiration) < DateTime.UtcNow;
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using Microsoft.VisualStudio.Composition;
@@ -24,7 +25,23 @@ namespace Microsoft.VisualStudio.IO
         void WriteAllText(string path, string content);
         void WriteAllText(string path, string content, Encoding encoding);
         void WriteAllBytes(string path, byte[] bytes);
-        DateTime LastFileWriteTimeUtc(string path);
+
+
+        /// <summary>
+        ///     Return the date and time, in coordinated universal time (UTC), that the specified file or directory was last written to, 
+        ///     or <see cref="DateTime.MinValue"/> if the path does not exist or is not accessible.
+        /// </summary>
+        DateTime GetLastFileWriteTimeOrMinValueUtc(string path);
+
+        /// <summary>
+        ///     Return the date and time, in coordinated universal time (UTC), that the specified file or directory was last written to, 
+        ///     indicating if the path exists and is accessible.
+        /// </summary>
+        /// <returns>
+        ///     <see langword="true"/> if <paramref name="path"/> exists and is accessible; otherwise, <see langword="false"/>.
+        /// </returns>
+        bool TryGetLastFileWriteTimeUtc(string path, [NotNullWhen(true)]out DateTime? result);
+
         long FileLength(string filename);
 
         bool DirectoryExists(string path);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.TimestampCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.TimestampCache.cs
@@ -26,12 +26,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 if (!_timestampCache.TryGetValue(path, out DateTime time))
                 {
-                    if (!_fileSystem.FileExists(path))
+                    if (!_fileSystem.TryGetLastFileWriteTimeUtc(path, out DateTime? newTime))
                     {
                         return null;
                     }
 
-                    time = _fileSystem.LastFileWriteTimeUtc(path);
+                    time = newTime.Value;
                     _timestampCache[path] = time;
                 }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/IO/Win32FileSystemTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/IO/Win32FileSystemTests.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.VisualStudio.IO
+{
+    public class Win32FileSystemTests
+    {
+        [Fact]
+        public void GetLastFileWriteTimeOrMinValueUtc_WhenPathDoesNotExist_ReturnsDateTimeMinValue()
+        {
+            var fileSystem = CreateInstance();
+
+            DateTime result = fileSystem.GetLastFileWriteTimeOrMinValueUtc("This path does not exist!");
+
+            Assert.Equal(result, DateTime.MinValue);
+        }
+
+        [Fact]
+        public void TryGetLastFileWriteTimeUtc_WhenPathDoesNotExist_ReturnsFalse()
+        {
+            var fileSystem = CreateInstance();
+
+            bool value = fileSystem.TryGetLastFileWriteTimeUtc("This path does not exist!", out DateTime? result);
+
+            Assert.False(value);
+            Assert.Null(result);
+        }
+
+        private Win32FileSystem CreateInstance()
+        {
+            return new Win32FileSystem();
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -221,9 +222,26 @@ namespace Microsoft.VisualStudio.IO
             }
         }
 
-        public DateTime LastFileWriteTimeUtc(string path)
+        public DateTime GetLastFileWriteTimeOrMinValueUtc(string path)
         {
-            return Files[path].LastWriteTimeUtc;
+            if (TryGetLastFileWriteTimeUtc(path, out DateTime? result))
+            {
+                return result.Value;
+            }
+
+            return DateTime.MinValue;
+        }
+
+        public bool TryGetLastFileWriteTimeUtc(string path, [NotNullWhen(true)]out DateTime? result)
+        {
+            if (Files.TryGetValue(path, out FileData value))
+            {
+                result = value.LastWriteTimeUtc;
+                return true;
+            }
+
+            result = null;
+            return false;
         }
 
         public void RemoveDirectory(string directoryPath, bool recursive)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -266,7 +266,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             moqFS.WriteAllText(provider.LaunchSettingsFile, JsonString1);
 
             Assert.True(await provider.SettingsFileHasChangedAsyncTest());
-            provider.LastSettingsFileSyncTimeTest = moqFS.LastFileWriteTimeUtc(provider.LaunchSettingsFile);
+            provider.LastSettingsFileSyncTimeTest = moqFS.GetLastFileWriteTimeOrMinValueUtc(provider.LaunchSettingsFile);
             Assert.False(await provider.SettingsFileHasChangedAsyncTest());
         }
 
@@ -373,7 +373,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             await provider.SaveSettingsToDiskAsyncTest(testSettings.Object);
 
             // Last Write time should be set
-            Assert.Equal(moqFS.LastFileWriteTimeUtc(provider.LaunchSettingsFile), provider.LastSettingsFileSyncTimeTest);
+            Assert.Equal(moqFS.GetLastFileWriteTimeOrMinValueUtc(provider.LaunchSettingsFile), provider.LastSettingsFileSyncTimeTest);
 
             // Check disk contents
             Assert.Equal(JsonStringWithWebSettings, moqFS.ReadAllText(provider.LaunchSettingsFile), ignoreLineEndingDifferences: true);
@@ -425,7 +425,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             // Write new file, but set the timestamp to match
             moqFS.WriteAllText(provider.LaunchSettingsFile, JsonStringWithWebSettings);
-            provider.LastSettingsFileSyncTimeTest = moqFS.LastFileWriteTimeUtc(provider.LaunchSettingsFile);
+            provider.LastSettingsFileSyncTimeTest = moqFS.GetLastFileWriteTimeOrMinValueUtc(provider.LaunchSettingsFile);
             Assert.Equal(provider.LaunchSettingsFile_ChangedTest(), Task.CompletedTask);
             AssertEx.CollectionLength(provider.CurrentSnapshot.Profiles, 4);
 


### PR DESCRIPTION
We had races between checking that a file exists and reading its last write time, meaning that we could end up with DateTime.FromFileTime(0) in caches and fields.

Add two methods for the common usage in the tree, and treat situations where file cannot be accessed the same as the file not existing.