### PR TITLE
Don't throw if unknown active framework is "Unsupported"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
@@ -9,6 +9,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public static readonly ITargetFramework Empty = new TargetFramework(string.Empty);
 
         /// <summary>
+        /// The target framework used when a TFM short-name cannot be resolved.
+        /// </summary>
+        public static readonly ITargetFramework Unsupported = new TargetFramework("Unsupported,Version=v0.0");
+
+        /// <summary>
         /// Any represents all TFMs, no need to be localized, used only in internal data.
         /// </summary>
         public static readonly ITargetFramework Any = new TargetFramework("any");

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -165,7 +165,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             Requires.NotNull(activeTargetFramework, nameof(activeTargetFramework));
             Requires.NotNull(dependenciesByTargetFramework, nameof(dependenciesByTargetFramework));
 
-            if (!activeTargetFramework.Equals(TargetFramework.Empty))
+            // We have seen NFEs where the active target framework is unsupported. Skipping validation in such cases is better than faulting the dataflow.
+            if (!activeTargetFramework.Equals(TargetFramework.Empty) && !activeTargetFramework.Equals(TargetFramework.Unsupported))
             {
                 Requires.Argument(
                     dependenciesByTargetFramework.ContainsKey(activeTargetFramework),

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
@@ -36,6 +36,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         }
 
         [Fact]
+        public void Constructor_NoThrowIfActiveTargetFrameworkIsEmptyAndNotPresentInDependenciesByTargetFramework()
+        {
+            _ = new DependenciesSnapshot(
+                activeTargetFramework: TargetFramework.Empty,
+                ImmutableDictionary<ITargetFramework, TargetedDependenciesSnapshot>.Empty);
+        }
+
+        [Fact]
+        public void Constructor_NoThrowIfActiveTargetFrameworkIsUnsupportedAndNotPresentInDependenciesByTargetFramework()
+        {
+            _ = new DependenciesSnapshot(
+                activeTargetFramework: TargetFramework.Unsupported,
+                ImmutableDictionary<ITargetFramework, TargetedDependenciesSnapshot>.Empty);
+        }
+
+        [Fact]
         public void Constructor()
         {
             var catalogs = IProjectCatalogSnapshotFactory.Create();


### PR DESCRIPTION
Fixes #6204
Fixes [AB#1126588](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1126588)

We are seeing some customer NFEs around this check. The validation is theoretically correct, but the consequences of continuing in such a scenario are minor-to-non-existant. Therefore I'm leaving it as an assert to assist during development of this code.

This code would likely disappear as part of #6183.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6205)