### PR TITLE
Make IVsHierarchyItemExtensions public

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IVsHierarchyItemExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IVsHierarchyItemExtensions.cs
@@ -148,7 +148,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
             return false;
         }
 
-        public static bool TryGetFlagsString(this IVsHierarchyItem item, [NotNullWhen(returnValue: true)] out string? flagsString)
+        /// <summary>
+        /// Gets the string of space-separated project tree flags stored in the
+        /// <see cref="__VSHPROPID7.VSHPROPID_ProjectTreeCapabilities"/> property of
+        /// <paramref name="item"/>.
+        /// </summary>
+        /// <param name="item">The item to retrieve the flags from.</param>
+        /// <param name="flagsString">The resulting string, if found, otherwise <see langword="null"/>.</param>
+        /// <returns><see langword="true"/> if the flags string was found, otherwise <see langword="false"/>.</returns>
+        public static bool TryGetFlagsString(
+            this IVsHierarchyItem item,
+            [NotNullWhen(returnValue: true)] out string? flagsString)
         {
             IVsHierarchyItemIdentity identity = item.HierarchyIdentity;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IVsHierarchyItemExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IVsHierarchyItemExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     /// <summary>
     /// Extension methods for <see cref="IVsHierarchyItem"/> that support attached collections.
     /// </summary>
-    internal static class IVsHierarchyItemExtensions
+    public static class IVsHierarchyItemExtensions
     {
         private static Regex? s_targetFlagsRegex;
         private static Regex? s_packageFlagsRegex;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -7,6 +7,7 @@ Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic.VisualBasicProjec
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AggregateContainsRelationCollection
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AggregateContainsRelationCollection.OnStateUpdated() -> void
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IAggregateRelationCollection.HasItemsChanged -> System.EventHandler!
+Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IVsHierarchyItemExtensions
 override Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.RelatableItemBase.ContextMenuController.get -> Microsoft.Internal.VisualStudio.PlatformUI.IContextMenuController?
 static Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AggregateContainsRelationCollection.TryCreate(Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IRelatableItem! parentItem, Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IRelationProvider! relationProvider, out Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AggregateContainsRelationCollection? collection) -> bool
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AggregateContainsRelationCollectionSpan
@@ -51,6 +52,12 @@ Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.At
 abstract Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AttachedCollectionItemBase.IconMoniker.get -> Microsoft.VisualStudio.Imaging.Interop.ImageMoniker
 abstract Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AttachedCollectionItemBase.Priority.get -> int
 override Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AttachedCollectionItemBase.ToString() -> string!
+static Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IVsHierarchyItemExtensions.TryFindTarget(this Microsoft.VisualStudio.Shell.IVsHierarchyItem! item, out string? target) -> bool
+static Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IVsHierarchyItemExtensions.TryGetFlagsString(this Microsoft.VisualStudio.Shell.IVsHierarchyItem! item, out string? flagsString) -> bool
+static Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IVsHierarchyItemExtensions.TryGetPackageDetails(string! flagsString, out string? packageId, out string? packageVersion) -> bool
+static Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IVsHierarchyItemExtensions.TryGetPackageDetails(this Microsoft.VisualStudio.Shell.IVsHierarchyItem! item, out string? packageId, out string? packageVersion) -> bool
+static Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IVsHierarchyItemExtensions.TryGetProjectDetails(string! flagsString, out string? projectId) -> bool
+static Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IVsHierarchyItemExtensions.TryGetProjectDetails(this Microsoft.VisualStudio.Shell.IVsHierarchyItem! item, out string? projectId) -> bool
 virtual Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AttachedCollectionItemBase.CompareTo(object! obj) -> int
 virtual Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AttachedCollectionItemBase.ContextMenuController.get -> Microsoft.Internal.VisualStudio.PlatformUI.IContextMenuController?
 virtual Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AttachedCollectionItemBase.ExpandedIconMoniker.get -> Microsoft.VisualStudio.Imaging.Interop.ImageMoniker


### PR DESCRIPTION
This type is needed by the NuGet implementation. It serves as a way for others to extract information from tree items for other purposes too, such as command handlers.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6175)