### PR TITLE
Change warning message to fit and be consistent.

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/FixedWidthTextBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/FixedWidthTextBox.vb
@@ -1,0 +1,31 @@
+﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+Imports System.Windows.Forms
+
+Namespace Microsoft.VisualStudio.Editors.PropertyPages
+
+    ''' <summary>
+    ''' This is a class to automatically set the height of textbox.
+    ''' </summary>
+    Friend Class FixedWidthTextBox
+        Inherits TextBox
+
+        Protected Overrides Sub OnTextChanged(e As EventArgs)
+            CalculateAndSetHeight()
+            MyBase.OnTextChanged(e)
+        End Sub
+
+        Protected Overrides Sub OnSizeChanged(e As EventArgs)
+            CalculateAndSetHeight()
+            MyBase.OnSizeChanged(e)
+        End Sub
+
+        Private Sub CalculateAndSetHeight()
+            Using graphics = CreateGraphics()
+                Dim area = graphics.MeasureString(Text, Font, Width)
+                Height = CInt(area.Height)
+            End Using
+        End Sub
+    End Class
+
+End Namespace

--- a/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.Designer.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.Copyright = New System.Windows.Forms.TextBox()
             Me.PackageLicenseLabel = New System.Windows.Forms.Label()
             Me.LicenseLineLabel = New System.Windows.Forms.Label()
-            Me.LicenseUrlWarning = New System.Windows.Forms.TextBox()
+            Me.LicenseUrlWarning = New Microsoft.VisualStudio.Editors.PropertyPages.FixedWidthTextBox()
             Me.ExpressionLabel = New System.Windows.Forms.Label()
             Me.ExpressionLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
             Me.LicenseExpressionRadioButton = New System.Windows.Forms.RadioButton()
@@ -75,7 +75,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.FileVersionMinorTextBox = New System.Windows.Forms.TextBox()
             Me.FileVersionMajorTextBox = New System.Windows.Forms.TextBox()
             Me.PackageIconLineLabel = New System.Windows.Forms.Label()
-            Me.PackageIconUrlWarning = New System.Windows.Forms.TextBox()
+            Me.PackageIconUrlWarning = New Microsoft.VisualStudio.Editors.PropertyPages.FixedWidthTextBox()
             Me.LicenseLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
             Me.OrLabel = New System.Windows.Forms.Label()
             Me.TableLayoutPanel.SuspendLayout()
@@ -532,7 +532,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Friend WithEvents FileVersionMajorTextBox As Windows.Forms.TextBox
         Friend WithEvents AssemblyFileVersionLabel As Windows.Forms.Label
         Friend WithEvents LicenseLineLabel As System.Windows.Forms.Label
-        Friend WithEvents LicenseUrlWarning As System.Windows.Forms.TextBox
+        Friend WithEvents LicenseUrlWarning As FixedWidthTextBox
 
         Friend WithEvents LicenseLayoutPanel As Windows.Forms.TableLayoutPanel
         Friend WithEvents ExpressionLayoutPanel As Windows.Forms.TableLayoutPanel
@@ -551,7 +551,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Friend WithEvents LicenseBrowseButton As System.Windows.Forms.Button
         Friend WithEvents IconFileBrowseButton As Windows.Forms.Button
         Friend WithEvents PackageIconLineLabel As Windows.Forms.Label
-        Friend WithEvents PackageIconUrlWarning As Windows.Forms.TextBox
+        Friend WithEvents PackageIconUrlWarning As FixedWidthTextBox
     End Class
 
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx
@@ -720,6 +720,9 @@
   <data name="ExpressionLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Right</value>
   </data>
+  <data name="ExpressionLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="ExpressionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx
@@ -700,7 +700,7 @@
     <value>10</value>
   </data>
   <data name="LicenseUrlWarning.Text" xml:space="preserve">
-    <value>PackageLicenseURL property was detected, but it has been deprecated. Please change to either an Expression or File.</value>
+    <value>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</value>
   </data>
   <data name="LicenseUrlWarning.Visible" type="System.Boolean, mscorlib">
     <value>False</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx
@@ -700,7 +700,7 @@
     <value>10</value>
   </data>
   <data name="LicenseUrlWarning.Text" xml:space="preserve">
-    <value>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</value>
+    <value>PackageLicenseURL detected but is deprecated. Please use Expression or File instead.</value>
   </data>
   <data name="LicenseUrlWarning.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1870,7 +1870,7 @@
     <value>10</value>
   </data>
   <data name="PackageIconUrlWarning.Text" xml:space="preserve">
-    <value>PackageIconUrl detected but is deprecated. Use PackageIcon instead.</value>
+    <value>PackageIconUrl detected but is deprecated. Please use PackageIcon instead.</value>
   </data>
   <data name="PackageIconUrlWarning.Visible" type="System.Boolean, mscorlib">
     <value>False</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.cs.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackageIconUrlWarning.Text">
-        <source>PackageIconUrl detected but is deprecated. Use PackageIcon instead.</source>
-        <target state="translated">Zjistil se parametr PackageIconUrl, který je zastaralý. Použijte místo něj parametr PackageIcon.</target>
+        <source>PackageIconUrl detected but is deprecated. Please use PackageIcon instead.</source>
+        <target state="needs-review-translation">Zjistil se parametr PackageIconUrl, který je zastaralý. Použijte místo něj parametr PackageIcon.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageVersionLabel.Text">
@@ -268,7 +268,7 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <source>PackageLicenseURL detected but is deprecated. Please use Expression or File instead.</source>
         <target state="needs-review-translation">Zjistila se vlastnost PackageLicenseURL, ale ta se už nepoužívá. Použijte prosím výraz nebo soubor.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.cs.xlf
@@ -268,8 +268,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL property was detected, but it has been deprecated. Please change to either an Expression or File.</source>
-        <target state="translated">Zjistila se vlastnost PackageLicenseURL, ale ta se už nepoužívá. Použijte prosím výraz nebo soubor.</target>
+        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <target state="needs-review-translation">Zjistila se vlastnost PackageLicenseURL, ale ta se už nepoužívá. Použijte prosím výraz nebo soubor.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.de.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackageIconUrlWarning.Text">
-        <source>PackageIconUrl detected but is deprecated. Use PackageIcon instead.</source>
-        <target state="translated">PackageIconUrl wurde erkannt, ist aber veraltet. Verwenden Sie stattdessen "PackageIcon".</target>
+        <source>PackageIconUrl detected but is deprecated. Please use PackageIcon instead.</source>
+        <target state="needs-review-translation">PackageIconUrl wurde erkannt, ist aber veraltet. Verwenden Sie stattdessen "PackageIcon".</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageVersionLabel.Text">
@@ -268,7 +268,7 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <source>PackageLicenseURL detected but is deprecated. Please use Expression or File instead.</source>
         <target state="needs-review-translation">Die veraltete Eigenschaft "PackageLicenseURL" wurde ermittelt. Ändern Sie den Ausdruck oder die Datei.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.de.xlf
@@ -268,8 +268,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL property was detected, but it has been deprecated. Please change to either an Expression or File.</source>
-        <target state="translated">Die veraltete Eigenschaft "PackageLicenseURL" wurde ermittelt. Ändern Sie den Ausdruck oder die Datei.</target>
+        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <target state="needs-review-translation">Die veraltete Eigenschaft "PackageLicenseURL" wurde ermittelt. Ändern Sie den Ausdruck oder die Datei.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.es.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackageIconUrlWarning.Text">
-        <source>PackageIconUrl detected but is deprecated. Use PackageIcon instead.</source>
-        <target state="translated">Se ha detectado un objeto PackageIconUrl, pero está en desuso. Use PackageIcon en su lugar.</target>
+        <source>PackageIconUrl detected but is deprecated. Please use PackageIcon instead.</source>
+        <target state="needs-review-translation">Se ha detectado un objeto PackageIconUrl, pero está en desuso. Use PackageIcon en su lugar.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageVersionLabel.Text">
@@ -268,7 +268,7 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <source>PackageLicenseURL detected but is deprecated. Please use Expression or File instead.</source>
         <target state="needs-review-translation">Se ha detectado la propiedad PackageLicenseURL, pero ha quedado obsoleta. Cámbiela por un archivo o una expresión.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.es.xlf
@@ -268,8 +268,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL property was detected, but it has been deprecated. Please change to either an Expression or File.</source>
-        <target state="translated">Se ha detectado la propiedad PackageLicenseURL, pero ha quedado obsoleta. Cámbiela por un archivo o una expresión.</target>
+        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <target state="needs-review-translation">Se ha detectado la propiedad PackageLicenseURL, pero ha quedado obsoleta. Cámbiela por un archivo o una expresión.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.fr.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackageIconUrlWarning.Text">
-        <source>PackageIconUrl detected but is deprecated. Use PackageIcon instead.</source>
-        <target state="translated">PackageIconUrl détecté, mais déprécié. Utilisez PackageIcon à la place.</target>
+        <source>PackageIconUrl detected but is deprecated. Please use PackageIcon instead.</source>
+        <target state="needs-review-translation">PackageIconUrl détecté, mais déprécié. Utilisez PackageIcon à la place.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageVersionLabel.Text">
@@ -268,7 +268,7 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <source>PackageLicenseURL detected but is deprecated. Please use Expression or File instead.</source>
         <target state="needs-review-translation">La propriété PackageLicenseURL a été détectée, mais elle est dépréciée. Remplacez-la par une expression ou un fichier.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.fr.xlf
@@ -268,8 +268,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL property was detected, but it has been deprecated. Please change to either an Expression or File.</source>
-        <target state="translated">La propriété PackageLicenseURL a été détectée, mais elle est dépréciée. Remplacez-la par une expression ou un fichier.</target>
+        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <target state="needs-review-translation">La propriété PackageLicenseURL a été détectée, mais elle est dépréciée. Remplacez-la par une expression ou un fichier.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.it.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackageIconUrlWarning.Text">
-        <source>PackageIconUrl detected but is deprecated. Use PackageIcon instead.</source>
-        <target state="translated">PackageIconUrl è stato rilevato ma è deprecato. In alternativa, usare PackageIcon.</target>
+        <source>PackageIconUrl detected but is deprecated. Please use PackageIcon instead.</source>
+        <target state="needs-review-translation">PackageIconUrl è stato rilevato ma è deprecato. In alternativa, usare PackageIcon.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageVersionLabel.Text">
@@ -268,7 +268,7 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <source>PackageLicenseURL detected but is deprecated. Please use Expression or File instead.</source>
         <target state="needs-review-translation">La proprietà PackageLicenseURL è stata rilevata ma è deprecata. Modificare in un elemento Expression o File.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.it.xlf
@@ -268,8 +268,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL property was detected, but it has been deprecated. Please change to either an Expression or File.</source>
-        <target state="translated">La proprietà PackageLicenseURL è stata rilevata ma è deprecata. Modificare in un elemento Expression o File.</target>
+        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <target state="needs-review-translation">La proprietà PackageLicenseURL è stata rilevata ma è deprecata. Modificare in un elemento Expression o File.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ja.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackageIconUrlWarning.Text">
-        <source>PackageIconUrl detected but is deprecated. Use PackageIcon instead.</source>
-        <target state="translated">PackageIconUrl が検出されましたが、非推奨です。代わりに PackageIcon をご使用ください。</target>
+        <source>PackageIconUrl detected but is deprecated. Please use PackageIcon instead.</source>
+        <target state="needs-review-translation">PackageIconUrl が検出されましたが、非推奨です。代わりに PackageIcon をご使用ください。</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageVersionLabel.Text">
@@ -268,7 +268,7 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <source>PackageLicenseURL detected but is deprecated. Please use Expression or File instead.</source>
         <target state="needs-review-translation">PackageLicenseURL プロパティが検出されましたが、このプロパティは非推奨です。式またはファイルに変更してください。</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ja.xlf
@@ -268,8 +268,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL property was detected, but it has been deprecated. Please change to either an Expression or File.</source>
-        <target state="translated">PackageLicenseURL プロパティが検出されましたが、このプロパティは非推奨です。式またはファイルに変更してください。</target>
+        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <target state="needs-review-translation">PackageLicenseURL プロパティが検出されましたが、このプロパティは非推奨です。式またはファイルに変更してください。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ko.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackageIconUrlWarning.Text">
-        <source>PackageIconUrl detected but is deprecated. Use PackageIcon instead.</source>
-        <target state="translated">PackageIconUrl이 검색되었지만 사용되지 않습니다. 대신 PackageIcon을 사용합니다.</target>
+        <source>PackageIconUrl detected but is deprecated. Please use PackageIcon instead.</source>
+        <target state="needs-review-translation">PackageIconUrl이 검색되었지만 사용되지 않습니다. 대신 PackageIcon을 사용합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageVersionLabel.Text">
@@ -268,7 +268,7 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <source>PackageLicenseURL detected but is deprecated. Please use Expression or File instead.</source>
         <target state="needs-review-translation">PackageLicenseURL 속성이 검색되었지만 사용되지 않습니다. 식 또는 파일로 변경하세요.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ko.xlf
@@ -268,8 +268,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL property was detected, but it has been deprecated. Please change to either an Expression or File.</source>
-        <target state="translated">PackageLicenseURL 속성이 검색되었지만 사용되지 않습니다. 식 또는 파일로 변경하세요.</target>
+        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <target state="needs-review-translation">PackageLicenseURL 속성이 검색되었지만 사용되지 않습니다. 식 또는 파일로 변경하세요.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pl.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackageIconUrlWarning.Text">
-        <source>PackageIconUrl detected but is deprecated. Use PackageIcon instead.</source>
-        <target state="translated">Wykryto element PackageIconUrl, ale jest on przestarzały. Użyj zamiast niego elementu PackageIcon.</target>
+        <source>PackageIconUrl detected but is deprecated. Please use PackageIcon instead.</source>
+        <target state="needs-review-translation">Wykryto element PackageIconUrl, ale jest on przestarzały. Użyj zamiast niego elementu PackageIcon.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageVersionLabel.Text">
@@ -268,7 +268,7 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <source>PackageLicenseURL detected but is deprecated. Please use Expression or File instead.</source>
         <target state="needs-review-translation">Wykryto właściwość PackageLicenseURL, ale została ona oznaczona jako przestarzała. Zmień wartość na wyrażenie lub plik.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pl.xlf
@@ -268,8 +268,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL property was detected, but it has been deprecated. Please change to either an Expression or File.</source>
-        <target state="translated">Wykryto właściwość PackageLicenseURL, ale została ona oznaczona jako przestarzała. Zmień wartość na wyrażenie lub plik.</target>
+        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <target state="needs-review-translation">Wykryto właściwość PackageLicenseURL, ale została ona oznaczona jako przestarzała. Zmień wartość na wyrażenie lub plik.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pt-BR.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackageIconUrlWarning.Text">
-        <source>PackageIconUrl detected but is deprecated. Use PackageIcon instead.</source>
-        <target state="translated">A PackageIconUrl foi detectada, mas foi preterida. Nesse caso, use o PackageIcon.</target>
+        <source>PackageIconUrl detected but is deprecated. Please use PackageIcon instead.</source>
+        <target state="needs-review-translation">A PackageIconUrl foi detectada, mas foi preterida. Nesse caso, use o PackageIcon.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageVersionLabel.Text">
@@ -268,7 +268,7 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <source>PackageLicenseURL detected but is deprecated. Please use Expression or File instead.</source>
         <target state="needs-review-translation">A propriedade PackageLicenseURL foi detectada, mas está preterida. Altere uma Expressão ou Arquivo.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pt-BR.xlf
@@ -268,8 +268,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL property was detected, but it has been deprecated. Please change to either an Expression or File.</source>
-        <target state="translated">A propriedade PackageLicenseURL foi detectada, mas está preterida. Altere uma Expressão ou Arquivo.</target>
+        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <target state="needs-review-translation">A propriedade PackageLicenseURL foi detectada, mas está preterida. Altere uma Expressão ou Arquivo.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ru.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackageIconUrlWarning.Text">
-        <source>PackageIconUrl detected but is deprecated. Use PackageIcon instead.</source>
-        <target state="translated">Обнаружен параметр PackageIconUrl, но он является устаревшим. Вместо этого используйте параметр PackageIcon.</target>
+        <source>PackageIconUrl detected but is deprecated. Please use PackageIcon instead.</source>
+        <target state="needs-review-translation">Обнаружен параметр PackageIconUrl, но он является устаревшим. Вместо этого используйте параметр PackageIcon.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageVersionLabel.Text">
@@ -268,7 +268,7 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <source>PackageLicenseURL detected but is deprecated. Please use Expression or File instead.</source>
         <target state="needs-review-translation">Обнаружено свойство PackageLicenseURL, которое является устаревшим. Пожалуйста, измените выражение (Expression) или файл (File).</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ru.xlf
@@ -268,8 +268,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL property was detected, but it has been deprecated. Please change to either an Expression or File.</source>
-        <target state="translated">Обнаружено свойство PackageLicenseURL, которое является устаревшим. Пожалуйста, измените выражение (Expression) или файл (File).</target>
+        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <target state="needs-review-translation">Обнаружено свойство PackageLicenseURL, которое является устаревшим. Пожалуйста, измените выражение (Expression) или файл (File).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.tr.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackageIconUrlWarning.Text">
-        <source>PackageIconUrl detected but is deprecated. Use PackageIcon instead.</source>
-        <target state="translated">PackageIconUrl saptandı ancak kullanım dışı bırakılmış. Bunun yerine PackageIcon kullanın.</target>
+        <source>PackageIconUrl detected but is deprecated. Please use PackageIcon instead.</source>
+        <target state="needs-review-translation">PackageIconUrl saptandı ancak kullanım dışı bırakılmış. Bunun yerine PackageIcon kullanın.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageVersionLabel.Text">
@@ -268,7 +268,7 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <source>PackageLicenseURL detected but is deprecated. Please use Expression or File instead.</source>
         <target state="needs-review-translation">PackageLicenseURL özelliği algılandı ancak kullanım dışı bırakıldı. Lütfen bir İfade veya Dosya olarak değiştirin.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.tr.xlf
@@ -268,8 +268,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL property was detected, but it has been deprecated. Please change to either an Expression or File.</source>
-        <target state="translated">PackageLicenseURL özelliği algılandı ancak kullanım dışı bırakıldı. Lütfen bir İfade veya Dosya olarak değiştirin.</target>
+        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <target state="needs-review-translation">PackageLicenseURL özelliği algılandı ancak kullanım dışı bırakıldı. Lütfen bir İfade veya Dosya olarak değiştirin.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hans.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackageIconUrlWarning.Text">
-        <source>PackageIconUrl detected but is deprecated. Use PackageIcon instead.</source>
-        <target state="translated">检测到 PackageIconUrl，但此属性已弃用。请改用 PackageIcon。</target>
+        <source>PackageIconUrl detected but is deprecated. Please use PackageIcon instead.</source>
+        <target state="needs-review-translation">检测到 PackageIconUrl，但此属性已弃用。请改用 PackageIcon。</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageVersionLabel.Text">
@@ -268,7 +268,7 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <source>PackageLicenseURL detected but is deprecated. Please use Expression or File instead.</source>
         <target state="needs-review-translation">检测到 PackageLicenseURL 属性，但它已被弃用。请更改为 Expression 或 File。</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hans.xlf
@@ -268,8 +268,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL property was detected, but it has been deprecated. Please change to either an Expression or File.</source>
-        <target state="translated">检测到 PackageLicenseURL 属性，但它已被弃用。请更改为 Expression 或 File。</target>
+        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <target state="needs-review-translation">检测到 PackageLicenseURL 属性，但它已被弃用。请更改为 Expression 或 File。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hant.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackageIconUrlWarning.Text">
-        <source>PackageIconUrl detected but is deprecated. Use PackageIcon instead.</source>
-        <target state="translated">偵測到 PackageIconUrl，但已淘汰。請改用 PackageIcon。</target>
+        <source>PackageIconUrl detected but is deprecated. Please use PackageIcon instead.</source>
+        <target state="needs-review-translation">偵測到 PackageIconUrl，但已淘汰。請改用 PackageIcon。</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageVersionLabel.Text">
@@ -268,7 +268,7 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <source>PackageLicenseURL detected but is deprecated. Please use Expression or File instead.</source>
         <target state="needs-review-translation">偵測到 PackageLicenseURL 屬性，但該屬性已淘汰。請變更為運算式或檔案。</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hant.xlf
@@ -268,8 +268,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">
-        <source>PackageLicenseURL property was detected, but it has been deprecated. Please change to either an Expression or File.</source>
-        <target state="translated">偵測到 PackageLicenseURL 屬性，但該屬性已淘汰。請變更為運算式或檔案。</target>
+        <source>PackageLicenseURL detected but is deprecated. Please change to either an Expression or File.</source>
+        <target state="needs-review-translation">偵測到 PackageLicenseURL 屬性，但該屬性已淘汰。請變更為運算式或檔案。</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
Fixes #4904. 
The warning message was long and couldn't fit in the row space. Changed the text to be consistent to the other warning message.

Here's what it would look like if PackageLicenseUrl and PackageIconUrl were found in the project file:
![image](https://user-images.githubusercontent.com/8518253/79394172-be39c600-7f2b-11ea-9ab1-184f5ce7e48e.png)
