### PR TITLE
Show file name in unit test output

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Setup/SwrTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Setup/SwrTests.cs
@@ -26,11 +26,12 @@ namespace Microsoft.VisualStudio.Setup
         {
             var rootPath = RepoUtil.FindRepoRootPath();
 
+            var commonFilesFileName = "CommonFiles.swr";
             var swrPath = Path.Combine(
                 rootPath,
                 "setup",
                 "Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles",
-                "CommonFiles.swr");
+                commonFilesFileName);
 
             var setupFilesByCulture = ReadSwrFiles(swrPath)
                 .Select(ParseSwrFile)
@@ -76,7 +77,7 @@ namespace Microsoft.VisualStudio.Setup
                 }
             }
 
-            Assert.False(guilty, "See test output for details");
+            Assert.False(guilty, $"There are setup errors in {commonFilesFileName}. See test output for details.");
 
             return;
 


### PR DESCRIPTION
When adding a new .xaml file I always forget to update CommonFiles.swr to include it. Happily, we have a unit test that catches this problem. However, it doesn't currently tell you which file you need to update to correct the problem--and that's another thing I never remember.

This commit updates the test to be explicit about needing to update CommonFiles.swr.