### PR TITLE
Remove id and version data from project tree flags

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IVsHierarchyItemExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IVsHierarchyItemExtensions.cs
@@ -13,8 +13,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     internal static class IVsHierarchyItemExtensions
     {
         private static Regex? s_targetFlagsRegex;
-        private static Regex? s_packageFlagsRegex;
-        private static Regex? s_projectFlagsRegex;
 
         /// <summary>
         /// Detects the target configuration dimension associated with a given hierarchy item in the dependencies tree, if
@@ -24,9 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         /// <param name="item">The item to test.</param>
         /// <param name="target">The detected target, if found.</param>
         /// <returns><see langword="true"/> if the target was found, otherwise <see langword="false"/>.</returns>
-        public static bool TryFindTarget(
-            this IVsHierarchyItem item,
-            [NotNullWhen(returnValue: true)] out string? target)
+        public static bool TryFindTarget(this IVsHierarchyItem item, [NotNullWhen(returnValue: true)] out string? target)
         {
             s_targetFlagsRegex ??= new Regex(@"^(?=.*\b" + nameof(DependencyTreeFlags.TargetNode) + @"\b)(?=.*\$TFM:(?<target>[^ ]+)\b).*$", RegexOptions.Compiled);
 
@@ -44,107 +40,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
             }
 
             target = null;
-            return false;
-        }
-
-        /// <summary>
-        /// Detects the package ID and version associated with a given hierarchy item in the dependencies tree, if
-        /// that node represents a package reference.
-        /// </summary>
-        /// <param name="item">The item to test.</param>
-        /// <param name="packageId">The detected package ID, if found.</param>
-        /// <param name="packageVersion">The detected package version, if found.</param>
-        /// <returns><see langword="true"/> if package ID and version were found, otherwise <see langword="false"/>.</returns>
-        public static bool TryGetPackageDetails(
-            this IVsHierarchyItem item,
-            [NotNullWhen(returnValue: true)] out string? packageId,
-            [NotNullWhen(returnValue: true)] out string? packageVersion)
-        {
-            s_packageFlagsRegex ??= new Regex(@"^(?=.*\b" + nameof(DependencyTreeFlags.PackageDependency) + @"\b)(?=.*\$ID:(?<id>[^ ]+)\b)(?=.*\$VER:(?<version>[^ ]+)\b).*$", RegexOptions.Compiled);
-
-            if (item.TryGetFlagsString(out string? flagsString))
-            {
-                return TryGetPackageDetails(flagsString, out packageId, out packageVersion);
-            }
-
-            packageId = null;
-            packageVersion = null;
-            return false;
-        }
-
-        /// <summary>
-        /// Detects the package ID and version within a dependencies tree item's flags string, if
-        /// that node represents a package reference.
-        /// </summary>
-        /// <param name="flagsString">The string of flags to inspect.</param>
-        /// <param name="packageId">The detected package ID, if found.</param>
-        /// <param name="packageVersion">The detected package version, if found.</param>
-        /// <returns><see langword="true"/> if package ID and version were found, otherwise <see langword="false"/>.</returns>
-        public static bool TryGetPackageDetails(
-            string flagsString,
-            [NotNullWhen(returnValue: true)] out string? packageId,
-            [NotNullWhen(returnValue: true)] out string? packageVersion)
-        {
-            s_packageFlagsRegex ??= new Regex(@"^(?=.*\b" + nameof(DependencyTreeFlags.PackageDependency) + @"\b)(?=.*\$ID:(?<id>[^ ]+)\b)(?=.*\$VER:(?<version>[^ ]+)\b).*$", RegexOptions.Compiled);
-
-            Match match = s_packageFlagsRegex.Match(flagsString);
-
-            if (match.Success)
-            {
-                packageId = match.Groups["id"].Value;
-                packageVersion = match.Groups["version"].Value;
-                return true;
-            }
-
-            packageId = null;
-            packageVersion = null;
-            return false;
-        }
-
-        /// <summary>
-        /// Detects the project associated with a given hierarchy item in the dependencies tree, if
-        /// that node represents a project reference.
-        /// </summary>
-        /// <param name="item">The item to test.</param>
-        /// <param name="projectId">The detected project ID, if found.</param>
-        /// <returns><see langword="true"/> if project ID was found, otherwise <see langword="false"/>.</returns>
-        public static bool TryGetProjectDetails(
-            this IVsHierarchyItem item,
-            [NotNullWhen(returnValue: true)] out string? projectId)
-        {
-            if (item.TryGetFlagsString(out string? flagsString))
-            {
-                if (TryGetProjectDetails(flagsString, out projectId))
-                {
-                    return true;
-                }
-            }
-
-            projectId = null;
-            return false;
-        }
-
-        /// <summary>
-        /// Detects the project ID within a dependencies tree item's flags string, if
-        /// that node represents a project reference.
-        /// </summary>
-        /// <param name="flagsString">The string of flags to inspect.</param>
-        /// <param name="projectId">The detected project ID, if found.</param>
-        /// <returns><see langword="true"/> if project ID was found, otherwise <see langword="false"/>.</returns>
-        public static bool TryGetProjectDetails(
-            string flagsString,
-            [NotNullWhen(returnValue: true)] out string? projectId)
-        {
-            s_projectFlagsRegex ??= new Regex(@"^(?=.*\b" + nameof(DependencyTreeFlags.ProjectDependency) + @"\b)(?=.*\$ID:(?<id>[^ ]+)\b).*$", RegexOptions.Compiled);
-
-            Match match = s_projectFlagsRegex.Match(flagsString);
-            if (match.Success)
-            {
-                projectId = match.Groups["id"].Value;
-                return true;
-            }
-
-            projectId = null;
             return false;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/PackageDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/PackageDependencyModel.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             : base(
                 path,
                 originalItemSpec,
-                flags: s_flagCache.Get(isResolved, isImplicit).Add($"$ID:{originalItemSpec}").Add($"$VER:{version}"),
+                flags: s_flagCache.Get(isResolved, isImplicit),
                 isResolved,
                 isImplicit,
                 properties,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModel.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             : base(
                 path,
                 originalItemSpec,
-                flags: s_flagCache.Get(isResolved, isImplicit) + ProjectTreeFlags.Create("$ID:" + System.IO.Path.GetFileNameWithoutExtension(path)),
+                flags: s_flagCache.Get(isResolved, isImplicit),
                 isResolved,
                 isImplicit,
                 properties)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/PackageDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/PackageDependencyModelTests.cs
@@ -42,9 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.PackageDependency +
-                DependencyTreeFlags.GenericResolvedDependencyFlags +
-                ProjectTreeFlags.Create("$ID:myOriginalItemSpec") +
-                ProjectTreeFlags.Create("$VER:myVersion"),
+                DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
         }
 
@@ -80,9 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.PackageDependency +
-                DependencyTreeFlags.GenericUnresolvedDependencyFlags +
-                ProjectTreeFlags.Create("$ID:myOriginalItemSpec") +
-                ProjectTreeFlags.Create("$VER:myVersion"),
+                DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
         }
 
@@ -118,9 +114,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.PackageDependency +
-                DependencyTreeFlags.GenericResolvedDependencyFlags +
-                ProjectTreeFlags.Create("$ID:myOriginalItemSpec") +
-                ProjectTreeFlags.Create("$VER:") -
+                DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove,
                 model.Flags);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
@@ -38,8 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.ApplicationWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
-                DependencyTreeFlags.GenericResolvedDependencyFlags +
-                ProjectTreeFlags.Create("$ID:myPath"),
+                DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
         }
 
@@ -70,8 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.ApplicationWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
-                DependencyTreeFlags.GenericUnresolvedDependencyFlags +
-                ProjectTreeFlags.Create("$ID:myPath"),
+                DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
         }
 
@@ -103,8 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
-                DependencyTreeFlags.SupportsRemove +
-                ProjectTreeFlags.Create("$ID:myPath"),
+                DependencyTreeFlags.SupportsRemove,
                 model.Flags);
         }
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IVsHierarchyItemExtensionsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IVsHierarchyItemExtensionsTests.cs
@@ -40,33 +40,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
             Assert.Equal(expectedConfiguration, actualConfiguration);
         }
 
-        [Theory]
-        [InlineData("PackageDependency $ID:FooBar $VER:1.2.3", "FooBar", "1.2.3")]
-        [InlineData("PackageDependency $VER:1.2.3 $ID:FooBar", "FooBar", "1.2.3")]
-        [InlineData("$VER:1.2.3 $ID:FooBar PackageDependency", "FooBar", "1.2.3")]
-        [InlineData("PackageDependency $ID:FooBar",            null, null)]
-        [InlineData("PackageDependency $VER:1.2.3",            null, null)]
-        [InlineData("$ID:FooBar $VER:1.2.3",                   null, null)]
-        [InlineData("PackageDependency $ID: $VER:1.2.3",       null, null)]
-        [InlineData("PackageDependency $ID:FooBar $VER:",      null, null)]
-        [InlineData("PACKAGEDEPENDENCY $ID:FooBar $VER:1.2.3", null, null)]
-        [InlineData("PackageDependency $id:FooBar $VER:1.2.3", null, null)]
-        [InlineData("PackageDependency $ID:FooBar $ver:1.2.3", null, null)]
-        [InlineData("",                                        null, null)]
-        public void TryGetPackageDetails(string flagsString, string? expectedId, string? expectedVersion)
-        {
-            Assert.True((expectedId == null) == (expectedVersion == null)); // sanity check on test data
-
-            IVsHierarchyItem item = CreateItemWithFlags(flagsString);
-
-            var result = item.TryGetPackageDetails(out string? actualId, out string? actualVersion);
-
-            Assert.Equal(actualId != null, result);
-            Assert.Equal(actualVersion != null, result);
-            Assert.Equal(expectedId, actualId);
-            Assert.Equal(expectedVersion, actualVersion);
-        }
-
         private static IVsHierarchyItem CreateItemWithFlags(string flagsString)
         {
             var hierarchy = IVsHierarchyFactory.Create();


### PR DESCRIPTION
This data is now obtained from an item's browse object.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6199)