### PR TITLE
Show diagnostics on project reference nodes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/NuGet/Relations/ProjectToDiagnosticRelation.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/NuGet/Relations/ProjectToDiagnosticRelation.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections;
+
+namespace Microsoft.VisualStudio.NuGet
+{
+    [Export(typeof(IRelation))]
+    internal sealed class ProjectToDiagnosticRelation : RelationBase<ProjectReferenceItem, DiagnosticItem>
+    {
+        protected override bool HasContainedItems(ProjectReferenceItem parent)
+        {
+            return parent.Target.Logs.Any(log => log.LibraryName == parent.Library.Name);
+        }
+
+        protected override void UpdateContainsCollection(ProjectReferenceItem parent, AggregateContainsRelationCollectionSpan span)
+        {
+            span.UpdateContainsItems(
+                parent.Target.Logs.Where(log => log.LibraryName == parent.Library.Name).OrderBy(log => log.LibraryName).ThenBy(log => log.Message),
+                (log, item) => StringComparer.Ordinal.Compare(log.LibraryName, item.Library.Name),
+                (log, item) => item.TryUpdateState(parent.Target, parent.Library, log),
+                log => new DiagnosticItem(parent.Target, parent.Library, log));
+        }
+
+        protected override IEnumerable<ProjectReferenceItem>? CreateContainedByItems(DiagnosticItem child)
+        {
+            yield return new ProjectReferenceItem(child.Target, child.Library);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2436.

Adds the relation required to show NuGet diagnostics as children of project reference nodes.

![image](https://user-images.githubusercontent.com/350947/80675346-933c9e00-8af7-11ea-9fb3-a5a951075b9e.png)

In future I'd like to distinguish between warnings and errors on the ancestors too. 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6146)