### PR TITLE
Remove unused ITargetFramework code

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TargetFrameworkProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TargetFrameworkProvider.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-using System.Linq;
 using System.Runtime.Versioning;
 using NuGet.VisualStudio;
 
@@ -13,7 +11,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     [Export(typeof(ITargetFrameworkProvider))]
     internal sealed class TargetFrameworkProvider : ITargetFrameworkProvider
     {
-        private readonly IVsFrameworkCompatibility _nuGetComparer;
         private readonly IVsFrameworkParser _nuGetFrameworkParser;
 
         /// <summary>
@@ -23,11 +20,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         private ImmutableDictionary<string, ITargetFramework> _targetFrameworkByName = ImmutableDictionary.Create<string, ITargetFramework>(StringComparer.Ordinal);
 
         [ImportingConstructor]
-        public TargetFrameworkProvider(
-            IVsFrameworkCompatibility nugetComparer,
-            IVsFrameworkParser nugetFrameworkParser)
+        public TargetFrameworkProvider(IVsFrameworkParser nugetFrameworkParser)
         {
-            _nuGetComparer = nugetComparer;
             _nuGetFrameworkParser = nugetFrameworkParser;
         }
 
@@ -84,33 +78,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 // Note: catching all exceptions and return a generic TargetFramework for given shortOrFullName
                 return new TargetFramework(shortOrFullName);
             }
-        }
-
-        public ITargetFramework? GetNearestFramework(
-            ITargetFramework? targetFramework,
-            IEnumerable<ITargetFramework>? otherFrameworks)
-        {
-            if (targetFramework?.FrameworkName == null || otherFrameworks == null)
-            {
-                return null;
-            }
-
-            var others = otherFrameworks.Where(other => other.FrameworkName != null).ToList();
-
-            if (others.Count == 0)
-            {
-                return null;
-            }
-
-            FrameworkName? nearestFrameworkName = _nuGetComparer.GetNearest(
-                targetFramework.FrameworkName, others.Select(x => x.FrameworkName));
-
-            if (nearestFrameworkName == null)
-            {
-                return null;
-            }
-
-            return others.FirstOrDefault((other, nearest) => nearest.Equals(other.FrameworkName), nearestFrameworkName);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/ITargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/ITargetFramework.cs
@@ -1,18 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.Runtime.Versioning;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal interface ITargetFramework : IEquatable<ITargetFramework?>,
                                           IEquatable<string?>
     {
-        /// <summary>
-        /// Basic target framework info. Can be <see langword="null" /> if the framework is unknown.
-        /// </summary>
-        FrameworkName? FrameworkName { get; }
-
         /// <summary>
         /// Gets the full moniker (TFM).
         /// </summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/ITargetFrameworkProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/ITargetFrameworkProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System.Collections.Generic;
 using Microsoft.VisualStudio.Composition;
 
 namespace Microsoft.VisualStudio.ProjectSystem
@@ -13,11 +12,5 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// instance, or <see langword="null" /> if the framework name has an invalid format.
         /// </summary>
         ITargetFramework? GetTargetFramework(string? shortOrFullName);
-
-        /// <summary>
-        /// Returns the item in <paramref name="otherFrameworks"/> that is most compatible/closest to
-        /// <paramref name="targetFramework"/>, or <see langword="null" /> if none are compatible.
-        /// </summary>
-        ITargetFramework? GetNearestFramework(ITargetFramework? targetFramework, IEnumerable<ITargetFramework>? otherFrameworks);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
@@ -17,7 +17,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             Requires.NotNull(frameworkName, nameof(frameworkName));
 
-            FrameworkName = frameworkName;
             FullName = frameworkName.FullName;
             ShortName = shortName ?? string.Empty;
             FriendlyName = $"{frameworkName.Identifier} {frameworkName.Version}";
@@ -36,8 +35,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
             ShortName = moniker;
             FriendlyName = moniker;
         }
-
-        public FrameworkName? FrameworkName { get; }
 
         public string FullName { get; }
 


### PR DESCRIPTION
Contributes towards #4886.

- Removes `ITargetFrameworkProvider.GetNearestFramework`
- Removes `ITargetFramework.FrameworkName`