### PR TITLE
Update ResolvedPackageReference rule

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
@@ -49,6 +49,17 @@
                   ReadOnly="True"
                   Visible="False" />
 
+  <BoolProperty Name="GeneratePathProperty"
+                Description="Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'."
+                DisplayName="Generate path property">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="PackageReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
+
   <StringProperty Name="IncludeAssets"
                   Description="Assets to include from this reference."
                   DisplayName="IncludeAssets">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
@@ -25,11 +25,6 @@
     </StringListProperty.DataSource>
   </StringListProperty>
 
-  <StringProperty Name="Description"
-                  Description="Dependency description."
-                  DisplayName="Description"
-                  ReadOnly="True" />
-
   <StringProperty Name="ExcludeAssets"
                   Description="Assets to exclude from this reference."
                   DisplayName="ExcludeAssets">
@@ -40,14 +35,6 @@
                   SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-
-  <StringProperty Name="FrameworkName"
-                  ReadOnly="True"
-                  Visible="False" />
-
-  <StringProperty Name="FrameworkVersion"
-                  ReadOnly="True"
-                  Visible="False" />
 
   <BoolProperty Name="GeneratePathProperty"
                 Description="Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'."
@@ -114,14 +101,6 @@
                   SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-
-  <StringProperty Name="RuntimeIdentifier"
-                  ReadOnly="True"
-                  Visible="False" />
-
-  <StringProperty Name="TargetFramework"
-                  ReadOnly="True"
-                  Visible="False" />
 
   <StringProperty Name="Type"
                   ReadOnly="True"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.cs.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Vlastnosti balíčku</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Popis</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Popis závislosti</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Verze</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.cs.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../ResolvedPackageReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
         <source>Package</source>
         <target state="translated">Balíček</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.de.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Paketeigenschaften</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Beschreibung</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Beschreibung der Abhängigkeit.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Version</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.de.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../ResolvedPackageReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
         <source>Package</source>
         <target state="translated">Paket</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.es.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../ResolvedPackageReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
         <source>Package</source>
         <target state="translated">Paquete</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.es.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Propiedades de paquete</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Descripción</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Descripción de la dependencia.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Versión</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.fr.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Propriétés du package</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Description</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Description de la dépendance.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Version</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.fr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../ResolvedPackageReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
         <source>Package</source>
         <target state="translated">Package</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.it.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../ResolvedPackageReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
         <source>Package</source>
         <target state="translated">Pacchetto</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.it.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Proprietà del pacchetto</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Descrizione</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Descrizione della dipendenza.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Versione</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ja.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../ResolvedPackageReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
         <source>Package</source>
         <target state="translated">パッケージ</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ja.xlf
@@ -22,16 +22,6 @@
         <target state="translated">パッケージのプロパティ</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">説明</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">依存関係の説明。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">バージョン</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ko.xlf
@@ -22,16 +22,6 @@
         <target state="translated">패키지 속성</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">설명</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">종속성 설명입니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">버전</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ko.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../ResolvedPackageReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
         <source>Package</source>
         <target state="translated">패키지</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pl.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../ResolvedPackageReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
         <source>Package</source>
         <target state="translated">Pakiet</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pl.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Właściwości pakietu</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Opis</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Opis zależności.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Wersja</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pt-BR.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ResolvedPackageReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
         <source>Package</source>
         <target state="translated">Pacote</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pt-BR.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Propriedades do Pacote</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Descrição</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Descrição da dependência.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Versão</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ru.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../ResolvedPackageReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
         <source>Package</source>
         <target state="translated">Пакет</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ru.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Свойства пакета</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Описание</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Описание зависимости.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Версия</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.tr.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Paket Özellikleri</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Açıklama</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Bağımlılık açıklaması</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Sürüm</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.tr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../ResolvedPackageReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
         <source>Package</source>
         <target state="translated">Paket</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hans.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ResolvedPackageReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
         <source>Package</source>
         <target state="translated">打包</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hans.xlf
@@ -22,16 +22,6 @@
         <target state="translated">包属性</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">说明</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">依赖项说明。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">版本</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hant.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ResolvedPackageReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
         <source>Package</source>
         <target state="translated">套件</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hant.xlf
@@ -22,16 +22,6 @@
         <target state="translated">套件屬性</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">說明</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">相依性描述。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">版本</target>


### PR DESCRIPTION
Adds `GeneratePathProperty` which is present on the (unresolved) `PackageReference` rule, and
should be available for resolved packages too.

Removes unused `ResolvedPackageReference` properties.