### PR TITLE
Create a customized dataflow block to remove configuration versions.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreUnconfiguredInputDataSource.DropConfiguredProjectVersionDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreUnconfiguredInputDataSource.DropConfiguredProjectVersionDataSource.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
@@ -12,32 +15,138 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         ///     <see cref="ProjectDataSources.ConfiguredProjectVersion"/> versions from each value of the original
         ///     <see cref="IProjectValueDataSource{T}"/>.
         /// </summary>
-        private sealed class DropConfiguredProjectVersionDataSource<T> : ChainedProjectValueDataSourceBase<T>
+        private sealed class DropConfiguredProjectVersionDataSource<T> : IProjectValueDataSource<T>
             where T : class
         {
             private readonly IProjectValueDataSource<T> _dataSource;
 
-            public DropConfiguredProjectVersionDataSource(IProjectServices commonServices, IProjectValueDataSource<T> dataSource)
-                : base(commonServices, synchronousDisposal: true, registerDataSource: false)
+            public IReceivableSourceBlock<IProjectVersionedValue<T>> SourceBlock => new DropConfiguredProjectVersionPropagator(_dataSource.SourceBlock);
+
+            public NamedIdentity? DataSourceKey => null;
+
+            public IComparable? DataSourceVersion => null;
+
+            ISourceBlock<IProjectVersionedValue<object>> IProjectValueDataSource.SourceBlock => new DropConfiguredProjectVersionPropagator(_dataSource.SourceBlock);
+
+            public DropConfiguredProjectVersionDataSource(IProjectValueDataSource<T> dataSource)
             {
                 _dataSource = dataSource;
             }
 
-            protected override IDisposable LinkExternalInput(ITargetBlock<IProjectVersionedValue<T>> targetBlock)
+            public IDisposable? Join()
             {
-                DisposableValue<ISourceBlock<IProjectVersionedValue<T>>> block = _dataSource.SourceBlock.Transform(DropConfiguredProjectVersion);
-
-                block.Value.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
-
-                JoinUpstreamDataSources(_dataSource);
-
-                return block;
+                return _dataSource.Join();
             }
 
-            private static IProjectVersionedValue<T> DropConfiguredProjectVersion(IProjectVersionedValue<T> data)
+            private class DropConfiguredProjectVersionPropagator : IPropagatorBlock<IProjectVersionedValue<T>, IProjectVersionedValue<T>>, IReceivableSourceBlock<IProjectVersionedValue<T>>
             {
-                return new ProjectVersionedValue<T>(data.Value, data.DataSourceVersions.Remove(ProjectDataSources.ConfiguredProjectIdentity)
-                                                                                       .Remove(ProjectDataSources.ConfiguredProjectVersion));
+                private readonly IReceivableSourceBlock<IProjectVersionedValue<T>> _source;
+                private ITargetBlock<IProjectVersionedValue<T>>? _target;
+
+                public DropConfiguredProjectVersionPropagator(IReceivableSourceBlock<IProjectVersionedValue<T>> source)
+                {
+                    _source = source;
+                }
+
+                public Task Completion => _source.Completion;
+
+                public void Complete()
+                {
+                    _target?.Complete();
+                }
+
+#pragma warning disable CS8613 // Nullability of reference types in return type doesn't match implicitly implemented member.
+                public IProjectVersionedValue<T>? ConsumeMessage(DataflowMessageHeader messageHeader, ITargetBlock<IProjectVersionedValue<T>> target, out bool messageConsumed)
+#pragma warning restore CS8613 // Nullability of reference types in return type doesn't match implicitly implemented member.
+                {
+                    IProjectVersionedValue<T>? input = _source.ConsumeMessage(messageHeader, this, out messageConsumed);
+                    if (messageConsumed && input != null)
+                    {
+                        return DropConfiguredProjectVersion(input);
+                    }
+
+                    return null;
+                }
+
+                public void Fault(Exception exception)
+                {
+                    _target?.Fault(exception);
+                }
+
+                public IDisposable LinkTo(ITargetBlock<IProjectVersionedValue<T>> target, DataflowLinkOptions linkOptions)
+                {
+                    Requires.NotNull(target, nameof(target));
+                    Interlocked.CompareExchange(ref _target, target, null);
+
+                    if (_target != target)
+                    {
+                        throw new NotSupportedException();
+                    }
+
+                    return _source.LinkTo(this, linkOptions);
+                }
+
+                public DataflowMessageStatus OfferMessage(DataflowMessageHeader messageHeader, IProjectVersionedValue<T> messageValue, ISourceBlock<IProjectVersionedValue<T>>? source, bool consumeToAccept)
+                {
+                    IProjectVersionedValue<T> data;
+                    try
+                    {
+                        data = DropConfiguredProjectVersion(messageValue);
+                    }
+                    catch (Exception ex)
+                    {
+                        Fault(ex);
+                        return DataflowMessageStatus.DecliningPermanently;
+                    }
+
+                    return _target!.OfferMessage(messageHeader, data, this, consumeToAccept);
+                }
+
+                public void ReleaseReservation(DataflowMessageHeader messageHeader, ITargetBlock<IProjectVersionedValue<T>> target)
+                {
+                    _source.ReleaseReservation(messageHeader, this);
+                }
+
+                public bool ReserveMessage(DataflowMessageHeader messageHeader, ITargetBlock<IProjectVersionedValue<T>> target)
+                {
+                    return _source.ReserveMessage(messageHeader, this);
+                }
+
+                private static IProjectVersionedValue<T> DropConfiguredProjectVersion(IProjectVersionedValue<T> data)
+                {
+                    return new ProjectVersionedValue<T>(data.Value, data.DataSourceVersions.Remove(ProjectDataSources.ConfiguredProjectIdentity)
+                                                                                           .Remove(ProjectDataSources.ConfiguredProjectVersion));
+                }
+
+#pragma warning disable CS8614 // Nullability of reference types in type of parameter doesn't match implicitly implemented member.
+                public bool TryReceive(Predicate<IProjectVersionedValue<T>>? filter, out IProjectVersionedValue<T>? item)
+#pragma warning restore CS8614 // Nullability of reference types in type of parameter doesn't match implicitly implemented member.
+                {
+                    if (_source.TryReceive(
+                        filter == null ? filter : (x => filter!(DropConfiguredProjectVersion(x))),
+                        out item))
+                    {
+                        item = DropConfiguredProjectVersion(item);
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                public bool TryReceiveAll(out IList<IProjectVersionedValue<T>> items)
+                {
+                    if (_source.TryReceiveAll(out items))
+                    {
+                        for (int i = 0; i < items.Count; i++)
+                        {
+                            items[i] = DropConfiguredProjectVersion(items[i]);
+                        }
+
+                        return true;
+                    }
+
+                    return false;
+                }
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreUnconfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreUnconfiguredInputDataSource.cs
@@ -215,7 +215,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         {
             // Wrap it in a data source that will drop project version and identity versions so as they will never agree
             // on these versions as they are unique to each configuration. They'll be consistent by all other versions.
-            return new DropConfiguredProjectVersionDataSource<PackageRestoreConfiguredInput>(_project.Services, dataSource);
+            return new DropConfiguredProjectVersionDataSource<PackageRestoreConfiguredInput>(dataSource);
         }
     }
 }


### PR DESCRIPTION
Hi, @davkean 

This is not a piece of finished work, but a draft of concept to address the problem that we leak DropConfiguredProjectVersionDataSource blocks in the current implementation. The reason of this leak is that when configuration changes, it triggers code to rerun a LinQ expression to recreate a set of those blocks. The Unwrap block will dispose links from the original set of those blocks, and link to the new set. However, that will not unlink those blocks from its source, so those blocks will be still chained in the dataflow and handle the inputs, although no other block will consume its data.

It is actually quite hard to fix the problem with standard dataflow blocks, so I end up with implementing a completely customized block (which we did in quite a few places inside CPS). The core protocol of the dataflow is actually straight. When two blocks are linked, the source one will call offerMessage to pass data to the next block, and then you pass to the next one in the same way. The complexity is all related to load balance between multiple process blocks, which can delay process and reserve data, which is hardly useful in our scenario.

The implementation is largely copied from SimpleInlineTransformPropagator block in CPS.