### PR TITLE
Implement dependencies tree search

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -124,10 +124,10 @@
     <PackageReference Update="Roslyn.Diagnostics.Analyzers"                                           Version="3.0.0-beta2.20059.3+77df2220" />
 
     <!-- NuGet -->
-    <PackageReference Update="NuGet.SolutionRestoreManager.Interop"                                   Version="5.6.0-preview.2.6489" />
-    <PackageReference Update="NuGet.VisualStudio"                                                     Version="5.6.0-preview.2.6489" />
-    <PackageReference Update="NuGet.ProjectModel"                                                     Version="5.6.0-preview.2.6489" />
-    <PackageReference Update="NuGet.Common"                                                           Version="5.6.0-preview.2.6489" />
+    <PackageReference Update="NuGet.SolutionRestoreManager.Interop"                                   Version="5.6.0-preview.2.6532" />
+    <PackageReference Update="NuGet.VisualStudio"                                                     Version="5.6.0-preview.2.6532" />
+    <PackageReference Update="NuGet.ProjectModel"                                                     Version="5.6.0-preview.2.6532" />
+    <PackageReference Update="NuGet.Common"                                                           Version="5.6.0-preview.2.6532" />
 
     <!-- MSBuild -->
     <PackageReference Update="Microsoft.Build"                                                        Version="16.4.0"/>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IUnconfiguredProjectVsServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IUnconfiguredProjectVsServices.cs
@@ -20,5 +20,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         ///     Gets <see cref="IVsProject4"/> provided by the <see cref="UnconfiguredProject"/>.
         /// </summary>
         IVsProject4 VsProject { get; }
+
+        /// <summary>
+        ///     Gets <see cref="IPhysicalProjectTree"/> provided by the <see cref="UnconfiguredProject"/>.
+        /// </summary>
+        IPhysicalProjectTree ProjectTree { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AssetsFileAttachedCollectionSourceBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AssetsFileAttachedCollectionSourceBase.cs
@@ -35,6 +35,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         protected AssetsFileAttachedCollectionSourceBase(IVsHierarchyItem hierarchyItem, IAssetsFileDependenciesDataSource dataSource, JoinableTaskContext joinableTaskContext)
         {
+            Requires.NotNull(hierarchyItem, nameof(hierarchyItem));
+            Requires.NotNull(dataSource, nameof(dataSource));
+            Requires.NotNull(joinableTaskContext, nameof(joinableTaskContext));
+
             _hierarchyItem = hierarchyItem;
 
             IsUpdatingHasItems = true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AssetsFileAttachedCollectionSourceBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AssetsFileAttachedCollectionSourceBase.cs
@@ -7,9 +7,9 @@ using System.Collections.Immutable;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
-using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections
 {
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                     if (log.LibraryId == libraryId)
                     {
                         items ??= new List<object>();
-                        items.Add(new DiagnosticItem(log));
+                        items.Add(DiagnosticItem.Create(log));
                     }
                 }
             }
@@ -117,8 +117,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                     items.Add(
                         dependency.Type switch
                         {
-                            AssetsFileLibraryType.Package => new PackageReferenceItem(dependency, target, snapshot),
-                            AssetsFileLibraryType.Project => new ProjectReferenceItem(dependency, target, snapshot),
+                            AssetsFileLibraryType.Package => PackageReferenceItem.CreateWithContainsItems(snapshot, dependency, target),
+                            AssetsFileLibraryType.Project => ProjectReferenceItem.CreateWithContainsItems(snapshot, dependency, target),
                             _ => throw Assumes.NotReachable()
                         });
                 }
@@ -130,13 +130,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
             if (!library.CompileTimeAssemblies.IsEmpty)
             {
                 items ??= new List<object>();
-                items.Add(new PackageAssemblyGroupItem(PackageAssemblyGroupType.CompileTime, library.CompileTimeAssemblies, snapshot, library));
+                items.Add(PackageAssemblyGroupItem.CreateWithContainsItems(snapshot, library, PackageAssemblyGroupType.CompileTime, library.CompileTimeAssemblies));
             }
 
             if (!library.FrameworkAssemblies.IsEmpty)
             {
                 items ??= new List<object>();
-                items.Add(new PackageAssemblyGroupItem(PackageAssemblyGroupType.Framework, library.FrameworkAssemblies, snapshot, library));
+                items.Add(PackageAssemblyGroupItem.CreateWithContainsItems(snapshot, library, PackageAssemblyGroupType.Framework, library.FrameworkAssemblies));
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AttachedCollectionItemBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AttachedCollectionItemBase.cs
@@ -1,16 +1,25 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Windows;
 using Microsoft.Internal.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections
 {
     /// <summary>
     /// Base class for attached items in the dependencies tree in Solution Explorer.
     /// </summary>
+    /// <remarks>
+    /// Subclasses should implement one or both of:
+    /// <list type="bullet">
+    ///     <item><see cref="IContainsAttachedItems"/> if, when expanded by the user, the item may have children.</item>
+    ///     <item><see cref="IContainedByAttachedItems"/> if the item may appear in search results.</item>
+    /// </list>
+    /// </remarks>
     internal abstract class AttachedCollectionItemBase
         : ITreeDisplayItem,
           ITreeDisplayItemWithImages,
@@ -89,5 +98,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         }
 
         public override string ToString() => Text;
+
+        /// <summary>
+        /// Simple implementation of <see cref="IAttachedCollectionSource"/> that provides an existing
+        /// set of items (i.e. not lazily constructed), expected to be used primarily for
+        /// <see cref="KnownRelationships.ContainedBy"/> queries of search result item's parentage.
+        /// </summary>
+        protected sealed class MaterializedAttachedCollectionSource : IAttachedCollectionSource
+        {
+            public MaterializedAttachedCollectionSource(object sourceItem, IEnumerable? items)
+            {
+                SourceItem = sourceItem;
+                Items = items;
+            }
+
+            public object SourceItem { get; }
+            public bool HasItems => Items != null;
+            public IEnumerable? Items { get; }
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AttachedCollectionItemBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AttachedCollectionItemBase.cs
@@ -44,10 +44,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         private static readonly HashSet<Type> s_supportedPatterns = new HashSet<Type>
         {
             typeof(ITreeDisplayItem),
-            typeof(IBrowsablePattern),
+            typeof(IBrowsablePattern)
         };
 
-        protected AttachedCollectionItemBase(string name) => Text = name;
+        protected AttachedCollectionItemBase(string name)
+        {
+            Requires.NotNullOrWhiteSpace(name, nameof(name));
+
+            Text = name;
+        }
 
         public string Text { get; }
 
@@ -108,6 +113,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         {
             public MaterializedAttachedCollectionSource(object sourceItem, IEnumerable? items)
             {
+                Requires.NotNull(sourceItem, nameof(sourceItem));
+
                 SourceItem = sourceItem;
                 Items = items;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesAttachedCollectionSourceProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesAttachedCollectionSourceProvider.cs
@@ -38,7 +38,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                 {
                     if (hierarchyItem.TryGetFlagsString(out string? flagsString))
                     {
-                        // TODO only call providers for top-level dependencies
                         foreach (Lazy<IDependenciesTreeAttachedCollectionSourceProvider, IOrderPrecedenceMetadataView> provider in Providers)
                         {
                             if (provider.Value.FlagsDetector.Matches(flagsString))
@@ -52,6 +51,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                 {
                     // Tree items which are themselves sources are delegated to, avoiding the need for more providers
                     return containsAttachedItems.ContainsAttachedCollectionSource;
+                }
+            }
+            else if (relationshipName == KnownRelationships.ContainedBy)
+            {
+                if (item is IContainedByAttachedItems containedByAttachedItems)
+                {
+                    // Tree items which are themselves sources are delegated to, avoiding the need for more providers
+                    return containedByAttachedItems.ContainedByAttachedCollectionSource;
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesSearchContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesSearchContext.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Threading;
+using Microsoft.Internal.VisualStudio.PlatformUI;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections
+{
+    /// <summary>
+    /// Provides services throughout the lifetime of a search operation.
+    /// </summary>
+    internal sealed class DependenciesSearchContext : IDisposable
+    {
+        private readonly string _searchString;
+        private readonly int _maximumResults;
+        private readonly Action<ISearchResult> _resultAccumulator;
+        private readonly CancellationTokenSource _cts;
+        private int _submittedResultCount;
+
+        public DependenciesSearchContext(IRelationshipSearchParameters parameters, Action<ISearchResult> resultAccumulator)
+        {
+            _searchString = parameters.SearchQuery.SearchString;
+            _maximumResults = checked((int)parameters.MaximumResults);
+            _resultAccumulator = resultAccumulator;
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(parameters.CancellationToken);
+        }
+
+        /// <summary>
+        /// Gets a token that aborts the search operation if cancelled.
+        /// </summary>
+        public CancellationToken CancellationToken => _cts.Token;
+
+        /// <summary>
+        /// Gets whether <paramref name="s"/> contains the search string.
+        /// </summary>
+        public bool IsMatch(string s) => s.IndexOf(_searchString, StringComparisons.UserEnteredSearchTermIgnoreCase) != -1;
+
+        /// <summary>
+        /// Submits <paramref name="item"/> as a search result.
+        /// </summary>
+        /// <remarks>
+        /// The result is not submitted if:
+        /// <list type="bullet">
+        ///     <item><paramref name="item"/> is <see langword="null"/></item>
+        ///     <item><see cref="CancellationToken"/> has been cancelled</item>
+        ///     <item>the maximum number of items have already been returned, in which case <see cref="CancellationToken"/> is cancelled</item>
+        /// </list>
+        /// </remarks>
+        public void SubmitResult(object? item)
+        {
+            if (item == null || CancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            if (Interlocked.Increment(ref _submittedResultCount) >= _maximumResults)
+            {
+                _cts.Cancel();
+                return;
+            }
+
+            _resultAccumulator(new DependenciesSearchResult(item));
+        }
+
+        public void Dispose()
+        {
+            _cts.Dispose();
+        }
+
+        private sealed class DependenciesSearchResult : ISearchResult
+        {
+            private readonly object _item;
+
+            public DependenciesSearchResult(object item) => _item = item;
+
+            public object GetDisplayItem() => _item;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesSearchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesSearchProvider.cs
@@ -1,0 +1,282 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using Microsoft.Internal.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections
+{
+    /// <summary>
+    /// Provides search results for non-top-level dependency tree nodes of all projects across the solution.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Because we only materialize dependencies tree items when needed, we cannot assume here that search results
+    /// coincide with existing tree items. Instead, for each match we find we create a new tree item. The tree then
+    /// calls back via the 'contained by' relationship to determine the ancestors of result items, repeating the
+    /// process until a known node is returned. For our purposes, these 'root' nodes are <see cref="IVsHierarchyItem"/>
+    /// instances that correspond to top-level project dependencies.
+    /// </para>
+    /// <para>
+    /// Top level dependencies participate in search for free, via the hierarchy.
+    /// </para>
+    /// </remarks>
+    [Export(typeof(ISearchProvider))]
+    internal sealed class DependenciesSearchProvider : ISearchProvider
+    {
+        private readonly JoinableTaskContext _joinableTaskContext;
+        private readonly IVsHierarchyItemManager _hierarchyItemManager;
+        private readonly IProjectServiceAccessor _projectServiceAccessor;
+
+        [ImportingConstructor]
+        public DependenciesSearchProvider(
+            JoinableTaskContext joinableTaskContext,
+            IVsHierarchyItemManager hierarchyItemManager,
+            IProjectServiceAccessor projectServiceAccessor)
+        {
+            _joinableTaskContext = joinableTaskContext;
+            _hierarchyItemManager = hierarchyItemManager;
+            _projectServiceAccessor = projectServiceAccessor;
+        }
+
+        public void Search(IRelationshipSearchParameters parameters, Action<ISearchResult> resultAccumulator)
+        {
+            Requires.NotNull(parameters, nameof(parameters));
+            Requires.NotNull(resultAccumulator, nameof(resultAccumulator));
+
+            if (!parameters.Options.SearchExternalItems)
+            {
+                // Consider the dependencies tree as containing 'external items', allowing the
+                // tree to be excluded from search results via this option.
+                return;
+            }
+
+            using var context = new DependenciesSearchContext(parameters, resultAccumulator);
+
+            _joinableTaskContext.Factory.Run(SearchAsync);
+
+            return;
+
+            async Task SearchAsync()
+            {
+                // Search projects concurrently
+                await Task.WhenAll(_projectServiceAccessor.GetProjectService().LoadedUnconfiguredProjects.Select(SearchProjectAsync));
+            }
+
+            async Task SearchProjectAsync(UnconfiguredProject unconfiguredProject)
+            {
+                IAssetsFileDependenciesDataSource? dataSource = unconfiguredProject.Services.ExportProvider.GetExportedValueOrDefault<IAssetsFileDependenciesDataSource>(unconfiguredProject.Capabilities);
+                IUnconfiguredProjectVsServices? projectVsServices = unconfiguredProject.Services.ExportProvider.GetExportedValue<IUnconfiguredProjectVsServices>();
+                IProjectTree? dependenciesNode = projectVsServices?.ProjectTree.CurrentTree?.FindChildWithFlags(DependencyTreeFlags.DependenciesRootNode);
+
+                if (dataSource == null || projectVsServices == null || dependenciesNode == null)
+                {
+                    // dataSource will be null for shared projects, for example
+                    return;
+                }
+
+                AssetsFileDependenciesSnapshot snapshot = (await dataSource.GetLatestVersionAsync(unconfiguredProject.Services.DataSourceRegistry, cancellationToken: context.CancellationToken)).Value;
+
+                foreach ((string target, AssetsFileTarget data) in snapshot.DataByTarget)
+                {
+                    IProjectTree subtreeNode;
+                    if (snapshot.DataByTarget.Count > 1)
+                    {
+                        IProjectTree? targetNode = dependenciesNode.FindChildWithFlags(ProjectTreeFlags.Create("$TFM:" + target));
+
+                        if (targetNode == null)
+                        {
+                            // TODO have seen this -- a race condition? can we prevent via sync link?
+                            System.Diagnostics.Debug.Fail("Should not fail to find the target node.");
+
+                            // If we cannot find the target node for this library, we won't find it for others in the same target.
+                            continue;
+                        }
+
+                        subtreeNode = targetNode;
+                    }
+                    else
+                    {
+                        subtreeNode = dependenciesNode;
+                    }
+
+                    var itemByNameAndNodeType = new Dictionary<(string LibraryName, NodeType Type), object?>();
+
+                    foreach ((_, AssetsFileTargetLibrary library) in data.LibraryByName)
+                    {
+                        if (context.CancellationToken.IsCancellationRequested)
+                        {
+                            // Search was cancelled
+                            return;
+                        }
+
+                        if (context.IsMatch(library.Name))
+                        {
+                            context.SubmitResult(GetOrCreateLibraryItem(library));
+                        }
+
+                        SearchAssemblies(library, library.CompileTimeAssemblies, PackageAssemblyGroupType.CompileTime);
+                        SearchAssemblies(library, library.FrameworkAssemblies, PackageAssemblyGroupType.Framework);
+                    }
+
+                    foreach (AssetsFileLogMessage log in data.Logs)
+                    {
+                        if (context.IsMatch(log.Message))
+                        {
+                            context.SubmitResult(CreateLogItem(log));
+                        }
+                    }
+
+                    return;
+
+                    void SearchAssemblies(AssetsFileTargetLibrary library, ImmutableArray<string> assemblies, PackageAssemblyGroupType groupType)
+                    {
+                        List<string>? matches = null;
+
+                        foreach (string assembly in assemblies)
+                        {
+                            if (context.IsMatch(Path.GetFileName(assembly)))
+                            {
+                                matches ??= new List<string>();
+                                matches.Add(assembly);
+                            }
+                        }
+
+                        if (matches != null)
+                        {
+                            var groupItem = PackageAssemblyGroupItem.CreateWithContainedByItems(snapshot, library, groupType, containedByItems: new[] { GetOrCreateLibraryItem(library) });
+
+                            foreach (string match in matches)
+                            {
+                                context.SubmitResult(new PackageAssemblyItem(match, groupItem));
+                            }
+                        }
+                    }
+
+                    object? GetOrCreateLibraryItem(AssetsFileTargetLibrary library)
+                    {
+                        NodeType libraryType = library.Type switch
+                        {
+                            AssetsFileLibraryType.Package => NodeType.Package,
+                            AssetsFileLibraryType.Project => NodeType.Project,
+                            _ => throw Assumes.NotReachable()
+                        };
+
+                        (string Name, NodeType Package) key = (library.Name, libraryType);
+
+                        if (!itemByNameAndNodeType.TryGetValue(key, out object? item))
+                        {
+                            if (data.IsTopLevel(library))
+                            {
+                                // Top level dependencies are special in that they anchor the nodes we
+                                // create during a search operation to existing hierarchy tree items.
+                                // Those hierarchy items are created via IProjectTree using evaluation data.
+                                if (TryGetHierarchyItem(out IVsHierarchyItem hierarchyItem))
+                                {
+                                    itemByNameAndNodeType[key] = item = hierarchyItem;
+                                }
+                            }
+                            else
+                            {
+                                // Look up containing items recursively, and cache results
+                                List<object>? containedByItems = FindContainedByItems(library);
+
+                                if (containedByItems == null)
+                                {
+                                    itemByNameAndNodeType[key] = null;
+                                }
+                                else
+                                {
+                                    itemByNameAndNodeType[key] = item = library.Type switch
+                                    {
+                                        AssetsFileLibraryType.Package => PackageReferenceItem.CreateWithContainedByItems(snapshot, library, containedByItems),
+                                        AssetsFileLibraryType.Project => ProjectReferenceItem.CreateWithContainedByItems(library, containedByItems),
+                                        _ => throw Assumes.NotReachable()
+                                    };
+                                }
+                            }
+                        }
+
+                        return item;
+
+                        bool TryGetHierarchyItem(out IVsHierarchyItem hierarchyItem)
+                        {
+                            IProjectTree? typeGroupNode = library.Type switch
+                            {
+                                AssetsFileLibraryType.Package => subtreeNode.FindChildWithFlags(DependencyTreeFlags.PackageDependencyGroup),
+                                AssetsFileLibraryType.Project => subtreeNode.FindChildWithFlags(DependencyTreeFlags.ProjectDependencyGroup),
+                                _ => throw Assumes.NotReachable()
+                            };
+
+                            IProjectTree? libraryNode = typeGroupNode?.FindChildWithFlags(ProjectTreeFlags.Create("$ID:" + library.Name));
+
+                            if (libraryNode == null)
+                            {
+                                System.Diagnostics.Debug.Fail("Could not find tree item for library: " + library.Name);
+                                hierarchyItem = default!;
+                                return false;
+                            }
+
+                            uint itemId = (uint)libraryNode.Identity.ToInt32();
+                            hierarchyItem = _hierarchyItemManager.GetHierarchyItem(projectVsServices.VsHierarchy, itemId);
+                            return true;
+                        }
+                    }
+
+                    object? CreateLogItem(AssetsFileLogMessage log)
+                    {
+                        if (data.LibraryByName.TryGetValue(log.LibraryId, out AssetsFileTargetLibrary library))
+                        {
+                            object? libraryItem = GetOrCreateLibraryItem(library);
+
+                            if (libraryItem != null)
+                            {
+                                return DiagnosticItem.CreateWithContainedByItems(log, new[] { libraryItem });
+                            }
+                        }
+
+                        return null;
+                    }
+
+                    List<object>? FindContainedByItems(AssetsFileTargetLibrary library)
+                    {
+                        List<object>? containedByItems = null;
+
+                        // Find all dependents
+                        if (data.TryGetDependents(library.Name, out ImmutableArray<AssetsFileTargetLibrary> dependents))
+                        {
+                            // Library has at least one other library that depends upon it. Add these to the 'contained by' collection.
+                            foreach (AssetsFileTargetLibrary dependent in dependents)
+                            {
+                                object? dependentItem = GetOrCreateLibraryItem(dependent);
+
+                                if (dependentItem != null)
+                                {
+                                    containedByItems ??= new List<object>();
+                                    containedByItems.Add(dependentItem);
+                                }
+                            }
+                        }
+
+                        return containedByItems;
+                    }
+                }
+            }
+        }
+
+        private enum NodeType
+        {
+            Project,
+            Package
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesSearchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesSearchProvider.cs
@@ -227,7 +227,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                             }
 
                             uint itemId = (uint)libraryNode.Identity.ToInt32();
-                            hierarchyItem = _hierarchyItemManager.GetHierarchyItem(projectVsServices.VsHierarchy, itemId);
+                            hierarchyItem = _hierarchyItemManager.GetHierarchyItem(projectVsServices!.VsHierarchy, itemId);
                             return true;
                         }
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DiagnosticItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DiagnosticItem.cs
@@ -1,19 +1,30 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Collections;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models;
+using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections
 {
     /// <summary>
     /// Backing object for library (package/project) diagnostic nodes in the dependencies tree.
     /// </summary>
-    internal sealed class DiagnosticItem : AttachedCollectionItemBase
+    internal sealed class DiagnosticItem : AttachedCollectionItemBase, IContainedByAttachedItems
     {
         private readonly AssetsFileLogMessage _log;
 
-        public DiagnosticItem(AssetsFileLogMessage log)
+        public static DiagnosticItem Create(AssetsFileLogMessage log) => new DiagnosticItem(log);
+
+        public static DiagnosticItem CreateWithContainedByItems(AssetsFileLogMessage log, IEnumerable containedByItems)
+        {
+            var item = new DiagnosticItem(log);
+            item.ContainedByAttachedCollectionSource = new MaterializedAttachedCollectionSource(item, containedByItems);
+            return item;
+        }
+
+        private DiagnosticItem(AssetsFileLogMessage log)
             : base(log.Message)
         {
             _log = log;
@@ -29,6 +40,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         };
 
         public override object GetBrowseObject() => new BrowseObject(_log);
+
+        public IAttachedCollectionSource? ContainedByAttachedCollectionSource { get; private set; }
 
         private sealed class BrowseObject : BrowseObjectBase
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IContainedByAttachedItems.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IContainedByAttachedItems.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.Internal.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections
+{
+    /// <summary>
+    /// Dependency tree items may implement this interface to handle their own <see cref="KnownRelationships.ContainedBy"/> queries.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="KnownRelationships.ContainedBy"/> is used primarily by search, as
+    /// the tree must walk upwards from a search result until it finds a known node
+    /// (usually a hierarchy node) to attach the result to along with any intermediary
+    /// nodes returned along the way.
+    /// </remarks>
+    internal interface IContainedByAttachedItems
+    {
+        /// <summary>
+        /// Gets the source for this item's contained items.
+        /// May return <see langword="null"/> if no items will ever be contained.
+        /// </summary>
+        /// <remarks>
+        /// If there are currently no contained items, but there may later be, then
+        /// an empty source should be returned so that it may later notify the tree
+        /// when it contains items.
+        /// </remarks>
+        IAttachedCollectionSource? ContainedByAttachedCollectionSource { get; }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageAssemblyGroupItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageAssemblyGroupItem.cs
@@ -22,7 +22,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public static PackageAssemblyGroupItem CreateWithContainsItems(AssetsFileDependenciesSnapshot snapshot, AssetsFileTargetLibrary library, PackageAssemblyGroupType groupType, ImmutableArray<string> paths)
         {
-            Requires.Argument(!paths.IsEmpty, nameof(paths), "May not be empty");
+            Requires.NotNull(snapshot, nameof(snapshot));
+            Requires.NotNull(library, nameof(library));
+            Requires.Argument(!paths.IsDefaultOrEmpty, nameof(paths), "May not be default or empty");
 
             var item = new PackageAssemblyGroupItem(groupType, snapshot, library);
             item.ContainsAttachedCollectionSource = new ContainsCollectionSource(item, paths);
@@ -31,6 +33,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public static PackageAssemblyGroupItem CreateWithContainedByItems(AssetsFileDependenciesSnapshot snapshot, AssetsFileTargetLibrary library, PackageAssemblyGroupType groupType, IEnumerable containedByItems)
         {
+            Requires.NotNull(snapshot, nameof(snapshot));
+            Requires.NotNull(library, nameof(library));
+            Requires.NotNull(containedByItems, nameof(containedByItems));
+
             var item = new PackageAssemblyGroupItem(groupType, snapshot, library);
             item.ContainedByAttachedCollectionSource = new MaterializedAttachedCollectionSource(item, containedByItems);
             return item;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageAssemblyGroupItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageAssemblyGroupItem.cs
@@ -3,9 +3,7 @@
 using System.Collections;
 using System.Collections.Immutable;
 using System.ComponentModel;
-using System.IO;
 using System.Linq;
-using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models;
 using Microsoft.VisualStudio.Shell;
@@ -15,25 +13,38 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     /// <summary>
     /// Backing object for named group of assemblies within the dependencies tree.
     /// </summary>
-    internal sealed class PackageAssemblyGroupItem : AttachedCollectionItemBase, IContainsAttachedItems, IAttachedCollectionSource
+    internal sealed class PackageAssemblyGroupItem : AttachedCollectionItemBase, IContainsAttachedItems, IContainedByAttachedItems
     {
         private readonly PackageAssemblyGroupType _groupType;
-        private readonly ImmutableArray<string> _paths;
-        private readonly AssetsFileDependenciesSnapshot _snapshot;
-        private readonly AssetsFileTargetLibrary _library;
-        private IEnumerable? _items;
 
-        public PackageAssemblyGroupItem(PackageAssemblyGroupType groupType, ImmutableArray<string> paths, AssetsFileDependenciesSnapshot snapshot, AssetsFileTargetLibrary library)
-            : base(GetGroupLabel(groupType))
+        internal AssetsFileDependenciesSnapshot Snapshot { get; }
+        internal AssetsFileTargetLibrary Library { get; }
+
+        public static PackageAssemblyGroupItem CreateWithContainsItems(AssetsFileDependenciesSnapshot snapshot, AssetsFileTargetLibrary library, PackageAssemblyGroupType groupType, ImmutableArray<string> paths)
         {
             Requires.Argument(!paths.IsEmpty, nameof(paths), "May not be empty");
+
+            var item = new PackageAssemblyGroupItem(groupType, snapshot, library);
+            item.ContainsAttachedCollectionSource = new ContainsCollectionSource(item, paths);
+            return item;
+        }
+
+        public static PackageAssemblyGroupItem CreateWithContainedByItems(AssetsFileDependenciesSnapshot snapshot, AssetsFileTargetLibrary library, PackageAssemblyGroupType groupType, IEnumerable containedByItems)
+        {
+            var item = new PackageAssemblyGroupItem(groupType, snapshot, library);
+            item.ContainedByAttachedCollectionSource = new MaterializedAttachedCollectionSource(item, containedByItems);
+            return item;
+        }
+
+        private PackageAssemblyGroupItem(PackageAssemblyGroupType groupType, AssetsFileDependenciesSnapshot snapshot, AssetsFileTargetLibrary library)
+            : base(GetGroupLabel(groupType))
+        {
             Requires.NotNull(snapshot, nameof(snapshot));
             Requires.NotNull(library, nameof(library));
 
             _groupType = groupType;
-            _paths = paths;
-            _snapshot = snapshot;
-            _library = library;
+            Snapshot = snapshot;
+            Library = library;
         }
 
         private static string GetGroupLabel(PackageAssemblyGroupType groupType)
@@ -59,62 +70,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public override object? GetBrowseObject() => null;
 
-        public object? SourceItem => null;
-        
-        public bool HasItems => true;
-        
-        public IEnumerable Items => _items ??= _paths.Select(path => new PackageAssemblyItem(path, this)).ToList();
+        public IAttachedCollectionSource? ContainsAttachedCollectionSource { get; private set; }
 
-        public IAttachedCollectionSource ContainsAttachedCollectionSource => this;
+        public IAttachedCollectionSource? ContainedByAttachedCollectionSource { get; private set; }
 
-        private sealed class PackageAssemblyItem : AttachedCollectionItemBase
+        private sealed class ContainsCollectionSource : IAttachedCollectionSource
         {
-            private readonly string _path;
             private readonly PackageAssemblyGroupItem _groupItem;
+            private readonly ImmutableArray<string> _paths;
+            private IEnumerable? _items;
 
-            public PackageAssemblyItem(string path, PackageAssemblyGroupItem groupItem)
-                : base(Path.GetFileName(path))
+            public ContainsCollectionSource(PackageAssemblyGroupItem groupItem, ImmutableArray<string> paths)
             {
-                _path = path;
                 _groupItem = groupItem;
+                _paths = paths;
             }
 
-            // All siblings are assemblies, so no prioritization needed (sort alphabetically)
-            public override int Priority => 0;
+            public object? SourceItem => _groupItem;
 
-            public override ImageMoniker IconMoniker => KnownMonikers.Reference;
+            public bool HasItems => true;
 
-            public override object? GetBrowseObject() => new BrowseObject(this);
-
-            private sealed class BrowseObject : BrowseObjectBase
-            {
-                private readonly PackageAssemblyItem _assembly;
-
-                public BrowseObject(PackageAssemblyItem library) => _assembly = library;
-
-                public override string GetComponentName() => _assembly.Text;
-
-                public override string GetClassName() => VSResources.PackageAssemblyBrowseObjectClassName;
-
-                [BrowseObjectDisplayName(nameof(VSResources.PackageAssemblyNameDisplayName))]
-                [BrowseObjectDescription(nameof(VSResources.PackageAssemblyNameDescription))]
-                public string Name => _assembly.Text;
-
-                [BrowseObjectDisplayName(nameof(VSResources.PackageAssemblyPathDisplayName))]
-                [BrowseObjectDescription(nameof(VSResources.PackageAssemblyPathDescription))]
-                public string? Path
-                {
-                    get
-                    {
-                        PackageAssemblyGroupItem groupItem = _assembly._groupItem;
-                        AssetsFileTargetLibrary library = groupItem._library;
-
-                        return groupItem._snapshot.TryResolvePackagePath(library.Name, library.Version, out string? fullPath)
-                            ? System.IO.Path.GetFullPath(System.IO.Path.Combine(fullPath, _assembly._path))
-                            : null;
-                    }
-                }
-            }
+            public IEnumerable Items => _items ??= _paths.Select(path => new PackageAssemblyItem(path, _groupItem)).ToList();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageAssemblyGroupItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageAssemblyGroupItem.cs
@@ -66,8 +66,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public override ImageMoniker IconMoniker => ManagedImageMonikers.ReferenceGroup;
 
-        public override ImageMoniker ExpandedIconMoniker => ManagedImageMonikers.ReferenceGroup;
-
         public override object? GetBrowseObject() => null;
 
         public IAttachedCollectionSource? ContainsAttachedCollectionSource { get; private set; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageAssemblyItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageAssemblyItem.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.IO;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections
+{
+    /// <summary>
+    /// Backing object for an assembly within a library within the dependencies tree.
+    /// </summary>
+    /// <remarks>
+    /// Items of this type are grouped within <see cref="PackageAssemblyGroupItem"/>.
+    /// </remarks>
+    internal sealed class PackageAssemblyItem : AttachedCollectionItemBase, IContainedByAttachedItems
+    {
+        private readonly string _path;
+        private readonly PackageAssemblyGroupItem _groupItem;
+
+        public PackageAssemblyItem(string path, PackageAssemblyGroupItem groupItem)
+            : base(Path.GetFileName(path))
+        {
+            _path = path;
+            _groupItem = groupItem;
+        }
+
+        // All siblings are assemblies, so no prioritization needed (sort alphabetically)
+        public override int Priority => 0;
+
+        public override ImageMoniker IconMoniker => KnownMonikers.Reference;
+
+        public override object? GetBrowseObject() => new BrowseObject(this);
+
+        public IAttachedCollectionSource? ContainedByAttachedCollectionSource => new MaterializedAttachedCollectionSource(this, new[] { _groupItem });
+
+        private sealed class BrowseObject : BrowseObjectBase
+        {
+            private readonly PackageAssemblyItem _assembly;
+
+            public BrowseObject(PackageAssemblyItem library) => _assembly = library;
+
+            public override string GetComponentName() => _assembly.Text;
+
+            public override string GetClassName() => VSResources.PackageAssemblyBrowseObjectClassName;
+
+            [BrowseObjectDisplayName(nameof(VSResources.PackageAssemblyNameDisplayName))]
+            [BrowseObjectDescription(nameof(VSResources.PackageAssemblyNameDescription))]
+            public string Name => _assembly.Text;
+
+            [BrowseObjectDisplayName(nameof(VSResources.PackageAssemblyPathDisplayName))]
+            [BrowseObjectDescription(nameof(VSResources.PackageAssemblyPathDescription))]
+            public string? Path
+            {
+                get
+                {
+                    PackageAssemblyGroupItem groupItem = _assembly._groupItem;
+                    AssetsFileTargetLibrary library = groupItem.Library;
+
+                    return groupItem.Snapshot.TryResolvePackagePath(library.Name, library.Version, out string? fullPath)
+                        ? System.IO.Path.GetFullPath(System.IO.Path.Combine(fullPath, _assembly._path))
+                        : null;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageReferenceItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageReferenceItem.cs
@@ -42,8 +42,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public override ImageMoniker IconMoniker => ManagedImageMonikers.NuGetGrey;
 
-        public override ImageMoniker ExpandedIconMoniker => IconMoniker;
-
         public override object? GetBrowseObject() => new BrowseObject(_library, _snapshot);
 
         public IAttachedCollectionSource? ContainsAttachedCollectionSource { get; private set; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageReferenceItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageReferenceItem.cs
@@ -12,18 +12,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     /// <summary>
     /// Backing object for transitive package reference nodes in the dependencies tree.
     /// </summary>
-    internal sealed class PackageReferenceItem : AttachedCollectionItemBase, IContainsAttachedItems, IAttachedCollectionSource
+    internal sealed class PackageReferenceItem : AttachedCollectionItemBase, IContainsAttachedItems, IContainedByAttachedItems
     {
         private readonly AssetsFileTargetLibrary _library;
-        private readonly string? _configuration;
         private readonly AssetsFileDependenciesSnapshot _snapshot;
-        private IEnumerable? _items;
 
-        public PackageReferenceItem(AssetsFileTargetLibrary library, string? configuration, AssetsFileDependenciesSnapshot snapshot)
+        public static PackageReferenceItem CreateWithContainsItems(AssetsFileDependenciesSnapshot snapshot, AssetsFileTargetLibrary library, string? target)
+        {
+            var item = new PackageReferenceItem(library, snapshot);
+            item.ContainsAttachedCollectionSource = new ContainsCollectionSource(item, snapshot, library, target);
+            return item;
+        }
+
+        public static PackageReferenceItem CreateWithContainedByItems(AssetsFileDependenciesSnapshot snapshot, AssetsFileTargetLibrary library, IEnumerable items)
+        {
+            var item = new PackageReferenceItem(library, snapshot);
+            item.ContainedByAttachedCollectionSource = new MaterializedAttachedCollectionSource(item, items);
+            return item;
+        }
+
+        private PackageReferenceItem(AssetsFileTargetLibrary library, AssetsFileDependenciesSnapshot snapshot)
             : base($"{library.Name} ({library.Version})")
         {
             _library = library;
-            _configuration = configuration;
             _snapshot = snapshot;
         }
 
@@ -35,42 +46,60 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public override object? GetBrowseObject() => new BrowseObject(_library, _snapshot);
 
-        public IAttachedCollectionSource ContainsAttachedCollectionSource => this;
+        public IAttachedCollectionSource? ContainsAttachedCollectionSource { get; private set; }
 
-        bool IAttachedCollectionSource.HasItems => !_library.Dependencies.IsEmpty || !_library.CompileTimeAssemblies.IsEmpty;
+        public IAttachedCollectionSource? ContainedByAttachedCollectionSource { get; private set; }
 
-        IEnumerable IAttachedCollectionSource.Items
+        private sealed class ContainsCollectionSource : IAttachedCollectionSource
         {
-            get
+            private readonly AssetsFileDependenciesSnapshot _snapshot;
+            private readonly AssetsFileTargetLibrary _library;
+            private readonly string? _target;
+            private IEnumerable? _items;
+
+            public ContainsCollectionSource(PackageReferenceItem sourceItem, AssetsFileDependenciesSnapshot snapshot, AssetsFileTargetLibrary library, string? target)
             {
-                // NOTE any change to the construction of these items must be reflected in the implementation of HasItems
-                if (_items == null)
+                SourceItem = sourceItem;
+                _snapshot = snapshot;
+                _library = library;
+                _target = target;
+            }
+
+            public object? SourceItem { get; }
+
+            public bool HasItems => !_library.Dependencies.IsEmpty || !_library.CompileTimeAssemblies.IsEmpty;
+
+            public IEnumerable Items
+            {
+                get
                 {
-                    if (_snapshot.TryGetDependencies(_library.Name, _library.Version, _configuration, out ImmutableArray<AssetsFileTargetLibrary> dependencies))
+                    // NOTE any change to the construction of these items must be reflected in the implementation of HasItems
+                    if (_items == null)
                     {
-                        int length = _library.CompileTimeAssemblies.IsEmpty ? dependencies.Length : dependencies.Length + 1;
-                        
-                        ImmutableArray<object>.Builder builder = ImmutableArray.CreateBuilder<object>(length);
-                        builder.AddRange(dependencies.Select(dep => new PackageReferenceItem(dep, _configuration, _snapshot)));
-                        
-                        if (!_library.CompileTimeAssemblies.IsEmpty)
+                        if (_snapshot.TryGetDependencies(_library.Name, _library.Version, _target, out ImmutableArray<AssetsFileTargetLibrary> dependencies))
                         {
-                            builder.Add(new PackageAssemblyGroupItem(PackageAssemblyGroupType.CompileTime, _library.CompileTimeAssemblies, _snapshot, _library));
+                            int length = _library.CompileTimeAssemblies.IsEmpty ? dependencies.Length : dependencies.Length + 1;
+
+                            ImmutableArray<object>.Builder builder = ImmutableArray.CreateBuilder<object>(length);
+                            builder.AddRange(dependencies.Select(dep => CreateWithContainsItems(_snapshot, dep, _target)));
+
+                            if (!_library.CompileTimeAssemblies.IsEmpty)
+                            {
+                                builder.Add(PackageAssemblyGroupItem.CreateWithContainsItems(_snapshot, _library, PackageAssemblyGroupType.CompileTime, _library.CompileTimeAssemblies));
+                            }
+
+                            _items = builder.MoveToImmutable();
                         }
+                        else
+                        {
+                            _items = Enumerable.Empty<object>();
+                        }
+                    }
 
-                        _items = builder.MoveToImmutable();
-                    }
-                    else
-                    {
-                        _items = Enumerable.Empty<object>();
-                    }
+                    return _items;
                 }
-
-                return _items;
             }
         }
-
-        object? IAttachedCollectionSource.SourceItem => null;
 
         private sealed class BrowseObject : BrowseObjectBase
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/ProjectReferenceItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/ProjectReferenceItem.cs
@@ -40,8 +40,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public override ImageMoniker IconMoniker => ManagedImageMonikers.Application;
 
-        public override ImageMoniker ExpandedIconMoniker => IconMoniker;
-
         public override object? GetBrowseObject() => new BrowseObject(_library);
 
         public IAttachedCollectionSource? ContainsAttachedCollectionSource { get; private set; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/ProjectReferenceItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/ProjectReferenceItem.cs
@@ -12,19 +12,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     /// <summary>
     /// Backing object for transitive project reference nodes in the dependencies tree.
     /// </summary>
-    internal sealed class ProjectReferenceItem : AttachedCollectionItemBase, IContainsAttachedItems, IAttachedCollectionSource
+    internal sealed class ProjectReferenceItem : AttachedCollectionItemBase, IContainsAttachedItems, IContainedByAttachedItems
     {
         private readonly AssetsFileTargetLibrary _library;
-        private readonly string? _configuration;
-        private readonly AssetsFileDependenciesSnapshot _snapshot;
-        private IEnumerable? _items;
 
-        public ProjectReferenceItem(AssetsFileTargetLibrary library, string? configuration, AssetsFileDependenciesSnapshot snapshot)
+        public static ProjectReferenceItem CreateWithContainsItems(AssetsFileDependenciesSnapshot snapshot, AssetsFileTargetLibrary library, string? target)
+        {
+            var item = new ProjectReferenceItem(library);
+            item.ContainsAttachedCollectionSource = new ContainsCollectionSource(item, snapshot, library, target);
+            return item;
+        }
+
+        public static ProjectReferenceItem CreateWithContainedByItems(AssetsFileTargetLibrary library, IEnumerable containedByItems)
+        {
+            var item = new ProjectReferenceItem(library);
+            item.ContainedByAttachedCollectionSource = new MaterializedAttachedCollectionSource(item, containedByItems);
+            return item;
+        }
+
+        private ProjectReferenceItem(AssetsFileTargetLibrary library)
             : base(library.Name)
         {
             _library = library;
-            _configuration = configuration;
-            _snapshot = snapshot;
         }
 
         public override int Priority => AttachedItemPriority.Project;
@@ -35,34 +44,52 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public override object? GetBrowseObject() => new BrowseObject(_library);
 
-        public IAttachedCollectionSource ContainsAttachedCollectionSource => this;
+        public IAttachedCollectionSource? ContainsAttachedCollectionSource { get; private set; }
 
-        bool IAttachedCollectionSource.HasItems => !_library.Dependencies.IsEmpty;
+        public IAttachedCollectionSource? ContainedByAttachedCollectionSource { get; private set; }
 
-        IEnumerable IAttachedCollectionSource.Items
+        private sealed class ContainsCollectionSource : IAttachedCollectionSource
         {
-            get
-            {
-                // NOTE any change to the construction of these items must be reflected in the implementation of HasItems
-                if (_items == null)
-                {
-                    if (_snapshot.TryGetDependencies(_library.Name, _library.Version, _configuration, out ImmutableArray<AssetsFileTargetLibrary> dependencies))
-                    {
-                        ImmutableArray<object>.Builder builder = ImmutableArray.CreateBuilder<object>(dependencies.Length);
-                        builder.AddRange(dependencies.Select(dep => new PackageReferenceItem(dep, _configuration, _snapshot)));
-                        _items = builder.MoveToImmutable();
-                    }
-                    else
-                    {
-                        _items = Enumerable.Empty<object>();
-                    }
-                }
+            private readonly AssetsFileDependenciesSnapshot _snapshot;
+            private readonly AssetsFileTargetLibrary _library;
+            private readonly string? _target;
+            private IEnumerable? _items;
 
-                return _items;
+            public ContainsCollectionSource(ProjectReferenceItem sourceItem, AssetsFileDependenciesSnapshot snapshot, AssetsFileTargetLibrary library, string? target)
+            {
+                SourceItem = sourceItem;
+                _snapshot = snapshot;
+                _library = library;
+                _target = target;
+            }
+
+            public object? SourceItem { get; }
+
+            public bool HasItems => !_library.Dependencies.IsEmpty;
+
+            public IEnumerable Items
+            {
+                get
+                {
+                    // NOTE any change to the construction of these items must be reflected in the implementation of HasItems
+                    if (_items == null)
+                    {
+                        if (_snapshot.TryGetDependencies(_library.Name, _library.Version, _target, out ImmutableArray<AssetsFileTargetLibrary> dependencies))
+                        {
+                            ImmutableArray<object>.Builder builder = ImmutableArray.CreateBuilder<object>(dependencies.Length);
+                            builder.AddRange(dependencies.Select(dep => PackageReferenceItem.CreateWithContainsItems(_snapshot, dep, _target)));
+                            _items = builder.MoveToImmutable();
+                        }
+                        else
+                        {
+                            _items = Enumerable.Empty<object>();
+                        }
+                    }
+
+                    return _items;
+                }
             }
         }
-
-        object? IAttachedCollectionSource.SourceItem => null;
 
         private sealed class BrowseObject : BrowseObjectBase
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/MefExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/MefExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections
+{
+    internal static class MefExtensions
+    {
+        /// <summary>
+        /// Get a single component, if present
+        /// </summary>
+        /// <typeparam name="T">The type identity of the export to retrieve.</typeparam>
+        /// <param name="exportProvider">The container to query.</param>
+        /// <param name="capabilitiesScope"></param>
+        /// <returns>The exported component</returns>
+        [return: MaybeNull]
+        public static T GetExportedValueOrDefault<T>(this ExportProvider exportProvider, IProjectCapabilitiesScope capabilitiesScope)
+        {
+            Requires.NotNull(exportProvider, nameof(exportProvider));
+            Requires.NotNull(capabilitiesScope, nameof(capabilitiesScope));
+
+            Lazy<T, IAppliesToMetadataView> lazy = exportProvider
+                .GetExports<T, IAppliesToMetadataView>()
+                .SingleOrDefault(export => export.Metadata.AppliesTo(capabilitiesScope));
+            
+            return lazy == null ? default : lazy.Value;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectTreeExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectTreeExtensions.cs
@@ -16,9 +16,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         /// <summary>
-        /// Finds a tree node by its flags. If there many nodes that satisfy flags, returns first.
+        /// Finds the first child node having <paramref name="flags"/>, or <see langword="null"/> if no child matches.
         /// </summary>
-        internal static IProjectTree? GetSubTreeNode(this IProjectTree self, ProjectTreeFlags flags)
+        internal static IProjectTree? FindChildWithFlags(this IProjectTree self, ProjectTreeFlags flags)
         {
             foreach (IProjectTree child in self.Children)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectTreeExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectTreeExtensions.cs
@@ -1,5 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Diagnostics.Contracts;
+
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class IProjectTreeExtensions
@@ -8,6 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// Gets the direct child of <paramref name="tree"/> with <paramref name="caption"/>
         /// if found, otherwise <see langword="null"/>.
         /// </summary>
+        [Pure]
         public static IProjectTree? FindChildWithCaption(this IProjectTree tree, string caption)
         {
             return tree.Children.FirstOrDefault(
@@ -18,6 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <summary>
         /// Finds the first child node having <paramref name="flags"/>, or <see langword="null"/> if no child matches.
         /// </summary>
+        [Pure]
         internal static IProjectTree? FindChildWithFlags(this IProjectTree self, ProjectTreeFlags flags)
         {
             foreach (IProjectTree child in self.Children)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
@@ -14,17 +14,6 @@
                 SourceType="TargetResults" />
   </Rule.DataSource>
 
-  <StringListProperty Name="Dependencies"
-                      Separator=";"
-                      Visible="false">
-    <StringListProperty.DataSource>
-      <DataSource HasConfigurationCondition="False"
-                  ItemType="PackageReference"
-                  Persistence="ResolvedReference"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringListProperty.DataSource>
-  </StringListProperty>
-
   <StringProperty Name="ExcludeAssets"
                   Description="Assets to exclude from this reference."
                   DisplayName="ExcludeAssets">
@@ -61,10 +50,6 @@
   <StringProperty Name="IsImplicitlyDefined"
                   ReadOnly="True"
                   Visible="False" />
-
-  <BoolProperty Name="IsTopLevelDependency"
-                ReadOnly="True"
-                Visible="False" />
 
   <StringProperty Name="Name"
                   ReadOnly="True"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
@@ -102,6 +102,7 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <!-- NOTE since 16.7 the SDK only returns "Package" items, however we keep this field to allow filtering in the case a user explicitly uses an older SDK version -->
   <StringProperty Name="Type"
                   ReadOnly="True"
                   Visible="False" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Assets/Models/AssetsFileDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Assets/Models/AssetsFileDependenciesSnapshot.cs
@@ -44,6 +44,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models
         /// </summary>
         public AssetsFileDependenciesSnapshot UpdateFromAssetsFile(string path)
         {
+            Requires.NotNull(path, nameof(path));
+
             try
             {
                 // Parse the file
@@ -166,6 +168,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models
 
         public bool TryGetDependencies(string libraryName, string? version, string? target, out ImmutableArray<AssetsFileTargetLibrary> dependencies)
         {
+            Requires.NotNull(libraryName, nameof(libraryName));
+
             if (!TryGetTarget(target, out AssetsFileTarget? targetData))
             {
                 dependencies = default;
@@ -207,6 +211,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models
 
         public bool TryGetPackage(string packageId, string version, string? target, [NotNullWhen(returnValue: true)] out AssetsFileTargetLibrary? assetsFileLibrary)
         {
+            Requires.NotNull(packageId, nameof(packageId));
+            Requires.NotNull(version, nameof(version));
+
             if (!TryGetTarget(target, out AssetsFileTarget? targetData))
             {
                 assetsFileLibrary = default;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Assets/Models/AssetsFileDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Assets/Models/AssetsFileDependenciesSnapshot.cs
@@ -284,5 +284,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models
                 return false;
             }
         }
+
+        public override string ToString() => $"{DataByTarget.Count} target{(DataByTarget.Count == 1 ? "" : "s")}";
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Assets/Models/AssetsFileDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Assets/Models/AssetsFileDependenciesSnapshot.cs
@@ -75,9 +75,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models
 
             ImmutableDictionary<string, AssetsFileTarget>.Builder dataByTarget = ImmutableDictionary.CreateBuilder<string, AssetsFileTarget>(StringComparers.FrameworkIdentifiers); // TODO review comparer here -- should it be ignore case?
 
-            var topLevelDependenciesByTarget = lockFile.PackageSpec.TargetFrameworks.ToDictionary(
-                targetFramework => targetFramework.FrameworkName.DotNetFrameworkName,
-                targetFramework => targetFramework.Dependencies.Select(dep => dep.Name).ToHashSet());
+            var topLevelDependenciesByTarget = lockFile.ProjectFileDependencyGroups.ToDictionary(
+                dependencyGroup => dependencyGroup.FrameworkName,
+                dependencyGroup => dependencyGroup.Dependencies.Select(ParseLibraryNameFromDependencyGroupString).ToHashSet());
 
             foreach (LockFileTarget lockFileTarget in lockFile.Targets)
             {
@@ -102,6 +102,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models
 
             DataByTarget = dataByTarget.ToImmutable();
             return;
+
+            static string ParseLibraryNameFromDependencyGroupString(string dependency)
+            {
+                // "MyLibrary >= 1.0.0"
+                int spaceIndex = dependency.IndexOf(' ');
+                if (spaceIndex != -1)
+                    return dependency.Substring(0, spaceIndex);
+                return dependency;
+            }
 
             static ImmutableArray<AssetsFileLogMessage> ParseLogMessages(LockFile lockFile, AssetsFileTarget previousTarget, string target)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Assets/Models/AssetsFileLogMessage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Assets/Models/AssetsFileLogMessage.cs
@@ -33,5 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models
                 && other.Message == Message
                 && other.LibraryId == LibraryId;
         }
+
+        public override string ToString() => $"{Level} {Code} ({LibraryId}) {Message}";
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Assets/Models/AssetsFileTarget.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Assets/Models/AssetsFileTarget.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Text;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models
 {
@@ -87,6 +88,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models
             }
 
             return _dependentsByLibrary.TryGetValue(libraryName, out dependents);
+        }
+
+        public override string ToString()
+        {
+            var s = new StringBuilder();
+            s.Append("Target \"").Append(Target).Append("\" ");
+            s.Append(LibraryByName.Count).Append(LibraryByName.Count == 1 ? " library (" : " libraries (");
+            s.Append(_topLevelDependencies?.Count ?? 0).Append(" top level) ");
+            s.Append(Logs.Length).Append(Logs.Length == 1 ? " log" : " logs");
+            return s.ToString();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Assets/Models/AssetsFileTargetLibrary.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Assets/Models/AssetsFileTargetLibrary.cs
@@ -58,5 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models
         public ImmutableArray<string> Dependencies { get; }
         public ImmutableArray<string> FrameworkAssemblies { get; }
         public ImmutableArray<string> CompileTimeAssemblies { get; }
+
+        public override string ToString() => $"{Type} {Name} ({Version}) {Dependencies.Length} {(Dependencies.Length == 1 ? "dependency" : "dependencies")}";
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -163,7 +163,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             IProjectTree? dependenciesNode = root.Flags.Contains(DependencyTreeFlags.DependenciesRootNode)
                 ? root
-                : root.GetSubTreeNode(DependencyTreeFlags.DependenciesRootNode);
+                : root.FindChildWithFlags(DependencyTreeFlags.DependenciesRootNode);
 
             return dependenciesNode?.GetSelfAndDescendentsBreadthFirst()
                 .FirstOrDefault((node, p) => string.Equals(node.FilePath, p, StringComparisons.Paths), path);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageDependencyModel.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
         public override DependencyIconSet IconSet => Implicit ? s_implicitIconSet : s_iconSet;
 
-        public override string Name { get; }
+        public override string Name => OriginalItemSpec;
 
         public override string ProviderType => PackageRuleHandler.ProviderTypeString;
 
@@ -35,7 +35,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
         public PackageDependencyModel(
             string path,
             string originalItemSpec,
-            string name,
             string version,
             bool isResolved,
             bool isImplicit,
@@ -44,16 +43,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             : base(
                 path,
                 originalItemSpec,
-                flags: s_flagCache.Get(isResolved, isImplicit).Add($"$ID:{name}").Add($"$VER:{version}"),
+                flags: s_flagCache.Get(isResolved, isImplicit).Add($"$ID:{originalItemSpec}").Add($"$VER:{version}"),
                 isResolved,
                 isImplicit,
                 properties,
                 isVisible)
         {
-            Requires.NotNullOrEmpty(name, nameof(name));
-
-            Name = name;
-            Caption = string.IsNullOrEmpty(version) ? name : $"{name} ({version})";
+            Caption = string.IsNullOrEmpty(version) ? originalItemSpec : $"{originalItemSpec} ({version})";
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -56,7 +56,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 properties: projectChange.After.GetProjectItemProperties(addedItem)!,
                 isEvaluatedItemSpec,
                 targetFramework,
-                _targetFrameworkProvider,
                 out PackageDependencyModel? dependencyModel))
             {
                 changesBuilder.Added(dependencyModel);
@@ -77,7 +76,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 properties: projectChange.After.GetProjectItemProperties(changedItem)!,
                 isEvaluatedItemSpec,
                 targetFramework,
-                _targetFrameworkProvider,
                 out PackageDependencyModel? dependencyModel))
             {
                 changesBuilder.Removed(ProviderTypeString, dependencyModel.OriginalItemSpec);
@@ -99,7 +97,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 properties: projectChange.Before.GetProjectItemProperties(removedItem)!,
                 isEvaluatedItemSpec,
                 targetFramework,
-                _targetFrameworkProvider,
                 out PackageDependencyModel? dependencyModel))
             {
                 changesBuilder.Removed(ProviderTypeString, dependencyModel.OriginalItemSpec);
@@ -110,13 +107,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         private static readonly InternPool<string> s_targetFrameworkInternPool = new InternPool<string>(StringComparer.Ordinal);
 
-        private static bool TryCreatePackageDependencyModel(
+        private bool TryCreatePackageDependencyModel(
             string itemSpec,
             bool isResolved,
             IImmutableDictionary<string, string> properties,
             Func<string, bool>? isEvaluatedItemSpec,
             ITargetFramework targetFramework,
-            ITargetFrameworkProvider targetFrameworkProvider,
             [NotNullWhen(returnValue: true)] out PackageDependencyModel? dependencyModel)
         {
             Requires.NotNullOrEmpty(itemSpec, nameof(itemSpec));
@@ -129,7 +125,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 // We have design-time build data
 
                 Requires.NotNull(targetFramework, nameof(targetFramework));
-                Requires.NotNull(targetFrameworkProvider, nameof(targetFrameworkProvider));
                 Requires.NotNull(isEvaluatedItemSpec!, nameof(isEvaluatedItemSpec));
 
                 string? dependencyType = properties.GetStringProperty(ProjectItemMetadata.Type);
@@ -154,7 +149,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     // ItemSpec contains more than one '/'. It's the old format and we must apply filtering.
                     string targetFrameworkName = s_targetFrameworkInternPool.Intern(itemSpec.Substring(0, slashIndex));
 
-                    if (targetFrameworkProvider.GetTargetFramework(targetFrameworkName)?.Equals(targetFramework) != true)
+                    if (_targetFrameworkProvider.GetTargetFramework(targetFrameworkName)?.Equals(targetFramework) != true)
                     {
                         dependencyModel = default;
                         return false;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModelTests.cs
@@ -17,7 +17,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var model = new PackageDependencyModel(
                 path: "c:\\myPath",
                 originalItemSpec: "myOriginalItemSpec",
-                name: "myPath",
                 version: "myVersion",
                 isResolved: true,
                 isImplicit: false,
@@ -26,10 +25,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             Assert.Equal(PackageRuleHandler.ProviderTypeString, model.ProviderType);
             Assert.Equal("c:\\myPath", model.Path);
-            Assert.Equal("myPath", model.Name);
+            Assert.Equal("myOriginalItemSpec", model.Name);
             Assert.Equal("myOriginalItemSpec", model.OriginalItemSpec);
             Assert.Equal("myOriginalItemSpec", model.Id);
-            Assert.Equal("myPath (myVersion)", model.Caption);
+            Assert.Equal("myOriginalItemSpec (myVersion)", model.Caption);
             Assert.Equal(ResolvedPackageReference.SchemaName, model.SchemaName);
             Assert.Equal(PackageReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.True(model.Visible);
@@ -43,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(
                 DependencyTreeFlags.PackageDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags +
-                ProjectTreeFlags.Create("$ID:myPath") +
+                ProjectTreeFlags.Create("$ID:myOriginalItemSpec") +
                 ProjectTreeFlags.Create("$VER:myVersion"),
                 model.Flags);
         }
@@ -56,7 +55,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var model = new PackageDependencyModel(
                 path: "c:\\myPath",
                 originalItemSpec: "myOriginalItemSpec",
-                name: "myPath",
                 version: "myVersion",
                 isResolved: false,
                 isImplicit: false,
@@ -65,10 +63,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             Assert.Equal(PackageRuleHandler.ProviderTypeString, model.ProviderType);
             Assert.Equal("c:\\myPath", model.Path);
-            Assert.Equal("myPath", model.Name);
+            Assert.Equal("myOriginalItemSpec", model.Name);
             Assert.Equal("myOriginalItemSpec", model.OriginalItemSpec);
             Assert.Equal("myOriginalItemSpec", model.Id);
-            Assert.Equal("myPath (myVersion)", model.Caption);
+            Assert.Equal("myOriginalItemSpec (myVersion)", model.Caption);
             Assert.Equal(PackageReference.SchemaName, model.SchemaName);
             Assert.Equal(PackageReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.True(model.Visible);
@@ -82,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(
                 DependencyTreeFlags.PackageDependency +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags +
-                ProjectTreeFlags.Create("$ID:myPath") +
+                ProjectTreeFlags.Create("$ID:myOriginalItemSpec") +
                 ProjectTreeFlags.Create("$VER:myVersion"),
                 model.Flags);
         }
@@ -95,7 +93,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var model = new PackageDependencyModel(
                 path: "c:\\myPath",
                 originalItemSpec: "myOriginalItemSpec",
-                name: "myPath",
                 version: "",
                 isResolved: true,
                 isImplicit: true,
@@ -104,10 +101,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             Assert.Equal(PackageRuleHandler.ProviderTypeString, model.ProviderType);
             Assert.Equal("c:\\myPath", model.Path);
-            Assert.Equal("myPath", model.Name);
+            Assert.Equal("myOriginalItemSpec", model.Name);
             Assert.Equal("myOriginalItemSpec", model.OriginalItemSpec);
             Assert.Equal("myOriginalItemSpec", model.Id);
-            Assert.Equal("myPath", model.Caption);
+            Assert.Equal("myOriginalItemSpec", model.Caption);
             Assert.Equal(ResolvedPackageReference.SchemaName, model.SchemaName);
             Assert.Equal(PackageReference.PrimaryDataSourceItemType, model.SchemaItemType);
             Assert.True(model.Visible);
@@ -121,7 +118,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(
                 DependencyTreeFlags.PackageDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags +
-                ProjectTreeFlags.Create("$ID:myPath") +
+                ProjectTreeFlags.Create("$ID:myOriginalItemSpec") +
                 ProjectTreeFlags.Create("$VER:") -
                 DependencyTreeFlags.SupportsRemove,
                 model.Flags);


### PR DESCRIPTION
This PR introduces a functional version of dependencies tree search. Next week I will be working to consolidate the dual tree construction approaches (top-down during user expansion, vs. bottom-up during search) as part of the extensibility API design.

---

Solution Explorer search occurs via the `ISearchProvider` interface. When a search is requested, we pass back tree items that match the search expression for the tree to display. At that point we are unlikely to have materialised items ready to return, so we create just those nodes that match. The tree then uses the "contained by" relationship to populate ancestor nodes, with the expectation that an ancestor will eventually exist in the current tree. For search, these are the `IVsHierarchyItem` objects that back top-level dependencies.

This bottom-up approach to building the tree required some new interfaces and data structures. Items that implement `IContainedByAttachedItems` can report their ancestors to the tree during search, meaning they can appear in search results. The snapshot now has the ability to lazily create a bottom-up dependency map for constant-time queries of a given item's ancestors.

Dependency tree item types now have factories for constructing their instances with a given directionality (relationship) in mind.

`DependenciesSearchContext` acts as a context object for a single search operation and monitors things like cancellation and ensuring maximum result limits are respected.

`ResolvedPackageReference` rule properties `Dependencies` (which listed child dependencies) and `IsTopLevelDependency` (which is computed via different means) have been removed.

A 'legacy mode' is introduced for best-effort support for using older SDKs. Once 16.7 releases with SDK 3.1.4xx, the data exchange between DTB targets and the dependencies node for package references will change considerably. The legacy mode (documented in `PackageRuleHandler`) kicks in when it detects old-style data and makes the tree look as sensible as possible. Specifically, top-level dependencies should appear correctly, though transitive dependencies will be filtered out. There's also some swizzling to IDs necessary in legacy mode which will not be required going forward.

![image](https://user-images.githubusercontent.com/350947/78342204-a6397c80-75e4-11ea-9feb-a89f0e1b1905.png)
