### PR TITLE
Allow IInterceptingPropertyValueProvider to handle multiple properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
@@ -23,6 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
         }
 
         public override async Task<string> OnGetEvaluatedPropertyValueAsync(
+            string propertyName,
             string evaluatedPropertyValue,
             IProjectProperties defaultProperties)
         {
@@ -37,6 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
         }
 
         public override async Task<string?> OnSetPropertyValueAsync(
+            string propertyName,
             string unevaluatedPropertyValue,
             IProjectProperties defaultProperties,
             IReadOnlyDictionary<string, string>? dimensionalConditions = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeValueProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeValueProviderBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             _properties = properties;
         }
 
-        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             ConfigurationGeneral configuration = await _properties.GetConfigurationGeneralPropertiesAsync();
             string value = await configuration.OutputType.GetEvaluatedValueAtEndAsync();
@@ -33,6 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         public override async Task<string?> OnSetPropertyValueAsync(
+            string propertyName,
             string unevaluatedPropertyValue,
             IProjectProperties defaultProperties,
             IReadOnlyDictionary<string, string>? dimensionalConditions = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikerValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikerValueProvider.cs
@@ -27,6 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         public override async Task<string?> OnSetPropertyValueAsync(
+            string propertyName,
             string unevaluatedPropertyValue,
             IProjectProperties defaultProperties,
             IReadOnlyDictionary<string, string>? dimensionalConditions = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             _projectProvider = projectProvider;
         }
 
-        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             ActiveConfiguredObjects<ConfiguredProject>? configuredProjects = await _projectProvider.GetActiveConfiguredProjectsAsync();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationManifestValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationManifestValueProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// These three values map to two MSBuild properties - ApplicationManifest (specified if it's a path) or NoWin32Manifest 
         /// which is true for the second case and false or non-existent for the third.
         /// </remarks>
-        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             if (!string.IsNullOrEmpty(evaluatedPropertyValue))
             {
@@ -59,6 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// Sets the application manifest property
         /// </summary>
         public override async Task<string> OnSetPropertyValueAsync(
+            string propertyName,
             string unevaluatedPropertyValue,
             IProjectProperties defaultProperties,
             IReadOnlyDictionary<string, string> dimensionalConditions = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileNameValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileNameValueProvider.cs
@@ -30,12 +30,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             _launchSettings = launchSettings;
         }
 
-        public override Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        public override Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             return GetPropertyValueAsync();
         }
 
-        public override Task<string> OnGetUnevaluatedPropertyValueAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+        public override Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             return GetPropertyValueAsync();
         }
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             return launchSettings.ActiveProfile?.Name ?? string.Empty;
         }
 
-        public override async Task<string?> OnSetPropertyValueAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+        public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
             await _launchSettings.SetActiveProfileAsync(unevaluatedPropertyValue);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileValueProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileValueProviderBase.cs
@@ -29,12 +29,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             _projectThreadingService = projectThreadingService;
         }
 
-        public override Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        public override Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             return GetPropertyValueAsync();
         }
 
-        public override Task<string> OnGetUnevaluatedPropertyValueAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+        public override Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             return GetPropertyValueAsync();
         }
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             return GetValueFromLaunchSettings(launchSettings.ActiveProfile);
         }
-        public override Task<string?> OnSetPropertyValueAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+        public override Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
             _projectThreadingService.RunAndForget(async () =>
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ExportInterceptingPropertyValueProviderAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ExportInterceptingPropertyValueProviderAttribute.cs
@@ -12,17 +12,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
     internal sealed class ExportInterceptingPropertyValueProviderAttribute : ExportAttribute
     {
-        public string PropertyName { get; }
+        public string[] PropertyNames { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ExportInterceptingPropertyValueProviderAttribute"/> class.
         /// </summary>
         public ExportInterceptingPropertyValueProviderAttribute(string propertyName, ExportInterceptingPropertyValueProviderFile file)
+            : this(new[] { propertyName }, file)
+        {
+        }
+
+        public ExportInterceptingPropertyValueProviderAttribute(string[] propertyNames, ExportInterceptingPropertyValueProviderFile file)
             : base(GetFile(file), typeof(IInterceptingPropertyValueProvider))
         {
-            Requires.NotNullOrEmpty(propertyName, nameof(propertyName));
-
-            PropertyName = propertyName;
+            PropertyNames = propertyNames;
         }
 
         private static string GetFile(ExportInterceptingPropertyValueProviderFile file)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/IInterceptingPropertyValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/IInterceptingPropertyValueProvider.cs
@@ -14,16 +14,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// <summary>
         /// Validate and/or transform the given evaluated property value.
         /// </summary>
-        Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties);
+        Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties);
 
         /// <summary>
         /// Validate and/or transform the given unevaluated property value, i.e. "raw" value read from the project file.
         /// </summary>
-        Task<string> OnGetUnevaluatedPropertyValueAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties);
+        Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties);
 
         /// <summary>
         /// Validate and/or transform the given unevaluated property value to be written back to the project file.
         /// </summary>
-        Task<string?> OnSetPropertyValueAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null);
+        Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/IInterceptingPropertyValueProviderMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/IInterceptingPropertyValueProviderMetadata.cs
@@ -7,6 +7,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     /// </summary>
     public interface IInterceptingPropertyValueProviderMetadata
     {
-        string PropertyName { get; }
+#pragma warning disable CA1819 // Properties should not return arrays
+
+        /// <summary>
+        /// Property names handled by the provider.
+        /// This must match <see cref="ExportInterceptingPropertyValueProviderAttribute.PropertyNames" />.
+        /// </summary>
+        string[] PropertyNames { get; }
+
+#pragma warning restore CA1819 // Properties should not return arrays
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptingPropertyValueProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptingPropertyValueProviderBase.cs
@@ -11,17 +11,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     /// </summary>
     internal abstract class InterceptingPropertyValueProviderBase : IInterceptingPropertyValueProvider
     {
-        public virtual Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        public virtual Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             return Task.FromResult(evaluatedPropertyValue);
         }
 
-        public virtual Task<string> OnGetUnevaluatedPropertyValueAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+        public virtual Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             return Task.FromResult(unevaluatedPropertyValue);
         }
 
-        public virtual Task<string?> OnSetPropertyValueAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+        public virtual Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
             return Task.FromResult<string?>(unevaluatedPropertyValue);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/BaseVersionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/BaseVersionValueProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
             return Version.TryParse(versionStr, out Version version) ? version : DefaultVersion;
         }
 
-        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             if (!string.IsNullOrEmpty(evaluatedPropertyValue))
             {
@@ -42,6 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
         }
 
         public override async Task<string?> OnSetPropertyValueAsync(
+            string propertyName,
             string unevaluatedPropertyValue,
             IProjectProperties defaultProperties,
             IReadOnlyDictionary<string, string>? dimensionalConditions = null)
@@ -63,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
                 }
             }
 
-            return await base.OnSetPropertyValueAsync(unevaluatedPropertyValue, defaultProperties, dimensionalConditions);
+            return await base.OnSetPropertyValueAsync(propertyName, unevaluatedPropertyValue, defaultProperties, dimensionalConditions);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/SigningPropertyPage/AssemblyOriginatorKeyFileValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/SigningPropertyPage/AssemblyOriginatorKeyFileValueProvider.cs
@@ -19,6 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         public override Task<string?> OnSetPropertyValueAsync(
+            string propertyName,
             string unevaluatedPropertyValue,
             IProjectProperties defaultProperties,
             IReadOnlyDictionary<string, string>? dimensionalConditions = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/TargetFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/TargetFrameworkValueProvider.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             _properties = properties;
         }
 
-        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             ConfigurationGeneral configuration = await _properties.GetConfigurationGeneralPropertiesAsync();
             string? targetFrameworkMoniker = (string?)await configuration.TargetFrameworkMoniker.GetValueAsync();
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 return propertyValue.ToString();
             }
 
-            return await base.OnGetEvaluatedPropertyValueAsync(evaluatedPropertyValue, defaultProperties);
+            return await base.OnGetEvaluatedPropertyValueAsync(propertyName, evaluatedPropertyValue, defaultProperties);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Shipped.txt
@@ -85,4 +85,3 @@ Microsoft.VisualStudio.ProjectSystem.Debug.IWritablePersistOption.DoNotPersist.g
 Microsoft.VisualStudio.ProjectSystem.Debug.IWritablePersistOption.DoNotPersist.set -> void
 Microsoft.VisualStudio.ProjectSystem.Debug.UIProfilePropertyName
 Microsoft.VisualStudio.ProjectSystem.Properties.IInterceptingPropertyValueProviderMetadata
-Microsoft.VisualStudio.ProjectSystem.Properties.IInterceptingPropertyValueProviderMetadata.PropertyName.get -> string!

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+Microsoft.VisualStudio.ProjectSystem.Properties.IInterceptingPropertyValueProviderMetadata.PropertyNames.get -> string![]!
 Microsoft.VisualStudio.ProjectSystem.VS.Extensibility.IProjectExportProvider
 Microsoft.VisualStudio.ProjectSystem.VS.Extensibility.IProjectExportProvider.GetExport<T>(string! projectFilePath) -> T?
 Microsoft.VisualStudio.ProjectSystem.VS.ManagedImageMonikers

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IInterceptingPropertyValueProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IInterceptingPropertyValueProviderFactory.cs
@@ -21,25 +21,28 @@ namespace Microsoft.VisualStudio.ProjectSystem
             {
                 mock.Setup(t => t.OnGetEvaluatedPropertyValueAsync(
                     It.IsAny<string>(),
+                    It.IsAny<string>(),
                     It.IsAny<IProjectProperties>()))
-                     .Returns<string, IProjectProperties>((u, p) => Task.FromResult(onGetEvaluatedPropertyValue(u, p)));
+                     .Returns<string, string, IProjectProperties>((n, u, p) => Task.FromResult(onGetEvaluatedPropertyValue(u, p)));
             }
 
             if (onGetUnevaluatedPropertyValue != null)
             {
                 mock.Setup(t => t.OnGetUnevaluatedPropertyValueAsync(
                     It.IsAny<string>(),
+                    It.IsAny<string>(),
                     It.IsAny<IProjectProperties>()))
-                     .Returns<string, IProjectProperties>((u, p) => Task.FromResult(onGetUnevaluatedPropertyValue(u, p)));
+                     .Returns<string, string, IProjectProperties>((n, u, p) => Task.FromResult(onGetUnevaluatedPropertyValue(u, p)));
             }
 
             if (onSetPropertyValue != null)
             {
                 mock.Setup(t => t.OnSetPropertyValueAsync(
                     It.IsAny<string>(),
+                    It.IsAny<string>(),
                     It.IsAny<IProjectProperties>(),
                     It.IsAny<IReadOnlyDictionary<string, string>>()))
-                     .Returns<string, IProjectProperties, IReadOnlyDictionary<string, string>>((u, p, d) => Task.FromResult(onSetPropertyValue(u, p, d)));
+                     .Returns<string, string, IProjectProperties, IReadOnlyDictionary<string, string>>((n, u, p, d) => Task.FromResult(onSetPropertyValue(u, p, d)));
             }
 
             return mock.Object;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IInterceptingPropertyValueProviderMetadataFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IInterceptingPropertyValueProviderMetadataFactory.cs
@@ -11,8 +11,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var mock = new Mock<IInterceptingPropertyValueProviderMetadata>();
 
-            mock.SetupGet(s => s.PropertyName)
-                .Returns(propertyName);
+            mock.SetupGet(s => s.PropertyNames)
+                .Returns(new[] { propertyName });
 
             return mock.Object;
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                   interceptingValueProviders: interceptingProvider == null ?
                     new[] { new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>(
                         () => IInterceptingPropertyValueProviderFactory.Create(),
-                        IInterceptingPropertyValueProviderMetadataFactory.Create("")) } :
+                        IInterceptingPropertyValueProviderMetadataFactory.Create("TestPropertyName")) } :
                     new[] { interceptingProvider },
                   project: project,
                   getActiveProjectId: getActiveProjectId ?? (() => workspace.CurrentSolution.ProjectIds.SingleOrDefault()),

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var launchProfileProvider = new ActiveLaunchProfileNameValueProvider(settingsProvider);
 
-            var actualValue = await launchProfileProvider.OnGetEvaluatedPropertyValueAsync(string.Empty, Mock.Of<IProjectProperties>());
+            var actualValue = await launchProfileProvider.OnGetEvaluatedPropertyValueAsync(string.Empty, string.Empty, Mock.Of<IProjectProperties>());
 
             Assert.Equal(expected: activeProfileName, actual: actualValue);
         }
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName);
             var launchProfileProvider = new ActiveLaunchProfileNameValueProvider(settingsProvider);
 
-            var actualValue = await launchProfileProvider.OnGetUnevaluatedPropertyValueAsync(string.Empty, Mock.Of<IProjectProperties>());
+            var actualValue = await launchProfileProvider.OnGetUnevaluatedPropertyValueAsync(string.Empty, string.Empty, Mock.Of<IProjectProperties>());
 
             Assert.Equal(expected: activeProfileName, actual: actualValue);
         }
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName, setActiveProfileCallback: v => activeProfileName = v);
             var launchProfileProvider = new ActiveLaunchProfileNameValueProvider(settingsProvider);
 
-            var result = await launchProfileProvider.OnSetPropertyValueAsync("Delta", Mock.Of<IProjectProperties>());
+            var result = await launchProfileProvider.OnSetPropertyValueAsync(string.Empty, "Delta", Mock.Of<IProjectProperties>());
 
             Assert.Null(result);
             Assert.Equal(expected: "Delta", actual: activeProfileName);
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var threadingService = IProjectThreadingServiceFactory.Create();
             var launchProfileProvider = new ExecutablePathValueProvider(project, settingsProvider, threadingService);
 
-            var actualValue = await launchProfileProvider.OnGetEvaluatedPropertyValueAsync(string.Empty, Mock.Of<IProjectProperties>());
+            var actualValue = await launchProfileProvider.OnGetEvaluatedPropertyValueAsync(string.Empty, string.Empty, Mock.Of<IProjectProperties>());
 
             Assert.Equal(expected: activeProfileExecutablePath, actual: actualValue);
         }
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var threadingService = IProjectThreadingServiceFactory.Create();
             var launchProfileProvider = new ExecutablePathValueProvider(project, settingsProvider, threadingService);
 
-            var actualValue = await launchProfileProvider.OnGetUnevaluatedPropertyValueAsync(string.Empty, Mock.Of<IProjectProperties>());
+            var actualValue = await launchProfileProvider.OnGetUnevaluatedPropertyValueAsync(string.Empty, string.Empty, Mock.Of<IProjectProperties>());
 
             Assert.Equal(expected: activeProfileExecutablePath, actual: actualValue);
         }
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var threadingService = IProjectThreadingServiceFactory.Create();
             var launchProfileProvider = new ExecutablePathValueProvider(project, settingsProvider, threadingService);
 
-            await launchProfileProvider.OnSetPropertyValueAsync(@"C:\user\bin\delta.exe", Mock.Of<IProjectProperties>());
+            await launchProfileProvider.OnSetPropertyValueAsync(string.Empty, @"C:\user\bin\delta.exe", Mock.Of<IProjectProperties>());
 
             Assert.Equal(expected: @"C:\user\bin\delta.exe", actual: activeProfileExecutablePath);
         }
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var threadingService = IProjectThreadingServiceFactory.Create();
             var launchProfileProvider = new LaunchTargetValueProvider(project, settingsProvider, threadingService);
 
-            var actualValue = await launchProfileProvider.OnGetEvaluatedPropertyValueAsync(string.Empty, Mock.Of<IProjectProperties>());
+            var actualValue = await launchProfileProvider.OnGetEvaluatedPropertyValueAsync(string.Empty, string.Empty, Mock.Of<IProjectProperties>());
 
             Assert.Equal(expected: activeProfileLaunchTarget, actual: actualValue);
         }
@@ -124,7 +124,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var threadingService = IProjectThreadingServiceFactory.Create();
             var launchProfileProvider = new LaunchTargetValueProvider(project, settingsProvider, threadingService);
 
-            var actualValue = await launchProfileProvider.OnGetEvaluatedPropertyValueAsync(string.Empty, Mock.Of<IProjectProperties>());
+            var actualValue = await launchProfileProvider.OnGetEvaluatedPropertyValueAsync(string.Empty, string.Empty, Mock.Of<IProjectProperties>());
 
             Assert.Equal(expected: activeProfileLaunchTarget, actual: actualValue);
         }
@@ -145,7 +145,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var threadingService = IProjectThreadingServiceFactory.Create();
             var launchProfileProvider = new LaunchTargetValueProvider(project, settingsProvider, threadingService);
 
-            await launchProfileProvider.OnSetPropertyValueAsync("NewCommand", Mock.Of<IProjectProperties>());
+            await launchProfileProvider.OnSetPropertyValueAsync(string.Empty, "NewCommand", Mock.Of<IProjectProperties>());
 
             Assert.Equal(expected: "NewCommand", actual: activeProfileLaunchTarget);
         }
@@ -160,7 +160,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var threadingService = IProjectThreadingServiceFactory.Create();
             var commandLineArgumentsProvider = new CommandLineArgumentsValueProvider(project, settingsProvider, threadingService);
 
-            var actualValue = await commandLineArgumentsProvider.OnGetEvaluatedPropertyValueAsync(string.Empty, Mock.Of<IProjectProperties>());
+            var actualValue = await commandLineArgumentsProvider.OnGetEvaluatedPropertyValueAsync(string.Empty, string.Empty, Mock.Of<IProjectProperties>());
 
             Assert.Equal(expected: activeProfileCommandLineArguments, actual: actualValue);
         }
@@ -175,7 +175,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var threadingService = IProjectThreadingServiceFactory.Create();
             var commandLineArgumentsProvider = new CommandLineArgumentsValueProvider(project, settingsProvider, threadingService);
 
-            var actualValue = await commandLineArgumentsProvider.OnGetUnevaluatedPropertyValueAsync(string.Empty, Mock.Of<IProjectProperties>());
+            var actualValue = await commandLineArgumentsProvider.OnGetUnevaluatedPropertyValueAsync(string.Empty, string.Empty, Mock.Of<IProjectProperties>());
 
             Assert.Equal(expected: activeProfileCommandLineArguments, actual: actualValue);
         }
@@ -196,7 +196,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var threadingService = IProjectThreadingServiceFactory.Create();
             var commandLineArgumentsProvider = new CommandLineArgumentsValueProvider(project, settingsProvider, threadingService);
 
-            await commandLineArgumentsProvider.OnSetPropertyValueAsync("/seaotters:YES /seals:YES", Mock.Of<IProjectProperties>());
+            await commandLineArgumentsProvider.OnSetPropertyValueAsync(string.Empty, "/seaotters:YES /seals:YES", Mock.Of<IProjectProperties>());
 
             Assert.Equal(expected: "/seaotters:YES /seals:YES", actual: activeProfileCommandLineArgs);
         }
@@ -211,7 +211,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var threadingService = IProjectThreadingServiceFactory.Create();
             var workingDirectoryProvider = new WorkingDirectoryValueProvider(project, settingsProvider, threadingService);
 
-            var actualValue = await workingDirectoryProvider.OnGetEvaluatedPropertyValueAsync(string.Empty, Mock.Of<IProjectProperties>());
+            var actualValue = await workingDirectoryProvider.OnGetEvaluatedPropertyValueAsync(string.Empty, string.Empty, Mock.Of<IProjectProperties>());
 
             Assert.Equal(expected: activeProfileWorkingDirectory, actual: actualValue);
         }
@@ -226,7 +226,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var threadingService = IProjectThreadingServiceFactory.Create();
             var workingDirectoryProvider = new WorkingDirectoryValueProvider(project, settingsProvider, threadingService);
 
-            var actualValue = await workingDirectoryProvider.OnGetUnevaluatedPropertyValueAsync(string.Empty, Mock.Of<IProjectProperties>());
+            var actualValue = await workingDirectoryProvider.OnGetUnevaluatedPropertyValueAsync(string.Empty, string.Empty, Mock.Of<IProjectProperties>());
 
             Assert.Equal(expected: activeProfileWorkingDirectory, actual: actualValue);
         }
@@ -247,7 +247,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var threadingService = IProjectThreadingServiceFactory.Create();
             var workingDirectoryProvider = new WorkingDirectoryValueProvider(project, settingsProvider, threadingService);
 
-            await workingDirectoryProvider.OnSetPropertyValueAsync(@"C:\four\five\six", Mock.Of<IProjectProperties>());
+            await workingDirectoryProvider.OnSetPropertyValueAsync(string.Empty, @"C:\four\five\six", Mock.Of<IProjectProperties>());
 
             Assert.Equal(expected: @"C:\four\five\six", actual: activeProfileWorkingDirectory);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationManifestValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationManifestValueProviderTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var provider = new ApplicationManifestValueProvider(UnconfiguredProjectFactory.Create());
             var defaultProperties = IProjectPropertiesFactory.CreateWithPropertyAndValue("NoWin32Manifest", noManifestValue);
 
-            var appManifestValue = await provider.OnGetEvaluatedPropertyValueAsync(appManifestPropValue, defaultProperties);
+            var appManifestValue = await provider.OnGetEvaluatedPropertyValueAsync(string.Empty, appManifestPropValue, defaultProperties);
             Assert.Equal(expectedValue, appManifestValue);
         }
 
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                                                                                                 { "NoWin32Manifest", noManifestPropValue }
                                                                                             });
 
-            var appManifestValue = await provider.OnSetPropertyValueAsync(valueToSet, defaultProperties);
+            var appManifestValue = await provider.OnSetPropertyValueAsync(string.Empty, valueToSet, defaultProperties);
             var noManifestValue = await defaultProperties.GetEvaluatedPropertyValueAsync("NoWin32Manifest");
 
             Assert.Equal(expectedAppManifestValue, appManifestValue);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeExValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeExValueProviderTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
                 new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputTypeProperty, outputTypePropertyValue));
             var provider = new OutputTypeExValueProvider(properties);
 
-            var actualPropertyValue = await provider.OnGetEvaluatedPropertyValueAsync(string.Empty, null!);
+            var actualPropertyValue = await provider.OnGetEvaluatedPropertyValueAsync(string.Empty, string.Empty, null!);
             Assert.Equal(expectedMappedValue, actualPropertyValue);
         }
 
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
                 UnconfiguredProjectFactory.Create(),
                 new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputTypeProperty, "InitialValue", setValues));
             var provider = new OutputTypeExValueProvider(properties);
-            await provider.OnSetPropertyValueAsync(incomingValue, null!);
+            await provider.OnSetPropertyValueAsync(string.Empty, incomingValue, null!);
 
             Assert.Equal(setValues.Single(), expectedOutputTypeValue);
         }
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
             await Assert.ThrowsAsync<KeyNotFoundException>(async () =>
             {
-                await provider.OnSetPropertyValueAsync("InvalidValue", null!);
+                await provider.OnSetPropertyValueAsync(string.Empty, "InvalidValue", null!);
             });
         }
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeValueProviderTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
                 new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputTypeProperty, outputTypePropertyValue));
             var provider = new OutputTypeValueProvider(properties);
 
-            var actualPropertyValue = await provider.OnGetEvaluatedPropertyValueAsync(string.Empty, null!);
+            var actualPropertyValue = await provider.OnGetEvaluatedPropertyValueAsync(string.Empty, string.Empty, null!);
             Assert.Equal(expectedMappedValue, actualPropertyValue);
         }
 
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
                 new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputTypeProperty, "InitialValue", setValues));
             var provider = new OutputTypeValueProvider(properties);
 
-            await provider.OnSetPropertyValueAsync(incomingValue, null!);
+            await provider.OnSetPropertyValueAsync(string.Empty, incomingValue, null!);
             Assert.Equal(setValues.Single(), expectedOutputTypeValue);
         }
 
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
             await Assert.ThrowsAsync<KeyNotFoundException>(async () =>
             {
-                await provider.OnSetPropertyValueAsync(invalidValue, null!);
+                await provider.OnSetPropertyValueAsync(string.Empty, invalidValue, null!);
             });
         }
     }


### PR DESCRIPTION
Related to #6210.

The `IInterceptingPropertyValueProvider` interface allows an implementor to easily "intercept" get or set operations for a particular property and modify or redirect the value as it sees fit. For example, reading an writing the "ApplicationManifest" property through a property page actually involves two MSBuild properties: ApplicationManifest, and NoWin32Manifest. The `ApplicationManifestValueProvider` handles reading and writing the two in concert to produce the final value exposed through the property page. Similarly the `ExecutablePathValueProvider` redirects reads and writes of the path to the .exe to debug to the launchSettings.json file, instead of reading and writing that value from the project file.

The name of the intercepted property is declared via the `ExportInterceptingPropertyValueProviderAttribute`. Currently, this only accepts a single property name, meaning that each implementation of `IInterceptingPropertyValueProvider` can handle a single property. This is very limiting when it comes to the various properties related to debugging as they all require more or less the same handling. We end up with an abstract base class with a bunch of implementations that basically do nothing other than expose their property name to the base.

This change makes it possible for a single implementation to handle multiple properties. First, we update the attribute with a constructor that takes an array of strings rather than a single string, and update the consuming classes to deal with multiple values.

Second, the `OnGetEvaluatedPropertyValueAsync`, `OnGetUnevaluatedPropertyValueAsync`, and `OnSetPropertyValueAsync` methods have been updated to take the property name as the first argument. Most of the changes in this commit deal with updating the existing implementations accordingly, though currently none of them use the parameter as they only handle one property. Future changes will consolidate some of the existing providers and add new ones that make use of this functionality.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6207)