### PR TITLE
Signal changes to IAttachedCollectionSource.HasItems

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateContainedByRelationCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateContainedByRelationCollection.cs
@@ -8,6 +8,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 {
     public sealed class AggregateContainedByRelationCollection : IAggregateRelationCollection
     {
+        /// <summary>
+        /// <see cref="HasItems"/> doesn't change for this collection type.
+        /// </summary>
+        event EventHandler IAggregateRelationCollection.HasItemsChanged { add { } remove { } }
+
         private readonly List<object> _parentItems;
 
         internal AggregateContainedByRelationCollection(List<object> parentItems)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateRelationCollectionSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateRelationCollectionSource.cs
@@ -28,7 +28,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         public AggregateRelationCollectionSource(object sourceItem, IAggregateRelationCollection? collection = null)
         {
             _sourceItem = Requires.NotNull(sourceItem, nameof(sourceItem));
-            _collection = collection;
+
+            if (collection != null)
+            {
+                SetCollection(collection);
+            }
         }
 
         object IAttachedCollectionSource.SourceItem => _sourceItem;
@@ -64,6 +68,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
             }
 
             _collection = Requires.NotNull(collection, nameof(collection));
+            _collection.HasItemsChanged += delegate
+            {
+                PropertyChanged?.Invoke(this, KnownEventArgs.HasItemsPropertyChanged);
+            };
+
             PropertyChanged?.Invoke(this, KnownEventArgs.IsUpdatingItemsPropertyChanged);
             PropertyChanged?.Invoke(this, KnownEventArgs.HasItemsPropertyChanged);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IAggregateRelationCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IAggregateRelationCollection.cs
@@ -1,7 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using System.Collections;
 using System.Windows.Data;
+using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections
 {
@@ -27,6 +29,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     /// </remarks>
     public interface IAggregateRelationCollection : IList
     {
+        /// <summary>
+        /// Raised whenever <see cref="HasItems"/> changes.
+        /// </summary>
+        /// <remarks>
+        /// Used by <see cref="AggregateRelationCollectionSource"/> to trigger changes to its
+        /// <see cref="IAttachedCollectionSource.HasItems"/> property.
+        /// </remarks>
+        event EventHandler HasItemsChanged;
+
         /// <summary>
         /// Gets whether this collection contains items. The return value can be computed without materializing items.
         /// This allows expansion indicators to be displayed correctly without actually instantiating items.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.VisualStudio.ProjectSystem.VS.Properties.CSharp.CSharpProjectConfigura
 Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic.VisualBasicProjectConfigurationProperties
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AggregateContainsRelationCollection
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AggregateContainsRelationCollection.OnStateUpdated() -> void
+Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IAggregateRelationCollection.HasItemsChanged -> System.EventHandler!
 static Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AggregateContainsRelationCollection.TryCreate(Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IRelatableItem! parentItem, Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IRelationProvider! relationProvider, out Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AggregateContainsRelationCollection? collection) -> bool
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AggregateContainsRelationCollectionSpan
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AggregateContainsRelationCollectionSpan.UpdateContainsItems<TData, TItem>(System.Collections.Generic.IEnumerable<TData>! sources, System.Func<TData, TItem!, int>! comparer, System.Func<TData, TItem!, bool>! update, System.Func<TData, TItem!>! factory) -> void


### PR DESCRIPTION
This fixes:

1. the tree shows a lingering triangle after the last child is removed, and
2. the tree not adding a triangle/children when an item has its first child added post-initialization.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6151)