### PR TITLE
Remove NuGet package references

### DIFF
--- a/build/import/HostAgnostic.props
+++ b/build/import/HostAgnostic.props
@@ -49,10 +49,6 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
     <PackageReference Include="Microsoft.Build.Engine" />
 
-    <!-- NuGet -->
-    <PackageReference Include="NuGet.ProjectModel" />
-    <PackageReference Include="NuGet.Common" />
-    
     <!-- 3rd party -->
     <PackageReference Include="Newtonsoft.Json" />
 

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -117,8 +117,6 @@
     <!-- NuGet -->
     <PackageReference Update="NuGet.SolutionRestoreManager.Interop"                                   Version="5.6.0-preview.2.6554" />
     <PackageReference Update="NuGet.VisualStudio"                                                     Version="5.6.0-preview.2.6554" />
-    <PackageReference Update="NuGet.ProjectModel"                                                     Version="5.7.0-preview.1.6568" />
-    <PackageReference Update="NuGet.Common"                                                           Version="5.7.0-preview.1.6568" />
 
     <!-- MSBuild -->
     <PackageReference Update="Microsoft.Build"                                                        Version="16.4.0"/>


### PR DESCRIPTION
These packages are the reason we have to move a bunch of code from here to NuGet. They contain assemblies for which there are no binding redirects.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6167)