### PR TITLE
Opt out of code sign valiation

### DIFF
--- a/build/ci/unit-tests.yml
+++ b/build/ci/unit-tests.yml
@@ -19,6 +19,10 @@ pr:
     - dev*
     - feature/*
 
+variables:
+  # Opt out of running Codesign Validation (https://aka.ms/gdn-injection)
+  runCodesignValidationInjection: false
+
 jobs:
 - template: unit-tests-template.yml
   parameters:


### PR DESCRIPTION
A job is automatically being injected into the build to validate that the builds produced signed binaries. It currently does not validate, but produces an output. Opt completely our CI builds completely out of this as they don't produce signed binaries.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6174)