### PR TITLE
Ignore the first output from design-time build

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetector.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.References;
-using Microsoft.VisualStudio.ProjectSystem.UpToDate;
 using Microsoft.VisualStudio.ProjectSystem.VS.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.UI;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
@@ -575,7 +574,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public int OnBeforeOpenSolution(string pszSolutionFilename)
         {
-            BuildUpToDateCheck.State.FirstTimeLoaded = false;
             return HResult.OK;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetector.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.References;
+using Microsoft.VisualStudio.ProjectSystem.UpToDate;
 using Microsoft.VisualStudio.ProjectSystem.VS.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.UI;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
@@ -574,6 +575,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public int OnBeforeOpenSolution(string pszSolutionFilename)
         {
+            BuildUpToDateCheck.State.FirstTimeLoaded = false;
             return HResult.OK;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
@@ -119,8 +119,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             /// </summary>
             public DateTime LastAdditionalDependentFileTimesChangedAtUtc { get; }
 
-            public static bool FirstTimeLoaded = false;
-
 
             private State()
             {
@@ -221,8 +219,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                                                                                           .ToImmutableHashSet();
 
                 bool AdditionalDependentFilesChanged = !lastExistingAdditionalDependentFiles.SetEquals(currentExistingAdditionalDependentFiles);
-                DateTime lastAdditionalDependentFileTimesChangedAtUtc = AdditionalDependentFilesChanged && FirstTimeLoaded ? DateTime.UtcNow : LastAdditionalDependentFileTimesChangedAtUtc;
-                FirstTimeLoaded = true;
+                DateTime lastAdditionalDependentFileTimesChangedAtUtc =
+                    AdditionalDependentFilesChanged && lastExistingAdditionalDependentFiles.Count != 0 ? DateTime.UtcNow : LastAdditionalDependentFileTimesChangedAtUtc;
 
                 // The first item in this semicolon-separated list of project files will always be the one
                 // with the newest timestamp. As we are only interested in timestamps on these files, we can

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
@@ -382,7 +382,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 // See https://github.com/dotnet/project-system/issues/5386
                 DateTime lastItemsChangedAtUtc = itemsChanged && ItemTypes.Count != 0 ? DateTime.UtcNow : LastItemsChangedAtUtc;
 
-                DateTime lastAdditionalDependentFileTimesChangedAtUtc = getLastTimeAdditionalDependentFilesAddedOrRemoved();
+                DateTime lastAdditionalDependentFileTimesChangedAtUtc = GetLastTimeAdditionalDependentFilesAddedOrRemoved();
 
                 return new State(
                     msBuildProjectFullPath,
@@ -406,7 +406,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     lastItemsChangedAtUtc: lastItemsChangedAtUtc, lastCheckedAtUtc: LastCheckedAtUtc);
 
 
-                DateTime getLastTimeAdditionalDependentFilesAddedOrRemoved()
+                DateTime GetLastTimeAdditionalDependentFilesAddedOrRemoved()
                 {
                     var lastExistingAdditionalDependentFiles = AdditionalDependentFileTimes.Where(pair => pair.Value != DateTime.MinValue)
                                                                        .Select(pair => pair.Key)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
@@ -11,6 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 {
     internal sealed partial class BuildUpToDateCheck
     {
+
         internal sealed class State
         {
             public static State Empty { get; } = new State();
@@ -118,6 +119,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             /// </summary>
             public DateTime LastAdditionalDependentFileTimesChangedAtUtc { get; }
 
+            public static bool FirstTimeLoaded = false;
+
+
             private State()
             {
                 var emptyPathSet = ImmutableHashSet.Create<string>(StringComparers.Paths);
@@ -217,7 +221,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                                                                                           .ToImmutableHashSet();
 
                 bool AdditionalDependentFilesChanged = !lastExistingAdditionalDependentFiles.SetEquals(currentExistingAdditionalDependentFiles);
-                DateTime lastAdditionalDependentFileTimesChangedAtUtc = AdditionalDependentFilesChanged ? DateTime.UtcNow : LastAdditionalDependentFileTimesChangedAtUtc;
+                DateTime lastAdditionalDependentFileTimesChangedAtUtc = AdditionalDependentFilesChanged && FirstTimeLoaded ? DateTime.UtcNow : LastAdditionalDependentFileTimesChangedAtUtc;
+                FirstTimeLoaded = true;
 
                 // The first item in this semicolon-separated list of project files will always be the one
                 // with the newest timestamp. As we are only interested in timestamps on these files, we can

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -1096,7 +1096,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         }
 
         [Fact]
-        public async Task IsUpToDateAsync_True_AdditionalDependentFilesIgnoredWhenCountIsZero()
+        public async Task IsUpToDateAsync_True_InitialItemDataDoesNotUpdateLastItemsChangedAtUtc()
         {
             var projectSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
             {
@@ -1104,9 +1104,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 [UpToDateCheckInput.SchemaName] = ItemWithMetadata("Input1", "Set", "Set1"),
             };
 
-            var dependentTime = DateTime.UtcNow.AddMinutes(-5);
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
             var lastCheckTime = DateTime.UtcNow.AddMinutes(-3);
+            var dependentTime = DateTime.UtcNow.AddMinutes(-3);
             var buildTime = DateTime.UtcNow.AddMinutes(-2);
             var inputTime = DateTime.UtcNow.AddMinutes(-1);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -1098,21 +1098,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         [Fact]
         public async Task IsUpToDateAsync_True_InitialItemDataDoesNotUpdateLastAdditionalDependentFileTimesChangedAtUtc()
         {
-            var projectSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
-            {
-                [UpToDateCheckBuilt.SchemaName] = SimpleItems("BuiltOutputPath1")
-            };
-
-            var sourceSnapshot1 = new Dictionary<string, IProjectRuleSnapshotModel>
-            {
-                [Compile.SchemaName] = SimpleItems("ItemPath1")
-            };
-
-            var sourceSnapshot2 = new Dictionary<string, IProjectRuleSnapshotModel>
-            {
-                [Compile.SchemaName] = SimpleItems("ItemPath1", "ItemPath2")
-            };
-
             await _buildUpToDateCheck.LoadAsync();
 
             Assert.Equal(DateTime.MinValue, _buildUpToDateCheck.TestAccess.State.LastAdditionalDependentFileTimesChangedAtUtc);
@@ -1123,7 +1108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var dependentTimeFiles = ImmutableDictionary.Create<string, DateTime>(StringComparers.Paths).Add(dependentPath, dependentTime);
 
             // Initial change does NOT set LastAdditionalDependentFileTimesChangedAtUtc
-            BroadcastChange(projectSnapshot, sourceSnapshot1, dependentTimeFiles: dependentTimeFiles);
+            BroadcastChange(dependentTimeFiles: dependentTimeFiles);
 
             Assert.Equal(DateTime.MinValue, _buildUpToDateCheck.TestAccess.State.LastAdditionalDependentFileTimesChangedAtUtc);
 
@@ -1133,10 +1118,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             Assert.Equal(DateTime.MinValue, _buildUpToDateCheck.TestAccess.State.LastAdditionalDependentFileTimesChangedAtUtc);
 
             // Broadcasting removing Additional Dependent Files DOES set LastAdditionalDependentFileTimesChangedAtUtc
-            BroadcastChange(projectSnapshot, sourceSnapshot2);
+            BroadcastChange();
 
             Assert.NotEqual(DateTime.MinValue, _buildUpToDateCheck.TestAccess.State.LastAdditionalDependentFileTimesChangedAtUtc);
-
         }
 
         [Fact]


### PR DESCRIPTION
fixes #6181 

**Problem**:
Fast up-to-date detects a project is out of date with message:
_The set of AdditionalDependentFileTimes was changed more recently...._

Update() erroneously  change the timestamp of `lastAdditionalDependentFileTimesChangedAtUtc `when the project is loaded.

**What this change does:**
When the project is first loaded we have zero additional dependent files in `AdditionalDependentFileTimes`.
In this change we do not change the timestamp when lastExistingAdditionalDependentFiles.Count is zero.

The refactor extract method was applied to create `getLastTimeAdditionalDependentFilesAddedOrRemoved`() 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6200)