### PR TITLE
[16.6.x] Revert "Revert "Don't modify collection while enumerating""

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -135,7 +135,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 // Remove any extra target frameworks
                 if (builder.Count != targetFrameworks.Length)
                 {
-                    IEnumerable<ITargetFramework> targetFrameworksToRemove = builder.Keys.Except(targetFrameworks);
+                    // NOTE We need "ToList" here as "Except" is lazy, and attempts to remove from the builder
+                    // while iterating will throw "Collection was modified"
+                    IEnumerable<ITargetFramework> targetFrameworksToRemove = builder.Keys.Except(targetFrameworks).ToList();
 
                     foreach (ITargetFramework targetFramework in targetFrameworksToRemove)
                     {


### PR DESCRIPTION
This reverts commit f73f31699960f0488b8fba53d5217cf21436758b.

This fix was reverted on the 16.5.x branch after it didn't make the QB bar. That
reversion was then automatically forward integrated into master.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6162)