### PR TITLE
Show assemblies within target frameworks

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/BrowseObjectDescriptionAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/BrowseObjectDescriptionAttribute.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Resources;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.Implementation
+{
+    /// <summary>
+    /// Specifies a localized description for a property or event.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    internal sealed class BrowseObjectDescriptionAttribute : BrowseObjectDescriptionAttributeBase
+    {
+        public BrowseObjectDescriptionAttribute(string key) : base(key)
+        { }
+
+        protected override ResourceManager ResourceManager => VSResources.ResourceManager;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/BrowseObjectDisplayNameAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/BrowseObjectDisplayNameAttribute.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Resources;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.Implementation
+{
+    /// <summary>
+    /// Specifies the localized display name for a property, event or public void method which takes no arguments.
+    /// </summary>
+    internal sealed class BrowseObjectDisplayNameAttribute : BrowseObjectDisplayNameAttributeBase
+    {
+        public BrowseObjectDisplayNameAttribute(string key)
+            : base(key)
+        { }
+
+        protected override ResourceManager ResourceManager => VSResources.ResourceManager;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyAttachedCollectionSourceProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyAttachedCollectionSourceProvider.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Internal.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.Implementation
+{
+    [Export(typeof(IAttachedCollectionSourceProvider))]
+    [Name(nameof(FrameworkReferenceAssemblyAttachedCollectionSourceProvider))]
+    [VisualStudio.Utilities.Order(Before = HierarchyItemsProviderNames.Contains)]
+    internal sealed class FrameworkReferenceAssemblyAttachedCollectionSourceProvider : DependenciesAttachedCollectionSourceProviderBase
+    {
+        private readonly IRelationProvider _relationProvider;
+
+        [ImportingConstructor]
+        public FrameworkReferenceAssemblyAttachedCollectionSourceProvider(IRelationProvider relationProvider)
+            : base(DependencyTreeFlags.FrameworkDependency)
+        {
+            _relationProvider = relationProvider;
+        }
+
+        protected override bool TryCreateCollectionSource(
+            IVsHierarchyItem hierarchyItem,
+            string flagsString,
+            string? target,
+            IRelationProvider relationProvider,
+            [NotNullWhen(returnValue: true)] out AggregateRelationCollectionSource? containsCollectionSource)
+        {
+            if (ErrorHandler.Succeeded(hierarchyItem.HierarchyIdentity.Hierarchy.GetProperty(
+                hierarchyItem.HierarchyIdentity.ItemID, (int)__VSHPROPID.VSHPROPID_BrowseObject, out object browseObject)))
+            {
+                ICustomTypeDescriptor? desc = browseObject as ICustomTypeDescriptor;
+                PropertyDescriptorCollection? props = desc?.GetProperties();
+
+                if (props?["TargetingPackPath"]?.GetValue(browseObject) is string path &&
+                    props?["OriginalItemSpec"]?.GetValue(browseObject) is string name)
+                {
+                    string? profile = props?["Profile"]?.GetValue(browseObject) as string;
+
+                    var framework = new FrameworkReferenceIdentity(path, profile, name);
+                    var item = new FrameworkReferenceItem(framework);
+                    if (AggregateContainsRelationCollection.TryCreate(item, _relationProvider, out AggregateContainsRelationCollection? collection))
+                    {
+                        containsCollectionSource = new AggregateRelationCollectionSource(hierarchyItem, collection);
+                        return true;
+                    }
+                }
+            }
+
+            containsCollectionSource = null;
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyItem.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Imaging.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.Implementation
+{
+    internal sealed class FrameworkReferenceAssemblyItem : RelatableItemBase
+    {
+        public string AssemblyName { get; }
+        public string? Path { get; }
+        public string? AssemblyVersion { get; }
+        public string? FileVersion { get; }
+        public FrameworkReferenceIdentity Framework { get; }
+
+        public FrameworkReferenceAssemblyItem(string assemblyName, string? path, string? assemblyVersion, string? fileVersion, FrameworkReferenceIdentity framework)
+            : base(assemblyName)
+        {
+            Requires.NotNull(framework, nameof(framework));
+            AssemblyName = assemblyName;
+            Path = path;
+            AssemblyVersion = assemblyVersion;
+            FileVersion = fileVersion;
+            Framework = framework;
+        }
+
+        public override object Identity => Text;
+        public override int Priority => 0;
+        public override ImageMoniker IconMoniker => ManagedImageMonikers.ReferencePrivate;
+
+        public override object? GetBrowseObject() => new BrowseObject(this);
+
+        private sealed class BrowseObject : BrowseObjectBase
+        {
+            private readonly FrameworkReferenceAssemblyItem _item;
+
+            public BrowseObject(FrameworkReferenceAssemblyItem log) => _item = log;
+
+            public override string GetComponentName() => _item.AssemblyName;
+
+            public override string GetClassName() => VSResources.FrameworkAssemblyBrowseObjectClassName;
+
+            [BrowseObjectDisplayName(nameof(VSResources.FrameworkAssemblyAssemblyNameDisplayName))]
+            [BrowseObjectDescription(nameof(VSResources.FrameworkAssemblyAssemblyNameDescription))]
+            public string AssemblyName => _item.Text;
+
+            [BrowseObjectDisplayName(nameof(VSResources.FrameworkAssemblyPathDisplayName))]
+            [BrowseObjectDescription(nameof(VSResources.FrameworkAssemblyPathDescription))]
+            public string Path => _item.Path != null
+                ? System.IO.Path.GetFullPath(System.IO.Path.Combine(_item.Framework.Path, _item.Path))
+                : "";
+
+            [BrowseObjectDisplayName(nameof(VSResources.FrameworkAssemblyAssemblyVersionDisplayName))]
+            [BrowseObjectDescription(nameof(VSResources.FrameworkAssemblyAssemblyVersionDescription))]
+            public string AssemblyVersion => _item.AssemblyVersion ?? "";
+
+            [BrowseObjectDisplayName(nameof(VSResources.FrameworkAssemblyFileVersionDisplayName))]
+            [BrowseObjectDescription(nameof(VSResources.FrameworkAssemblyFileVersionDescription))]
+            public string FileVersion => _item.FileVersion ?? "";
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceIdentity.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceIdentity.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.Implementation
+{
+    internal sealed class FrameworkReferenceIdentity
+    {
+        public string Path { get; }
+        public string? Profile { get; }
+        public string Name { get; }
+
+        public FrameworkReferenceIdentity(string path, string? profile, string name)
+        {
+            Requires.NotNullOrEmpty(path, nameof(path));
+            Requires.NotNullOrEmpty(name, nameof(name));
+
+            Path = path;
+            Profile = profile;
+            Name = name;
+        }
+
+        private bool Equals(FrameworkReferenceIdentity other)
+        {
+            return Path == other.Path && Profile == other.Profile;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return ReferenceEquals(this, obj) || obj is FrameworkReferenceIdentity other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Path.GetHashCode() * 397) ^ (Profile != null ? Profile.GetHashCode() : 0);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceItem.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.Imaging.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.Implementation
+{
+    internal sealed class FrameworkReferenceItem : RelatableItemBase
+    {
+        public FrameworkReferenceIdentity Framework { get; }
+
+        public FrameworkReferenceItem(FrameworkReferenceIdentity framework)
+            : base(framework.Name)
+        {
+            Framework = framework;
+        }
+
+        public override object Identity => (Framework.Path, Framework.Profile);
+        public override int Priority => 0;
+        public override ImageMoniker IconMoniker => ManagedImageMonikers.FrameworkPrivate;
+
+        protected override bool TryGetProjectNode(IProjectTree targetRootNode, IRelatableItem item, [NotNullWhen(true)] out IProjectTree? projectTree)
+        {
+            return base.TryGetProjectNode(targetRootNode, item, out projectTree);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkToFrameworkAssemblyRelation.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkToFrameworkAssemblyRelation.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Linq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.Implementation
+{
+    [Export(typeof(IRelation))]
+    internal sealed class FrameworkToFrameworkAssemblyRelation : RelationBase<FrameworkReferenceItem, FrameworkReferenceAssemblyItem>
+    {
+        private readonly ITargetFrameworkContentCache _frameworkContentCache;
+
+        [ImportingConstructor]
+        public FrameworkToFrameworkAssemblyRelation(ITargetFrameworkContentCache frameworkContentCache)
+        {
+            _frameworkContentCache = frameworkContentCache;
+        }
+
+        protected override bool HasContainedItems(FrameworkReferenceItem parent)
+        {
+            return _frameworkContentCache.GetContents(parent.Framework).Length != 0;
+        }
+
+        protected override void UpdateContainsCollection(FrameworkReferenceItem parent, AggregateContainsRelationCollectionSpan span)
+        {
+            ImmutableArray<FrameworkReferenceAssemblyItem> assemblies = _frameworkContentCache.GetContents(parent.Framework);
+
+            span.UpdateContainsItems(
+                assemblies.OrderBy(assembly => assembly.Text),
+                (sourceItem, targetItem) => StringComparer.Ordinal.Compare(sourceItem.Text, targetItem.Text),
+                (sourceItem, targetItem) => false,
+                sourceItem => sourceItem);
+        }
+
+        protected override IEnumerable<FrameworkReferenceItem>? CreateContainedByItems(FrameworkReferenceAssemblyItem child)
+        {
+            yield return new FrameworkReferenceItem(child.Framework);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/ITargetFrameworkContentCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/ITargetFrameworkContentCache.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.Implementation
+{
+    /// <summary>
+    /// Global service that reads and caches the contents of framework references.
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Extension, Cardinality = ImportCardinality.ExactlyOne)]
+    internal interface ITargetFrameworkContentCache
+    {
+        /// <summary>
+        /// Returns an array of framework reference assembly items, lazily loading them on the first invocation.
+        /// </summary>
+        ImmutableArray<FrameworkReferenceAssemblyItem> GetContents(FrameworkReferenceIdentity framework);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/TargetFrameworkContentCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/TargetFrameworkContentCache.cs
@@ -1,0 +1,87 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.Implementation
+{
+    [Export(typeof(ITargetFrameworkContentCache))]
+    internal sealed class TargetFrameworkContentCache : ITargetFrameworkContentCache
+    {
+        private ImmutableDictionary<FrameworkReferenceIdentity, ImmutableArray<FrameworkReferenceAssemblyItem>> _cache = ImmutableDictionary<FrameworkReferenceIdentity, ImmutableArray<FrameworkReferenceAssemblyItem>>.Empty;
+
+        public ImmutableArray<FrameworkReferenceAssemblyItem> GetContents(FrameworkReferenceIdentity framework)
+        {
+            return ImmutableInterlocked.GetOrAdd(ref _cache, framework, LoadItems);
+
+            static ImmutableArray<FrameworkReferenceAssemblyItem> LoadItems(FrameworkReferenceIdentity framework)
+            {
+                string frameworkListPath = Path.Combine(framework.Path, "data", "FrameworkList.xml");
+                var pool = new Dictionary<string, string>(StringComparer.Ordinal);
+
+                var doc = XDocument.Load(frameworkListPath);
+                ImmutableArray<FrameworkReferenceAssemblyItem>.Builder results = ImmutableArray.CreateBuilder<FrameworkReferenceAssemblyItem>();
+
+                foreach (XElement file in doc.Root.Elements("File"))
+                {
+                    if (!Strings.IsNullOrEmpty(framework.Profile))
+                    {
+                        //  We must filter to a specific profile
+                        string? fileProfile = file.Attribute("Profile")?.Value;
+
+                        if (fileProfile == null)
+                        {
+                            // The file doesn't specify a profile, so skip it
+                            continue;
+                        }
+
+                        if (!new LazyStringSplit(fileProfile, ';').Contains(framework.Profile, StringComparer.OrdinalIgnoreCase))
+                        {
+                            // File file specifies a profile, but not one we are looking for, so skip it
+                            continue;
+                        }
+                    }
+
+                    if (file.Attribute("ReferencedByDefault")?.Value.Equals("false", StringComparison.OrdinalIgnoreCase) == true)
+                    {
+                        // Don't include if ReferencedByDefault=false
+                        continue;
+                    }
+
+                    string? assemblyName = Pool(file.Attribute("AssemblyName")?.Value);
+                    string? path = Pool(file.Attribute("Path")?.Value);
+                    string? assemblyVersion = Pool(file.Attribute("AssemblyVersion")?.Value);
+                    string? fileVersion = Pool(file.Attribute("FileVersion")?.Value);
+
+                    if (assemblyName != null)
+                    {
+                        results.Add(new FrameworkReferenceAssemblyItem(assemblyName, path, assemblyVersion, fileVersion, framework));
+                    }
+                }
+
+                return results.ToImmutable();
+
+                string? Pool(string? s)
+                {
+                    if (s != null)
+                    {
+                        if (pool.TryGetValue(s, out string existing))
+                        {
+                            return existing;
+                        }
+
+                        pool.Add(s, s);
+                    }
+
+                    return s;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -241,6 +241,87 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The framework assembly&apos;s assembly name..
+        /// </summary>
+        internal static string FrameworkAssemblyAssemblyNameDescription {
+            get {
+                return ResourceManager.GetString("FrameworkAssemblyAssemblyNameDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Assembly Name.
+        /// </summary>
+        internal static string FrameworkAssemblyAssemblyNameDisplayName {
+            get {
+                return ResourceManager.GetString("FrameworkAssemblyAssemblyNameDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The assembly version of the framework assembly..
+        /// </summary>
+        internal static string FrameworkAssemblyAssemblyVersionDescription {
+            get {
+                return ResourceManager.GetString("FrameworkAssemblyAssemblyVersionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Assembly Version.
+        /// </summary>
+        internal static string FrameworkAssemblyAssemblyVersionDisplayName {
+            get {
+                return ResourceManager.GetString("FrameworkAssemblyAssemblyVersionDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Framework Assembly.
+        /// </summary>
+        internal static string FrameworkAssemblyBrowseObjectClassName {
+            get {
+                return ResourceManager.GetString("FrameworkAssemblyBrowseObjectClassName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The file version of the framework assembly..
+        /// </summary>
+        internal static string FrameworkAssemblyFileVersionDescription {
+            get {
+                return ResourceManager.GetString("FrameworkAssemblyFileVersionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File Version.
+        /// </summary>
+        internal static string FrameworkAssemblyFileVersionDisplayName {
+            get {
+                return ResourceManager.GetString("FrameworkAssemblyFileVersionDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path of the framework assembly..
+        /// </summary>
+        internal static string FrameworkAssemblyPathDescription {
+            get {
+                return ResourceManager.GetString("FrameworkAssemblyPathDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path.
+        /// </summary>
+        internal static string FrameworkAssemblyPathDisplayName {
+            get {
+                return ResourceManager.GetString("FrameworkAssemblyPathDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} - Import comes fom target file. This import cannot be removed..
         /// </summary>
         internal static string ImportsFromTargetCannotBeDeleted {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -218,6 +218,34 @@ In order to debug this project, add an executable project to this solution which
   <data name="Renaming_Type_from_0_to_1" xml:space="preserve">
     <value>Renaming Type from '{0}' to '{1}'</value>
   </data>
+  <data name="FrameworkAssemblyBrowseObjectClassName" xml:space="preserve">
+    <value>Framework Assembly</value>
+  </data>
+  <data name="FrameworkAssemblyAssemblyNameDisplayName" xml:space="preserve">
+    <value>Assembly Name</value>
+  </data>
+  <data name="FrameworkAssemblyAssemblyNameDescription" xml:space="preserve">
+    <value>The framework assembly's assembly name.</value>
+  </data>
+  <data name="FrameworkAssemblyPathDisplayName" xml:space="preserve">
+    <value>Path</value>
+  </data>
+  <data name="FrameworkAssemblyPathDescription" xml:space="preserve">
+    <value>Path of the framework assembly.</value>
+  </data>
+  <data name="FrameworkAssemblyAssemblyVersionDisplayName" xml:space="preserve">
+    <value>Assembly Version</value>
+  </data>
+  <data name="FrameworkAssemblyAssemblyVersionDescription" xml:space="preserve">
+    <value>The assembly version of the framework assembly.</value>
+  </data>
+  <data name="FrameworkAssemblyFileVersionDisplayName" xml:space="preserve">
+    <value>File Version</value>
+  </data>
+  <data name="FrameworkAssemblyFileVersionDescription" xml:space="preserve">
+    <value>The file version of the framework assembly.</value>
+  </data>
+  <!-- Assets file dependency resources below here (being moved to NuGet soon) -->
   <data name="PackageReferenceBrowseObjectClassName" xml:space="preserve">
     <value>Package Reference</value>
   </data>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -57,6 +57,51 @@
         <target state="new">Warning Level</target>
         <note />
       </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
+        <source>The framework assembly's assembly name.</source>
+        <target state="new">The framework assembly's assembly name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDescription">
+        <source>The assembly version of the framework assembly.</source>
+        <target state="new">The assembly version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDisplayName">
+        <source>Assembly Version</source>
+        <target state="new">Assembly Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyBrowseObjectClassName">
+        <source>Framework Assembly</source>
+        <target state="new">Framework Assembly</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDescription">
+        <source>The file version of the framework assembly.</source>
+        <target state="new">The file version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDisplayName">
+        <source>File Version</source>
+        <target state="new">File Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDescription">
+        <source>Path of the framework assembly.</source>
+        <target state="new">Path of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} – import pochází z cílového souboru. Tento import nelze odebrat.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -57,6 +57,51 @@
         <target state="new">Warning Level</target>
         <note />
       </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
+        <source>The framework assembly's assembly name.</source>
+        <target state="new">The framework assembly's assembly name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDescription">
+        <source>The assembly version of the framework assembly.</source>
+        <target state="new">The assembly version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDisplayName">
+        <source>Assembly Version</source>
+        <target state="new">Assembly Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyBrowseObjectClassName">
+        <source>Framework Assembly</source>
+        <target state="new">Framework Assembly</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDescription">
+        <source>The file version of the framework assembly.</source>
+        <target state="new">The file version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDisplayName">
+        <source>File Version</source>
+        <target state="new">File Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDescription">
+        <source>Path of the framework assembly.</source>
+        <target state="new">Path of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} – Import kommt von der Zieldatei. Dieser Import kann nicht entfernt werden.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -57,6 +57,51 @@
         <target state="new">Warning Level</target>
         <note />
       </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
+        <source>The framework assembly's assembly name.</source>
+        <target state="new">The framework assembly's assembly name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDescription">
+        <source>The assembly version of the framework assembly.</source>
+        <target state="new">The assembly version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDisplayName">
+        <source>Assembly Version</source>
+        <target state="new">Assembly Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyBrowseObjectClassName">
+        <source>Framework Assembly</source>
+        <target state="new">Framework Assembly</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDescription">
+        <source>The file version of the framework assembly.</source>
+        <target state="new">The file version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDisplayName">
+        <source>File Version</source>
+        <target state="new">File Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDescription">
+        <source>Path of the framework assembly.</source>
+        <target state="new">Path of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0}: la importación procede del archivo de destino. Esta importación no se puede quitar.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -57,6 +57,51 @@
         <target state="new">Warning Level</target>
         <note />
       </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
+        <source>The framework assembly's assembly name.</source>
+        <target state="new">The framework assembly's assembly name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDescription">
+        <source>The assembly version of the framework assembly.</source>
+        <target state="new">The assembly version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDisplayName">
+        <source>Assembly Version</source>
+        <target state="new">Assembly Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyBrowseObjectClassName">
+        <source>Framework Assembly</source>
+        <target state="new">Framework Assembly</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDescription">
+        <source>The file version of the framework assembly.</source>
+        <target state="new">The file version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDisplayName">
+        <source>File Version</source>
+        <target state="new">File Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDescription">
+        <source>Path of the framework assembly.</source>
+        <target state="new">Path of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} - L'importation provient du fichier cible. Impossible de supprimer cette importation.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -57,6 +57,51 @@
         <target state="new">Warning Level</target>
         <note />
       </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
+        <source>The framework assembly's assembly name.</source>
+        <target state="new">The framework assembly's assembly name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDescription">
+        <source>The assembly version of the framework assembly.</source>
+        <target state="new">The assembly version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDisplayName">
+        <source>Assembly Version</source>
+        <target state="new">Assembly Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyBrowseObjectClassName">
+        <source>Framework Assembly</source>
+        <target state="new">Framework Assembly</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDescription">
+        <source>The file version of the framework assembly.</source>
+        <target state="new">The file version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDisplayName">
+        <source>File Version</source>
+        <target state="new">File Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDescription">
+        <source>Path of the framework assembly.</source>
+        <target state="new">Path of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} - L'importazione proviene dal file di destinazione e non può essere rimossa.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -57,6 +57,51 @@
         <target state="new">Warning Level</target>
         <note />
       </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
+        <source>The framework assembly's assembly name.</source>
+        <target state="new">The framework assembly's assembly name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDescription">
+        <source>The assembly version of the framework assembly.</source>
+        <target state="new">The assembly version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDisplayName">
+        <source>Assembly Version</source>
+        <target state="new">Assembly Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyBrowseObjectClassName">
+        <source>Framework Assembly</source>
+        <target state="new">Framework Assembly</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDescription">
+        <source>The file version of the framework assembly.</source>
+        <target state="new">The file version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDisplayName">
+        <source>File Version</source>
+        <target state="new">File Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDescription">
+        <source>Path of the framework assembly.</source>
+        <target state="new">Path of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} - インポートは、ターゲット ファイルからのものです。このインポートは削除できません。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -57,6 +57,51 @@
         <target state="new">Warning Level</target>
         <note />
       </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
+        <source>The framework assembly's assembly name.</source>
+        <target state="new">The framework assembly's assembly name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDescription">
+        <source>The assembly version of the framework assembly.</source>
+        <target state="new">The assembly version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDisplayName">
+        <source>Assembly Version</source>
+        <target state="new">Assembly Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyBrowseObjectClassName">
+        <source>Framework Assembly</source>
+        <target state="new">Framework Assembly</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDescription">
+        <source>The file version of the framework assembly.</source>
+        <target state="new">The file version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDisplayName">
+        <source>File Version</source>
+        <target state="new">File Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDescription">
+        <source>Path of the framework assembly.</source>
+        <target state="new">Path of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} - 대상 파일에서 가져옵니다. 이 가져오기는 제거할 수 없습니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -57,6 +57,51 @@
         <target state="new">Warning Level</target>
         <note />
       </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
+        <source>The framework assembly's assembly name.</source>
+        <target state="new">The framework assembly's assembly name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDescription">
+        <source>The assembly version of the framework assembly.</source>
+        <target state="new">The assembly version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDisplayName">
+        <source>Assembly Version</source>
+        <target state="new">Assembly Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyBrowseObjectClassName">
+        <source>Framework Assembly</source>
+        <target state="new">Framework Assembly</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDescription">
+        <source>The file version of the framework assembly.</source>
+        <target state="new">The file version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDisplayName">
+        <source>File Version</source>
+        <target state="new">File Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDescription">
+        <source>Path of the framework assembly.</source>
+        <target state="new">Path of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} — import pochodzi z pliku docelowego. Nie można usunąć importu.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -57,6 +57,51 @@
         <target state="new">Warning Level</target>
         <note />
       </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
+        <source>The framework assembly's assembly name.</source>
+        <target state="new">The framework assembly's assembly name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDescription">
+        <source>The assembly version of the framework assembly.</source>
+        <target state="new">The assembly version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDisplayName">
+        <source>Assembly Version</source>
+        <target state="new">Assembly Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyBrowseObjectClassName">
+        <source>Framework Assembly</source>
+        <target state="new">Framework Assembly</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDescription">
+        <source>The file version of the framework assembly.</source>
+        <target state="new">The file version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDisplayName">
+        <source>File Version</source>
+        <target state="new">File Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDescription">
+        <source>Path of the framework assembly.</source>
+        <target state="new">Path of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} – a importação é proveniente do arquivo de destino. Essa importação não pode ser removida.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -57,6 +57,51 @@
         <target state="new">Warning Level</target>
         <note />
       </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
+        <source>The framework assembly's assembly name.</source>
+        <target state="new">The framework assembly's assembly name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDescription">
+        <source>The assembly version of the framework assembly.</source>
+        <target state="new">The assembly version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDisplayName">
+        <source>Assembly Version</source>
+        <target state="new">Assembly Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyBrowseObjectClassName">
+        <source>Framework Assembly</source>
+        <target state="new">Framework Assembly</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDescription">
+        <source>The file version of the framework assembly.</source>
+        <target state="new">The file version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDisplayName">
+        <source>File Version</source>
+        <target state="new">File Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDescription">
+        <source>Path of the framework assembly.</source>
+        <target state="new">Path of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} — источником импорта является целевой файл. Удалить этот импорт невозможно.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -57,6 +57,51 @@
         <target state="new">Warning Level</target>
         <note />
       </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
+        <source>The framework assembly's assembly name.</source>
+        <target state="new">The framework assembly's assembly name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDescription">
+        <source>The assembly version of the framework assembly.</source>
+        <target state="new">The assembly version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDisplayName">
+        <source>Assembly Version</source>
+        <target state="new">Assembly Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyBrowseObjectClassName">
+        <source>Framework Assembly</source>
+        <target state="new">Framework Assembly</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDescription">
+        <source>The file version of the framework assembly.</source>
+        <target state="new">The file version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDisplayName">
+        <source>File Version</source>
+        <target state="new">File Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDescription">
+        <source>Path of the framework assembly.</source>
+        <target state="new">Path of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} - İçeri aktarım hedef dosyadan geliyor. Bu içeri aktarım kaldırılamaz.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -57,6 +57,51 @@
         <target state="new">Warning Level</target>
         <note />
       </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
+        <source>The framework assembly's assembly name.</source>
+        <target state="new">The framework assembly's assembly name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDescription">
+        <source>The assembly version of the framework assembly.</source>
+        <target state="new">The assembly version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDisplayName">
+        <source>Assembly Version</source>
+        <target state="new">Assembly Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyBrowseObjectClassName">
+        <source>Framework Assembly</source>
+        <target state="new">Framework Assembly</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDescription">
+        <source>The file version of the framework assembly.</source>
+        <target state="new">The file version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDisplayName">
+        <source>File Version</source>
+        <target state="new">File Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDescription">
+        <source>Path of the framework assembly.</source>
+        <target state="new">Path of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} - 导入项来自目标文件。无法删除此导入。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -57,6 +57,51 @@
         <target state="new">Warning Level</target>
         <note />
       </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
+        <source>The framework assembly's assembly name.</source>
+        <target state="new">The framework assembly's assembly name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyNameDisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDescription">
+        <source>The assembly version of the framework assembly.</source>
+        <target state="new">The assembly version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyAssemblyVersionDisplayName">
+        <source>Assembly Version</source>
+        <target state="new">Assembly Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyBrowseObjectClassName">
+        <source>Framework Assembly</source>
+        <target state="new">Framework Assembly</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDescription">
+        <source>The file version of the framework assembly.</source>
+        <target state="new">The file version of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyFileVersionDisplayName">
+        <source>File Version</source>
+        <target state="new">File Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDescription">
+        <source>Path of the framework assembly.</source>
+        <target state="new">Path of the framework assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkAssemblyPathDisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} - 匯入來自目標檔案。此項匯入無法移除。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -544,7 +544,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 ? dependency.Path
                 : dependency.OriginalItemSpec;
 
-            var context = ProjectPropertiesContext.GetContext(UnconfiguredProject,
+            var context = ProjectPropertiesContext.GetContext(
+                UnconfiguredProject,
                 itemType: dependency.SchemaItemType,
                 itemName: itemSpec);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
@@ -3,7 +3,6 @@
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
-using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.RuleHandlers;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 {
@@ -59,14 +58,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             return string.IsNullOrEmpty(self.Path)
                 ? string.Equals(self.Id, id, StringComparisons.DependencyTreeIds)
                 : Dependency.IdEquals(id, self.TargetFramework, self.ProviderType, self.Path);
-        }
-
-        /// <summary>
-        /// Returns true if given dependency is a project.
-        /// </summary>
-        public static bool IsProject(this IDependency self)
-        {
-            return StringComparers.DependencyProviderTypes.Equals(self.ProviderType, ProjectRuleHandler.ProviderTypeString);
         }
 
         /// <summary>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Microsoft.VisualStudio.Imaging;
-using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.RuleHandlers;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
@@ -62,24 +62,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             Assert.Equal(iconSet.UnresolvedExpandedIcon,           viewModelUnresolved.ExpandedIcon);
         }
 
-        [Theory]
-        [InlineData(AnalyzerRuleHandler.ProviderTypeString,  false)]
-        [InlineData(AssemblyRuleHandler.ProviderTypeString,  false)]
-        [InlineData(ComRuleHandler.ProviderTypeString,       false)]
-        [InlineData(FrameworkRuleHandler.ProviderTypeString, false)]
-        [InlineData(PackageRuleHandler.ProviderTypeString,   false)]
-        [InlineData(ProjectRuleHandler.ProviderTypeString,   true)]
-        [InlineData(SdkRuleHandler.ProviderTypeString,       false)]
-        public void IsProject(string providerType, bool isProject)
-        {
-            var dependency = new TestDependency
-            {
-                ProviderType = providerType
-            };
-
-            Assert.Equal(isProject, dependency.IsProject());
-        }
-
         [Fact]
         public void HasSameTarget()
         {


### PR DESCRIPTION
Fixes #4444.

This allows a Target Framework reference to be expanded to show its constituent assemblies beneath.

![image](https://user-images.githubusercontent.com/350947/80433832-693e7c80-893b-11ea-8a7c-34ee9946038f.png)

![image](https://user-images.githubusercontent.com/350947/80433855-82472d80-893b-11ea-95cf-f956dca693a2.png)

Note you cannot yet search these nodes. #6139 is tracking that.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6136)