### PR TITLE
Mark command as client compliant

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -38,7 +38,7 @@
     <PackageReference Update="Microsoft.DevDiv.Validation.MediaRecorder"                              Version="15.0.199" />
 
     <!-- VS SDK -->
-    <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="16.5.2044" />
+    <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="16.7.2" />
     <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost"                              Version="16.0.198-g52de9c2988"/>
     <PackageReference Update="Microsoft.VisualStudio.Composition"                                     Version="16.1.8"/>
     <PackageReference Update="Microsoft.VisualStudio.Data.Core"                                       Version="9.0.21022" />

--- a/setup/ProjectSystemSetup/source.extension.vsixmanifest
+++ b/setup/ProjectSystemSetup/source.extension.vsixmanifest
@@ -6,6 +6,7 @@
     <DisplayName>C#, Visual Basic and F# project systems</DisplayName>
     <Description xml:space="preserve">C#, Visual Basic and F# project systems.</Description>
     <PackageId>Microsoft.VisualStudio.ProjectSystem.Managed</PackageId>
+    <AllowClientRole>true</AllowClientRole>
   </Metadata>
   <Installation SystemComponent="true" Experimental="true">
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.Pro" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Menus.vsct
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Menus.vsct
@@ -35,6 +35,7 @@
       <Button guid="guidManagedProjectSystemClientProjectCommandSet" id="cmdidEditProjectFile" priority="0x0100" type="Button">
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>AllowClientRole</CommandFlag>
         <Strings>
           <ButtonText>Edit Project File</ButtonText>
           <CommandName>SolutionExplorer.Project.Edit</CommandName>
@@ -43,7 +44,7 @@
         </Strings>
       </Button>
     </Buttons>
-  
+
   </Commands>
 
   <CommandPlacements>
@@ -51,13 +52,13 @@
     <CommandPlacement guid="guidManagedProjectSystemClientProjectCommandSet" id="cmdidEditProjectFile" priority="0x0100">
       <Parent guid="guidManagedProjectSystemClientProjectCommandSet" id="groupidEditProjectFile" />
     </CommandPlacement>
-  
+
   </CommandPlacements>
 
   <Symbols>
     <!-- This is our managed package guid. -->
     <GuidSymbol name="PackageGuidString" value="{AE74FDFC-B9CE-4948-9E2F-F443B5BE8D37}" />
-  
+
     <!-- Guid and IDs for our commands and groups -->
     <GuidSymbol name="guidManagedProjectSystemClientProjectCommandSet" value="{28C12D02-11CB-437D-B84D-9CEA7A5333A3}">
       <IDSymbol name="cmdidEditProjectFile" value="0x0100" />


### PR DESCRIPTION
This marks the 'Edit project file' command as client compliant.

Testing is **blocked**, not merging this to master yet.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6157)