### PR TITLE
Make sure project stays open

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectTasksServiceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectTasksServiceFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     {
         public static IUnconfiguredProjectTasksService Create()
         {
-            return Mock.Of<IUnconfiguredProjectTasksService>();
+            return ImplementLoadedProjectAsync(func => func());
         }
 
         public static IUnconfiguredProjectTasksService ImplementPrioritizedProjectLoadedInHost(Func<Task> action)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
@@ -185,6 +185,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             var project = UnconfiguredProjectFactory.Create();
             var instance = new StartupProjectRegistrar(
                 project,
+                IUnconfiguredProjectTasksServiceFactory.Create(),
                 IVsServiceFactory.Create<SVsStartupProjectsListService, IVsStartupProjectsListService>(vsStartupProjectsListService!),
                 threadingService ?? IProjectThreadingServiceFactory.Create(),
                 projectGuidService ?? ISafeProjectGuidServiceFactory.ImplementGetProjectGuidAsync(Guid.NewGuid()),


### PR DESCRIPTION
Make sure the project stays open until we've finished registering. Seeing a fault where we're being called during shutdown, and IVsStartupProjectsListService has gone away.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6127)