### PR TITLE
Treat missing assets file as failure

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
@@ -162,9 +162,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             if (projectAssetsFilePath.Length == 0)
                 return new RestoreData(string.Empty, DateTime.MinValue, succeeded: false);
 
+            DateTime lastWriteTime = _fileSystem.GetLastFileWriteTimeOrMinValueUtc(projectAssetsFilePath);
+
             return new RestoreData(
                 projectAssetsFilePath,
-                _fileSystem.GetLastFileWriteTimeOrMinValueUtc(projectAssetsFilePath), succeeded: succeeded);
+                lastWriteTime,
+                succeeded: succeeded && lastWriteTime != DateTime.MinValue);
         }
 
         public Task LoadAsync()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
@@ -154,15 +154,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 
         private RestoreData CreateRestoreData(ProjectRestoreInfo restoreInfo, bool succeeded)
         {
+            string projectAssetsFilePath = restoreInfo.ProjectAssetsFilePath;
+
             // Restore service gives us a guarantee that the assets file
             // will contain *at least* the changes that we pushed to it.
 
-            if (restoreInfo.ProjectAssetsFilePath.Length == 0)
+            if (projectAssetsFilePath.Length == 0)
                 return new RestoreData(string.Empty, DateTime.MinValue, succeeded: false);
 
             return new RestoreData(
-                restoreInfo.ProjectAssetsFilePath,
-                _fileSystem.GetLastFileWriteTimeOrMinValueUtc(restoreInfo.ProjectAssetsFilePath), succeeded: succeeded);
+                projectAssetsFilePath,
+                _fileSystem.GetLastFileWriteTimeOrMinValueUtc(projectAssetsFilePath), succeeded: succeeded);
         }
 
         public Task LoadAsync()


### PR DESCRIPTION
If the assets file was not written after restore, treat the restore as a failure.

This is one of the causes of https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1052518, which is fixed by NuGet/NuGet.Client#3320, but doing this as a defense in deep in case we hit future issues like this.