### PR TITLE
Make BrowseObjectBase internal

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/BrowseObjectBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/BrowseObjectBase.cs
@@ -4,17 +4,24 @@ using System;
 using System.ComponentModel;
 using Microsoft.VisualStudio.Shell;
 
-namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.Implementation
 {
-    /// <summary>
+    /// <remarks>
+    /// <para>
     /// This is a slightly modified copy of Microsoft.VisualStudio.Shell.LocalizableProperties.
     /// http://index/#Microsoft.VisualStudio.Shell.12.0/LocalizableProperties.cs.html
     /// Unfortunately we can't reuse that class because the GetComponentName method on
     /// it is not virtual, so we can't provide a name string for the VS Property Grid's
     /// combo box (which shows ComponentName in bold and ClassName in regular to the
     /// right from it)
-    /// </summary>
-    public abstract class BrowseObjectBase : ICustomTypeDescriptor
+    /// </para>
+    /// <param>
+    /// PR https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/248337 makes the method
+    /// virtual, so once that update becomes available this type can be removed and
+    /// <see cref="LocalizableProperties"/> used directly in its place.
+    /// </param>
+    /// </remarks>
+    internal abstract class BrowseObjectBase : ICustomTypeDescriptor
     {
 #pragma warning disable CA1822
         [Browsable(false)]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -60,11 +60,6 @@ virtual Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollec
 virtual Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AttachedCollectionItemBase.OverlayIconMoniker.get -> Microsoft.VisualStudio.Imaging.Interop.ImageMoniker
 virtual Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AttachedCollectionItemBase.StateIconMoniker.get -> Microsoft.VisualStudio.Imaging.Interop.ImageMoniker
 virtual Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AttachedCollectionItemBase.StateToolTipText.get -> string?
-Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.BrowseObjectBase
-Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.BrowseObjectBase.BrowseObjectBase() -> void
-Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.BrowseObjectBase.ExtenderCATID.get -> string!
-abstract Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.BrowseObjectBase.GetClassName() -> string!
-abstract Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.BrowseObjectBase.GetComponentName() -> string!
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.DependenciesAttachedCollectionSourceProviderBase
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.DependenciesAttachedCollectionSourceProviderBase.DependenciesAttachedCollectionSourceProviderBase(Microsoft.VisualStudio.ProjectSystem.ProjectTreeFlags flags) -> void
 abstract Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.DependenciesAttachedCollectionSourceProviderBase.TryCreateCollectionSource(Microsoft.VisualStudio.Shell.IVsHierarchyItem! hierarchyItem, string! flagsString, string? target, Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IRelationProvider! relationProvider, out Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AggregateRelationCollectionSource? containsCollectionSource) -> bool


### PR DESCRIPTION
This type was added to support extenders such as NuGet.

The type itself exists because the shell's `LocalizableProperties` did not define `GetComponentName` as `virtual`. PR https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/248337 changes that, and once that updates trickles through we'll be able to remove this type completely. For now it should be removed from our public API surface.

I will copy it into NuGet for now, and remove it from there too once the updated shell assembly is available.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6198)