### PR TITLE
Only define SharedProjectReferences for C#/VB projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.CSharp.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.CSharp.DesignTime.targets
@@ -32,7 +32,8 @@
     <ProjectCapability Include="
                           CSharp;
                           Managed;
-                          ClassDesigner;" />
+                          ClassDesigner;
+                          SharedProjectReferences;" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DefineCommonManagedItemSchemas)' == 'true'">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.FSharp.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.FSharp.DesignTime.targets
@@ -1,6 +1,6 @@
 <!--
 
-  This file contains Visual Studio and designer-related properties and items for C# projects.
+  This file contains Visual Studio and designer-related properties and items for F# projects.
 
 -->
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -101,8 +101,7 @@
     -->
     <ProjectCapability Include="
                           AssemblyReferences;
-                          ProjectReferences;
-                          SharedProjectReferences;
+                          ProjectReferences;                          
                           WinRTReferences;
                           OutputGroups;
                           AllTargetOutputGroups;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.VisualBasic.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.VisualBasic.DesignTime.targets
@@ -38,7 +38,8 @@
                           VB;
                           Managed;
                           ClassDesigner;
-                          PreventAutomaticMyApplication;" />
+                          PreventAutomaticMyApplication;
+                          SharedProjectReferences;" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DefineCommonManagedItemSchemas)' == 'true'">


### PR DESCRIPTION
This hides the Add Shared Project reference node, and Shared Projects category in Reference Manager for F# projects.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6148)