### PR TITLE
Mark PackageRestore faults as "LimitedFunctionaity"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreProgressTracker.PackageRestoreProgressTrackerInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreProgressTracker.PackageRestoreProgressTrackerInstance.cs
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
                 _subscription = ProjectDataSources.SyncLinkTo(
                     _projectSubscriptionService.ProjectSource.SourceBlock.SyncLinkOptions(),
                     _dataSource.SourceBlock.SyncLinkOptions(),
-                        DataflowBlockFactory.CreateActionBlock(action, ConfiguredProject.UnconfiguredProject),
+                        DataflowBlockFactory.CreateActionBlock(action, ConfiguredProject.UnconfiguredProject, ProjectFaultSeverity.LimitedFunctionality),
                         linkOptions: DataflowOption.PropagateCompletion);
 
                 return Task.CompletedTask;


### PR DESCRIPTION
This makes sure the project gets unsubscribed from contributing to operation progress if it faults.

This is a targeted version of https://github.com/dotnet/project-system/pull/6172 because making all usages as required needs a little more thought.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6173)