### PR TITLE
Hide Add XXX Reference commands on folders

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/ReferenceManagerCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/ReferenceManagerCommandHandler.cs
@@ -19,6 +19,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
     [Order(ProjectSystem.Order.Default)]
     internal sealed class ReferenceManagerCommandHandler : ICommandGroupHandler
     {
+        // WORKAROUND: Until we can consume the new CommandStatus from CPS
+        public const CommandStatus InvisibleOnContextMenu = (CommandStatus)unchecked((int)0x20);
+
         public const int CmdidAddAssemblyReference       = 0x200;
         public const int CmdidAddComReference            = 0x201;
         public const int CmdidAddProjectReference        = 0x202;
@@ -46,6 +49,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
             {
                 progressiveStatus &= ~CommandStatus.Invisible;
                 progressiveStatus |= CommandStatus.Enabled | CommandStatus.Supported;
+
+                if (items.Count > 1 || !items.First().IsRoot())
+                {   // We only want these commands to be visible for the right-click Project -> Add menu
+
+                    progressiveStatus |= InvisibleOnContextMenu;
+                }
+
                 return new CommandStatusResult(handled: true, commandText, progressiveStatus);
             }
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/6158.

Add Reference used to have two commands; AddReference and AddReferenceProjectOnly. The former is bound to the Project menu and is always available regardless of what node is selected, and the latter is bound to the right-click Project/Folder Add menu and is only available when just the project node is selected.

Rather than duplicating the same commands to achieve the same thing, we just hide the commands on the context menu when a non-project node is selected.

The PR to add & respect the flag is in https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/246630.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6160)