### PR TITLE
Reinstate package/project ID in flags

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/PackageDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/PackageDependencyModel.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             : base(
                 path,
                 originalItemSpec,
-                flags: s_flagCache.Get(isResolved, isImplicit),
+                flags: s_flagCache.Get(isResolved, isImplicit).Add($"$ID:{originalItemSpec}"),
                 isResolved,
                 isImplicit,
                 properties,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModel.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             : base(
                 path,
                 originalItemSpec,
-                flags: s_flagCache.Get(isResolved, isImplicit),
+                flags: s_flagCache.Get(isResolved, isImplicit).Add($"$ID:{System.IO.Path.GetFileNameWithoutExtension(path)}"),
                 isResolved,
                 isImplicit,
                 properties)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/PackageDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/PackageDependencyModelTests.cs
@@ -42,7 +42,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.PackageDependency +
-                DependencyTreeFlags.GenericResolvedDependencyFlags,
+                DependencyTreeFlags.GenericResolvedDependencyFlags +
+                ProjectTreeFlags.Create("$ID:myOriginalItemSpec"),
                 model.Flags);
         }
 
@@ -78,7 +79,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.PackageDependency +
-                DependencyTreeFlags.GenericUnresolvedDependencyFlags,
+                DependencyTreeFlags.GenericUnresolvedDependencyFlags +
+                ProjectTreeFlags.Create("$ID:myOriginalItemSpec"),
                 model.Flags);
         }
 
@@ -114,7 +116,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.PackageDependency +
-                DependencyTreeFlags.GenericResolvedDependencyFlags -
+                DependencyTreeFlags.GenericResolvedDependencyFlags +
+                ProjectTreeFlags.Create("$ID:myOriginalItemSpec") -
                 DependencyTreeFlags.SupportsRemove,
                 model.Flags);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
@@ -38,7 +38,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.ApplicationWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
-                DependencyTreeFlags.GenericResolvedDependencyFlags,
+                DependencyTreeFlags.GenericResolvedDependencyFlags +
+                ProjectTreeFlags.Create("$ID:myPath"),
                 model.Flags);
         }
 
@@ -69,7 +70,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.ApplicationWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
-                DependencyTreeFlags.GenericUnresolvedDependencyFlags,
+                DependencyTreeFlags.GenericUnresolvedDependencyFlags +
+                ProjectTreeFlags.Create("$ID:myPath"),
                 model.Flags);
         }
 
@@ -101,7 +103,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
-                DependencyTreeFlags.SupportsRemove,
+                DependencyTreeFlags.SupportsRemove +
+                ProjectTreeFlags.Create("$ID:myPath"),
                 model.Flags);
         }
     }


### PR DESCRIPTION
The intention was to have consumers source this data from the browse object, but that's non-trivial from an IProjectTree in a sync context.

I will revisit this in preview 3. Right now this will unblock NuGet from merging, hopefully in time for P2.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6213)