### PR TITLE
Show packages' content files in tree

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -124,10 +124,10 @@
     <PackageReference Update="Roslyn.Diagnostics.Analyzers"                                           Version="3.0.0-beta2.20059.3+77df2220" />
 
     <!-- NuGet -->
-    <PackageReference Update="NuGet.SolutionRestoreManager.Interop"                                   Version="5.6.0-preview.2.6532" />
-    <PackageReference Update="NuGet.VisualStudio"                                                     Version="5.6.0-preview.2.6532" />
-    <PackageReference Update="NuGet.ProjectModel"                                                     Version="5.6.0-preview.2.6532" />
-    <PackageReference Update="NuGet.Common"                                                           Version="5.6.0-preview.2.6532" />
+    <PackageReference Update="NuGet.SolutionRestoreManager.Interop"                                   Version="5.6.0-preview.2.6554" />
+    <PackageReference Update="NuGet.VisualStudio"                                                     Version="5.6.0-preview.2.6554" />
+    <PackageReference Update="NuGet.ProjectModel"                                                     Version="5.6.0-preview.2.6554" />
+    <PackageReference Update="NuGet.Common"                                                           Version="5.6.0-preview.2.6554" />
 
     <!-- MSBuild -->
     <PackageReference Update="Microsoft.Build"                                                        Version="16.4.0"/>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AttachedItemPriority.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AttachedItemPriority.cs
@@ -19,5 +19,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         public const int Project                  = 300;
         public const int CompileTimeAssemblyGroup = 400;
         public const int FrameworkAssemblyGroup   = 500;
+        public const int ContentFilesGroup        = 600;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesAttachedCollectionSourceProvider.Providers.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesAttachedCollectionSourceProvider.Providers.cs
@@ -51,16 +51,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         private sealed class PackageProvider : AssetsFileProviderBase
         {
             private readonly JoinableTaskContext _joinableTaskContext;
+            private readonly IFileIconProvider _fileIconProvider;
 
             [ImportingConstructor]
-            public PackageProvider(JoinableTaskContext joinableTaskContext)
+            public PackageProvider(JoinableTaskContext joinableTaskContext, IFileIconProvider fileIconProvider)
                 : base(DependencyTreeFlags.PackageDependency)
-                    => _joinableTaskContext = joinableTaskContext;
+            {
+                _joinableTaskContext = joinableTaskContext;
+                _fileIconProvider = fileIconProvider;
+            }
 
             protected override IAttachedCollectionSource? TryCreateSource(IVsHierarchyItem hierarchyItem, IAssetsFileDependenciesDataSource dataSource, string? target)
             {
                 return hierarchyItem.TryGetPackageDetails(out string? packageId, out string? packageVersion)
-                    ? new PackageReferenceAttachedCollectionSource(hierarchyItem, target, packageId, packageVersion, dataSource, _joinableTaskContext)
+                    ? new PackageReferenceAttachedCollectionSource(hierarchyItem, target, packageId, packageVersion, dataSource, _joinableTaskContext, _fileIconProvider)
                     : null;
             }
         }
@@ -70,16 +74,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         private sealed class ProjectProvider : AssetsFileProviderBase
         {
             private readonly JoinableTaskContext _joinableTaskContext;
+            private readonly IFileIconProvider _fileIconProvider;
 
             [ImportingConstructor]
-            public ProjectProvider(JoinableTaskContext joinableTaskContext)
+            public ProjectProvider(JoinableTaskContext joinableTaskContext, IFileIconProvider fileIconProvider)
                 : base(DependencyTreeFlags.ProjectDependency)
-                    => _joinableTaskContext = joinableTaskContext;
+            {
+                _joinableTaskContext = joinableTaskContext;
+                _fileIconProvider = fileIconProvider;
+            }
 
             protected override IAttachedCollectionSource? TryCreateSource(IVsHierarchyItem hierarchyItem, IAssetsFileDependenciesDataSource dataSource, string? target)
             {
                 return hierarchyItem.TryGetProjectDetails(out string? projectId)
-                    ? new ProjectReferenceAttachedCollectionSource(hierarchyItem, target, projectId, dataSource, _joinableTaskContext)
+                    ? new ProjectReferenceAttachedCollectionSource(hierarchyItem, target, projectId, dataSource, _joinableTaskContext, _fileIconProvider)
                     : null;
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageAssemblyGroupItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageAssemblyGroupItem.cs
@@ -72,8 +72,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public override ImageMoniker IconMoniker => ManagedImageMonikers.ReferenceGroup;
 
-        public override object? GetBrowseObject() => null;
-
         public IAttachedCollectionSource? ContainsAttachedCollectionSource { get; private set; }
 
         public IAttachedCollectionSource? ContainedByAttachedCollectionSource { get; private set; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageContentFileItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageContentFileItem.cs
@@ -19,17 +19,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         private readonly AssetsFileTargetLibraryContentFile _contentFile;
 
         public PackageContentFileItem(IFileIconProvider fileIconProvider, PackageContentFilesGroupItem groupItem, AssetsFileTargetLibraryContentFile contentFile)
-            : base(contentFile.Path)
+            : base(GetProcessedContentFilePath(contentFile.Path))
         {
             _fileIconProvider = fileIconProvider;
             _groupItem = groupItem;
             _contentFile = contentFile;
         }
 
+        private static string GetProcessedContentFilePath(string rawPath)
+        {
+            // Content file paths always start with "contentFiles/" so remove it from display strings
+            const string Prefix = "contentFiles/";
+            return rawPath.StartsWith(Prefix) ? rawPath.Substring(Prefix.Length) : rawPath;
+        }
+
         // All siblings are content files, so no prioritization needed (sort alphabetically)
         public override int Priority => 0;
 
-        public override ImageMoniker IconMoniker => _fileIconProvider.GetFileExtensionImageMoniker(_contentFile.Path);
+        public override ImageMoniker IconMoniker => _fileIconProvider.GetFileExtensionImageMoniker(Text);
 
         public override object? GetBrowseObject() => new BrowseObject(this);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageContentFileItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageContentFileItem.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections
+{
+    /// <summary>
+    /// Backing object for a content file within a package within the dependencies tree.
+    /// </summary>
+    /// <remarks>
+    /// Items of this type are grouped within <see cref="PackageContentFilesGroupItem"/>.
+    /// </remarks>
+    internal sealed class PackageContentFileItem : AttachedCollectionItemBase, IContainedByAttachedItems
+    {
+        private readonly IFileIconProvider _fileIconProvider;
+        private readonly PackageContentFilesGroupItem _groupItem;
+        private readonly AssetsFileTargetLibraryContentFile _contentFile;
+
+        public PackageContentFileItem(IFileIconProvider fileIconProvider, PackageContentFilesGroupItem groupItem, AssetsFileTargetLibraryContentFile contentFile)
+            : base(contentFile.Path)
+        {
+            _fileIconProvider = fileIconProvider;
+            _groupItem = groupItem;
+            _contentFile = contentFile;
+        }
+
+        // All siblings are content files, so no prioritization needed (sort alphabetically)
+        public override int Priority => 0;
+
+        public override ImageMoniker IconMoniker => _fileIconProvider.GetFileExtensionImageMoniker(_contentFile.Path);
+
+        public override object? GetBrowseObject() => new BrowseObject(this);
+
+        public IAttachedCollectionSource? ContainedByAttachedCollectionSource => new MaterializedAttachedCollectionSource(this, new[] { _groupItem });
+
+        private sealed class BrowseObject : BrowseObjectBase
+        {
+            private readonly PackageContentFileItem _item;
+
+            public BrowseObject(PackageContentFileItem item) => _item = item;
+
+            public override string GetComponentName() => _item.Text;
+
+            public override string GetClassName() => VSResources.PackageContentFileBrowseObjectClassName;
+
+            [BrowseObjectDisplayName(nameof(VSResources.PackageContentFilePathDisplayName))]
+            [BrowseObjectDescription(nameof(VSResources.PackageContentFilePathDescription))]
+            public string Path => _item._contentFile.Path;
+
+            [BrowseObjectDisplayName(nameof(VSResources.PackageContentFileOutputPathDisplayName))]
+            [BrowseObjectDescription(nameof(VSResources.PackageContentFileOutputPathDescription))]
+            public string? OutputPath => _item._contentFile.OutputPath;
+
+            [BrowseObjectDisplayName(nameof(VSResources.PackageContentFilePPOutputPathDisplayName))]
+            [BrowseObjectDescription(nameof(VSResources.PackageContentFilePPOutputPathDescription))]
+            public string? PPOutputPath => _item._contentFile.PPOutputPath;
+
+            [BrowseObjectDisplayName(nameof(VSResources.PackageContentFileCodeLanguageDisplayName))]
+            [BrowseObjectDescription(nameof(VSResources.PackageContentFileCodeLanguageDescription))]
+            public string? CodeLanguage => _item._contentFile.CodeLanguage;
+
+            [BrowseObjectDisplayName(nameof(VSResources.PackageContentFileBuildActionDisplayName))]
+            [BrowseObjectDescription(nameof(VSResources.PackageContentFileBuildActionDescription))]
+            public string? BuildAction => _item._contentFile.BuildAction;
+
+            [BrowseObjectDisplayName(nameof(VSResources.PackageContentFileCopyToOutputDisplayName))]
+            [BrowseObjectDescription(nameof(VSResources.PackageContentFileCopyToOutputDescription))]
+            public bool CopyToOutput => _item._contentFile.CopyToOutput;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageContentFilesGroupItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageContentFilesGroupItem.cs
@@ -1,0 +1,75 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections
+{
+    /// <summary>
+    /// Backing object for grouping a package's content files within the dependencies tree.
+    /// </summary>
+    internal sealed class PackageContentFilesGroupItem : AttachedCollectionItemBase, IContainsAttachedItems, IContainedByAttachedItems
+    {
+        public static PackageContentFilesGroupItem CreateWithContainsItems(IFileIconProvider fileIconProvider, ImmutableArray<AssetsFileTargetLibraryContentFile> contentFiles)
+        {
+            Requires.NotNull(fileIconProvider, nameof(fileIconProvider));
+            Requires.Argument(!contentFiles.IsDefaultOrEmpty, nameof(contentFiles), "May not be default or empty");
+
+            var item = new PackageContentFilesGroupItem();
+            item.ContainsAttachedCollectionSource = new ContainsCollectionSource(fileIconProvider, item, contentFiles);
+            return item;
+        }
+
+        public static PackageContentFilesGroupItem CreateWithContainedByItems(AssetsFileDependenciesSnapshot snapshot, AssetsFileTargetLibrary library, IEnumerable containedByItems)
+        {
+            Requires.NotNull(snapshot, nameof(snapshot));
+            Requires.NotNull(library, nameof(library));
+            Requires.NotNull(containedByItems, nameof(containedByItems));
+
+            var item = new PackageContentFilesGroupItem();
+            item.ContainedByAttachedCollectionSource = new MaterializedAttachedCollectionSource(item, containedByItems);
+            return item;
+        }
+
+        private PackageContentFilesGroupItem()
+            : base(VSResources.PackageContentFilesGroupName)
+        {
+        }
+
+        public override int Priority => AttachedItemPriority.ContentFilesGroup;
+
+        public override ImageMoniker IconMoniker => KnownMonikers.PackageFolderClosed;
+
+        public override ImageMoniker ExpandedIconMoniker => KnownMonikers.PackageFolderOpened;
+
+        public IAttachedCollectionSource? ContainsAttachedCollectionSource { get; private set; }
+
+        public IAttachedCollectionSource? ContainedByAttachedCollectionSource { get; private set; }
+
+        private sealed class ContainsCollectionSource : IAttachedCollectionSource
+        {
+            private readonly IFileIconProvider _fileIconProvider;
+            private readonly PackageContentFilesGroupItem _groupItem;
+            private readonly ImmutableArray<AssetsFileTargetLibraryContentFile> _contentFiles;
+            private IEnumerable? _items;
+
+            public ContainsCollectionSource(IFileIconProvider fileIconProvider, PackageContentFilesGroupItem groupItem, ImmutableArray<AssetsFileTargetLibraryContentFile> contentFiles)
+            {
+                _fileIconProvider = fileIconProvider;
+                _groupItem = groupItem;
+                _contentFiles = contentFiles;
+            }
+
+            public object? SourceItem => _groupItem;
+
+            public bool HasItems => true;
+
+            public IEnumerable Items => _items ??= _contentFiles.Select(contentFile => new PackageContentFileItem(_fileIconProvider, _groupItem, contentFile)).ToList();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageReferenceAttachedCollectionSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/PackageReferenceAttachedCollectionSource.cs
@@ -24,8 +24,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
             string packageId,
             string version,
             IAssetsFileDependenciesDataSource dataSource,
-            JoinableTaskContext joinableTaskContext)
-            : base(hierarchyItem, dataSource, joinableTaskContext)
+            JoinableTaskContext joinableTaskContext,
+            IFileIconProvider fileIconProvider)
+            : base(hierarchyItem, dataSource, joinableTaskContext, fileIconProvider)
         {
             _target = target;
             _packageId = packageId;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/ProjectReferenceAttachedCollectionSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/ProjectReferenceAttachedCollectionSource.cs
@@ -22,8 +22,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
             string? target,
             string projectId,
             IAssetsFileDependenciesDataSource dataSource,
-            JoinableTaskContext joinableTaskContext)
-            : base(hierarchyItem, dataSource, joinableTaskContext)
+            JoinableTaskContext joinableTaskContext,
+            IFileIconProvider fileIconProvider)
+            : base(hierarchyItem, dataSource, joinableTaskContext, fileIconProvider)
         {
             _target = target;
             _projectId = projectId;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/ProjectReferenceItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/ProjectReferenceItem.cs
@@ -16,10 +16,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     {
         private readonly AssetsFileTargetLibrary _library;
 
-        public static ProjectReferenceItem CreateWithContainsItems(AssetsFileDependenciesSnapshot snapshot, AssetsFileTargetLibrary library, string? target)
+        public static ProjectReferenceItem CreateWithContainsItems(AssetsFileDependenciesSnapshot snapshot, AssetsFileTargetLibrary library, string? target, IFileIconProvider fileIconProvider)
         {
             var item = new ProjectReferenceItem(library);
-            item.ContainsAttachedCollectionSource = new ContainsCollectionSource(item, snapshot, library, target);
+            item.ContainsAttachedCollectionSource = new ContainsCollectionSource(item, snapshot, library, target, fileIconProvider);
             return item;
         }
 
@@ -51,14 +51,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
             private readonly AssetsFileDependenciesSnapshot _snapshot;
             private readonly AssetsFileTargetLibrary _library;
             private readonly string? _target;
+            private readonly IFileIconProvider _fileIconProvider;
             private IEnumerable? _items;
 
-            public ContainsCollectionSource(ProjectReferenceItem sourceItem, AssetsFileDependenciesSnapshot snapshot, AssetsFileTargetLibrary library, string? target)
+            public ContainsCollectionSource(ProjectReferenceItem sourceItem, AssetsFileDependenciesSnapshot snapshot, AssetsFileTargetLibrary library, string? target, IFileIconProvider fileIconProvider)
             {
                 SourceItem = sourceItem;
                 _snapshot = snapshot;
                 _library = library;
                 _target = target;
+                _fileIconProvider = fileIconProvider;
             }
 
             public object? SourceItem { get; }
@@ -75,7 +77,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                         if (_snapshot.TryGetDependencies(_library.Name, _library.Version, _target, out ImmutableArray<AssetsFileTargetLibrary> dependencies))
                         {
                             ImmutableArray<object>.Builder builder = ImmutableArray.CreateBuilder<object>(dependencies.Length);
-                            builder.AddRange(dependencies.Select(dep => PackageReferenceItem.CreateWithContainsItems(_snapshot, dep, _target)));
+                            builder.AddRange(dependencies.Select(dep => PackageReferenceItem.CreateWithContainsItems(_snapshot, dep, _target, _fileIconProvider)));
                             _items = builder.MoveToImmutable();
                         }
                         else

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/FileIconProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/FileIconProvider.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.IO;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree
+{
+    [Export(typeof(IFileIconProvider))]
+    internal sealed class FileIconProvider : IFileIconProvider
+    {
+        private readonly IVsUIService<SVsImageService, IVsImageService2> _vsImageService;
+
+        private ImmutableDictionary<string, ImageMoniker> _imageMonikerByExtensions = ImmutableDictionary.Create<string, ImageMoniker>(StringComparers.Paths);
+
+        [ImportingConstructor]
+        public FileIconProvider(IVsUIService<SVsImageService, IVsImageService2> vsImageService)
+        {
+            _vsImageService = vsImageService;
+        }
+
+        public ImageMoniker GetFileExtensionImageMoniker(string path)
+        {
+            string extension = Path.GetExtension(path);
+
+            return ImmutableInterlocked.GetOrAdd(ref _imageMonikerByExtensions, extension, GetImageMoniker, path);
+
+            ImageMoniker GetImageMoniker(string _, string p)
+            {
+                ImageMoniker imageMoniker = _vsImageService.Value.GetImageMonikerForFile(p);
+                
+                if (imageMoniker.Id == -1)
+                {
+                    // No specific icon exists for this extension
+                    imageMoniker = KnownMonikers.Document;
+                }
+
+                return imageMoniker;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/IFileIconProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/IFileIconProvider.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Composition;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree
+{
+    /// <summary>
+    /// Provides icons for files based on their file names.
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne, Provider = ProjectSystemContractProvider.Private)]
+    internal interface IFileIconProvider
+    {
+        /// <summary>
+        /// Gets the icon associated with <paramref name="path"/>'s extension.
+        /// </summary>
+        /// <remarks>
+        /// If no specific icon could be determined, <see cref="KnownMonikers.Document"/> is returned.
+        /// </remarks>
+        ImageMoniker GetFileExtensionImageMoniker(string path);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -376,6 +376,132 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Content File.
+        /// </summary>
+        internal static string PackageContentFileBrowseObjectClassName {
+            get {
+                return ResourceManager.GetString("PackageContentFileBrowseObjectClassName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The content file&apos;s build action..
+        /// </summary>
+        internal static string PackageContentFileBuildActionDescription {
+            get {
+                return ResourceManager.GetString("PackageContentFileBuildActionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Build Action.
+        /// </summary>
+        internal static string PackageContentFileBuildActionDisplayName {
+            get {
+                return ResourceManager.GetString("PackageContentFileBuildActionDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Controls whether this file should be included in the referencing project based on that project&apos;s language..
+        /// </summary>
+        internal static string PackageContentFileCodeLanguageDescription {
+            get {
+                return ResourceManager.GetString("PackageContentFileCodeLanguageDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Code Language.
+        /// </summary>
+        internal static string PackageContentFileCodeLanguageDisplayName {
+            get {
+                return ResourceManager.GetString("PackageContentFileCodeLanguageDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Whether the content file is copied to the output directory during build..
+        /// </summary>
+        internal static string PackageContentFileCopyToOutputDescription {
+            get {
+                return ResourceManager.GetString("PackageContentFileCopyToOutputDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Copy to Output.
+        /// </summary>
+        internal static string PackageContentFileCopyToOutputDisplayName {
+            get {
+                return ResourceManager.GetString("PackageContentFileCopyToOutputDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The content file&apos;s output path..
+        /// </summary>
+        internal static string PackageContentFileOutputPathDescription {
+            get {
+                return ResourceManager.GetString("PackageContentFileOutputPathDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Output Path.
+        /// </summary>
+        internal static string PackageContentFileOutputPathDisplayName {
+            get {
+                return ResourceManager.GetString("PackageContentFileOutputPathDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The content file&apos;s path..
+        /// </summary>
+        internal static string PackageContentFilePathDescription {
+            get {
+                return ResourceManager.GetString("PackageContentFilePathDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path.
+        /// </summary>
+        internal static string PackageContentFilePathDisplayName {
+            get {
+                return ResourceManager.GetString("PackageContentFilePathDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The content file&apos;s preprocessed output path..
+        /// </summary>
+        internal static string PackageContentFilePPOutputPathDescription {
+            get {
+                return ResourceManager.GetString("PackageContentFilePPOutputPathDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Preprocessed Output Path.
+        /// </summary>
+        internal static string PackageContentFilePPOutputPathDisplayName {
+            get {
+                return ResourceManager.GetString("PackageContentFilePPOutputPathDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Content Files.
+        /// </summary>
+        internal static string PackageContentFilesGroupName {
+            get {
+                return ResourceManager.GetString("PackageContentFilesGroupName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Framework Assemblies.
         /// </summary>
         internal static string PackageFrameworkAssemblyGroupName {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -284,6 +284,48 @@ In order to debug this project, add an executable project to this solution which
   <data name="PackageCompileTimeAssemblyGroupName" xml:space="preserve">
     <value>Compile Time Assemblies</value>
   </data>
+  <data name="PackageContentFilesGroupName" xml:space="preserve">
+    <value>Content Files</value>
+  </data>
+  <data name="PackageContentFileBrowseObjectClassName" xml:space="preserve">
+    <value>Content File</value>
+  </data>
+  <data name="PackageContentFilePathDisplayName" xml:space="preserve">
+    <value>Path</value>
+  </data>
+  <data name="PackageContentFilePathDescription" xml:space="preserve">
+    <value>The content file's path.</value>
+  </data>
+  <data name="PackageContentFileOutputPathDisplayName" xml:space="preserve">
+    <value>Output Path</value>
+  </data>
+  <data name="PackageContentFileOutputPathDescription" xml:space="preserve">
+    <value>The content file's output path.</value>
+  </data>
+  <data name="PackageContentFilePPOutputPathDisplayName" xml:space="preserve">
+    <value>Preprocessed Output Path</value>
+  </data>
+  <data name="PackageContentFilePPOutputPathDescription" xml:space="preserve">
+    <value>The content file's preprocessed output path.</value>
+  </data>
+  <data name="PackageContentFileCodeLanguageDisplayName" xml:space="preserve">
+    <value>Code Language</value>
+  </data>
+  <data name="PackageContentFileCodeLanguageDescription" xml:space="preserve">
+    <value>Controls whether this file should be included in the referencing project based on that project's language.</value>
+  </data>
+  <data name="PackageContentFileBuildActionDisplayName" xml:space="preserve">
+    <value>Build Action</value>
+  </data>
+  <data name="PackageContentFileBuildActionDescription" xml:space="preserve">
+    <value>The content file's build action.</value>
+  </data>
+  <data name="PackageContentFileCopyToOutputDisplayName" xml:space="preserve">
+    <value>Copy to Output</value>
+  </data>
+  <data name="PackageContentFileCopyToOutputDescription" xml:space="preserve">
+    <value>Whether the content file is copied to the output directory during build.</value>
+  </data>
   <data name="PackageFrameworkAssemblyGroupName" xml:space="preserve">
     <value>Framework Assemblies</value>
   </data>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -92,6 +92,76 @@
         <target state="new">Compile Time Assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageContentFileBrowseObjectClassName">
+        <source>Content File</source>
+        <target state="new">Content File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDescription">
+        <source>The content file's build action.</source>
+        <target state="new">The content file's build action.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDisplayName">
+        <source>Build Action</source>
+        <target state="new">Build Action</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDescription">
+        <source>Controls whether this file should be included in the referencing project based on that project's language.</source>
+        <target state="new">Controls whether this file should be included in the referencing project based on that project's language.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDisplayName">
+        <source>Code Language</source>
+        <target state="new">Code Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDescription">
+        <source>Whether the content file is copied to the output directory during build.</source>
+        <target state="new">Whether the content file is copied to the output directory during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDisplayName">
+        <source>Copy to Output</source>
+        <target state="new">Copy to Output</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDescription">
+        <source>The content file's output path.</source>
+        <target state="new">The content file's output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDescription">
+        <source>The content file's preprocessed output path.</source>
+        <target state="new">The content file's preprocessed output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDisplayName">
+        <source>Preprocessed Output Path</source>
+        <target state="new">Preprocessed Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDescription">
+        <source>The content file's path.</source>
+        <target state="new">The content file's path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilesGroupName">
+        <source>Content Files</source>
+        <target state="new">Content Files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageFrameworkAssemblyGroupName">
         <source>Framework Assemblies</source>
         <target state="new">Framework Assemblies</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -92,6 +92,76 @@
         <target state="new">Compile Time Assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageContentFileBrowseObjectClassName">
+        <source>Content File</source>
+        <target state="new">Content File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDescription">
+        <source>The content file's build action.</source>
+        <target state="new">The content file's build action.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDisplayName">
+        <source>Build Action</source>
+        <target state="new">Build Action</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDescription">
+        <source>Controls whether this file should be included in the referencing project based on that project's language.</source>
+        <target state="new">Controls whether this file should be included in the referencing project based on that project's language.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDisplayName">
+        <source>Code Language</source>
+        <target state="new">Code Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDescription">
+        <source>Whether the content file is copied to the output directory during build.</source>
+        <target state="new">Whether the content file is copied to the output directory during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDisplayName">
+        <source>Copy to Output</source>
+        <target state="new">Copy to Output</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDescription">
+        <source>The content file's output path.</source>
+        <target state="new">The content file's output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDescription">
+        <source>The content file's preprocessed output path.</source>
+        <target state="new">The content file's preprocessed output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDisplayName">
+        <source>Preprocessed Output Path</source>
+        <target state="new">Preprocessed Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDescription">
+        <source>The content file's path.</source>
+        <target state="new">The content file's path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilesGroupName">
+        <source>Content Files</source>
+        <target state="new">Content Files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageFrameworkAssemblyGroupName">
         <source>Framework Assemblies</source>
         <target state="new">Framework Assemblies</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -92,6 +92,76 @@
         <target state="new">Compile Time Assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageContentFileBrowseObjectClassName">
+        <source>Content File</source>
+        <target state="new">Content File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDescription">
+        <source>The content file's build action.</source>
+        <target state="new">The content file's build action.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDisplayName">
+        <source>Build Action</source>
+        <target state="new">Build Action</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDescription">
+        <source>Controls whether this file should be included in the referencing project based on that project's language.</source>
+        <target state="new">Controls whether this file should be included in the referencing project based on that project's language.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDisplayName">
+        <source>Code Language</source>
+        <target state="new">Code Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDescription">
+        <source>Whether the content file is copied to the output directory during build.</source>
+        <target state="new">Whether the content file is copied to the output directory during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDisplayName">
+        <source>Copy to Output</source>
+        <target state="new">Copy to Output</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDescription">
+        <source>The content file's output path.</source>
+        <target state="new">The content file's output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDescription">
+        <source>The content file's preprocessed output path.</source>
+        <target state="new">The content file's preprocessed output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDisplayName">
+        <source>Preprocessed Output Path</source>
+        <target state="new">Preprocessed Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDescription">
+        <source>The content file's path.</source>
+        <target state="new">The content file's path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilesGroupName">
+        <source>Content Files</source>
+        <target state="new">Content Files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageFrameworkAssemblyGroupName">
         <source>Framework Assemblies</source>
         <target state="new">Framework Assemblies</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -92,6 +92,76 @@
         <target state="new">Compile Time Assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageContentFileBrowseObjectClassName">
+        <source>Content File</source>
+        <target state="new">Content File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDescription">
+        <source>The content file's build action.</source>
+        <target state="new">The content file's build action.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDisplayName">
+        <source>Build Action</source>
+        <target state="new">Build Action</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDescription">
+        <source>Controls whether this file should be included in the referencing project based on that project's language.</source>
+        <target state="new">Controls whether this file should be included in the referencing project based on that project's language.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDisplayName">
+        <source>Code Language</source>
+        <target state="new">Code Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDescription">
+        <source>Whether the content file is copied to the output directory during build.</source>
+        <target state="new">Whether the content file is copied to the output directory during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDisplayName">
+        <source>Copy to Output</source>
+        <target state="new">Copy to Output</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDescription">
+        <source>The content file's output path.</source>
+        <target state="new">The content file's output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDescription">
+        <source>The content file's preprocessed output path.</source>
+        <target state="new">The content file's preprocessed output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDisplayName">
+        <source>Preprocessed Output Path</source>
+        <target state="new">Preprocessed Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDescription">
+        <source>The content file's path.</source>
+        <target state="new">The content file's path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilesGroupName">
+        <source>Content Files</source>
+        <target state="new">Content Files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageFrameworkAssemblyGroupName">
         <source>Framework Assemblies</source>
         <target state="new">Framework Assemblies</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -92,6 +92,76 @@
         <target state="new">Compile Time Assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageContentFileBrowseObjectClassName">
+        <source>Content File</source>
+        <target state="new">Content File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDescription">
+        <source>The content file's build action.</source>
+        <target state="new">The content file's build action.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDisplayName">
+        <source>Build Action</source>
+        <target state="new">Build Action</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDescription">
+        <source>Controls whether this file should be included in the referencing project based on that project's language.</source>
+        <target state="new">Controls whether this file should be included in the referencing project based on that project's language.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDisplayName">
+        <source>Code Language</source>
+        <target state="new">Code Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDescription">
+        <source>Whether the content file is copied to the output directory during build.</source>
+        <target state="new">Whether the content file is copied to the output directory during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDisplayName">
+        <source>Copy to Output</source>
+        <target state="new">Copy to Output</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDescription">
+        <source>The content file's output path.</source>
+        <target state="new">The content file's output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDescription">
+        <source>The content file's preprocessed output path.</source>
+        <target state="new">The content file's preprocessed output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDisplayName">
+        <source>Preprocessed Output Path</source>
+        <target state="new">Preprocessed Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDescription">
+        <source>The content file's path.</source>
+        <target state="new">The content file's path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilesGroupName">
+        <source>Content Files</source>
+        <target state="new">Content Files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageFrameworkAssemblyGroupName">
         <source>Framework Assemblies</source>
         <target state="new">Framework Assemblies</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -92,6 +92,76 @@
         <target state="new">Compile Time Assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageContentFileBrowseObjectClassName">
+        <source>Content File</source>
+        <target state="new">Content File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDescription">
+        <source>The content file's build action.</source>
+        <target state="new">The content file's build action.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDisplayName">
+        <source>Build Action</source>
+        <target state="new">Build Action</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDescription">
+        <source>Controls whether this file should be included in the referencing project based on that project's language.</source>
+        <target state="new">Controls whether this file should be included in the referencing project based on that project's language.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDisplayName">
+        <source>Code Language</source>
+        <target state="new">Code Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDescription">
+        <source>Whether the content file is copied to the output directory during build.</source>
+        <target state="new">Whether the content file is copied to the output directory during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDisplayName">
+        <source>Copy to Output</source>
+        <target state="new">Copy to Output</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDescription">
+        <source>The content file's output path.</source>
+        <target state="new">The content file's output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDescription">
+        <source>The content file's preprocessed output path.</source>
+        <target state="new">The content file's preprocessed output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDisplayName">
+        <source>Preprocessed Output Path</source>
+        <target state="new">Preprocessed Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDescription">
+        <source>The content file's path.</source>
+        <target state="new">The content file's path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilesGroupName">
+        <source>Content Files</source>
+        <target state="new">Content Files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageFrameworkAssemblyGroupName">
         <source>Framework Assemblies</source>
         <target state="new">Framework Assemblies</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -92,6 +92,76 @@
         <target state="new">Compile Time Assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageContentFileBrowseObjectClassName">
+        <source>Content File</source>
+        <target state="new">Content File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDescription">
+        <source>The content file's build action.</source>
+        <target state="new">The content file's build action.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDisplayName">
+        <source>Build Action</source>
+        <target state="new">Build Action</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDescription">
+        <source>Controls whether this file should be included in the referencing project based on that project's language.</source>
+        <target state="new">Controls whether this file should be included in the referencing project based on that project's language.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDisplayName">
+        <source>Code Language</source>
+        <target state="new">Code Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDescription">
+        <source>Whether the content file is copied to the output directory during build.</source>
+        <target state="new">Whether the content file is copied to the output directory during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDisplayName">
+        <source>Copy to Output</source>
+        <target state="new">Copy to Output</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDescription">
+        <source>The content file's output path.</source>
+        <target state="new">The content file's output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDescription">
+        <source>The content file's preprocessed output path.</source>
+        <target state="new">The content file's preprocessed output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDisplayName">
+        <source>Preprocessed Output Path</source>
+        <target state="new">Preprocessed Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDescription">
+        <source>The content file's path.</source>
+        <target state="new">The content file's path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilesGroupName">
+        <source>Content Files</source>
+        <target state="new">Content Files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageFrameworkAssemblyGroupName">
         <source>Framework Assemblies</source>
         <target state="new">Framework Assemblies</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -92,6 +92,76 @@
         <target state="new">Compile Time Assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageContentFileBrowseObjectClassName">
+        <source>Content File</source>
+        <target state="new">Content File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDescription">
+        <source>The content file's build action.</source>
+        <target state="new">The content file's build action.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDisplayName">
+        <source>Build Action</source>
+        <target state="new">Build Action</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDescription">
+        <source>Controls whether this file should be included in the referencing project based on that project's language.</source>
+        <target state="new">Controls whether this file should be included in the referencing project based on that project's language.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDisplayName">
+        <source>Code Language</source>
+        <target state="new">Code Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDescription">
+        <source>Whether the content file is copied to the output directory during build.</source>
+        <target state="new">Whether the content file is copied to the output directory during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDisplayName">
+        <source>Copy to Output</source>
+        <target state="new">Copy to Output</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDescription">
+        <source>The content file's output path.</source>
+        <target state="new">The content file's output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDescription">
+        <source>The content file's preprocessed output path.</source>
+        <target state="new">The content file's preprocessed output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDisplayName">
+        <source>Preprocessed Output Path</source>
+        <target state="new">Preprocessed Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDescription">
+        <source>The content file's path.</source>
+        <target state="new">The content file's path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilesGroupName">
+        <source>Content Files</source>
+        <target state="new">Content Files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageFrameworkAssemblyGroupName">
         <source>Framework Assemblies</source>
         <target state="new">Framework Assemblies</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -92,6 +92,76 @@
         <target state="new">Compile Time Assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageContentFileBrowseObjectClassName">
+        <source>Content File</source>
+        <target state="new">Content File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDescription">
+        <source>The content file's build action.</source>
+        <target state="new">The content file's build action.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDisplayName">
+        <source>Build Action</source>
+        <target state="new">Build Action</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDescription">
+        <source>Controls whether this file should be included in the referencing project based on that project's language.</source>
+        <target state="new">Controls whether this file should be included in the referencing project based on that project's language.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDisplayName">
+        <source>Code Language</source>
+        <target state="new">Code Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDescription">
+        <source>Whether the content file is copied to the output directory during build.</source>
+        <target state="new">Whether the content file is copied to the output directory during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDisplayName">
+        <source>Copy to Output</source>
+        <target state="new">Copy to Output</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDescription">
+        <source>The content file's output path.</source>
+        <target state="new">The content file's output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDescription">
+        <source>The content file's preprocessed output path.</source>
+        <target state="new">The content file's preprocessed output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDisplayName">
+        <source>Preprocessed Output Path</source>
+        <target state="new">Preprocessed Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDescription">
+        <source>The content file's path.</source>
+        <target state="new">The content file's path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilesGroupName">
+        <source>Content Files</source>
+        <target state="new">Content Files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageFrameworkAssemblyGroupName">
         <source>Framework Assemblies</source>
         <target state="new">Framework Assemblies</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -92,6 +92,76 @@
         <target state="new">Compile Time Assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageContentFileBrowseObjectClassName">
+        <source>Content File</source>
+        <target state="new">Content File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDescription">
+        <source>The content file's build action.</source>
+        <target state="new">The content file's build action.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDisplayName">
+        <source>Build Action</source>
+        <target state="new">Build Action</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDescription">
+        <source>Controls whether this file should be included in the referencing project based on that project's language.</source>
+        <target state="new">Controls whether this file should be included in the referencing project based on that project's language.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDisplayName">
+        <source>Code Language</source>
+        <target state="new">Code Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDescription">
+        <source>Whether the content file is copied to the output directory during build.</source>
+        <target state="new">Whether the content file is copied to the output directory during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDisplayName">
+        <source>Copy to Output</source>
+        <target state="new">Copy to Output</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDescription">
+        <source>The content file's output path.</source>
+        <target state="new">The content file's output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDescription">
+        <source>The content file's preprocessed output path.</source>
+        <target state="new">The content file's preprocessed output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDisplayName">
+        <source>Preprocessed Output Path</source>
+        <target state="new">Preprocessed Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDescription">
+        <source>The content file's path.</source>
+        <target state="new">The content file's path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilesGroupName">
+        <source>Content Files</source>
+        <target state="new">Content Files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageFrameworkAssemblyGroupName">
         <source>Framework Assemblies</source>
         <target state="new">Framework Assemblies</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -92,6 +92,76 @@
         <target state="new">Compile Time Assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageContentFileBrowseObjectClassName">
+        <source>Content File</source>
+        <target state="new">Content File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDescription">
+        <source>The content file's build action.</source>
+        <target state="new">The content file's build action.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDisplayName">
+        <source>Build Action</source>
+        <target state="new">Build Action</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDescription">
+        <source>Controls whether this file should be included in the referencing project based on that project's language.</source>
+        <target state="new">Controls whether this file should be included in the referencing project based on that project's language.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDisplayName">
+        <source>Code Language</source>
+        <target state="new">Code Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDescription">
+        <source>Whether the content file is copied to the output directory during build.</source>
+        <target state="new">Whether the content file is copied to the output directory during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDisplayName">
+        <source>Copy to Output</source>
+        <target state="new">Copy to Output</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDescription">
+        <source>The content file's output path.</source>
+        <target state="new">The content file's output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDescription">
+        <source>The content file's preprocessed output path.</source>
+        <target state="new">The content file's preprocessed output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDisplayName">
+        <source>Preprocessed Output Path</source>
+        <target state="new">Preprocessed Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDescription">
+        <source>The content file's path.</source>
+        <target state="new">The content file's path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilesGroupName">
+        <source>Content Files</source>
+        <target state="new">Content Files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageFrameworkAssemblyGroupName">
         <source>Framework Assemblies</source>
         <target state="new">Framework Assemblies</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -92,6 +92,76 @@
         <target state="new">Compile Time Assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageContentFileBrowseObjectClassName">
+        <source>Content File</source>
+        <target state="new">Content File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDescription">
+        <source>The content file's build action.</source>
+        <target state="new">The content file's build action.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDisplayName">
+        <source>Build Action</source>
+        <target state="new">Build Action</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDescription">
+        <source>Controls whether this file should be included in the referencing project based on that project's language.</source>
+        <target state="new">Controls whether this file should be included in the referencing project based on that project's language.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDisplayName">
+        <source>Code Language</source>
+        <target state="new">Code Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDescription">
+        <source>Whether the content file is copied to the output directory during build.</source>
+        <target state="new">Whether the content file is copied to the output directory during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDisplayName">
+        <source>Copy to Output</source>
+        <target state="new">Copy to Output</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDescription">
+        <source>The content file's output path.</source>
+        <target state="new">The content file's output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDescription">
+        <source>The content file's preprocessed output path.</source>
+        <target state="new">The content file's preprocessed output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDisplayName">
+        <source>Preprocessed Output Path</source>
+        <target state="new">Preprocessed Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDescription">
+        <source>The content file's path.</source>
+        <target state="new">The content file's path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilesGroupName">
+        <source>Content Files</source>
+        <target state="new">Content Files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageFrameworkAssemblyGroupName">
         <source>Framework Assemblies</source>
         <target state="new">Framework Assemblies</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -92,6 +92,76 @@
         <target state="new">Compile Time Assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageContentFileBrowseObjectClassName">
+        <source>Content File</source>
+        <target state="new">Content File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDescription">
+        <source>The content file's build action.</source>
+        <target state="new">The content file's build action.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileBuildActionDisplayName">
+        <source>Build Action</source>
+        <target state="new">Build Action</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDescription">
+        <source>Controls whether this file should be included in the referencing project based on that project's language.</source>
+        <target state="new">Controls whether this file should be included in the referencing project based on that project's language.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCodeLanguageDisplayName">
+        <source>Code Language</source>
+        <target state="new">Code Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDescription">
+        <source>Whether the content file is copied to the output directory during build.</source>
+        <target state="new">Whether the content file is copied to the output directory during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileCopyToOutputDisplayName">
+        <source>Copy to Output</source>
+        <target state="new">Copy to Output</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDescription">
+        <source>The content file's output path.</source>
+        <target state="new">The content file's output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFileOutputPathDisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDescription">
+        <source>The content file's preprocessed output path.</source>
+        <target state="new">The content file's preprocessed output path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePPOutputPathDisplayName">
+        <source>Preprocessed Output Path</source>
+        <target state="new">Preprocessed Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDescription">
+        <source>The content file's path.</source>
+        <target state="new">The content file's path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilePathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageContentFilesGroupName">
+        <source>Content Files</source>
+        <target state="new">Content Files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageFrameworkAssemblyGroupName">
         <source>Framework Assemblies</source>
         <target state="new">Framework Assemblies</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Assets/Models/AssetsFileTargetLibrary.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Assets/Models/AssetsFileTargetLibrary.cs
@@ -38,9 +38,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models
             Name = library.Name;
             Version = library.Version.ToNormalizedString();
             Type = type;
-            
-            // TODO use each dependency's version range in caption
-            // TODO use each dependency's include/exclude in browse object
+
+            // TODO use each dependency's version range in caption (won't have parity with top-level item unless we update caption or change SDK to return this information)
+            // TODO use each dependency's include/exclude in browse object (won't have parity with top-level item until we rethink browse objects for them)
             Dependencies = library.Dependencies.Select(dep => dep.Id).ToImmutableArray();
 
             CompileTimeAssemblies = library.CompileTimeAssemblies

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Assets/Models/AssetsFileTargetLibrary.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Assets/Models/AssetsFileTargetLibrary.cs
@@ -51,7 +51,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models
 
             FrameworkAssemblies = library.FrameworkAssemblies.ToImmutableArray();
 
-            ContentFiles = library.ContentFiles.Select(file => new AssetsFileTargetLibraryContentFile(file)).ToImmutableArray();
+            // TODO filter by code language as well (requires knowing project language): https://github.com/dotnet/NuGet.BuildTasks/blob/5244c490a425353ac12445567d87d674ae118836/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs#L572-L575
+            ContentFiles = library.ContentFiles
+                .Where(file => !NuGetUtils.IsPlaceholderFile(file.Path))
+                .Select(file => new AssetsFileTargetLibraryContentFile(file))
+                .ToImmutableArray();
         }
 
         public string Name { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Assets/Models/AssetsFileTargetLibrary.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Assets/Models/AssetsFileTargetLibrary.cs
@@ -50,6 +50,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models
                 .ToImmutableArray(); // TODO do we want to use the 'properties' here? maybe for browse object
 
             FrameworkAssemblies = library.FrameworkAssemblies.ToImmutableArray();
+
+            ContentFiles = library.ContentFiles.Select(file => new AssetsFileTargetLibraryContentFile(file)).ToImmutableArray();
         }
 
         public string Name { get; }
@@ -58,6 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models
         public ImmutableArray<string> Dependencies { get; }
         public ImmutableArray<string> FrameworkAssemblies { get; }
         public ImmutableArray<string> CompileTimeAssemblies { get; }
+        public ImmutableArray<AssetsFileTargetLibraryContentFile> ContentFiles { get; }
 
         public override string ToString() => $"{Type} {Name} ({Version}) {Dependencies.Length} {(Dependencies.Length == 1 ? "dependency" : "dependencies")}";
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Assets/Models/AssetsFileTargetLibraryContentFile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Assets/Models/AssetsFileTargetLibraryContentFile.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using NuGet.ProjectModel;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Assets.Models
+{
+    /// <summary>
+    /// Data about a a content file within a package in a given target, from <c>project.assets.json</c>. Immutable.
+    /// </summary>
+    internal sealed class AssetsFileTargetLibraryContentFile
+    {
+        public AssetsFileTargetLibraryContentFile(LockFileContentFile file)
+        {
+            Requires.NotNull(file, nameof(file));
+            
+            BuildAction = file.BuildAction.Value;
+            CodeLanguage = file.CodeLanguage;
+            CopyToOutput = file.CopyToOutput;
+            OutputPath = file.OutputPath;
+            Path = file.Path ?? ""; // Path should always be present so don't require consumers to null check. Not worth throwing if null though.
+            PPOutputPath = file.PPOutputPath;
+        }
+
+        public string? BuildAction { get; }
+        public string? CodeLanguage { get; }
+        public bool CopyToOutput { get; }
+        public string? OutputPath { get; }
+        public string Path { get; }
+        public string? PPOutputPath { get; }
+    }
+}


### PR DESCRIPTION
Fixes #603.

Adds support for showing and searching a package's `contentFiles` items in the dependencies tree.

Apart from fixing an outstanding feature request, this PR serves as an example of what it would currently take to add support for a new item in the dependencies tree. My next unit of work is to improve the APIs required to do exactly that. My goal is to make adding a feature such as this simpler and more localised.

---

### In tree

![image](https://user-images.githubusercontent.com/350947/78655959-0b091580-790a-11ea-9d41-6cc2996430d2.png)

### In search

![image](https://user-images.githubusercontent.com/350947/78656062-2ffd8880-790a-11ea-9afd-62b47316cd85.png)

### Browse object

![image](https://user-images.githubusercontent.com/350947/78656138-515e7480-790a-11ea-953e-158c917b950d.png)
