### PR TITLE
Clean up of the Aliases property

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/PackageReference.xaml
@@ -13,10 +13,11 @@
                 SourceOfDefaultValue="AfterContext"
                 SourceType="TargetResults" />
   </Rule.DataSource>
-  
-  <StringProperty Name="Aliases"
-                  Description="Aliases for the assembly references coming from this PackageReference."
-                  DisplayName="Aliases" />
+
+  <StringListProperty Name="Aliases"
+                      Description="A comma-delimited list of aliases to assembly references contained in this package."
+                      DisplayName="Aliases"
+                      Separator="," />
 
   <StringProperty Name="ExcludeAssets"
                   Description="Assets to exclude from this reference."

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
@@ -14,6 +14,18 @@
                 SourceType="TargetResults" />
   </Rule.DataSource>
 
+  <StringListProperty Name="Aliases"
+                      Description="A comma-delimited list of aliases to assembly references contained in this package."
+                      DisplayName="Aliases"
+                      Separator="," >
+    <StringListProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="PackageReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringListProperty.DataSource>
+  </StringListProperty>
+
   <StringListProperty Name="Dependencies"
                       Separator=";"
                       Visible="false">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.cs.xlf
@@ -12,12 +12,12 @@
         <target state="translated">Vlastnosti balíčku</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|Description">
-        <source>Aliases for the assembly references coming from this PackageReference.</source>
-        <target state="new">Aliases for the assembly references coming from this PackageReference.</target>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|DisplayName">
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
         <source>Aliases</source>
         <target state="new">Aliases</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.de.xlf
@@ -12,12 +12,12 @@
         <target state="translated">Paketeigenschaften</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|Description">
-        <source>Aliases for the assembly references coming from this PackageReference.</source>
-        <target state="new">Aliases for the assembly references coming from this PackageReference.</target>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|DisplayName">
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
         <source>Aliases</source>
         <target state="new">Aliases</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.es.xlf
@@ -12,12 +12,12 @@
         <target state="translated">Propiedades de paquete</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|Description">
-        <source>Aliases for the assembly references coming from this PackageReference.</source>
-        <target state="new">Aliases for the assembly references coming from this PackageReference.</target>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|DisplayName">
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
         <source>Aliases</source>
         <target state="new">Aliases</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.fr.xlf
@@ -12,12 +12,12 @@
         <target state="translated">Propriétés du package</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|Description">
-        <source>Aliases for the assembly references coming from this PackageReference.</source>
-        <target state="new">Aliases for the assembly references coming from this PackageReference.</target>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|DisplayName">
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
         <source>Aliases</source>
         <target state="new">Aliases</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.it.xlf
@@ -12,12 +12,12 @@
         <target state="translated">Proprietà del pacchetto</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|Description">
-        <source>Aliases for the assembly references coming from this PackageReference.</source>
-        <target state="new">Aliases for the assembly references coming from this PackageReference.</target>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|DisplayName">
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
         <source>Aliases</source>
         <target state="new">Aliases</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ja.xlf
@@ -12,12 +12,12 @@
         <target state="translated">パッケージのプロパティ</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|Description">
-        <source>Aliases for the assembly references coming from this PackageReference.</source>
-        <target state="new">Aliases for the assembly references coming from this PackageReference.</target>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|DisplayName">
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
         <source>Aliases</source>
         <target state="new">Aliases</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ko.xlf
@@ -12,12 +12,12 @@
         <target state="translated">패키지 속성</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|Description">
-        <source>Aliases for the assembly references coming from this PackageReference.</source>
-        <target state="new">Aliases for the assembly references coming from this PackageReference.</target>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|DisplayName">
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
         <source>Aliases</source>
         <target state="new">Aliases</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pl.xlf
@@ -12,12 +12,12 @@
         <target state="translated">Właściwości pakietu</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|Description">
-        <source>Aliases for the assembly references coming from this PackageReference.</source>
-        <target state="new">Aliases for the assembly references coming from this PackageReference.</target>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|DisplayName">
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
         <source>Aliases</source>
         <target state="new">Aliases</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pt-BR.xlf
@@ -12,12 +12,12 @@
         <target state="translated">Propriedades do Pacote</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|Description">
-        <source>Aliases for the assembly references coming from this PackageReference.</source>
-        <target state="new">Aliases for the assembly references coming from this PackageReference.</target>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|DisplayName">
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
         <source>Aliases</source>
         <target state="new">Aliases</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ru.xlf
@@ -12,12 +12,12 @@
         <target state="translated">Свойства пакета</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|Description">
-        <source>Aliases for the assembly references coming from this PackageReference.</source>
-        <target state="new">Aliases for the assembly references coming from this PackageReference.</target>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|DisplayName">
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
         <source>Aliases</source>
         <target state="new">Aliases</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.tr.xlf
@@ -12,12 +12,12 @@
         <target state="translated">Paket Özellikleri</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|Description">
-        <source>Aliases for the assembly references coming from this PackageReference.</source>
-        <target state="new">Aliases for the assembly references coming from this PackageReference.</target>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|DisplayName">
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
         <source>Aliases</source>
         <target state="new">Aliases</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hans.xlf
@@ -12,12 +12,12 @@
         <target state="translated">包属性</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|Description">
-        <source>Aliases for the assembly references coming from this PackageReference.</source>
-        <target state="new">Aliases for the assembly references coming from this PackageReference.</target>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|DisplayName">
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
         <source>Aliases</source>
         <target state="new">Aliases</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hant.xlf
@@ -12,12 +12,12 @@
         <target state="translated">套件屬性</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|Description">
-        <source>Aliases for the assembly references coming from this PackageReference.</source>
-        <target state="new">Aliases for the assembly references coming from this PackageReference.</target>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Aliases|DisplayName">
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
         <source>Aliases</source>
         <target state="new">Aliases</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.cs.xlf
@@ -22,6 +22,16 @@
         <target state="translated">Vlastnosti balíčku</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Verze</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.de.xlf
@@ -22,6 +22,16 @@
         <target state="translated">Paketeigenschaften</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Version</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.es.xlf
@@ -22,6 +22,16 @@
         <target state="translated">Propiedades de paquete</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Versión</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.fr.xlf
@@ -22,6 +22,16 @@
         <target state="translated">Propriétés du package</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Version</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.it.xlf
@@ -22,6 +22,16 @@
         <target state="translated">Proprietà del pacchetto</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Versione</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ja.xlf
@@ -22,6 +22,16 @@
         <target state="translated">パッケージのプロパティ</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">バージョン</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ko.xlf
@@ -22,6 +22,16 @@
         <target state="translated">패키지 속성</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">버전</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pl.xlf
@@ -22,6 +22,16 @@
         <target state="translated">Właściwości pakietu</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Wersja</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pt-BR.xlf
@@ -22,6 +22,16 @@
         <target state="translated">Propriedades do Pacote</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Versão</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ru.xlf
@@ -22,6 +22,16 @@
         <target state="translated">Свойства пакета</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Версия</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.tr.xlf
@@ -22,6 +22,16 @@
         <target state="translated">Paket Özellikleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Sürüm</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hans.xlf
@@ -22,6 +22,16 @@
         <target state="translated">包属性</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">版本</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hant.xlf
@@ -22,6 +22,16 @@
         <target state="translated">套件屬性</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to assembly references contained in this package.</source>
+        <target state="new">A comma-delimited list of aliases to assembly references contained in this package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">版本</target>


### PR DESCRIPTION
- Description that is copied from the one on AssemblyReferences
- Applied to the resolved package reference so that it gets persisted correctly

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6135)