### PR TITLE
Enforce consistent display name/description across dependency rules

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/AnalyzerReference.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Rule Name="AnalyzerReference"
-      Description="Analyzer Properties"
+      Description="Analyzer Reference Properties"
       DisplayName="Analyzer Reference"
       PageTemplate="generic"
       xmlns="http://schemas.microsoft.com/build/2009/properties">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/AssemblyReference.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Rule Name="AssemblyReference"
-      Description="Reference Properties"
+      Description="Assembly Reference Properties"
       DisplayName="Assembly Reference"
       PageTemplate="generic"
       xmlns="http://schemas.microsoft.com/build/2009/properties">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/PackageReference.xaml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Rule Name="PackageReference"
-      Description="Package Properties"
-      DisplayName="Package"
+      Description="Package Reference Properties"
+      DisplayName="Package Reference"
       PageTemplate="generic"
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ProjectReference.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Rule Name="ProjectReference"
-      Description="Reference Properties"
+      Description="Project Reference Properties"
       DisplayName="Project Reference"
       PageTemplate="generic"
       xmlns="http://schemas.microsoft.com/build/2009/properties">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedAnalyzerReference.xaml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Rule Name="ResolvedAnalyzerReference"
-      Description="Analyzer Properties"
-      DisplayName="Resolved Analyzer Reference"
+      Description="Analyzer Reference Properties"
+      DisplayName="Analyzer Reference"
       PageTemplate="generic"
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedAssemblyReference.xaml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Rule Name="ResolvedAssemblyReference"
-      Description="Reference Properties"
-      DisplayName="Resolved Assembly Reference"
+      Description="Assembly Reference Properties"
+      DisplayName="Assembly Reference"
       PageTemplate="generic"
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedCOMReference.xaml
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Rule Name="ResolvedCOMReference"
       Description="COM Reference Properties"
-      DisplayName="Resolved COM Reference"
+      DisplayName="COM Reference"
       PageTemplate="generic"
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedFrameworkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedFrameworkReference.xaml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Rule Name="ResolvedFrameworkReference"
-      Description="Framework Properties"
-      DisplayName="Framework"
+      Description="Framework Reference Properties"
+      DisplayName="Framework Reference"
       PageTemplate="generic"
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Rule Name="ResolvedPackageReference"
-      Description="Package Properties"
-      DisplayName="Package"
+      Description="Package Reference Properties"
+      DisplayName="Package Reference"
       PageTemplate="generic"
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedProjectReference.xaml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Rule Name="ResolvedProjectReference"
-      Description="Reference Properties"
-      DisplayName="Resolved Project Reference"
+      Description="Project Reference Properties"
+      DisplayName="Project Reference"
       PageTemplate="generic"
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedSdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Rule Name="ResolvedSdkReference"
       Description="SDK Reference Properties"
-      DisplayName="Resolved SDK Reference"
+      DisplayName="SDK Reference"
       PageTemplate="generic"
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.cs.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Vlastnosti analyzátoru</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Vlastnosti analyzátoru</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.de.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Eigenschaften von Analysetools</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Eigenschaften von Analysetools</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.es.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Propiedades del analizador</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Propiedades del analizador</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.fr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Propriétés de l'analyseur</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Propriétés de l'analyseur</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.it.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Proprietà dell'analizzatore</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Proprietà dell'analizzatore</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.ja.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">アナライザーのプロパティ</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">アナライザーのプロパティ</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.ko.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">분석기 속성</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">분석기 속성</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.pl.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Właściwości analizatora</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Właściwości analizatora</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.pt-BR.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Propriedades do Analisador</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Propriedades do Analisador</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.ru.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Свойства анализатора</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Свойства анализатора</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.tr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Çözümleyici Özellikleri</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Çözümleyici Özellikleri</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.zh-Hans.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">分析器属性</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">分析器属性</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.zh-Hant.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">分析器屬性</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">分析器屬性</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.cs.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Vlastnosti odkazu</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Vlastnosti odkazu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.de.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Verweiseigenschaften</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Verweiseigenschaften</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.es.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Propiedades de la referencia</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Propiedades de la referencia</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.fr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Propriétés de la référence</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Propriétés de la référence</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.it.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Proprietà del riferimento</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Proprietà del riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.ja.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">参照プロパティ</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">参照プロパティ</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.ko.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">참조 속성</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">참조 속성</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.pl.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Właściwości odwołania</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Właściwości odwołania</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.pt-BR.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Propriedades de Referência</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Propriedades de Referência</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.ru.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Свойства ссылки</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Свойства ссылки</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.tr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Başvuru Özellikleri</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Başvuru Özellikleri</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.zh-Hans.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">引用属性</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">引用属性</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AssemblyReference.xaml.zh-Hant.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|AssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">參考屬性</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">參考屬性</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.cs.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../PackageReference.xaml">
     <body>
       <trans-unit id="Rule|PackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Balíček</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Balíček</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|PackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Vlastnosti balíčku</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Vlastnosti balíčku</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.de.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="de" original="../PackageReference.xaml">
     <body>
       <trans-unit id="Rule|PackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Paket</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Paket</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|PackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Paketeigenschaften</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Paketeigenschaften</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.es.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="es" original="../PackageReference.xaml">
     <body>
       <trans-unit id="Rule|PackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Paquete</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Paquete</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|PackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Propiedades de paquete</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Propiedades de paquete</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.fr.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../PackageReference.xaml">
     <body>
       <trans-unit id="Rule|PackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Package</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Package</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|PackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Propriétés du package</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Propriétés du package</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.it.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="it" original="../PackageReference.xaml">
     <body>
       <trans-unit id="Rule|PackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Pacchetto</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Pacchetto</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|PackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Proprietà del pacchetto</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Proprietà del pacchetto</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ja.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../PackageReference.xaml">
     <body>
       <trans-unit id="Rule|PackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">パッケージ</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">パッケージ</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|PackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">パッケージのプロパティ</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">パッケージのプロパティ</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ko.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../PackageReference.xaml">
     <body>
       <trans-unit id="Rule|PackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">패키지</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">패키지</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|PackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">패키지 속성</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">패키지 속성</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pl.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../PackageReference.xaml">
     <body>
       <trans-unit id="Rule|PackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Pakiet</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Pakiet</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|PackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Właściwości pakietu</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Właściwości pakietu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pt-BR.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../PackageReference.xaml">
     <body>
       <trans-unit id="Rule|PackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Pacote</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Pacote</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|PackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Propriedades do Pacote</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Propriedades do Pacote</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ru.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../PackageReference.xaml">
     <body>
       <trans-unit id="Rule|PackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Пакет</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Пакет</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|PackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Свойства пакета</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Свойства пакета</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.tr.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../PackageReference.xaml">
     <body>
       <trans-unit id="Rule|PackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Paket</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Paket</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|PackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Paket Özellikleri</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Paket Özellikleri</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hans.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../PackageReference.xaml">
     <body>
       <trans-unit id="Rule|PackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">打包</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">打包</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|PackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">包属性</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">包属性</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hant.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../PackageReference.xaml">
     <body>
       <trans-unit id="Rule|PackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">套件</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">套件</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|PackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">套件屬性</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">套件屬性</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.cs.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Vlastnosti odkazu</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Vlastnosti odkazu</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.de.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Verweiseigenschaften</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Verweiseigenschaften</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.es.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Propiedades de la referencia</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Propiedades de la referencia</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.fr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Propriétés de la référence</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Propriétés de la référence</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.it.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Proprietà del riferimento</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Proprietà del riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.ja.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">参照プロパティ</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">参照プロパティ</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.ko.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">참조 속성</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">참조 속성</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.pl.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Właściwości odwołania</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Właściwości odwołania</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.pt-BR.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Propriedades de Referência</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Propriedades de Referência</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.ru.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Свойства ссылки</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Свойства ссылки</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.tr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Başvuru Özellikleri</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Başvuru Özellikleri</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.zh-Hans.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">引用属性</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">引用属性</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ProjectReference.xaml.zh-Hant.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">參考屬性</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">參考屬性</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.cs.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../ResolvedAnalyzerReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAnalyzerReference|DisplayName">
-        <source>Resolved Analyzer Reference</source>
-        <target state="translated">Vyhodnocený odkaz na analyzátor</target>
+        <source>Analyzer Reference</source>
+        <target state="needs-review-translation">Vyhodnocený odkaz na analyzátor</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Vlastnosti analyzátoru</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Vlastnosti analyzátoru</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.de.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="de" original="../ResolvedAnalyzerReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAnalyzerReference|DisplayName">
-        <source>Resolved Analyzer Reference</source>
-        <target state="translated">Aufgelöster Analysetoolverweis</target>
+        <source>Analyzer Reference</source>
+        <target state="needs-review-translation">Aufgelöster Analysetoolverweis</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Eigenschaften von Analysetools</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Eigenschaften von Analysetools</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.es.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="es" original="../ResolvedAnalyzerReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAnalyzerReference|DisplayName">
-        <source>Resolved Analyzer Reference</source>
-        <target state="translated">Referencia de analizador resuelta</target>
+        <source>Analyzer Reference</source>
+        <target state="needs-review-translation">Referencia de analizador resuelta</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Propiedades del analizador</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Propiedades del analizador</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.fr.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../ResolvedAnalyzerReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAnalyzerReference|DisplayName">
-        <source>Resolved Analyzer Reference</source>
-        <target state="translated">Référence de l'analyseur résolue</target>
+        <source>Analyzer Reference</source>
+        <target state="needs-review-translation">Référence de l'analyseur résolue</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Propriétés de l'analyseur</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Propriétés de l'analyseur</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.it.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="it" original="../ResolvedAnalyzerReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAnalyzerReference|DisplayName">
-        <source>Resolved Analyzer Reference</source>
-        <target state="translated">Riferimento ad analizzatore risolto</target>
+        <source>Analyzer Reference</source>
+        <target state="needs-review-translation">Riferimento ad analizzatore risolto</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Proprietà dell'analizzatore</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Proprietà dell'analizzatore</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.ja.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../ResolvedAnalyzerReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAnalyzerReference|DisplayName">
-        <source>Resolved Analyzer Reference</source>
-        <target state="translated">解決されたアナライザー参照</target>
+        <source>Analyzer Reference</source>
+        <target state="needs-review-translation">解決されたアナライザー参照</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">アナライザーのプロパティ</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">アナライザーのプロパティ</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.ko.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../ResolvedAnalyzerReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAnalyzerReference|DisplayName">
-        <source>Resolved Analyzer Reference</source>
-        <target state="translated">확인된 분석기 참조</target>
+        <source>Analyzer Reference</source>
+        <target state="needs-review-translation">확인된 분석기 참조</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">분석기 속성</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">분석기 속성</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.pl.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../ResolvedAnalyzerReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAnalyzerReference|DisplayName">
-        <source>Resolved Analyzer Reference</source>
-        <target state="translated">Rozpoznane odwołanie analizatora</target>
+        <source>Analyzer Reference</source>
+        <target state="needs-review-translation">Rozpoznane odwołanie analizatora</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Właściwości analizatora</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Właściwości analizatora</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.pt-BR.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ResolvedAnalyzerReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAnalyzerReference|DisplayName">
-        <source>Resolved Analyzer Reference</source>
-        <target state="translated">Referência de Analisador Resolvida</target>
+        <source>Analyzer Reference</source>
+        <target state="needs-review-translation">Referência de Analisador Resolvida</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Propriedades do Analisador</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Propriedades do Analisador</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.ru.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../ResolvedAnalyzerReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAnalyzerReference|DisplayName">
-        <source>Resolved Analyzer Reference</source>
-        <target state="translated">Разрешенная ссылка на анализатор</target>
+        <source>Analyzer Reference</source>
+        <target state="needs-review-translation">Разрешенная ссылка на анализатор</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Свойства анализатора</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Свойства анализатора</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.tr.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../ResolvedAnalyzerReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAnalyzerReference|DisplayName">
-        <source>Resolved Analyzer Reference</source>
-        <target state="translated">Çözümlenen Çözümleyici Başvurusu</target>
+        <source>Analyzer Reference</source>
+        <target state="needs-review-translation">Çözümlenen Çözümleyici Başvurusu</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">Çözümleyici Özellikleri</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">Çözümleyici Özellikleri</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.zh-Hans.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ResolvedAnalyzerReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAnalyzerReference|DisplayName">
-        <source>Resolved Analyzer Reference</source>
-        <target state="translated">解析的分析器引用</target>
+        <source>Analyzer Reference</source>
+        <target state="needs-review-translation">解析的分析器引用</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">分析器属性</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">分析器属性</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAnalyzerReference.xaml.zh-Hant.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ResolvedAnalyzerReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAnalyzerReference|DisplayName">
-        <source>Resolved Analyzer Reference</source>
-        <target state="translated">已解析的分析器參考</target>
+        <source>Analyzer Reference</source>
+        <target state="needs-review-translation">已解析的分析器參考</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAnalyzerReference|Description">
-        <source>Analyzer Properties</source>
-        <target state="translated">分析器屬性</target>
+        <source>Analyzer Reference Properties</source>
+        <target state="needs-review-translation">分析器屬性</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.cs.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../ResolvedAssemblyReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAssemblyReference|DisplayName">
-        <source>Resolved Assembly Reference</source>
-        <target state="translated">Vyřešené odkazy sestavení</target>
+        <source>Assembly Reference</source>
+        <target state="needs-review-translation">Vyřešené odkazy sestavení</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Vlastnosti odkazu</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Vlastnosti odkazu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.de.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="de" original="../ResolvedAssemblyReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAssemblyReference|DisplayName">
-        <source>Resolved Assembly Reference</source>
-        <target state="translated">Aufgelöster Assemblyverweis</target>
+        <source>Assembly Reference</source>
+        <target state="needs-review-translation">Aufgelöster Assemblyverweis</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Verweiseigenschaften</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Verweiseigenschaften</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.es.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="es" original="../ResolvedAssemblyReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAssemblyReference|DisplayName">
-        <source>Resolved Assembly Reference</source>
-        <target state="translated">Referencia de ensamblado resuelta</target>
+        <source>Assembly Reference</source>
+        <target state="needs-review-translation">Referencia de ensamblado resuelta</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Propiedades de la referencia</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Propiedades de la referencia</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.fr.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../ResolvedAssemblyReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAssemblyReference|DisplayName">
-        <source>Resolved Assembly Reference</source>
-        <target state="translated">Référence d'assembly résolue</target>
+        <source>Assembly Reference</source>
+        <target state="needs-review-translation">Référence d'assembly résolue</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Propriétés de la référence</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Propriétés de la référence</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.it.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="it" original="../ResolvedAssemblyReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAssemblyReference|DisplayName">
-        <source>Resolved Assembly Reference</source>
-        <target state="translated">Riferimento ad assembly risolto</target>
+        <source>Assembly Reference</source>
+        <target state="needs-review-translation">Riferimento ad assembly risolto</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Proprietà del riferimento</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Proprietà del riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.ja.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../ResolvedAssemblyReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAssemblyReference|DisplayName">
-        <source>Resolved Assembly Reference</source>
-        <target state="translated">解決されたアセンブリ参照</target>
+        <source>Assembly Reference</source>
+        <target state="needs-review-translation">解決されたアセンブリ参照</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">参照プロパティ</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">参照プロパティ</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.ko.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../ResolvedAssemblyReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAssemblyReference|DisplayName">
-        <source>Resolved Assembly Reference</source>
-        <target state="translated">확인된 어셈블리 참조</target>
+        <source>Assembly Reference</source>
+        <target state="needs-review-translation">확인된 어셈블리 참조</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">참조 속성</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">참조 속성</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.pl.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../ResolvedAssemblyReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAssemblyReference|DisplayName">
-        <source>Resolved Assembly Reference</source>
-        <target state="translated">Rozpoznane odwołanie do zestawu</target>
+        <source>Assembly Reference</source>
+        <target state="needs-review-translation">Rozpoznane odwołanie do zestawu</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Właściwości odwołania</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Właściwości odwołania</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.pt-BR.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ResolvedAssemblyReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAssemblyReference|DisplayName">
-        <source>Resolved Assembly Reference</source>
-        <target state="translated">Referência de Assembly Resolvida</target>
+        <source>Assembly Reference</source>
+        <target state="needs-review-translation">Referência de Assembly Resolvida</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Propriedades de Referência</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Propriedades de Referência</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.ru.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../ResolvedAssemblyReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAssemblyReference|DisplayName">
-        <source>Resolved Assembly Reference</source>
-        <target state="translated">Разрешенная ссылка на сборку</target>
+        <source>Assembly Reference</source>
+        <target state="needs-review-translation">Разрешенная ссылка на сборку</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Свойства ссылки</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Свойства ссылки</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.tr.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../ResolvedAssemblyReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAssemblyReference|DisplayName">
-        <source>Resolved Assembly Reference</source>
-        <target state="translated">Çözümlenen Bütünleştirilmiş Kod Başvurusu</target>
+        <source>Assembly Reference</source>
+        <target state="needs-review-translation">Çözümlenen Bütünleştirilmiş Kod Başvurusu</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Başvuru Özellikleri</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">Başvuru Özellikleri</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.zh-Hans.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ResolvedAssemblyReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAssemblyReference|DisplayName">
-        <source>Resolved Assembly Reference</source>
-        <target state="translated">解析的程序集引用</target>
+        <source>Assembly Reference</source>
+        <target state="needs-review-translation">解析的程序集引用</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">引用属性</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">引用属性</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedAssemblyReference.xaml.zh-Hant.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ResolvedAssemblyReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedAssemblyReference|DisplayName">
-        <source>Resolved Assembly Reference</source>
-        <target state="translated">已解析的組件參考</target>
+        <source>Assembly Reference</source>
+        <target state="needs-review-translation">已解析的組件參考</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAssemblyReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">參考屬性</target>
+        <source>Assembly Reference Properties</source>
+        <target state="needs-review-translation">參考屬性</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.cs.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../ResolvedCOMReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
-        <source>Resolved COM Reference</source>
-        <target state="translated">Rozpoznaný odkaz modelu COM</target>
+        <source>COM Reference</source>
+        <target state="needs-review-translation">Rozpoznaný odkaz modelu COM</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.de.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="de" original="../ResolvedCOMReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
-        <source>Resolved COM Reference</source>
-        <target state="translated">Aufgelöster COM-Verweis</target>
+        <source>COM Reference</source>
+        <target state="needs-review-translation">Aufgelöster COM-Verweis</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.es.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="es" original="../ResolvedCOMReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
-        <source>Resolved COM Reference</source>
-        <target state="translated">Referencia COM resuelta</target>
+        <source>COM Reference</source>
+        <target state="needs-review-translation">Referencia COM resuelta</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.fr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../ResolvedCOMReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
-        <source>Resolved COM Reference</source>
-        <target state="translated">Référence COM résolue</target>
+        <source>COM Reference</source>
+        <target state="needs-review-translation">Référence COM résolue</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.it.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="it" original="../ResolvedCOMReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
-        <source>Resolved COM Reference</source>
-        <target state="translated">Riferimento COM risolto</target>
+        <source>COM Reference</source>
+        <target state="needs-review-translation">Riferimento COM risolto</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.ja.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../ResolvedCOMReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
-        <source>Resolved COM Reference</source>
-        <target state="translated">解決された COM 参照</target>
+        <source>COM Reference</source>
+        <target state="needs-review-translation">解決された COM 参照</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.ko.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../ResolvedCOMReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
-        <source>Resolved COM Reference</source>
-        <target state="translated">확인된 COM 참조</target>
+        <source>COM Reference</source>
+        <target state="needs-review-translation">확인된 COM 참조</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.pl.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../ResolvedCOMReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
-        <source>Resolved COM Reference</source>
-        <target state="translated">Rozpoznane odwołanie COM</target>
+        <source>COM Reference</source>
+        <target state="needs-review-translation">Rozpoznane odwołanie COM</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.pt-BR.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ResolvedCOMReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
-        <source>Resolved COM Reference</source>
-        <target state="translated">Referência COM resolvida</target>
+        <source>COM Reference</source>
+        <target state="needs-review-translation">Referência COM resolvida</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.ru.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../ResolvedCOMReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
-        <source>Resolved COM Reference</source>
-        <target state="translated">Разрешенная ссылка COM</target>
+        <source>COM Reference</source>
+        <target state="needs-review-translation">Разрешенная ссылка COM</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.tr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../ResolvedCOMReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
-        <source>Resolved COM Reference</source>
-        <target state="translated">Çözümlenen COM Başvurusu</target>
+        <source>COM Reference</source>
+        <target state="needs-review-translation">Çözümlenen COM Başvurusu</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.zh-Hans.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ResolvedCOMReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
-        <source>Resolved COM Reference</source>
-        <target state="translated">解析的 COM 引用</target>
+        <source>COM Reference</source>
+        <target state="needs-review-translation">解析的 COM 引用</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.zh-Hant.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ResolvedCOMReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
-        <source>Resolved COM Reference</source>
-        <target state="translated">已解析的 COM 參考</target>
+        <source>COM Reference</source>
+        <target state="needs-review-translation">已解析的 COM 參考</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.cs.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Properties</source>
-        <target state="translated">Vlastnosti rozhraní</target>
+        <source>Framework Reference Properties</source>
+        <target state="needs-review-translation">Vlastnosti rozhraní</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework</source>
-        <target state="translated">Architektura</target>
+        <source>Framework Reference</source>
+        <target state="needs-review-translation">Architektura</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.de.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="de" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Properties</source>
-        <target state="translated">Frameworkeigenschaften</target>
+        <source>Framework Reference Properties</source>
+        <target state="needs-review-translation">Frameworkeigenschaften</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework</source>
-        <target state="translated">Framework</target>
+        <source>Framework Reference</source>
+        <target state="needs-review-translation">Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.es.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="es" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Properties</source>
-        <target state="translated">Propiedades del marco de trabajo</target>
+        <source>Framework Reference Properties</source>
+        <target state="needs-review-translation">Propiedades del marco de trabajo</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework</source>
-        <target state="translated">Plataforma</target>
+        <source>Framework Reference</source>
+        <target state="needs-review-translation">Plataforma</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.fr.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Properties</source>
-        <target state="translated">Propriétés du framework</target>
+        <source>Framework Reference Properties</source>
+        <target state="needs-review-translation">Propriétés du framework</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework</source>
-        <target state="translated">Framework</target>
+        <source>Framework Reference</source>
+        <target state="needs-review-translation">Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.it.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="it" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Properties</source>
-        <target state="translated">Proprietà framework</target>
+        <source>Framework Reference Properties</source>
+        <target state="needs-review-translation">Proprietà framework</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework</source>
-        <target state="translated">Framework</target>
+        <source>Framework Reference</source>
+        <target state="needs-review-translation">Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.ja.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Properties</source>
-        <target state="translated">フレームワークのプロパティ</target>
+        <source>Framework Reference Properties</source>
+        <target state="needs-review-translation">フレームワークのプロパティ</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework</source>
-        <target state="translated">フレームワーク</target>
+        <source>Framework Reference</source>
+        <target state="needs-review-translation">フレームワーク</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.ko.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Properties</source>
-        <target state="translated">프레임워크 속성</target>
+        <source>Framework Reference Properties</source>
+        <target state="needs-review-translation">프레임워크 속성</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework</source>
-        <target state="translated">프레임워크</target>
+        <source>Framework Reference</source>
+        <target state="needs-review-translation">프레임워크</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.pl.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Properties</source>
-        <target state="translated">Właściwości struktury</target>
+        <source>Framework Reference Properties</source>
+        <target state="needs-review-translation">Właściwości struktury</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework</source>
-        <target state="translated">Platforma</target>
+        <source>Framework Reference</source>
+        <target state="needs-review-translation">Platforma</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.pt-BR.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Properties</source>
-        <target state="translated">Propriedades da Estrutura</target>
+        <source>Framework Reference Properties</source>
+        <target state="needs-review-translation">Propriedades da Estrutura</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework</source>
-        <target state="translated">Estrutura</target>
+        <source>Framework Reference</source>
+        <target state="needs-review-translation">Estrutura</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.ru.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Properties</source>
-        <target state="translated">Свойства платформы</target>
+        <source>Framework Reference Properties</source>
+        <target state="needs-review-translation">Свойства платформы</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework</source>
-        <target state="translated">Платформа</target>
+        <source>Framework Reference</source>
+        <target state="needs-review-translation">Платформа</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.tr.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Properties</source>
-        <target state="translated">Çerçeve Özellikleri</target>
+        <source>Framework Reference Properties</source>
+        <target state="needs-review-translation">Çerçeve Özellikleri</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework</source>
-        <target state="translated">Çerçeve</target>
+        <source>Framework Reference</source>
+        <target state="needs-review-translation">Çerçeve</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.zh-Hans.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Properties</source>
-        <target state="translated">框架属性</target>
+        <source>Framework Reference Properties</source>
+        <target state="needs-review-translation">框架属性</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework</source>
-        <target state="translated">框架</target>
+        <source>Framework Reference</source>
+        <target state="needs-review-translation">框架</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.zh-Hant.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Properties</source>
-        <target state="translated">架構屬性</target>
+        <source>Framework Reference Properties</source>
+        <target state="needs-review-translation">架構屬性</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework</source>
-        <target state="translated">架構</target>
+        <source>Framework Reference</source>
+        <target state="needs-review-translation">架構</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.cs.xlf
@@ -13,13 +13,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Balíček</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Balíček</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Vlastnosti balíčku</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Vlastnosti balíčku</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.de.xlf
@@ -13,13 +13,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Paket</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Paket</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Paketeigenschaften</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Paketeigenschaften</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.es.xlf
@@ -13,13 +13,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Paquete</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Paquete</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Propiedades de paquete</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Propiedades de paquete</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.fr.xlf
@@ -13,13 +13,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Package</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Package</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Propriétés du package</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Propriétés du package</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.it.xlf
@@ -13,13 +13,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Pacchetto</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Pacchetto</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Proprietà del pacchetto</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Proprietà del pacchetto</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ja.xlf
@@ -13,13 +13,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">パッケージ</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">パッケージ</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">パッケージのプロパティ</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">パッケージのプロパティ</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ko.xlf
@@ -13,13 +13,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">패키지</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">패키지</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">패키지 속성</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">패키지 속성</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pl.xlf
@@ -13,13 +13,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Pakiet</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Pakiet</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Właściwości pakietu</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Właściwości pakietu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pt-BR.xlf
@@ -13,13 +13,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Pacote</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Pacote</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Propriedades do Pacote</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Propriedades do Pacote</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ru.xlf
@@ -13,13 +13,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Пакет</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Пакет</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Свойства пакета</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Свойства пакета</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.tr.xlf
@@ -13,13 +13,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">Paket</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">Paket</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">Paket Özellikleri</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">Paket Özellikleri</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hans.xlf
@@ -13,13 +13,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">打包</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">打包</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">包属性</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">包属性</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hant.xlf
@@ -13,13 +13,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
-        <source>Package</source>
-        <target state="translated">套件</target>
+        <source>Package Reference</source>
+        <target state="needs-review-translation">套件</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|Description">
-        <source>Package Properties</source>
-        <target state="translated">套件屬性</target>
+        <source>Package Reference Properties</source>
+        <target state="needs-review-translation">套件屬性</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.cs.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../ResolvedProjectReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedProjectReference|DisplayName">
-        <source>Resolved Project Reference</source>
-        <target state="translated">Vyřešené odkazy projektu</target>
+        <source>Project Reference</source>
+        <target state="needs-review-translation">Vyřešené odkazy projektu</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Vlastnosti odkazu</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Vlastnosti odkazu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.de.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="de" original="../ResolvedProjectReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedProjectReference|DisplayName">
-        <source>Resolved Project Reference</source>
-        <target state="translated">Aufgelöster Projektverweis</target>
+        <source>Project Reference</source>
+        <target state="needs-review-translation">Aufgelöster Projektverweis</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Verweiseigenschaften</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Verweiseigenschaften</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.es.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="es" original="../ResolvedProjectReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedProjectReference|DisplayName">
-        <source>Resolved Project Reference</source>
-        <target state="translated">Referencia de proyecto resuelta</target>
+        <source>Project Reference</source>
+        <target state="needs-review-translation">Referencia de proyecto resuelta</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Propiedades de la referencia</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Propiedades de la referencia</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.fr.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../ResolvedProjectReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedProjectReference|DisplayName">
-        <source>Resolved Project Reference</source>
-        <target state="translated">Référence de projet résolue</target>
+        <source>Project Reference</source>
+        <target state="needs-review-translation">Référence de projet résolue</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Propriétés de la référence</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Propriétés de la référence</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.it.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="it" original="../ResolvedProjectReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedProjectReference|DisplayName">
-        <source>Resolved Project Reference</source>
-        <target state="translated">Riferimento a progetto risolto</target>
+        <source>Project Reference</source>
+        <target state="needs-review-translation">Riferimento a progetto risolto</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Proprietà del riferimento</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Proprietà del riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.ja.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../ResolvedProjectReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedProjectReference|DisplayName">
-        <source>Resolved Project Reference</source>
-        <target state="translated">解決されたプロジェクト参照</target>
+        <source>Project Reference</source>
+        <target state="needs-review-translation">解決されたプロジェクト参照</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">参照プロパティ</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">参照プロパティ</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.ko.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../ResolvedProjectReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedProjectReference|DisplayName">
-        <source>Resolved Project Reference</source>
-        <target state="translated">확인된 프로젝트 참조</target>
+        <source>Project Reference</source>
+        <target state="needs-review-translation">확인된 프로젝트 참조</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">참조 속성</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">참조 속성</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.pl.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../ResolvedProjectReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedProjectReference|DisplayName">
-        <source>Resolved Project Reference</source>
-        <target state="translated">Rozpoznane odwołanie do projektu</target>
+        <source>Project Reference</source>
+        <target state="needs-review-translation">Rozpoznane odwołanie do projektu</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Właściwości odwołania</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Właściwości odwołania</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.pt-BR.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ResolvedProjectReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedProjectReference|DisplayName">
-        <source>Resolved Project Reference</source>
-        <target state="translated">Referência de Projeto Resolvida</target>
+        <source>Project Reference</source>
+        <target state="needs-review-translation">Referência de Projeto Resolvida</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Propriedades de Referência</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Propriedades de Referência</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.ru.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../ResolvedProjectReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedProjectReference|DisplayName">
-        <source>Resolved Project Reference</source>
-        <target state="translated">Разрешенная ссылка проекта</target>
+        <source>Project Reference</source>
+        <target state="needs-review-translation">Разрешенная ссылка проекта</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Свойства ссылки</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Свойства ссылки</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.tr.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../ResolvedProjectReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedProjectReference|DisplayName">
-        <source>Resolved Project Reference</source>
-        <target state="translated">Çözümlenen Proje Başvurusu</target>
+        <source>Project Reference</source>
+        <target state="needs-review-translation">Çözümlenen Proje Başvurusu</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">Başvuru Özellikleri</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">Başvuru Özellikleri</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.zh-Hans.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ResolvedProjectReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedProjectReference|DisplayName">
-        <source>Resolved Project Reference</source>
-        <target state="translated">解析的项目引用</target>
+        <source>Project Reference</source>
+        <target state="needs-review-translation">解析的项目引用</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">引用属性</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">引用属性</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedProjectReference.xaml.zh-Hant.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ResolvedProjectReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedProjectReference|DisplayName">
-        <source>Resolved Project Reference</source>
-        <target state="translated">已解析的專案參考</target>
+        <source>Project Reference</source>
+        <target state="needs-review-translation">已解析的專案參考</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedProjectReference|Description">
-        <source>Reference Properties</source>
-        <target state="translated">參考屬性</target>
+        <source>Project Reference Properties</source>
+        <target state="needs-review-translation">參考屬性</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.cs.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../ResolvedSdkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedSdkReference|DisplayName">
-        <source>Resolved SDK Reference</source>
-        <target state="translated">Vyřešený odkaz na sadu SDK</target>
+        <source>SDK Reference</source>
+        <target state="needs-review-translation">Vyřešený odkaz na sadu SDK</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedSdkReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.de.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="de" original="../ResolvedSdkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedSdkReference|DisplayName">
-        <source>Resolved SDK Reference</source>
-        <target state="translated">Aufgelöster SDK-Verweis</target>
+        <source>SDK Reference</source>
+        <target state="needs-review-translation">Aufgelöster SDK-Verweis</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedSdkReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.es.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="es" original="../ResolvedSdkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedSdkReference|DisplayName">
-        <source>Resolved SDK Reference</source>
-        <target state="translated">Referencia de SDK resuelta</target>
+        <source>SDK Reference</source>
+        <target state="needs-review-translation">Referencia de SDK resuelta</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedSdkReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.fr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../ResolvedSdkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedSdkReference|DisplayName">
-        <source>Resolved SDK Reference</source>
-        <target state="translated">Référence SDK résolue</target>
+        <source>SDK Reference</source>
+        <target state="needs-review-translation">Référence SDK résolue</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedSdkReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.it.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="it" original="../ResolvedSdkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedSdkReference|DisplayName">
-        <source>Resolved SDK Reference</source>
-        <target state="translated">Riferimento a SDK risolto</target>
+        <source>SDK Reference</source>
+        <target state="needs-review-translation">Riferimento a SDK risolto</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedSdkReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.ja.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../ResolvedSdkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedSdkReference|DisplayName">
-        <source>Resolved SDK Reference</source>
-        <target state="translated">解決された SDK 参照</target>
+        <source>SDK Reference</source>
+        <target state="needs-review-translation">解決された SDK 参照</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedSdkReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.ko.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../ResolvedSdkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedSdkReference|DisplayName">
-        <source>Resolved SDK Reference</source>
-        <target state="translated">확인된 SDK 참조</target>
+        <source>SDK Reference</source>
+        <target state="needs-review-translation">확인된 SDK 참조</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedSdkReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.pl.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../ResolvedSdkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedSdkReference|DisplayName">
-        <source>Resolved SDK Reference</source>
-        <target state="translated">Rozpoznane odwołanie SDK</target>
+        <source>SDK Reference</source>
+        <target state="needs-review-translation">Rozpoznane odwołanie SDK</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedSdkReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.pt-BR.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ResolvedSdkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedSdkReference|DisplayName">
-        <source>Resolved SDK Reference</source>
-        <target state="translated">Referência do SDK Resolvida</target>
+        <source>SDK Reference</source>
+        <target state="needs-review-translation">Referência do SDK Resolvida</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedSdkReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.ru.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../ResolvedSdkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedSdkReference|DisplayName">
-        <source>Resolved SDK Reference</source>
-        <target state="translated">Разрешенная ссылка на пакет SDK</target>
+        <source>SDK Reference</source>
+        <target state="needs-review-translation">Разрешенная ссылка на пакет SDK</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedSdkReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.tr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../ResolvedSdkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedSdkReference|DisplayName">
-        <source>Resolved SDK Reference</source>
-        <target state="translated">Çözümlenen SDK Başvurusu</target>
+        <source>SDK Reference</source>
+        <target state="needs-review-translation">Çözümlenen SDK Başvurusu</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedSdkReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.zh-Hans.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ResolvedSdkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedSdkReference|DisplayName">
-        <source>Resolved SDK Reference</source>
-        <target state="translated">解析的 SDK 引用</target>
+        <source>SDK Reference</source>
+        <target state="needs-review-translation">解析的 SDK 引用</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedSdkReference|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedSdkReference.xaml.zh-Hant.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ResolvedSdkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedSdkReference|DisplayName">
-        <source>Resolved SDK Reference</source>
-        <target state="translated">已解析的 SDK 參考</target>
+        <source>SDK Reference</source>
+        <target state="needs-review-translation">已解析的 SDK 參考</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedSdkReference|Description">

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/XamlRuleTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/XamlRuleTestBase.cs
@@ -29,24 +29,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
 
             var searchOption = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
 
-            foreach (var fileName in Directory.EnumerateFiles(rulesPath, "*.xaml", searchOption))
+            foreach (var filePath in Directory.EnumerateFiles(rulesPath, "*.xaml", searchOption))
             {
-                XElement rule = LoadXamlRule(fileName);
+                XElement rule = LoadXamlRule(filePath);
 
                 // Ignore XAML documents for non-Rule types (such as ProjectSchemaDefinitions)
                 if (rule.Name.LocalName != "Rule")
                     continue;
 
-                yield return fileName;
+                yield return filePath;
             }
         }
 
-        /// <summary>Projects a XAML file name into the form used by unit tests theories.</summary>
-        protected static IEnumerable<object[]> Project(IEnumerable<string> fileNames)
+        /// <summary>Projects a XAML rule file's path into the form used by unit tests theories.</summary>
+        protected static IEnumerable<object[]> Project(IEnumerable<string> filePaths)
         {
             // we return the rule name separately mainly to get a readable display in Test Explorer so failures can be diagnosed more easily
-            return from fileName in fileNames
-                   select new object[] { Path.GetFileNameWithoutExtension(fileName), fileName };
+            return from filePath in filePaths
+                   select new object[] { Path.GetFileNameWithoutExtension(filePath), filePath };
         }
 
         protected static XElement LoadXamlRule(string filePath)


### PR DESCRIPTION
Fixes #5203.

- Following legacy behaviour, description ends with "Properties".
- All items must include the word "Reference".
- Enforce the same values between resolved/unresolved rules.
- Update existing rules and add unit tests to enforce these constraints.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6224)