### PR TITLE
Fix reliability of language service integration

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return ProcessProjectEvaluationHandlersAsync(version, update, isActiveContext, cancellationToken);
         }
 
-        public Task ApplyProjectEndBatchAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext, CancellationToken cancellationToken)
+        public Task ApplyProjectEndBatchAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, CancellationToken cancellationToken)
         {
             Requires.NotNull(update, nameof(update));
 
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 IComparable version = GetConfiguredProjectVersion(update);
 
-                ProcessProjectUpdateHandlers(version, update, isActiveContext, cancellationToken);
+                ProcessProjectUpdateHandlers(version, update, cancellationToken);
             }
 
             return Task.CompletedTask;
@@ -223,7 +223,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return Task.CompletedTask;
         }
 
-        private void ProcessProjectUpdateHandlers(IComparable version, IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext, CancellationToken cancellationToken)
+        private void ProcessProjectUpdateHandlers(IComparable version, IProjectVersionedValue<IProjectSubscriptionUpdate> update, CancellationToken cancellationToken)
         {
             foreach (ExportLifetimeContext<IWorkspaceContextHandler> handler in _handlers)
             {
@@ -233,7 +233,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     update.Value.ProjectChanges.TryGetValue(evaluationHandler.ProjectEvaluationRule, out IProjectChangeDescription projectChange) &&
                     projectChange.Difference.AnyChanges)
                 {
-                    evaluationHandler.HandleProjectUpdate(version, projectChange, isActiveContext, _logger);
+                    evaluationHandler.HandleProjectUpdate(version, projectChange, _logger);
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CompileItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CompileItemHandler.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             ApplyProjectBuild(version, difference, isActiveContext, logger);
         }
 
-        public void HandleProjectUpdate(IComparable version, IProjectChangeDescription projectChange, bool isActiveContext, IProjectLogger logger)
+        public void HandleProjectUpdate(IComparable version, IProjectChangeDescription projectChange, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(projectChange, nameof(projectChange));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
@@ -105,6 +105,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     to the project snapshot state. The cancellation token should only be cancelled with the
         ///     intention that the <see cref="IWorkspaceProjectContext"/> will be immediately disposed.
         /// </remarks>
-        Task ApplyProjectEndBatchAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext, CancellationToken cancellationToken);
+        Task ApplyProjectEndBatchAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IProjectUpdatedHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IProjectUpdatedHandler.cs
@@ -12,6 +12,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         /// </summary>
         string ProjectEvaluationRule { get; }
 
-        void HandleProjectUpdate(IComparable version, IProjectChangeDescription projectChange, bool isActiveContext, IProjectLogger logger);
+        void HandleProjectUpdate(IComparable version, IProjectChangeDescription projectChange, IProjectLogger logger);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
@@ -165,11 +165,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 finally
                 {
                     context.EndBatch();
+
+                    NotifyOutputDataCalculated(update.DataSourceVersions, evaluation);
                 }
 
                 await _applyChangesToWorkspaceContext.Value.ApplyProjectEndBatchAsync(update, cancellationToken);
-
-                NotifyOutputDataCalculated(update.DataSourceVersions, evaluation);
             }
 
             private void NotifyOutputDataCalculated(IImmutableDictionary<NamedIdentity, IComparable> dataSourceVersions, bool evaluation)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
@@ -164,7 +164,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     }
 
                     context.EndBatch();
-                    await _applyChangesToWorkspaceContext.Value.ApplyProjectEndBatchAsync(update, isActiveContext, cancellationToken);
+                    await _applyChangesToWorkspaceContext.Value.ApplyProjectEndBatchAsync(update, cancellationToken);
                     isBatchEnded = true;
                 }
                 finally

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
@@ -149,7 +149,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                 context.StartBatch();
 
-                bool isBatchEnded = false;
                 try
                 {
                     bool isActiveContext = _activeWorkspaceProjectContextTracker.IsActiveEditorContext(_contextAccessor.ContextId);
@@ -162,18 +161,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     {
                         await _applyChangesToWorkspaceContext!.Value.ApplyProjectBuildAsync(update, isActiveContext, cancellationToken);
                     }
-
-                    context.EndBatch();
-                    await _applyChangesToWorkspaceContext.Value.ApplyProjectEndBatchAsync(update, cancellationToken);
-                    isBatchEnded = true;
                 }
                 finally
                 {
-                    if (!isBatchEnded)
-                    {
-                        context.EndBatch();
-                    }
+                    context.EndBatch();
                 }
+
+                await _applyChangesToWorkspaceContext.Value.ApplyProjectEndBatchAsync(update, cancellationToken);
 
                 NotifyOutputDataCalculated(update.DataSourceVersions, evaluation);
             }


### PR DESCRIPTION
This makes three changes:

- Remove unused isActiveContext parameter 
- Avoid duplicate EndBatch calls (cause of this https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1087604 and hiding the underlying exception which will be captured in https://github.com/dotnet/project-system/pull/6051)
- Mark operation progress as finished _before_ we've done the rename prompts, not after.