### PR TITLE
Enable AppSettings project capability for WPF/WinForms

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -109,7 +109,7 @@
     <ProjectCapability Include="COMReferences" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0')" />
 
     <!-- Settings page capability -->
-    <ProjectCapability Include="AppSettings" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"/>
+    <ProjectCapability Include="AppSettings" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(UseWPF)' == 'true' Or '$(UseWindowsForms)' == 'true' "/>
 
     <!-- Publish capability enables the Publish command for the Project -->
     <ProjectCapability Include="Publish"/>


### PR DESCRIPTION
In Core the necessary ConfigurationManager dependency is always present for WinForms and WPF projects.

https://github.com/dotnet/winforms-designer/issues/356 is the WinForms designer issue for this.

I've manually tested this and everything seems fine, with or without a preexisting app.config.