### PR TITLE
Ban Debugger.Launch

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -333,8 +333,8 @@ dotnet_diagnostic.RS0024.severity = error
 dotnet_diagnostic.RS0025.severity = error
 dotnet_diagnostic.RS0026.severity = error
 dotnet_diagnostic.RS0027.severity = error
-dotnet_diagnostic.RS0030.severity = error
-dotnet_diagnostic.RS0031.severity = error
+dotnet_diagnostic.RS0030.severity = warning     # Do not use banned APIs
+dotnet_diagnostic.RS0031.severity = error       # The list of banned symbols contains a duplicate
 dotnet_diagnostic.RS0033.severity = none        # Importing constructor should be [Obsolete]
 dotnet_diagnostic.RS0034.severity = none        # Style rule that enforces public MEF constructor marked with [ImportingConstructor]
 

--- a/src/Common/BannedSymbols.txt
+++ b/src/Common/BannedSymbols.txt
@@ -86,3 +86,5 @@ T:System.Threading.Tasks.Dataflow.DataflowLinkOptions;Use DataflowOption.Propaga
 
 M:Microsoft.VisualStudio.ProjectSystem.OnceInitializedOnceDisposed.Initialize();Did you mean EnsureInitialized?
 M:Microsoft.VisualStudio.ProjectSystem.OnceInitializedOnceDisposedAsync.InitializeCoreAsync(System.Threading.CancellationToken);Did you mean InitializeAsync(CancellationToken)?
+
+M:System.Diagnostics.Debugger.Launch(); This should never appear in production code.

--- a/src/Common/BannedSymbols.txt
+++ b/src/Common/BannedSymbols.txt
@@ -87,4 +87,5 @@ T:System.Threading.Tasks.Dataflow.DataflowLinkOptions;Use DataflowOption.Propaga
 M:Microsoft.VisualStudio.ProjectSystem.OnceInitializedOnceDisposed.Initialize();Did you mean EnsureInitialized?
 M:Microsoft.VisualStudio.ProjectSystem.OnceInitializedOnceDisposedAsync.InitializeCoreAsync(System.Threading.CancellationToken);Did you mean InitializeAsync(CancellationToken)?
 
-M:System.Diagnostics.Debugger.Launch(); This should never appear in production code.
+M:System.Diagnostics.Debugger.Break(); This should not be used in production code as the resulting dialog is not meant to be shown to users.
+M:System.Diagnostics.Debugger.Launch(); This should not be used in production code as the resulting dialog is not meant to be shown to users.


### PR DESCRIPTION
Ban the use of `System.Diagnostics.Debugger.Launch()`. We've seen other teams accidentally commit code that used this method, leading to a completely unexpected dialog appearing in the middle of a scenario.

It's fine to use this in local development; in that case you can suppress the error with  #pragmas. Just please remember to remove them. 😊

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6195)