### PR TITLE
Fix disposal of SolutionService

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/SolutionService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/SolutionService.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -12,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     /// <inheritdoc cref="ISolutionService"/>
     [Export(typeof(ISolutionService))]
     [Export(typeof(IPackageService))]
-    internal sealed class SolutionService : ISolutionService, IVsSolutionEvents, IVsPrioritizedSolutionEvents, IPackageService
+    internal sealed class SolutionService : ISolutionService, IVsSolutionEvents, IVsPrioritizedSolutionEvents, IPackageService, IDisposable
     {
         private readonly JoinableTaskContext _context;
         private IVsSolution? _solution;


### PR DESCRIPTION
This type should be disposed when the solution is unloaded, but did not declare `IDisposable` in its interface list, so its `Dispose` method was never called.