### PR TITLE
Remove paths

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -16,12 +16,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
     {
         #region Factories and private constructor
 
-        public static DependenciesSnapshot CreateEmpty()
-        {
-            return new DependenciesSnapshot(
-                activeTargetFramework: TargetFramework.Empty,
-                dependenciesByTargetFramework: ImmutableDictionary<ITargetFramework, TargetedDependenciesSnapshot>.Empty);
-        }
+        public static DependenciesSnapshot Empty { get; } = new DependenciesSnapshot(
+            activeTargetFramework: TargetFramework.Empty,
+            dependenciesByTargetFramework: ImmutableDictionary<ITargetFramework, TargetedDependenciesSnapshot>.Empty);
 
         /// <summary>
         /// Updates the <see cref="TargetedDependenciesSnapshot"/> corresponding to <paramref name="changedTargetFramework"/>,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -226,9 +226,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         /// </summary>
         /// <param name="dependencyId">Unique id for dependency to be found.</param>
         /// <returns>The <see cref="IDependency"/> if found, otherwise <see langword="null"/>.</returns>
-        public IDependency? FindDependency(string dependencyId)
+        public IDependency? FindDependency(string? dependencyId)
         {
-            if (string.IsNullOrEmpty(dependencyId))
+            if (Strings.IsNullOrEmpty(dependencyId))
             {
                 return null;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             Flags = dependencyModel.Flags;
 
             // Just in case custom providers don't do it, add corresponding flags for Resolved state.
-            // This is needed for tree update logic to track if tree node changing state from unresolved 
+            // This is needed for tree update logic to track if tree node changing state from unresolved
             // to resolved or vice-versa (it helps to decide if we need to remove it or update in-place
             // in the tree to avoid flicks).
             if (Resolved)
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         #region IDependency
 
         /// <summary>
-        /// Id unique for a particular provider. We append target framework and provider type to it, 
+        /// Id unique for a particular provider. We append target framework and provider type to it,
         /// to get a unique id for the whole snapshot.
         /// </summary>
         private readonly string _modelId;
@@ -151,7 +151,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             get
             {
                 // For generic node types we do set correct, known item types, however for custom nodes
-                // provided by third party extensions we can not guarantee that item type will be known. 
+                // provided by third party extensions we can not guarantee that item type will be known.
                 // Thus always set predefined itemType for all custom nodes.
                 // TODO: generate specific xaml rule for generic Dependency nodes
                 // tracking issue: https://github.com/dotnet/project-system/issues/1102

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Buffers.PooledObjects;
-using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 using Microsoft.VisualStudio.Text;
@@ -11,18 +10,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 {
     internal sealed class Dependency : IDependency
     {
-        public Dependency(IDependencyModel dependencyModel, ITargetFramework targetFramework, string containingProjectPath)
+        public Dependency(IDependencyModel dependencyModel, ITargetFramework targetFramework)
         {
             Requires.NotNull(dependencyModel, nameof(dependencyModel));
             Requires.NotNullOrEmpty(dependencyModel.ProviderType, nameof(dependencyModel.ProviderType));
             Requires.NotNullOrEmpty(dependencyModel.Id, nameof(dependencyModel.Id));
             Requires.NotNull(targetFramework, nameof(targetFramework));
-            Requires.NotNullOrEmpty(containingProjectPath, nameof(containingProjectPath));
 
             TargetFramework = targetFramework;
 
             _modelId = dependencyModel.Id;
-            _containingProjectPath = containingProjectPath;
 
             ProviderType = dependencyModel.ProviderType;
             Name = dependencyModel.Name ?? string.Empty;
@@ -88,9 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             _id = dependency._id;
             _modelId = dependency._modelId;
-            _fullPath = dependency._fullPath;
             TargetFramework = dependency.TargetFramework;
-            _containingProjectPath = dependency._containingProjectPath;
             ProviderType = dependency.ProviderType;
             Name = dependency.Name;
             OriginalItemSpec = dependency.OriginalItemSpec;
@@ -114,8 +109,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         /// </summary>
         private readonly string _modelId;
         private string? _id;
-        private readonly string _containingProjectPath;
-        private string? _fullPath;
 
         public string Id => _id ??= GetID(TargetFramework, ProviderType, _modelId);
 
@@ -123,24 +116,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         public string Name { get; }
         public string OriginalItemSpec { get; }
         public string Path { get; }
-
-        public string FullPath
-        {
-            get
-            {
-                // Avoid calculating this unless absolutely needed as 
-                // we have a lot of Dependency instances floating around
-                return _fullPath ??= GetFullPath();
-
-                string GetFullPath()
-                {
-                    if (string.IsNullOrEmpty(OriginalItemSpec) || ManagedPathHelper.IsRooted(OriginalItemSpec))
-                        return OriginalItemSpec ?? string.Empty;
-
-                    return ManagedPathHelper.TryMakeRooted(_containingProjectPath, OriginalItemSpec);
-                }
-            }
-        }
 
         public string SchemaName { get; }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependency.cs
@@ -17,11 +17,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         ITargetFramework TargetFramework { get; }
 
         /// <summary>
-        /// Get the full path of the dependency, if relevant, otherwise, <see cref="string.Empty"/>.
-        /// </summary>
-        string FullPath { get; }
-
-        /// <summary>
         /// Gets the set of icons to use for this dependency based on its state (e.g. resolved, expanded).
         /// </summary>
         DependencyIconSet IconSet { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependency.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 {
     /// <summary>
-    /// Represents internal immutable dependency entity that is stored in immutable 
+    /// Represents internal immutable dependency entity that is stored in immutable
     /// snapshot <see cref="TargetedDependenciesSnapshot"/>.
     /// </summary>
     internal interface IDependency

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.SnapshotUpdater.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.SnapshotUpdater.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
             public SnapshotUpdater(IProjectThreadingService projectThreadingService, CancellationToken unloadCancellationToken)
             {
                 // Initial snapshot is empty.
-                _currentSnapshot = DependenciesSnapshot.CreateEmpty();
+                _currentSnapshot = DependenciesSnapshot.Empty;
 
                 // Updates will be published via Dataflow.
                 _source = DataflowBlockSlim.CreateBroadcastBlock<SnapshotChangedEventArgs>("DependenciesSnapshot {1}", skipIntermediateInputData: true);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.SnapshotUpdater.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.SnapshotUpdater.cs
@@ -25,10 +25,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
             private DependenciesSnapshot _currentSnapshot;
             private int _isDisposed;
 
-            public SnapshotUpdater(IUnconfiguredProjectCommonServices commonServices, CancellationToken unloadCancellationToken)
+            public SnapshotUpdater(IProjectThreadingService projectThreadingService, CancellationToken unloadCancellationToken)
             {
                 // Initial snapshot is empty.
-                _currentSnapshot = DependenciesSnapshot.CreateEmpty(commonServices.Project.FullPath);
+                _currentSnapshot = DependenciesSnapshot.CreateEmpty();
 
                 // Updates will be published via Dataflow.
                 _source = DataflowBlockSlim.CreateBroadcastBlock<SnapshotChangedEventArgs>("DependenciesSnapshot {1}", skipIntermediateInputData: true);
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
                 // Updates are debounced to conflate rapid updates and reduce frequency of tree updates downstream.
                 _debounce = new TaskDelayScheduler(
                     TimeSpan.FromMilliseconds(250),
-                    commonServices.ThreadingService,
+                    projectThreadingService,
                     unloadCancellationToken);
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
 
             _context = new ContextTracker(targetFrameworkProvider, commonServices, contextProvider, activeProjectConfigurationRefreshService);
 
-            _snapshot = new SnapshotUpdater(commonServices, tasksService.UnloadCancellationToken);
+            _snapshot = new SnapshotUpdater(commonServices.ThreadingService, tasksService.UnloadCancellationToken);
 
             _disposables = new DisposableBag { _snapshot, _contextUpdateGate };
         }
@@ -278,7 +278,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
 
             _snapshot.TryUpdate(
                 previousSnapshot => DependenciesSnapshot.FromChanges(
-                    _commonServices.Project.FullPath,
                     previousSnapshot,
                     changedTargetFramework,
                     changes,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             // Arrange
             var dependenciesRoot = new TestProjectTree { Caption = "MyDependencies" };
 
-            var snapshot = DependenciesSnapshot.CreateEmpty();
+            var snapshot = DependenciesSnapshot.Empty;
 
             // Act
             var resultTree = await CreateProvider().BuildTreeAsync(dependenciesRoot, snapshot);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Imaging;
@@ -15,8 +14,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 {
     public sealed class DependenciesTreeViewProviderTests
     {
-        private const string ProjectPath = @"c:\myfolder\mysubfolder\myproject.csproj";
-
         private readonly ITargetFramework _tfm1 = new TargetFramework("tfm1");
         private readonly ITargetFramework _tfm2 = new TargetFramework("tfm2");
 
@@ -570,11 +567,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
         public void WhenFindByPathAndNullNode_ShouldDoNothing()
         {
             // Arrange
-            var projectFolder = Path.GetDirectoryName(ProjectPath);
             var provider = CreateProvider();
 
             // Act
-            var resultTree = provider.FindByPath(null, Path.Combine(projectFolder, @"somenode"));
+            var resultTree = provider.FindByPath(null, "SomePath");
 
             // Assert
             Assert.Null(resultTree);
@@ -584,12 +580,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
         public void WhenFindByPathAndNotDependenciesRoot_ShouldDoNothing()
         {
             // Arrange
-            var projectFolder = Path.GetDirectoryName(ProjectPath);
             var provider = CreateProvider();
             var dependenciesRoot = new TestProjectTree { Caption = "MyDependencies" };
 
             // Act
-            var resultTree = provider.FindByPath(dependenciesRoot, Path.Combine(projectFolder, @"somenode"));
+            var resultTree = provider.FindByPath(dependenciesRoot, "SomePath");
 
             // Assert
             Assert.Null(resultTree);
@@ -658,8 +653,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
         public void WhenFindByPathAndRelativeNodePath_ShouldNotFind()
         {
             // Arrange
-            var projectFolder = Path.GetDirectoryName(ProjectPath);
-
             var provider = CreateProvider();
 
             var dependenciesRoot = new TestProjectTree
@@ -708,7 +701,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             };
 
             // Act
-            var resultTree = provider.FindByPath(dependenciesRoot, Path.Combine(projectFolder, @"level3Child32"));
+            var resultTree = provider.FindByPath(dependenciesRoot, "SomePath\\level3Child32");
 
             // Assert
             Assert.Null(resultTree);
@@ -718,8 +711,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
         public void WhenFindByPathAndNeedToFindDependenciesRoot_ShouldNotFind()
         {
             // Arrange
-            var projectFolder = Path.GetDirectoryName(ProjectPath);
-
             var provider = CreateProvider();
 
             var projectRoot = new TestProjectTree
@@ -775,7 +766,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             };
 
             // Act
-            var result = provider.FindByPath(projectRoot, Path.Combine(projectFolder, @"level3Child32"));
+            var result = provider.FindByPath(projectRoot, "SomePath\\level3Child32");
 
             // Assert
             Assert.Null(result);
@@ -792,8 +783,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 createRootViewModel: rootModels,
                 createTargetViewModel: targetModels);
 
-            var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(
-                project: UnconfiguredProjectFactory.Create(filePath: ProjectPath));
+            var commonServices = IUnconfiguredProjectCommonServicesFactory.Create();
 
             return new DependenciesTreeViewProvider(treeServices, treeViewModelFactory, commonServices);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             // Arrange
             var dependenciesRoot = new TestProjectTree { Caption = "MyDependencies" };
 
-            var snapshot = DependenciesSnapshot.CreateEmpty(ProjectPath);
+            var snapshot = DependenciesSnapshot.CreateEmpty();
 
             // Act
             var resultTree = await CreateProvider().BuildTreeAsync(dependenciesRoot, snapshot);
@@ -806,7 +806,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             foreach ((ITargetFramework tfm, IReadOnlyList<IDependency> dependencies) in testData)
             {
                 var targetedSnapshot = new TargetedDependenciesSnapshot(
-                    "ProjectPath",
                     tfm,
                     catalogs,
                     dependencies.ToImmutableArray());
@@ -815,7 +814,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             }
 
             return new DependenciesSnapshot(
-                ProjectPath,
                 testData[0].tfm,
                 dependenciesByTarget.ToImmutableDictionary());
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
@@ -128,7 +128,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             // Act
             var resultTree = await provider.BuildTreeAsync(dependenciesRoot, snapshot);
 
-            // Assert            
+            // Assert
             var expectedFlatHierarchy =
 @"Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
     Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
@@ -193,7 +193,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             // Act
             var resultTree = await provider.BuildTreeAsync(dependenciesRoot, snapshot);
 
-            // Assert            
+            // Assert
             var expectedFlatHierarchy =
 @"Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
     Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
@@ -253,7 +253,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             // Act
             var resultTree = await provider.BuildTreeAsync(dependenciesRoot, snapshot);
 
-            // Assert            
+            // Assert
             var expectedFlatHierarchy =
 @"Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
     Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
@@ -313,7 +313,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             // Act
             var resultTree = await provider.BuildTreeAsync(dependenciesRoot, snapshot);
 
-            // Assert            
+            // Assert
             var expectedFlatHierarchy =
 @"Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
     Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
@@ -364,7 +364,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             // Act
             var resultTree = await provider.BuildTreeAsync(dependenciesRoot, snapshot);
 
-            // Assert            
+            // Assert
             var expectedFlatHierarchy =
 @"Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
     Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=";
@@ -413,7 +413,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             // Act
             var resultTree = await provider.BuildTreeAsync(dependenciesRoot, snapshot);
 
-            // Assert            
+            // Assert
             var expectedFlatHierarchy =
 @"Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=";
             Assert.Equal(expectedFlatHierarchy, ToTestDataString((TestProjectTree)resultTree));

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
@@ -16,23 +16,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         [Fact]
         public void Constructor_WhenRequiredParamsNotProvided_ShouldThrow()
         {
-            var path = "path";
             var tfm = TargetFramework.Any;
             var dic = ImmutableDictionary<ITargetFramework, TargetedDependenciesSnapshot>.Empty;
 
-            Assert.Throws<ArgumentNullException>("projectPath",                   () => new DependenciesSnapshot(null!, tfm,   dic));
-            Assert.Throws<ArgumentNullException>("activeTargetFramework",         () => new DependenciesSnapshot(path,  null!, dic));
-            Assert.Throws<ArgumentNullException>("dependenciesByTargetFramework", () => new DependenciesSnapshot(path,  tfm,   null!));
+            Assert.Throws<ArgumentNullException>("activeTargetFramework",         () => new DependenciesSnapshot(null!, dic));
+            Assert.Throws<ArgumentNullException>("dependenciesByTargetFramework", () => new DependenciesSnapshot(tfm,   null!));
         }
 
         [Fact]
         public void Constructor_ThrowsIfActiveTargetFrameworkNotEmptyAndNotInDependenciesByTargetFramework()
         {
-            const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = new TargetFramework("tfm1");
 
             var ex = Assert.Throws<ArgumentException>(() => new DependenciesSnapshot(
-                projectPath,
                 activeTargetFramework: targetFramework,
                 ImmutableDictionary<ITargetFramework, TargetedDependenciesSnapshot>.Empty));
 
@@ -42,18 +38,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         [Fact]
         public void Constructor()
         {
-            const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var catalogs = IProjectCatalogSnapshotFactory.Create();
             var targetFramework = new TargetFramework("tfm1");
 
-            var dependenciesByTargetFramework = CreateDependenciesByTargetFramework(projectPath, catalogs, targetFramework);
+            var dependenciesByTargetFramework = CreateDependenciesByTargetFramework(catalogs, targetFramework);
 
             var snapshot = new DependenciesSnapshot(
-                projectPath,
                 activeTargetFramework: targetFramework,
                 dependenciesByTargetFramework);
 
-            Assert.Same(projectPath, snapshot.ProjectPath);
             Assert.Same(targetFramework, snapshot.ActiveTargetFramework);
             Assert.Same(dependenciesByTargetFramework, snapshot.DependenciesByTargetFramework);
             Assert.False(snapshot.HasVisibleUnresolvedDependency);
@@ -63,11 +56,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         [Fact]
         public void CreateEmpty()
         {
-            const string projectPath = @"c:\somefolder\someproject\a.csproj";
+            var snapshot = DependenciesSnapshot.CreateEmpty();
 
-            var snapshot = DependenciesSnapshot.CreateEmpty(projectPath);
-
-            Assert.Same(projectPath, snapshot.ProjectPath);
             Assert.Same(TargetFramework.Empty, snapshot.ActiveTargetFramework);
             Assert.Empty(snapshot.DependenciesByTargetFramework);
             Assert.False(snapshot.HasVisibleUnresolvedDependency);
@@ -77,19 +67,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         [Fact]
         public void FromChanges_NoChanges()
         {
-            const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var catalogs = IProjectCatalogSnapshotFactory.Create();
             var targetFramework = new TargetFramework("tfm1");
             var targetFrameworks = ImmutableArray<ITargetFramework>.Empty.Add(targetFramework);
-            var dependenciesByTargetFramework = CreateDependenciesByTargetFramework(projectPath, catalogs, targetFramework);
+            var dependenciesByTargetFramework = CreateDependenciesByTargetFramework(catalogs, targetFramework);
 
             var previousSnapshot = new DependenciesSnapshot(
-                projectPath,
                 activeTargetFramework: targetFramework,
                 dependenciesByTargetFramework);
 
             var snapshot = DependenciesSnapshot.FromChanges(
-                projectPath,
                 previousSnapshot,
                 targetFramework,
                 changes: null,
@@ -106,20 +93,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         [Fact]
         public void FromChanges_CatalogsChanged()
         {
-            const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var previousCatalogs = IProjectCatalogSnapshotFactory.Create();
             var updatedCatalogs = IProjectCatalogSnapshotFactory.Create();
             var targetFramework = new TargetFramework("tfm1");
             var targetFrameworks = ImmutableArray<ITargetFramework>.Empty.Add(targetFramework);
-            var dependenciesByTargetFramework = CreateDependenciesByTargetFramework(projectPath, previousCatalogs, targetFramework);
+            var dependenciesByTargetFramework = CreateDependenciesByTargetFramework(previousCatalogs, targetFramework);
 
             var previousSnapshot = new DependenciesSnapshot(
-                projectPath,
                 activeTargetFramework: targetFramework,
                 dependenciesByTargetFramework);
 
             var snapshot = DependenciesSnapshot.FromChanges(
-                projectPath,
                 previousSnapshot,
                 targetFramework,
                 changes: null,
@@ -131,7 +115,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 null);
 
             Assert.NotSame(previousSnapshot, snapshot);
-            Assert.Same(projectPath, snapshot.ProjectPath);
             Assert.Same(targetFramework, snapshot.ActiveTargetFramework);
             Assert.NotSame(previousSnapshot.DependenciesByTargetFramework, snapshot.DependenciesByTargetFramework);
 
@@ -141,15 +124,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         [Fact]
         public void FromChanges_WithDependenciesChanges()
         {
-            const string previousProjectPath = @"c:\somefolder\someproject\a.csproj";
-            const string newProjectPath = @"c:\somefolder\someproject\b.csproj";
-
             var catalogs = IProjectCatalogSnapshotFactory.Create();
             var targetFramework = new TargetFramework("tfm1");
-            var dependenciesByTargetFramework = CreateDependenciesByTargetFramework(previousProjectPath, catalogs, targetFramework);
+            var dependenciesByTargetFramework = CreateDependenciesByTargetFramework(catalogs, targetFramework);
 
             var previousSnapshot = new DependenciesSnapshot(
-                previousProjectPath,
                 activeTargetFramework: targetFramework,
                 dependenciesByTargetFramework);
 
@@ -162,7 +141,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             targetChanges.Added(model);
 
             var snapshot = DependenciesSnapshot.FromChanges(
-                newProjectPath,
                 previousSnapshot,
                 targetFramework,
                 targetChanges.TryBuildChanges()!,
@@ -174,7 +152,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 null);
 
             Assert.NotSame(previousSnapshot, snapshot);
-            Assert.Same(newProjectPath, snapshot.ProjectPath);
             Assert.Same(targetFramework, snapshot.ActiveTargetFramework);
             Assert.NotSame(previousSnapshot.DependenciesByTargetFramework, snapshot.DependenciesByTargetFramework);
 
@@ -188,12 +165,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         [Fact]
         public void SetTargets_FromEmpty()
         {
-            const string projectPath = @"c:\somefolder\someproject\a.csproj";
-
             ITargetFramework tfm1 = new TargetFramework("tfm1");
             ITargetFramework tfm2 = new TargetFramework("tfm2");
 
-            var snapshot = DependenciesSnapshot.CreateEmpty(projectPath)
+            var snapshot = DependenciesSnapshot.CreateEmpty()
                 .SetTargets(ImmutableArray.Create(tfm1, tfm2), tfm1);
 
             Assert.Same(tfm1, snapshot.ActiveTargetFramework);
@@ -205,12 +180,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         [Fact]
         public void SetTargets_SameMembers_DifferentActive()
         {
-            const string projectPath = @"c:\somefolder\someproject\a.csproj";
-
             ITargetFramework tfm1 = new TargetFramework("tfm1");
             ITargetFramework tfm2 = new TargetFramework("tfm2");
 
-            var before = DependenciesSnapshot.CreateEmpty(projectPath)
+            var before = DependenciesSnapshot.CreateEmpty()
                 .SetTargets(ImmutableArray.Create(tfm1, tfm2), tfm1);
 
             var after = before.SetTargets(ImmutableArray.Create(tfm1, tfm2), tfm2);
@@ -222,12 +195,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         [Fact]
         public void SetTargets_SameMembers_SameActive()
         {
-            const string projectPath = @"c:\somefolder\someproject\a.csproj";
-
             ITargetFramework tfm1 = new TargetFramework("tfm1");
             ITargetFramework tfm2 = new TargetFramework("tfm2");
 
-            var before = DependenciesSnapshot.CreateEmpty(projectPath)
+            var before = DependenciesSnapshot.CreateEmpty()
                 .SetTargets(ImmutableArray.Create(tfm1, tfm2), tfm1);
 
             var after = before.SetTargets(ImmutableArray.Create(tfm1, tfm2), tfm1);
@@ -238,13 +209,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         [Fact]
         public void SetTargets_DifferentMembers_DifferentActive()
         {
-            const string projectPath = @"c:\somefolder\someproject\a.csproj";
-
             ITargetFramework tfm1 = new TargetFramework("tfm1");
             ITargetFramework tfm2 = new TargetFramework("tfm2");
             ITargetFramework tfm3 = new TargetFramework("tfm3");
 
-            var before = DependenciesSnapshot.CreateEmpty(projectPath)
+            var before = DependenciesSnapshot.CreateEmpty()
                 .SetTargets(ImmutableArray.Create(tfm1, tfm2), tfm1);
 
             var after = before.SetTargets(ImmutableArray.Create(tfm2, tfm3), tfm3);
@@ -257,7 +226,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         }
 
         private static ImmutableDictionary<ITargetFramework, TargetedDependenciesSnapshot> CreateDependenciesByTargetFramework(
-            string projectPath,
             IProjectCatalogSnapshot catalogs,
             params ITargetFramework[] targetFrameworks)
         {
@@ -265,7 +233,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             foreach (var targetFramework in targetFrameworks)
             {
-                dic = dic.Add(targetFramework, TargetedDependenciesSnapshot.CreateEmpty(projectPath, targetFramework, catalogs));
+                dic = dic.Add(targetFramework, TargetedDependenciesSnapshot.CreateEmpty(targetFramework, catalogs));
             }
 
             return dic;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         [Fact]
         public void CreateEmpty()
         {
-            var snapshot = DependenciesSnapshot.CreateEmpty();
+            var snapshot = DependenciesSnapshot.Empty;
 
             Assert.Same(TargetFramework.Empty, snapshot.ActiveTargetFramework);
             Assert.Empty(snapshot.DependenciesByTargetFramework);
@@ -168,7 +168,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             ITargetFramework tfm1 = new TargetFramework("tfm1");
             ITargetFramework tfm2 = new TargetFramework("tfm2");
 
-            var snapshot = DependenciesSnapshot.CreateEmpty()
+            var snapshot = DependenciesSnapshot.Empty
                 .SetTargets(ImmutableArray.Create(tfm1, tfm2), tfm1);
 
             Assert.Same(tfm1, snapshot.ActiveTargetFramework);
@@ -183,7 +183,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             ITargetFramework tfm1 = new TargetFramework("tfm1");
             ITargetFramework tfm2 = new TargetFramework("tfm2");
 
-            var before = DependenciesSnapshot.CreateEmpty()
+            var before = DependenciesSnapshot.Empty
                 .SetTargets(ImmutableArray.Create(tfm1, tfm2), tfm1);
 
             var after = before.SetTargets(ImmutableArray.Create(tfm1, tfm2), tfm2);
@@ -198,7 +198,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             ITargetFramework tfm1 = new TargetFramework("tfm1");
             ITargetFramework tfm2 = new TargetFramework("tfm2");
 
-            var before = DependenciesSnapshot.CreateEmpty()
+            var before = DependenciesSnapshot.Empty
                 .SetTargets(ImmutableArray.Create(tfm1, tfm2), tfm1);
 
             var after = before.SetTargets(ImmutableArray.Create(tfm1, tfm2), tfm1);
@@ -213,7 +213,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             ITargetFramework tfm2 = new TargetFramework("tfm2");
             ITargetFramework tfm3 = new TargetFramework("tfm3");
 
-            var before = DependenciesSnapshot.CreateEmpty()
+            var before = DependenciesSnapshot.Empty
                 .SetTargets(ImmutableArray.Create(tfm1, tfm2), tfm1);
 
             var after = before.SetTargets(ImmutableArray.Create(tfm2, tfm3), tfm3);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -16,35 +16,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         public void Dependency_Constructor_WhenRequiredParamsNotProvided_ShouldThrow()
         {
             var targetFramework = new TargetFramework("tfm");
-            var containingProjectPath = @"c:\SomePath\SomeProject.csproj";
 
             Assert.Throws<ArgumentNullException>("dependencyModel", () =>
             {
-                new Dependency(null!, targetFramework, containingProjectPath);
+                new Dependency(null!, targetFramework);
             });
 
             Assert.Throws<ArgumentNullException>("ProviderType", () =>
             {
                 var dependencyModel = new TestDependencyModel { ProviderType = null!, Id = "Id" };
-                new Dependency(dependencyModel, targetFramework, containingProjectPath);
+                new Dependency(dependencyModel, targetFramework);
             });
 
             Assert.Throws<ArgumentNullException>("Id", () =>
             {
                 var dependencyModel = new TestDependencyModel { ProviderType = "providerType", Id = null! };
-                new Dependency(dependencyModel, targetFramework, containingProjectPath);
+                new Dependency(dependencyModel, targetFramework);
             });
 
             Assert.Throws<ArgumentNullException>("targetFramework", () =>
             {
                 var dependencyModel = new TestDependencyModel { ProviderType = "providerType", Id = "id" };
-                new Dependency(dependencyModel, null!, containingProjectPath);
-            });
-
-            Assert.Throws<ArgumentNullException>("containingProjectPath", () =>
-            {
-                var dependencyModel = new TestDependencyModel { ProviderType = "providerType", Id = "id" };
-                new Dependency(dependencyModel, targetFramework: targetFramework, containingProjectPath: null!);
+                new Dependency(dependencyModel, null!);
             });
         }
 
@@ -57,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 Id = "mymodel"
             };
 
-            var dependency = new Dependency(mockModel, new TargetFramework("tfm1"), @"C:\Foo\Project.csproj");
+            var dependency = new Dependency(mockModel, new TargetFramework("tfm1"));
 
             Assert.Equal(mockModel.ProviderType, dependency.ProviderType);
             Assert.Equal(string.Empty, dependency.Name);
@@ -97,7 +90,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             var targetFramework = new TargetFramework("Tfm1");
 
-            var dependency = new Dependency(mockModel, targetFramework, @"C:\Foo\Project.csproj");
+            var dependency = new Dependency(mockModel, targetFramework);
 
             Assert.Equal(mockModel.ProviderType, dependency.ProviderType);
             Assert.Equal(mockModel.Name, dependency.Name);
@@ -122,7 +115,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         {
             var dependencyModel = new TestDependencyModel { ProviderType = "xxx", Id = modelId };
 
-            var dependency = new Dependency(dependencyModel, new TargetFramework("tfm1"), @"C:\Foo\Project.cspoj");
+            var dependency = new Dependency(dependencyModel, new TargetFramework("tfm1"));
 
             Assert.Equal(dependencyModel.ProviderType, dependency.ProviderType);
             Assert.Equal(expectedId, dependency.Id);
@@ -137,7 +130,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var dependencyModel = new TestDependencyModel { ProviderType = "providerType", Id = modelId };
             var targetFramework = new TargetFramework("tfm");
 
-            var dependency = new Dependency(dependencyModel, targetFramework, @"C:\Foo\Project.csproj");
+            var dependency = new Dependency(dependencyModel, targetFramework);
 
             Assert.Equal(dependencyModel.ProviderType, dependency.ProviderType);
             Assert.Equal(expectedId, dependency.Id);
@@ -148,7 +141,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         {
             var dependencyModel = new TestDependencyModel { ProviderType = "providerType", Id = "someId" };
 
-            var dependency = new Dependency(dependencyModel, new TargetFramework("tfm1"), @"C:\Foo\Project.csproj");
+            var dependency = new Dependency(dependencyModel, new TargetFramework("tfm1"));
             var flags = ProjectTreeFlags.Create("TestFlag");
 
             var newDependency = dependency.SetProperties(
@@ -166,7 +159,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         {
             var dependencyModel = new TestDependencyModel { ProviderType = "providerType", Id = "someId" };
 
-            var dependency = (new Dependency(dependencyModel, new TargetFramework("tfm1"), @"C:\Foo\Project.csproj"))
+            var dependency = (new Dependency(dependencyModel, new TargetFramework("tfm1")))
                 .SetProperties(iconSet: new DependencyIconSet(KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference));
 
             var dependencyWithUpdatedIconSet = dependency.SetProperties(iconSet: new DependencyIconSet(KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference));
@@ -177,14 +170,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         [Fact]
         public void WhenCreatingADependencyFromAnotherDependency_ExistingIconSetInstanceIsReused()
         {
-            var projectPath = @"C:\Foo\Project.csproj";
-
             var dependencyModel = new TestableDependencyModel(
-                    projectPath,
+                    "Path",
                     "ItemSpec",
                     iconSet: new DependencyIconSet(KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference));
 
-            var dependency = new Dependency(dependencyModel, new TargetFramework("tfm2"), projectPath);
+            var dependency = new Dependency(dependencyModel, new TargetFramework("tfm2"));
 
             Assert.Same(dependencyModel.IconSet, dependency.IconSet);
         }
@@ -227,8 +218,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             var targetFramework = new TargetFramework("Tfm1");
 
-            var dependency1 = new Dependency(model1, targetFramework, @"C:\Foo\Project.csproj");
-            var dependency2 = new Dependency(model2, targetFramework, @"C:\Foo\Project.csproj");
+            var dependency1 = new Dependency(model1, targetFramework);
+            var dependency2 = new Dependency(model2, targetFramework);
 
             Assert.Same(dependency1.IconSet, dependency2.IconSet);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -24,7 +24,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 Caption = value.Caption;
                 OriginalItemSpec = value.OriginalItemSpec;
                 Path = value.Path;
-                FullPath = value.FullPath;
                 SchemaName = value.SchemaName;
                 SchemaItemType = value.SchemaItemType;
                 Resolved = value.Resolved;
@@ -44,7 +43,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         public string Caption { get; set; }
         public string OriginalItemSpec { get; set; }
         public string Path { get; set; }
-        public string FullPath { get; set; }
         public string SchemaName { get; set; }
         public string SchemaItemType { get; set; }
         public bool Resolved { get; set; } = false;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependencyExtensions.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependencyExtensions.cs
@@ -14,7 +14,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             Xunit.Assert.Equal(expected.Caption, actual.Caption);
             Xunit.Assert.Equal(expected.OriginalItemSpec, actual.OriginalItemSpec);
             Xunit.Assert.Equal(expected.Path, actual.Path);
-            Xunit.Assert.Equal(expected.FullPath, actual.FullPath);
             Xunit.Assert.Equal(expected.SchemaName, actual.SchemaName);
             Xunit.Assert.Equal(expected.SchemaItemType, actual.SchemaItemType);
             Xunit.Assert.Equal(expected.Resolved, actual.Resolved);


### PR DESCRIPTION
Fixes #4474.

With changes on this feature branch we no longer use:

- `DependenciesSnapshot.ProjectPath`
- `TargetedDependenciesSnapshot.ProjectPath`
- `IDependency.FullPath`

This PR removes them all.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6150)