### PR TITLE
Update VisualBasicImports to use ProjectHostBridge and fire events

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicNamespaceImportsList.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicNamespaceImportsList.cs
@@ -82,11 +82,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
             return Task.CompletedTask;
         }
 
-        protected override Task ApplyAsync(IProjectVersionedValue<ImmutableList<string>> value)
+        protected override async Task ApplyAsync(IProjectVersionedValue<ImmutableList<string>> value)
         {
+            await JoinableFactory.SwitchToMainThreadAsync();
+
             ImmutableList<string> current = AppliedValue?.Value ?? ImmutableList<string>.Empty;
             ImmutableList<string> input = value.Value;
-            
+
             IEnumerable<string> removed = current.Except(input);
             IEnumerable<string> added = input.Except(current);
 
@@ -106,8 +108,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
                     imports.OnImportAdded(import);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
         protected override Task<IProjectVersionedValue<ImmutableList<string>>> PreprocessAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> input, IProjectVersionedValue<ImmutableList<string>>? previousOutput)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicVSImports.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicVSImports.cs
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
 {
     [Export(typeof(Imports))]
     [Export(typeof(ImportsEvents))]
+    [Export(typeof(VisualBasicVSImports))]
     [AppliesTo(ProjectCapability.VisualBasic)]
     [Order(Order.Default)]
     internal class VisualBasicVSImports : ConnectionPointContainer,
@@ -68,8 +69,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
                         project.AddItem(ImportItemTypeName, bstrImport);
                     });
                 });
-
-                OnImportAdded(bstrImport);
             }
             else
             {
@@ -118,8 +117,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
                 });
 
                 Assumes.NotNull(importRemoved);
-
-                OnImportRemoved(importRemoved);
             }
             else if (index is string)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicVSImports.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicVSImports.cs
@@ -106,13 +106,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
                     });
                 });
             }
-            else if (index is string)
-            {
-                throw new ArgumentException(string.Format("{0} - Namespace is not present ", index), nameof(index));
-            }
             else
             {
-                throw new ArgumentException(string.Format("{0} - index is neither an Int nor a String", index), nameof(index));
+                throw new ArgumentException(string.Format("{0} - index is neither an Int nor a String, or the Namepsace was not found", index), nameof(index));
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicVSImports.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicVSImports.cs
@@ -62,12 +62,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
         {
             if (!_importsList.IsPresent(bstrImport))
             {
-                _threadingService.ExecuteSynchronously(() =>
+                _threadingService.ExecuteSynchronously(async () =>
                 {
-                    return _projectAccessor.OpenProjectXmlForWriteAsync(_unconfiguredProjectVSServices.Project, project =>
+                    await _projectAccessor.OpenProjectXmlForWriteAsync(_unconfiguredProjectVSServices.Project, project =>
                     {
                         project.AddItem(ImportItemTypeName, bstrImport);
                     });
+
+                    await _importsList.ReceiveLatestSnapshotAsync();
                 });
             }
             else
@@ -90,9 +92,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
 
             if (importToRemove != null)
             {
-                _threadingService.ExecuteSynchronously(() =>
+                _threadingService.ExecuteSynchronously(async () =>
                 {
-                    return _projectAccessor.OpenProjectForWriteAsync(ConfiguredProject, project =>
+                    await _projectAccessor.OpenProjectForWriteAsync(ConfiguredProject, project =>
                     {
                         Microsoft.Build.Evaluation.ProjectItem importProjectItem = project.GetItems(ImportItemTypeName)
                                                                                           .First(i => string.Equals(importToRemove, i.EvaluatedInclude, StringComparisons.ItemNames));
@@ -104,6 +106,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
 
                         project.RemoveItem(importProjectItem);
                     });
+
+                    await _importsList.ReceiveLatestSnapshotAsync();
                 });
             }
             else

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ContractNames.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ContractNames.cs
@@ -47,6 +47,17 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         /// <summary>
+        /// Contracts used by CPS exports of MSBuild objects.
+        /// </summary>
+        internal static class MSBuild
+        {
+            /// <summary>
+            /// The contract name on the IProjectGlobalPropertiesProvider export that publishes all the global properties on the GlobalProjectCollection.
+            /// </summary>
+            internal const string GlobalProjectCollectionGlobalProperties = Prefix + "GlobalProjectCollection.GlobalProperties";
+        }
+
+        /// <summary>
         /// Contracts used by tree providers.
         /// </summary>
         internal static class ProjectTreeProviders

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/VisualBasicNamespaceImportsListFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/VisualBasicNamespaceImportsListFactory.cs
@@ -1,17 +1,89 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System.Linq;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
 {
     internal static class VisualBasicNamespaceImportsListFactory
     {
-        public static VisualBasicNamespaceImportsList CreateInstance(params string[] list)
+        public static TestVisualBasicNamespaceImportsList CreateInstance(params string[] list)
         {
-            var newList = new VisualBasicNamespaceImportsList();
-            newList.SetList(list.ToList());
+            var newList = new TestVisualBasicNamespaceImportsList(
+                UnconfiguredProjectFactory.Create(),
+                IProjectThreadingServiceFactory.Create(),
+                IActiveConfiguredProjectSubscriptionServiceFactory.Create());
+
+            newList.VSImports = new Lazy<VisualBasicVSImports>(() => new TestVisualBasicVSImports(
+                Mock.Of<VSLangProj.VSProject>(),
+                IProjectThreadingServiceFactory.Create(),
+                ActiveConfiguredProjectFactory.ImplementValue<ConfiguredProject>(()=> ConfiguredProjectFactory.Create()),
+                IProjectAccessorFactory.Create(),
+                IUnconfiguredProjectVsServicesFactory.Create(),
+                newList));
+
+            newList.TestApply(list);
+
+            newList.ImportsAdded.Clear();
+            newList.ImportsRemoved.Clear();
 
             return newList;
+        }
+
+        internal class TestVisualBasicNamespaceImportsList : VisualBasicNamespaceImportsList
+        {
+            public TestVisualBasicNamespaceImportsList(UnconfiguredProject project,
+                                                       IProjectThreadingService threadingService,
+                                                       IActiveConfiguredProjectSubscriptionService activeConfiguredProjectSubscriptionService)
+                : base(project, threadingService, activeConfiguredProjectSubscriptionService)
+            {
+                SkipInitialization = true;
+            }
+
+            public List<string> ImportsAdded { get; } = new List<string>();
+
+            public List<string> ImportsRemoved { get; } = new List<string>();
+
+            internal void TestApply(IProjectSubscriptionUpdate projectSubscriptionUpdate)
+            {
+                var projectVersionedValue = IProjectVersionedValueFactory.Create(projectSubscriptionUpdate);
+
+                var result = PreprocessAsync(projectVersionedValue, null);
+
+                ApplyAsync(result.Result);
+            }
+
+            internal void TestApply(string[] list)
+            {
+                ApplyAsync(IProjectVersionedValueFactory.Create(ImmutableList.CreateRange(list)));
+            }
+        }
+
+        private class TestVisualBasicVSImports : VisualBasicVSImports
+        {
+            private readonly TestVisualBasicNamespaceImportsList _testImportsList;
+            public TestVisualBasicVSImports(VSLangProj.VSProject vsProject,
+                                            IProjectThreadingService threadingService,
+                                            ActiveConfiguredProject<ConfiguredProject> activeConfiguredProject,
+                                            IProjectAccessor projectAccessor,
+                                            IUnconfiguredProjectVsServices unconfiguredProjectVSServices,
+                                            TestVisualBasicNamespaceImportsList importsList)
+                : base(vsProject, threadingService, activeConfiguredProject, projectAccessor, unconfiguredProjectVSServices, importsList)
+            {
+                _testImportsList = importsList;
+            }
+
+            internal override void OnImportAdded(string importNamespace)
+            {
+                _testImportsList.ImportsAdded.Add(importNamespace);
+            }
+
+            internal override void OnImportRemoved(string importNamespace)
+            {
+                _testImportsList.ImportsRemoved.Add(importNamespace);
+            }
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/VisualBasicNamespaceImportsListFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/VisualBasicNamespaceImportsListFactory.cs
@@ -52,12 +52,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
 
                 var result = PreprocessAsync(projectVersionedValue, null);
 
-                ApplyAsync(result.Result);
+                _ = ApplyAsync(result.Result);
             }
 
             internal void TestApply(string[] list)
             {
-                ApplyAsync(IProjectVersionedValueFactory.Create(ImmutableList.CreateRange(list)));
+                _ = ApplyAsync(IProjectVersionedValueFactory.Create(ImmutableList.CreateRange(list)));
             }
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VisualBasic/VsImportsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VisualBasic/VsImportsTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
                                 Mock.Of<ActiveConfiguredProject<ConfiguredProject>>(),
                                 Mock.Of<IProjectAccessor>(),
                                 Mock.Of<IUnconfiguredProjectVsServices>(),
-                                new VisualBasicNamespaceImportsList());
+                                VisualBasicNamespaceImportsListFactory.CreateInstance());
 
             Assert.NotNull(vsimports);
         }
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
                                 Mock.Of<ActiveConfiguredProject<ConfiguredProject>>(),
                                 Mock.Of<IProjectAccessor>(),
                                 Mock.Of<IUnconfiguredProjectVsServices>(),
-                                Mock.Of<VisualBasicNamespaceImportsList>());
+                                VisualBasicNamespaceImportsListFactory.CreateInstance());
 
             Assert.Equal(dte, vsimports.DTE);
             Assert.Equal(project, vsimports.ContainingProject);


### PR DESCRIPTION
Fixes https://github.com/dotnet/project-system/issues/3101

This updates VisualBasicNamespaceImports to use ProjectHostBridge to guarantee consistency of the collection when on the UI thread. It also moves DTE events to be triggered after the list of imports is actually updated which fixes a UI bug in the app designer, where clicking an import adds it to the project file but doesn't make the list item appear checked.

~This _doesn't_ fix the (possible?) bug that after calling `VSProject.Imports.Add` the new import is not visible in the collection upon that method returning, however since that is already a bug we have now, and the ideal solution for that involves a change to CPS's public API, and nobody answered me when I asked about it on Teams (😛), it's not worth blocking this change on.~ Changed my mind! Trying to make the API public in CPS was ugly.