### PR TITLE
Fix some differences from the old Microsoft.VisualStudio.Editors.pkgdef

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AddImportsDialogService.vb
+++ b/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AddImportsDialogService.vb
@@ -1,11 +1,9 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 Imports System.Windows.Forms
-Imports Microsoft.VisualStudio.Shell
 Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.Editors.AddImports
-    <ProvideService(GetType(IVBAddImportsDialogService), ServiceName:="Add Imports Dialog Service")>
     Friend Class AddImportsDialogService
         Implements IVBAddImportsDialogService
 

--- a/src/Microsoft.VisualStudio.Editors/AttributeEditor/PermissionSetService.vb
+++ b/src/Microsoft.VisualStudio.Editors/AttributeEditor/PermissionSetService.vb
@@ -8,7 +8,6 @@ Imports System.Security.Permissions
 Imports System.Xml
 
 Imports Microsoft.Build.Tasks.Deployment.ManifestUtilities
-Imports Microsoft.VisualStudio.Shell
 Imports Microsoft.VisualStudio.Shell.Design.Serialization
 
 Imports NativeMethods = Microsoft.VisualStudio.Editors.Interop.NativeMethods
@@ -21,7 +20,6 @@ Namespace Microsoft.VisualStudio.Editors.VBAttributeEditor
     '   exposed via the IVbPermissionSetService interface.
     '--------------------------------------------------------------------------
     <CLSCompliant(False)>
-    <ProvideService(GetType(Interop.IVbPermissionSetService), ServiceName:="Vb Permission Set Service")>
     Friend NotInheritable Class PermissionSetService
         Implements Interop.IVbPermissionSetService
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialogService.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialogService.vb
@@ -1,9 +1,7 @@
-' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 Option Strict On
 Option Explicit On
-
-Imports Microsoft.VisualStudio.Shell
 
 Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
@@ -13,7 +11,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     '   exposed via the IVsBuildEventCommandLineDialogService interface.
     '--------------------------------------------------------------------------
     <CLSCompliant(False)>
-    <ProvideService(GetType(Interop.IVsBuildEventCommandLineDialogService), ServiceName:="Vb Build Event Command Line Dialog Service")>
     Friend NotInheritable Class BuildEventCommandLineDialogService
         Implements Interop.IVsBuildEventCommandLineDialogService
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorFactory.vb
@@ -21,8 +21,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     <CLSCompliant(False),
     Guid("ff4d6aca-9352-4a5f-821e-f4d6ebdcab11"),
     Shell.ProvideView(Shell.LogicalView.Designer, "Design"),
-    Shell.ProvideEditorExtension(GetType(ResourceEditorFactory), ".resw", 48),
-    Shell.ProvideEditorExtension(GetType(ResourceEditorFactory), ".resx", 48)>
+    Shell.ProvideEditorExtension(GetType(ResourceEditorFactory), ".resw", &H30),
+    Shell.ProvideEditorExtension(GetType(ResourceEditorFactory), ".resx", &H30)>
     Friend NotInheritable Class ResourceEditorFactory
         Inherits DesignerFramework.BaseEditorFactory
         Implements IVsTrackProjectDocumentsEvents2

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRefactorNotify.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRefactorNotify.vb
@@ -6,7 +6,6 @@ Option Compare Binary
 Imports System.Runtime.InteropServices
 
 Imports Microsoft.VisualStudio.Editors.Interop
-Imports Microsoft.VisualStudio.Shell
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports Microsoft.VSDesigner.Common
 
@@ -20,7 +19,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     ''' </summary>
     <CLSCompliant(False),
     Guid("0407F754-C199-403e-B89B-1D8E1FF3DC79"),
-    ProvideService(GetType(ResourceEditorRefactorNotify), ServiceName:="ResX RefactorNotify Service"),
     ProvideRefactorNotify(GetType(ResourceEditorRefactorNotify), ".resx", "E24C65DC-7377-472b-9ABA-BC803B73C61A")>
     Friend NotInheritable Class ResourceEditorRefactorNotify
         Implements IVsRefactorNotify

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerEditorFactory.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     ''' </summary>
     <Guid(SettingsDesignerEditorFactory.EditorGuidString),
     ProvideView(LogicalView.Designer, "Design"),
-    ProvideEditorExtension(GetType(SettingsDesignerEditorFactory), ".settings", 30)>
+    ProvideEditorExtension(GetType(SettingsDesignerEditorFactory), ".settings", &H30)>
     Friend NotInheritable Class SettingsDesignerEditorFactory
         Inherits DesignerFramework.BaseEditorFactory
 

--- a/src/Microsoft.VisualStudio.Editors/VBRefChangedSvc/VBReferenceChangedService.vb
+++ b/src/Microsoft.VisualStudio.Editors/VBRefChangedSvc/VBReferenceChangedService.vb
@@ -5,7 +5,6 @@ Option Explicit On
 Imports System.Runtime.InteropServices
 
 Imports Microsoft.VisualStudio.Editors.Interop
-Imports Microsoft.VisualStudio.Shell
 Imports Microsoft.VisualStudio.Shell.Interop
 
 Namespace Microsoft.VisualStudio.Editors.VBRefChangedSvc
@@ -21,7 +20,6 @@ Namespace Microsoft.VisualStudio.Editors.VBRefChangedSvc
     '''   and Microsoft.VisualStudio.Editors.vbexpress.vrg_33310.ddr.
     ''' </remarks>
     <CLSCompliant(False)>
-    <ProvideService(GetType(Interop.IVbReferenceChangedService), ServiceName:="VB Project Reference Changed Service")>
     Friend Class VBReferenceChangedService
         Implements Interop.IVbReferenceChangedService
 

--- a/src/Microsoft.VisualStudio.Editors/XmlIntellisense/XmlIntellisense.vb
+++ b/src/Microsoft.VisualStudio.Editors/XmlIntellisense/XmlIntellisense.vb
@@ -29,7 +29,6 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
     '   thread.
     '--------------------------------------------------------------------------
     <ClassInterface(ClassInterfaceType.None)>
-    <Shell.ProvideService(GetType(IXmlIntellisenseService), ServiceName:="Vb Xml Intellisense Service")>
     Friend NotInheritable Class XmlIntellisenseService
         Implements IXmlIntellisenseService
 

--- a/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
@@ -38,6 +38,12 @@ Namespace Microsoft.VisualStudio.Editors
     ProvideEditorFactory(GetType(SettingsDesigner.SettingsDesignerEditorFactory), 1200, True, TrustLevel:=__VSEDITORTRUSTLEVEL.ETL_AlwaysTrusted, CommonPhysicalViewAttributes:=3),
     ProvideEditorFactory(GetType(PropPageDesigner.PropPageDesignerEditorFactory), 1400, False, TrustLevel:=__VSEDITORTRUSTLEVEL.ETL_AlwaysTrusted),
     ProvideEditorFactory(GetType(ResourceEditor.ResourceEditorFactory), 1100, True, TrustLevel:=__VSEDITORTRUSTLEVEL.ETL_AlwaysTrusted, CommonPhysicalViewAttributes:=3),
+    ProvideService(GetType(ResourceEditor.ResourceEditorRefactorNotify), ServiceName:="ResX RefactorNotify Service"),
+    ProvideService(GetType(AddImports.IVBAddImportsDialogService), ServiceName:="Add Imports Dialog Service"),
+    ProvideService(GetType(XmlIntellisense.IXmlIntellisenseService), ServiceName:="Vb Xml Intellisense Service"),
+    ProvideService(GetType(VBAttributeEditor.Interop.IVbPermissionSetService), ServiceName:="Vb Permission Set Service"),
+    ProvideService(GetType(Interop.IVsBuildEventCommandLineDialogService), ServiceName:="Vb Build Event Command Line Dialog Service"),
+    ProvideService(GetType(VBRefChangedSvc.Interop.IVbReferenceChangedService), ServiceName:="VB Project Reference Changed Service"),
     ProvideKeyBindingTable(Constants.MenuConstants.GUID_SETTINGSDESIGNER_CommandUIString, 1200, AllowNavKeyBinding:=False),
     ProvideKeyBindingTable(Constants.MenuConstants.GUID_RESXEditorCommandUIString, 1100, AllowNavKeyBinding:=False),
     CLSCompliant(False)


### PR DESCRIPTION
Fixes #6035

When porting things from pkgdef to attributes I missed that the editor extension rank for the settings designer was specified in hex. I've fixed this and made it more clear for the resource editor too.

In fixing that, I noticed a few other things that were wrong, so fixed them too. Basically I forgot to compare key values last time, just existence of keys.