### PR TITLE
[16.6] Don't modify collection while enumerating

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -135,7 +135,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 // Remove any extra target frameworks
                 if (builder.Count != targetFrameworks.Length)
                 {
-                    IEnumerable<ITargetFramework> targetFrameworksToRemove = builder.Keys.Except(targetFrameworks);
+                    // NOTE We need "ToList" here as "Except" is lazy, and attempts to remove from the builder
+                    // while iterating will throw "Collection was modified"
+                    IEnumerable<ITargetFramework> targetFrameworksToRemove = builder.Keys.Except(targetFrameworks).ToList();
 
                     foreach (ITargetFramework targetFramework in targetFrameworksToRemove)
                     {


### PR DESCRIPTION
⚠ This PR is the 16.6.x equivalent of #6091 and should not be merged without QB approval.

---

This bug has existed in the dependencies node for some time. It started surfacing for users in 16.5.4 when faulting dataflow blocks were reported (PR #6073). The bug is tracked in #6090.

The result of `Except` is lazily computed, so attempting to remove from the builder while enumerating that result causes a "Collection was modified" exception. The fix is to materialise the result prior to enumerating the data that backs it.