### PR TITLE
Enforce consistent properties between resolved/unresolved dependeny pairs

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/AnalyzerReference.xaml
@@ -18,6 +18,12 @@
                   ReadOnly="True"
                   Visible="False" />
 
+  <!-- NOTE this property will never be populated for unresolved items, but is included to make the UI consistent -->
+  <StringProperty Name="ResolvedPath"
+                  Description="Location of the analyzer assembly."
+                  DisplayName="Path"
+                  ReadOnly="True" />
+
   <BoolProperty Name="Visible"
                 ReadOnly="True"
                 Visible="False" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/COMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/COMReference.xaml
@@ -12,9 +12,54 @@
                 SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
+  <StringListProperty Name="Aliases"
+                      Description="A comma-delimited list of aliases to this reference."
+                      DisplayName="Aliases"
+                      Separator=",">
+    <StringListProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="COMReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringListProperty.DataSource>
+  </StringListProperty>
+
+  <BoolProperty Name="CopyLocal"
+                Description="Indicates whether the reference will be copied to the output directory."
+                DisplayName="Copy Local">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="COMReference"
+                  PersistedName="Private"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
+
+  <BoolProperty Name="EmbedInteropTypes"
+                Description="Indicates whether types defined in this assembly will be embedded into the target assembly."
+                DisplayName="Embed Interop Types">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="COMReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
+
   <StringProperty Name="Guid"
                   Description="The GUID of the COM server."
                   DisplayName="CLSID" />
+
+  <StringProperty Name="Identity"
+                  Description="Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence)."
+                  DisplayName="Identity"
+                  ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="{}{Identity}"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <StringProperty Name="IsImplicitlyDefined"
                   ReadOnly="True"
@@ -39,5 +84,17 @@
 
   <StringProperty Name="WrapperTool"
                   DisplayName="Wrapper Tool" />
+
+  <!-- NOTE this property will never be populated for unresolved items, but is included to make the UI consistent -->
+  <StringProperty Name="ResolvedPath"
+                  DisplayName="Path"
+                  Description="Location of the file being referenced."
+                  ReadOnly="True" />
+
+  <!-- NOTE this property will never be populated for unresolved items, but is included to make the UI consistent -->
+  <StringProperty Name="Version"
+                  DisplayName="Version"
+                  Description="Version of reference."
+                  ReadOnly="True" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/FrameworkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/FrameworkReference.xaml
@@ -21,4 +21,18 @@
                 ReadOnly="True"
                 Visible="False" />
 
+  <!-- NOTE this property will never be populated for unresolved items, but is included to make the UI consistent -->
+  <StringProperty Name="TargetingPackPath"
+                  DisplayName="Path"
+                  ReadOnly="True" />
+
+  <!-- NOTE this property will never be populated for unresolved items, but is included to make the UI consistent -->
+  <StringProperty Name="TargetingPackVersion"
+                  DisplayName="Version"
+                  ReadOnly="True" />
+
+  <!-- NOTE this property will never be populated for unresolved items, but is included to make the UI consistent -->
+  <StringProperty Name="Profile"
+                  DisplayName="Profile"
+                  ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/PackageReference.xaml
@@ -21,15 +21,15 @@
 
   <StringProperty Name="ExcludeAssets"
                   Description="Assets to exclude from this reference."
-                  DisplayName="Excluded assets" />
+                  DisplayName="Excluded Assets" />
 
   <BoolProperty Name="GeneratePathProperty"
                 Description="Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'."
-                DisplayName="Generate path property" />
+                DisplayName="Generate Path Property" />
 
   <StringProperty Name="IncludeAssets"
                   Description="Assets to include from this reference."
-                  DisplayName="Included assets" />
+                  DisplayName="Included Assets" />
 
   <StringProperty Name="IsImplicitlyDefined"
                   ReadOnly="True"
@@ -46,11 +46,17 @@
 
   <StringProperty Name="NoWarn"
                   Description="Comma-delimited list of warnings that should be suppressed for this package."
-                  DisplayName="Suppress warnings" />
+                  DisplayName="Suppress Warnings" />
+
+  <!-- NOTE this property will never be populated for unresolved items, but is included to make the UI consistent -->
+  <StringProperty Name="Path"
+                  Description="Location of the package being referenced."
+                  DisplayName="Path"
+                  ReadOnly="True" />
 
   <StringProperty Name="PrivateAssets"
                   Description="Assets that are private in this reference."
-                  DisplayName="Private assets" />
+                  DisplayName="Private Assets" />
 
   <StringProperty Name="Version"
                   Description="Version of dependency."

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedCOMReference.xaml
@@ -73,7 +73,15 @@
                   Visible="False" />
 
   <StringProperty Name="Guid"
-                  Visible="False" />
+                  Description="The GUID of the COM server."
+                  DisplayName="CLSID">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="COMReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <StringProperty Name="HintPath"
                   Visible="false" />
@@ -92,8 +100,29 @@
                   ReadOnly="True"
                   Visible="False" />
 
+  <BoolProperty Name="Isolated"
+                DisplayName="Isolated">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="COMReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
+
   <BoolProperty Name="IsWinMDFile"
                 Visible="false" />
+
+  <StringProperty Name="Lcid"
+                  Description="The LCID of the COM server."
+                  DisplayName="Locale">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="COMReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <StringProperty Name="Name"
                   ReadOnly="True"
@@ -136,10 +165,24 @@
                   ReadOnly="True" />
 
   <IntProperty Name="VersionMajor"
-               Visible="False" />
+               DisplayName="Major Version">
+    <IntProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="COMReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </IntProperty.DataSource>
+  </IntProperty>
 
   <IntProperty Name="VersionMinor"
-               Visible="False" />
+               DisplayName="Minor Version">
+    <IntProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="COMReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </IntProperty.DataSource>
+  </IntProperty>
 
   <BoolProperty Name="Visible"
                 ReadOnly="True"
@@ -150,6 +193,13 @@
                 Visible="false" />
 
   <StringProperty Name="WrapperTool"
-                  Visible="False" />
+                  DisplayName="Wrapper Tool">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="COMReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
@@ -28,7 +28,7 @@
 
   <StringProperty Name="ExcludeAssets"
                   Description="Assets to exclude from this reference."
-                  DisplayName="ExcludeAssets">
+                  DisplayName="Excluded Assets">
     <StringProperty.DataSource>
       <DataSource HasConfigurationCondition="False"
                   ItemType="PackageReference"
@@ -39,7 +39,7 @@
 
   <BoolProperty Name="GeneratePathProperty"
                 Description="Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'."
-                DisplayName="Generate path property">
+                DisplayName="Generate Path Property">
     <BoolProperty.DataSource>
       <DataSource HasConfigurationCondition="False"
                   ItemType="PackageReference"
@@ -50,7 +50,7 @@
 
   <StringProperty Name="IncludeAssets"
                   Description="Assets to include from this reference."
-                  DisplayName="IncludeAssets">
+                  DisplayName="Included Assets">
     <StringProperty.DataSource>
       <DataSource HasConfigurationCondition="False"
                   ItemType="PackageReference"
@@ -69,7 +69,7 @@
 
   <StringProperty Name="NoWarn"
                   Description="Comma-delimited list of warnings that should be suppressed for this package."
-                  DisplayName="NoWarn"
+                  DisplayName="Suppress Warnings"
                   Visible="True">
     <StringProperty.DataSource>
       <DataSource HasConfigurationCondition="False"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.cs.xlf
@@ -12,6 +12,16 @@
         <target state="needs-review-translation">Vlastnosti analyzátoru</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the analyzer assembly.</source>
+        <target state="new">Location of the analyzer assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.de.xlf
@@ -12,6 +12,16 @@
         <target state="needs-review-translation">Eigenschaften von Analysetools</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the analyzer assembly.</source>
+        <target state="new">Location of the analyzer assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.es.xlf
@@ -12,6 +12,16 @@
         <target state="needs-review-translation">Propiedades del analizador</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the analyzer assembly.</source>
+        <target state="new">Location of the analyzer assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.fr.xlf
@@ -12,6 +12,16 @@
         <target state="needs-review-translation">Propriétés de l'analyseur</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the analyzer assembly.</source>
+        <target state="new">Location of the analyzer assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.it.xlf
@@ -12,6 +12,16 @@
         <target state="needs-review-translation">Proprietà dell'analizzatore</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the analyzer assembly.</source>
+        <target state="new">Location of the analyzer assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.ja.xlf
@@ -12,6 +12,16 @@
         <target state="needs-review-translation">アナライザーのプロパティ</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the analyzer assembly.</source>
+        <target state="new">Location of the analyzer assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.ko.xlf
@@ -12,6 +12,16 @@
         <target state="needs-review-translation">분석기 속성</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the analyzer assembly.</source>
+        <target state="new">Location of the analyzer assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.pl.xlf
@@ -12,6 +12,16 @@
         <target state="needs-review-translation">Właściwości analizatora</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the analyzer assembly.</source>
+        <target state="new">Location of the analyzer assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.pt-BR.xlf
@@ -12,6 +12,16 @@
         <target state="needs-review-translation">Propriedades do Analisador</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the analyzer assembly.</source>
+        <target state="new">Location of the analyzer assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.ru.xlf
@@ -12,6 +12,16 @@
         <target state="needs-review-translation">Свойства анализатора</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the analyzer assembly.</source>
+        <target state="new">Location of the analyzer assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.tr.xlf
@@ -12,6 +12,16 @@
         <target state="needs-review-translation">Çözümleyici Özellikleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the analyzer assembly.</source>
+        <target state="new">Location of the analyzer assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.zh-Hans.xlf
@@ -12,6 +12,16 @@
         <target state="needs-review-translation">分析器属性</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the analyzer assembly.</source>
+        <target state="new">Location of the analyzer assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/AnalyzerReference.xaml.zh-Hant.xlf
@@ -12,6 +12,16 @@
         <target state="needs-review-translation">分析器屬性</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the analyzer assembly.</source>
+        <target state="new">Location of the analyzer assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.cs.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../COMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|CopyLocal|Description">
+        <source>Indicates whether the reference will be copied to the output directory.</source>
+        <target state="new">Indicates whether the reference will be copied to the output directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|CopyLocal|DisplayName">
+        <source>Copy Local</source>
+        <target state="new">Copy Local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|Description">
+        <source>Indicates whether types defined in this assembly will be embedded into the target assembly.</source>
+        <target state="new">Indicates whether types defined in this assembly will be embedded into the target assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|DisplayName">
+        <source>Embed Interop Types</source>
+        <target state="new">Embed Interop Types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ComReference|DisplayName">
         <source>COM Reference</source>
         <target state="translated">Odkaz na model COM</target>
@@ -12,6 +32,16 @@
         <target state="translated">Vlastnosti odkazu na model COM</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to this reference.</source>
+        <target state="new">A comma-delimited list of aliases to this reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Guid|DisplayName">
         <source>CLSID</source>
         <target state="translated">CLSID</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|Guid|Description">
         <source>The GUID of the COM server.</source>
         <target state="translated">Identifikátor GUID serveru COM</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
+        <target state="new">Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|DisplayName">
+        <source>Identity</source>
+        <target state="new">Identity</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Lcid|DisplayName">
@@ -40,6 +80,26 @@
       <trans-unit id="IntProperty|VersionMinor|DisplayName">
         <source>Minor Version</source>
         <target state="translated">Podverze</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the file being referenced.</source>
+        <target state="new">Location of the file being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|Description">
+        <source>Version of reference.</source>
+        <target state="new">Version of reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WrapperTool|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.de.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../COMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|CopyLocal|Description">
+        <source>Indicates whether the reference will be copied to the output directory.</source>
+        <target state="new">Indicates whether the reference will be copied to the output directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|CopyLocal|DisplayName">
+        <source>Copy Local</source>
+        <target state="new">Copy Local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|Description">
+        <source>Indicates whether types defined in this assembly will be embedded into the target assembly.</source>
+        <target state="new">Indicates whether types defined in this assembly will be embedded into the target assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|DisplayName">
+        <source>Embed Interop Types</source>
+        <target state="new">Embed Interop Types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ComReference|DisplayName">
         <source>COM Reference</source>
         <target state="translated">COM-Verweis</target>
@@ -12,6 +32,16 @@
         <target state="translated">Eigenschaften für COM-Verweis</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to this reference.</source>
+        <target state="new">A comma-delimited list of aliases to this reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Guid|DisplayName">
         <source>CLSID</source>
         <target state="translated">CLSID</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|Guid|Description">
         <source>The GUID of the COM server.</source>
         <target state="translated">Die GUID des COM-Servers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
+        <target state="new">Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|DisplayName">
+        <source>Identity</source>
+        <target state="new">Identity</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Lcid|DisplayName">
@@ -40,6 +80,26 @@
       <trans-unit id="IntProperty|VersionMinor|DisplayName">
         <source>Minor Version</source>
         <target state="translated">Nebenversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the file being referenced.</source>
+        <target state="new">Location of the file being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|Description">
+        <source>Version of reference.</source>
+        <target state="new">Version of reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WrapperTool|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.es.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../COMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|CopyLocal|Description">
+        <source>Indicates whether the reference will be copied to the output directory.</source>
+        <target state="new">Indicates whether the reference will be copied to the output directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|CopyLocal|DisplayName">
+        <source>Copy Local</source>
+        <target state="new">Copy Local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|Description">
+        <source>Indicates whether types defined in this assembly will be embedded into the target assembly.</source>
+        <target state="new">Indicates whether types defined in this assembly will be embedded into the target assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|DisplayName">
+        <source>Embed Interop Types</source>
+        <target state="new">Embed Interop Types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ComReference|DisplayName">
         <source>COM Reference</source>
         <target state="translated">Referencia COM</target>
@@ -12,6 +32,16 @@
         <target state="translated">Propiedades de referencia COM</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to this reference.</source>
+        <target state="new">A comma-delimited list of aliases to this reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Guid|DisplayName">
         <source>CLSID</source>
         <target state="translated">CLSID</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|Guid|Description">
         <source>The GUID of the COM server.</source>
         <target state="translated">GUID del servidor COM.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
+        <target state="new">Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|DisplayName">
+        <source>Identity</source>
+        <target state="new">Identity</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Lcid|DisplayName">
@@ -40,6 +80,26 @@
       <trans-unit id="IntProperty|VersionMinor|DisplayName">
         <source>Minor Version</source>
         <target state="translated">Versión secundaria</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the file being referenced.</source>
+        <target state="new">Location of the file being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|Description">
+        <source>Version of reference.</source>
+        <target state="new">Version of reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WrapperTool|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.fr.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../COMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|CopyLocal|Description">
+        <source>Indicates whether the reference will be copied to the output directory.</source>
+        <target state="new">Indicates whether the reference will be copied to the output directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|CopyLocal|DisplayName">
+        <source>Copy Local</source>
+        <target state="new">Copy Local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|Description">
+        <source>Indicates whether types defined in this assembly will be embedded into the target assembly.</source>
+        <target state="new">Indicates whether types defined in this assembly will be embedded into the target assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|DisplayName">
+        <source>Embed Interop Types</source>
+        <target state="new">Embed Interop Types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ComReference|DisplayName">
         <source>COM Reference</source>
         <target state="translated">Référence COM</target>
@@ -12,6 +32,16 @@
         <target state="translated">Propriétés de la référence COM</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to this reference.</source>
+        <target state="new">A comma-delimited list of aliases to this reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Guid|DisplayName">
         <source>CLSID</source>
         <target state="translated">CLSID</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|Guid|Description">
         <source>The GUID of the COM server.</source>
         <target state="translated">GUID du serveur COM.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
+        <target state="new">Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|DisplayName">
+        <source>Identity</source>
+        <target state="new">Identity</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Lcid|DisplayName">
@@ -40,6 +80,26 @@
       <trans-unit id="IntProperty|VersionMinor|DisplayName">
         <source>Minor Version</source>
         <target state="translated">Version mineure</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the file being referenced.</source>
+        <target state="new">Location of the file being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|Description">
+        <source>Version of reference.</source>
+        <target state="new">Version of reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WrapperTool|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.it.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../COMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|CopyLocal|Description">
+        <source>Indicates whether the reference will be copied to the output directory.</source>
+        <target state="new">Indicates whether the reference will be copied to the output directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|CopyLocal|DisplayName">
+        <source>Copy Local</source>
+        <target state="new">Copy Local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|Description">
+        <source>Indicates whether types defined in this assembly will be embedded into the target assembly.</source>
+        <target state="new">Indicates whether types defined in this assembly will be embedded into the target assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|DisplayName">
+        <source>Embed Interop Types</source>
+        <target state="new">Embed Interop Types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ComReference|DisplayName">
         <source>COM Reference</source>
         <target state="translated">Riferimento COM</target>
@@ -12,6 +32,16 @@
         <target state="translated">Proprietà del riferimento COM</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to this reference.</source>
+        <target state="new">A comma-delimited list of aliases to this reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Guid|DisplayName">
         <source>CLSID</source>
         <target state="translated">CLSID</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|Guid|Description">
         <source>The GUID of the COM server.</source>
         <target state="translated">GUID del server COM.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
+        <target state="new">Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|DisplayName">
+        <source>Identity</source>
+        <target state="new">Identity</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Lcid|DisplayName">
@@ -40,6 +80,26 @@
       <trans-unit id="IntProperty|VersionMinor|DisplayName">
         <source>Minor Version</source>
         <target state="translated">Numero di versione secondario</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the file being referenced.</source>
+        <target state="new">Location of the file being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|Description">
+        <source>Version of reference.</source>
+        <target state="new">Version of reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WrapperTool|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.ja.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../COMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|CopyLocal|Description">
+        <source>Indicates whether the reference will be copied to the output directory.</source>
+        <target state="new">Indicates whether the reference will be copied to the output directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|CopyLocal|DisplayName">
+        <source>Copy Local</source>
+        <target state="new">Copy Local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|Description">
+        <source>Indicates whether types defined in this assembly will be embedded into the target assembly.</source>
+        <target state="new">Indicates whether types defined in this assembly will be embedded into the target assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|DisplayName">
+        <source>Embed Interop Types</source>
+        <target state="new">Embed Interop Types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ComReference|DisplayName">
         <source>COM Reference</source>
         <target state="translated">COM 参照</target>
@@ -12,6 +32,16 @@
         <target state="translated">COM 参照のプロパティ</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to this reference.</source>
+        <target state="new">A comma-delimited list of aliases to this reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Guid|DisplayName">
         <source>CLSID</source>
         <target state="translated">CLSID</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|Guid|Description">
         <source>The GUID of the COM server.</source>
         <target state="translated">COM サーバーの GUID です。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
+        <target state="new">Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|DisplayName">
+        <source>Identity</source>
+        <target state="new">Identity</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Lcid|DisplayName">
@@ -40,6 +80,26 @@
       <trans-unit id="IntProperty|VersionMinor|DisplayName">
         <source>Minor Version</source>
         <target state="translated">マイナー バージョン</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the file being referenced.</source>
+        <target state="new">Location of the file being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|Description">
+        <source>Version of reference.</source>
+        <target state="new">Version of reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WrapperTool|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.ko.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../COMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|CopyLocal|Description">
+        <source>Indicates whether the reference will be copied to the output directory.</source>
+        <target state="new">Indicates whether the reference will be copied to the output directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|CopyLocal|DisplayName">
+        <source>Copy Local</source>
+        <target state="new">Copy Local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|Description">
+        <source>Indicates whether types defined in this assembly will be embedded into the target assembly.</source>
+        <target state="new">Indicates whether types defined in this assembly will be embedded into the target assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|DisplayName">
+        <source>Embed Interop Types</source>
+        <target state="new">Embed Interop Types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ComReference|DisplayName">
         <source>COM Reference</source>
         <target state="translated">COM 참조</target>
@@ -12,6 +32,16 @@
         <target state="translated">COM 참조 속성</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to this reference.</source>
+        <target state="new">A comma-delimited list of aliases to this reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Guid|DisplayName">
         <source>CLSID</source>
         <target state="translated">CLSID</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|Guid|Description">
         <source>The GUID of the COM server.</source>
         <target state="translated">COM 서버의 GUID입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
+        <target state="new">Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|DisplayName">
+        <source>Identity</source>
+        <target state="new">Identity</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Lcid|DisplayName">
@@ -40,6 +80,26 @@
       <trans-unit id="IntProperty|VersionMinor|DisplayName">
         <source>Minor Version</source>
         <target state="translated">부 버전</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the file being referenced.</source>
+        <target state="new">Location of the file being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|Description">
+        <source>Version of reference.</source>
+        <target state="new">Version of reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WrapperTool|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.pl.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../COMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|CopyLocal|Description">
+        <source>Indicates whether the reference will be copied to the output directory.</source>
+        <target state="new">Indicates whether the reference will be copied to the output directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|CopyLocal|DisplayName">
+        <source>Copy Local</source>
+        <target state="new">Copy Local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|Description">
+        <source>Indicates whether types defined in this assembly will be embedded into the target assembly.</source>
+        <target state="new">Indicates whether types defined in this assembly will be embedded into the target assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|DisplayName">
+        <source>Embed Interop Types</source>
+        <target state="new">Embed Interop Types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ComReference|DisplayName">
         <source>COM Reference</source>
         <target state="translated">Odwołanie COM</target>
@@ -12,6 +32,16 @@
         <target state="translated">Właściwości odwołania COM</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to this reference.</source>
+        <target state="new">A comma-delimited list of aliases to this reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Guid|DisplayName">
         <source>CLSID</source>
         <target state="translated">CLSID</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|Guid|Description">
         <source>The GUID of the COM server.</source>
         <target state="translated">Identyfikator GUID serwera COM.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
+        <target state="new">Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|DisplayName">
+        <source>Identity</source>
+        <target state="new">Identity</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Lcid|DisplayName">
@@ -40,6 +80,26 @@
       <trans-unit id="IntProperty|VersionMinor|DisplayName">
         <source>Minor Version</source>
         <target state="translated">Wersja pomocnicza</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the file being referenced.</source>
+        <target state="new">Location of the file being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|Description">
+        <source>Version of reference.</source>
+        <target state="new">Version of reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WrapperTool|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.pt-BR.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../COMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|CopyLocal|Description">
+        <source>Indicates whether the reference will be copied to the output directory.</source>
+        <target state="new">Indicates whether the reference will be copied to the output directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|CopyLocal|DisplayName">
+        <source>Copy Local</source>
+        <target state="new">Copy Local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|Description">
+        <source>Indicates whether types defined in this assembly will be embedded into the target assembly.</source>
+        <target state="new">Indicates whether types defined in this assembly will be embedded into the target assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|DisplayName">
+        <source>Embed Interop Types</source>
+        <target state="new">Embed Interop Types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ComReference|DisplayName">
         <source>COM Reference</source>
         <target state="translated">Referência COM</target>
@@ -12,6 +32,16 @@
         <target state="translated">Propriedades de Referência COM</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to this reference.</source>
+        <target state="new">A comma-delimited list of aliases to this reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Guid|DisplayName">
         <source>CLSID</source>
         <target state="translated">CLSID</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|Guid|Description">
         <source>The GUID of the COM server.</source>
         <target state="translated">O GUID do servidor COM.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
+        <target state="new">Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|DisplayName">
+        <source>Identity</source>
+        <target state="new">Identity</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Lcid|DisplayName">
@@ -40,6 +80,26 @@
       <trans-unit id="IntProperty|VersionMinor|DisplayName">
         <source>Minor Version</source>
         <target state="translated">Versão Secundária </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the file being referenced.</source>
+        <target state="new">Location of the file being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|Description">
+        <source>Version of reference.</source>
+        <target state="new">Version of reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WrapperTool|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.ru.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../COMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|CopyLocal|Description">
+        <source>Indicates whether the reference will be copied to the output directory.</source>
+        <target state="new">Indicates whether the reference will be copied to the output directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|CopyLocal|DisplayName">
+        <source>Copy Local</source>
+        <target state="new">Copy Local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|Description">
+        <source>Indicates whether types defined in this assembly will be embedded into the target assembly.</source>
+        <target state="new">Indicates whether types defined in this assembly will be embedded into the target assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|DisplayName">
+        <source>Embed Interop Types</source>
+        <target state="new">Embed Interop Types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ComReference|DisplayName">
         <source>COM Reference</source>
         <target state="translated">Ссылка COM</target>
@@ -12,6 +32,16 @@
         <target state="translated">Свойства ссылки COM</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to this reference.</source>
+        <target state="new">A comma-delimited list of aliases to this reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Guid|DisplayName">
         <source>CLSID</source>
         <target state="translated">CLSID</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|Guid|Description">
         <source>The GUID of the COM server.</source>
         <target state="translated">Идентификатор GUID COM-сервера.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
+        <target state="new">Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|DisplayName">
+        <source>Identity</source>
+        <target state="new">Identity</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Lcid|DisplayName">
@@ -40,6 +80,26 @@
       <trans-unit id="IntProperty|VersionMinor|DisplayName">
         <source>Minor Version</source>
         <target state="translated">Дополнительный номер версии</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the file being referenced.</source>
+        <target state="new">Location of the file being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|Description">
+        <source>Version of reference.</source>
+        <target state="new">Version of reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WrapperTool|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.tr.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../COMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|CopyLocal|Description">
+        <source>Indicates whether the reference will be copied to the output directory.</source>
+        <target state="new">Indicates whether the reference will be copied to the output directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|CopyLocal|DisplayName">
+        <source>Copy Local</source>
+        <target state="new">Copy Local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|Description">
+        <source>Indicates whether types defined in this assembly will be embedded into the target assembly.</source>
+        <target state="new">Indicates whether types defined in this assembly will be embedded into the target assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|DisplayName">
+        <source>Embed Interop Types</source>
+        <target state="new">Embed Interop Types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ComReference|DisplayName">
         <source>COM Reference</source>
         <target state="translated">COM Başvurusu</target>
@@ -12,6 +32,16 @@
         <target state="translated">COM Başvurusu Özellikleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to this reference.</source>
+        <target state="new">A comma-delimited list of aliases to this reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Guid|DisplayName">
         <source>CLSID</source>
         <target state="translated">CLSID</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|Guid|Description">
         <source>The GUID of the COM server.</source>
         <target state="translated">COM sunucusunun GUID'i.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
+        <target state="new">Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|DisplayName">
+        <source>Identity</source>
+        <target state="new">Identity</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Lcid|DisplayName">
@@ -40,6 +80,26 @@
       <trans-unit id="IntProperty|VersionMinor|DisplayName">
         <source>Minor Version</source>
         <target state="translated">İkincil Sürüm </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the file being referenced.</source>
+        <target state="new">Location of the file being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|Description">
+        <source>Version of reference.</source>
+        <target state="new">Version of reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WrapperTool|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.zh-Hans.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../COMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|CopyLocal|Description">
+        <source>Indicates whether the reference will be copied to the output directory.</source>
+        <target state="new">Indicates whether the reference will be copied to the output directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|CopyLocal|DisplayName">
+        <source>Copy Local</source>
+        <target state="new">Copy Local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|Description">
+        <source>Indicates whether types defined in this assembly will be embedded into the target assembly.</source>
+        <target state="new">Indicates whether types defined in this assembly will be embedded into the target assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|DisplayName">
+        <source>Embed Interop Types</source>
+        <target state="new">Embed Interop Types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ComReference|DisplayName">
         <source>COM Reference</source>
         <target state="translated">COM 引用</target>
@@ -12,6 +32,16 @@
         <target state="translated">COM 引用属性</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to this reference.</source>
+        <target state="new">A comma-delimited list of aliases to this reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Guid|DisplayName">
         <source>CLSID</source>
         <target state="translated">CLSID</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|Guid|Description">
         <source>The GUID of the COM server.</source>
         <target state="translated">COM 服务器的 GUID。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
+        <target state="new">Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|DisplayName">
+        <source>Identity</source>
+        <target state="new">Identity</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Lcid|DisplayName">
@@ -40,6 +80,26 @@
       <trans-unit id="IntProperty|VersionMinor|DisplayName">
         <source>Minor Version</source>
         <target state="translated">次版本</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the file being referenced.</source>
+        <target state="new">Location of the file being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|Description">
+        <source>Version of reference.</source>
+        <target state="new">Version of reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WrapperTool|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ComReference.xaml.zh-Hant.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../COMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|CopyLocal|Description">
+        <source>Indicates whether the reference will be copied to the output directory.</source>
+        <target state="new">Indicates whether the reference will be copied to the output directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|CopyLocal|DisplayName">
+        <source>Copy Local</source>
+        <target state="new">Copy Local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|Description">
+        <source>Indicates whether types defined in this assembly will be embedded into the target assembly.</source>
+        <target state="new">Indicates whether types defined in this assembly will be embedded into the target assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|EmbedInteropTypes|DisplayName">
+        <source>Embed Interop Types</source>
+        <target state="new">Embed Interop Types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ComReference|DisplayName">
         <source>COM Reference</source>
         <target state="translated">COM 參考</target>
@@ -12,6 +32,16 @@
         <target state="translated">COM 參考屬性</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|Description">
+        <source>A comma-delimited list of aliases to this reference.</source>
+        <target state="new">A comma-delimited list of aliases to this reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringListProperty|Aliases|DisplayName">
+        <source>Aliases</source>
+        <target state="new">Aliases</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Guid|DisplayName">
         <source>CLSID</source>
         <target state="translated">CLSID</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|Guid|Description">
         <source>The GUID of the COM server.</source>
         <target state="translated">COM 伺服器的 GUID。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
+        <target state="new">Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|DisplayName">
+        <source>Identity</source>
+        <target state="new">Identity</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Lcid|DisplayName">
@@ -40,6 +80,26 @@
       <trans-unit id="IntProperty|VersionMinor|DisplayName">
         <source>Minor Version</source>
         <target state="translated">次要版本</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|Description">
+        <source>Location of the file being referenced.</source>
+        <target state="new">Location of the file being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ResolvedPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|Description">
+        <source>Version of reference.</source>
+        <target state="new">Version of reference.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WrapperTool|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.cs.xlf
@@ -12,6 +12,21 @@
         <target state="translated">Odkaz na rozhraní</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Profile|DisplayName">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.de.xlf
@@ -12,6 +12,21 @@
         <target state="translated">Frameworkverweis</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Profile|DisplayName">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.es.xlf
@@ -12,6 +12,21 @@
         <target state="translated">Referencia de Framework</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Profile|DisplayName">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.fr.xlf
@@ -12,6 +12,21 @@
         <target state="translated">Référence de l'infrastructure</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Profile|DisplayName">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.it.xlf
@@ -12,6 +12,21 @@
         <target state="translated">Riferimento a framework</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Profile|DisplayName">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.ja.xlf
@@ -12,6 +12,21 @@
         <target state="translated">フレームワーク参照</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Profile|DisplayName">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.ko.xlf
@@ -12,6 +12,21 @@
         <target state="translated">프레임워크 참조</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Profile|DisplayName">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.pl.xlf
@@ -12,6 +12,21 @@
         <target state="translated">Odwołanie platformy</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Profile|DisplayName">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.pt-BR.xlf
@@ -12,6 +12,21 @@
         <target state="translated">Referência do Framework</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Profile|DisplayName">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.ru.xlf
@@ -12,6 +12,21 @@
         <target state="translated">Ссылка на платформу</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Profile|DisplayName">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.tr.xlf
@@ -12,6 +12,21 @@
         <target state="translated">Framework Başvurusu</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Profile|DisplayName">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.zh-Hans.xlf
@@ -12,6 +12,21 @@
         <target state="translated">框架引用</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Profile|DisplayName">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.zh-Hant.xlf
@@ -12,6 +12,21 @@
         <target state="translated">Framework 參考</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Profile|DisplayName">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.cs.xlf
@@ -27,6 +27,16 @@
         <target state="new">Name</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Path|Description">
+        <source>Location of the package being referenced.</source>
+        <target state="new">Location of the package being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Verze</target>
@@ -38,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>Included assets</source>
-        <target state="translated">Zahrnuté prostředky</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">Zahrnuté prostředky</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -48,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>Excluded assets</source>
-        <target state="translated">Vyloučené prostředky</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">Vyloučené prostředky</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -58,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private assets</source>
-        <target state="translated">Privátní prostředky</target>
+        <source>Private Assets</source>
+        <target state="needs-review-translation">Privátní prostředky</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Potlačit upozornění</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">Potlačit upozornění</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -78,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Generovat vlastnost cesty</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Generovat vlastnost cesty</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.de.xlf
@@ -27,6 +27,16 @@
         <target state="new">Name</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Path|Description">
+        <source>Location of the package being referenced.</source>
+        <target state="new">Location of the package being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Version</target>
@@ -38,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>Included assets</source>
-        <target state="translated">Enthaltene Assets</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">Enthaltene Assets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -48,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>Excluded assets</source>
-        <target state="translated">Ausgeschlossene Assets</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">Ausgeschlossene Assets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -58,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private assets</source>
-        <target state="translated">Private Objekte</target>
+        <source>Private Assets</source>
+        <target state="needs-review-translation">Private Objekte</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Warnungen unterdrücken</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">Warnungen unterdrücken</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -78,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Pfadeigenschaft generieren</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Pfadeigenschaft generieren</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.es.xlf
@@ -27,6 +27,16 @@
         <target state="new">Name</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Path|Description">
+        <source>Location of the package being referenced.</source>
+        <target state="new">Location of the package being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Versión</target>
@@ -38,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>Included assets</source>
-        <target state="translated">Recursos incluidos</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">Recursos incluidos</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -48,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>Excluded assets</source>
-        <target state="translated">Recursos excluidos</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">Recursos excluidos</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -58,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private assets</source>
-        <target state="translated">Recursos privados</target>
+        <source>Private Assets</source>
+        <target state="needs-review-translation">Recursos privados</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Suprimir las advertencias</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">Suprimir las advertencias</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -78,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Generar la propiedad path</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Generar la propiedad path</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.fr.xlf
@@ -27,6 +27,16 @@
         <target state="new">Name</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Path|Description">
+        <source>Location of the package being referenced.</source>
+        <target state="new">Location of the package being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Version</target>
@@ -38,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>Included assets</source>
-        <target state="translated">Ressources incluses</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">Ressources incluses</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -48,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>Excluded assets</source>
-        <target state="translated">Ressources exclues</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">Ressources exclues</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -58,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private assets</source>
-        <target state="translated">Ressources privées</target>
+        <source>Private Assets</source>
+        <target state="needs-review-translation">Ressources privées</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Supprimer les avertissements</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">Supprimer les avertissements</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -78,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Générer la propriété path</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Générer la propriété path</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.it.xlf
@@ -27,6 +27,16 @@
         <target state="new">Name</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Path|Description">
+        <source>Location of the package being referenced.</source>
+        <target state="new">Location of the package being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Versione</target>
@@ -38,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>Included assets</source>
-        <target state="translated">Asset inclusi</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">Asset inclusi</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -48,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>Excluded assets</source>
-        <target state="translated">Asset esclusi</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">Asset esclusi</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -58,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private assets</source>
-        <target state="translated">Asset privati</target>
+        <source>Private Assets</source>
+        <target state="needs-review-translation">Asset privati</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Non visualizzare avvisi</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">Non visualizzare avvisi</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -78,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Genera la proprietà Path</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Genera la proprietà Path</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ja.xlf
@@ -27,6 +27,16 @@
         <target state="new">Name</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Path|Description">
+        <source>Location of the package being referenced.</source>
+        <target state="new">Location of the package being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">バージョン</target>
@@ -38,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>Included assets</source>
-        <target state="translated">含まれている資産</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">含まれている資産</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -48,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>Excluded assets</source>
-        <target state="translated">除外された資産</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">除外された資産</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -58,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private assets</source>
-        <target state="translated">プライベート資産</target>
+        <source>Private Assets</source>
+        <target state="needs-review-translation">プライベート資産</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">警告の抑制</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">警告の抑制</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -78,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">パス プロパティを生成します</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">パス プロパティを生成します</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ko.xlf
@@ -27,6 +27,16 @@
         <target state="new">Name</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Path|Description">
+        <source>Location of the package being referenced.</source>
+        <target state="new">Location of the package being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">버전</target>
@@ -38,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>Included assets</source>
-        <target state="translated">포함된 자산</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">포함된 자산</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -48,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>Excluded assets</source>
-        <target state="translated">제외된 자산</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">제외된 자산</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -58,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private assets</source>
-        <target state="translated">Private 자산</target>
+        <source>Private Assets</source>
+        <target state="needs-review-translation">Private 자산</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">경고 표시 안 함</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">경고 표시 안 함</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -78,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">경로 속성 생성</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">경로 속성 생성</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pl.xlf
@@ -27,6 +27,16 @@
         <target state="new">Name</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Path|Description">
+        <source>Location of the package being referenced.</source>
+        <target state="new">Location of the package being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Wersja</target>
@@ -38,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>Included assets</source>
-        <target state="translated">Uwzględnione zasoby</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">Uwzględnione zasoby</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -48,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>Excluded assets</source>
-        <target state="translated">Wykluczone zasoby</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">Wykluczone zasoby</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -58,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private assets</source>
-        <target state="translated">Zasoby prywatne</target>
+        <source>Private Assets</source>
+        <target state="needs-review-translation">Zasoby prywatne</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Pomiń ostrzeżenia</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">Pomiń ostrzeżenia</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -78,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Generuj właściwość ścieżki</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Generuj właściwość ścieżki</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pt-BR.xlf
@@ -27,6 +27,16 @@
         <target state="new">Name</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Path|Description">
+        <source>Location of the package being referenced.</source>
+        <target state="new">Location of the package being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Versão</target>
@@ -38,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>Included assets</source>
-        <target state="translated">Ativos incluídos</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">Ativos incluídos</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -48,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>Excluded assets</source>
-        <target state="translated">Bens excluídos</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">Bens excluídos</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -58,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private assets</source>
-        <target state="translated">Bens particulares</target>
+        <source>Private Assets</source>
+        <target state="needs-review-translation">Bens particulares</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Suprimir avisos</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">Suprimir avisos</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -78,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Gerar propriedade do caminho</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Gerar propriedade do caminho</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ru.xlf
@@ -27,6 +27,16 @@
         <target state="new">Name</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Path|Description">
+        <source>Location of the package being referenced.</source>
+        <target state="new">Location of the package being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Версия</target>
@@ -38,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>Included assets</source>
-        <target state="translated">Включенные ресурсы</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">Включенные ресурсы</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -48,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>Excluded assets</source>
-        <target state="translated">Исключенные ресурсы</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">Исключенные ресурсы</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -58,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private assets</source>
-        <target state="translated">Закрытые ресурсы</target>
+        <source>Private Assets</source>
+        <target state="needs-review-translation">Закрытые ресурсы</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Отключить предупреждения</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">Отключить предупреждения</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -78,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Создать свойство пути</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Создать свойство пути</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.tr.xlf
@@ -27,6 +27,16 @@
         <target state="new">Name</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Path|Description">
+        <source>Location of the package being referenced.</source>
+        <target state="new">Location of the package being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Sürüm</target>
@@ -38,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>Included assets</source>
-        <target state="translated">Dahil edilen varlıklar</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">Dahil edilen varlıklar</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -48,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>Excluded assets</source>
-        <target state="translated">Hariç tutulan varlıklar</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">Hariç tutulan varlıklar</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -58,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private assets</source>
-        <target state="translated">Özel varlıklar</target>
+        <source>Private Assets</source>
+        <target state="needs-review-translation">Özel varlıklar</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Uyarıları Gizle</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">Uyarıları Gizle</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -78,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Yol özelliği oluştur</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Yol özelliği oluştur</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hans.xlf
@@ -27,6 +27,16 @@
         <target state="new">Name</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Path|Description">
+        <source>Location of the package being referenced.</source>
+        <target state="new">Location of the package being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">版本</target>
@@ -38,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>Included assets</source>
-        <target state="translated">包含的资产</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">包含的资产</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -48,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>Excluded assets</source>
-        <target state="translated">排除资产</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">排除资产</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -58,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private assets</source>
-        <target state="translated">私有资产</target>
+        <source>Private Assets</source>
+        <target state="needs-review-translation">私有资产</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">取消显示警告</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">取消显示警告</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -78,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">生成路径属性</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">生成路径属性</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hant.xlf
@@ -27,6 +27,16 @@
         <target state="new">Name</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Path|Description">
+        <source>Location of the package being referenced.</source>
+        <target state="new">Location of the package being referenced.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">版本</target>
@@ -38,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>Included assets</source>
-        <target state="translated">包含的資產</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">包含的資產</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -48,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>Excluded assets</source>
-        <target state="translated">排除的資產</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">排除的資產</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -58,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private assets</source>
-        <target state="translated">私用資產</target>
+        <source>Private Assets</source>
+        <target state="needs-review-translation">私用資產</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">隱藏警告</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">隱藏警告</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -78,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">產生路徑屬性</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">產生路徑屬性</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.cs.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../ResolvedCOMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
         <source>COM Reference</source>
         <target state="needs-review-translation">Rozpoznaný odkaz modelu COM</target>
@@ -57,6 +72,16 @@
         <target state="translated">Nativní sestavení</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Guid|Description">
+        <source>The GUID of the COM server.</source>
+        <target state="new">The GUID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Guid|DisplayName">
+        <source>CLSID</source>
+        <target state="new">CLSID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Identity|DisplayName">
         <source>Identity</source>
         <target state="translated">Identita</target>
@@ -65,6 +90,16 @@
       <trans-unit id="StringProperty|Identity|Description">
         <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
         <target state="translated">Identita zabezpečení odkazovaného sestavení (viz System.Reflection.Assembly.Evidence nebo System.Security.Policy.Evidence)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|Description">
+        <source>The LCID of the COM server.</source>
+        <target state="new">The LCID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|DisplayName">
+        <source>Locale</source>
+        <target state="new">Locale</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">
@@ -85,6 +120,11 @@
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of reference.</source>
         <target state="translated">Verze odkazu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.de.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../ResolvedCOMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
         <source>COM Reference</source>
         <target state="needs-review-translation">Aufgelöster COM-Verweis</target>
@@ -57,6 +72,16 @@
         <target state="translated">Native Assembly</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Guid|Description">
+        <source>The GUID of the COM server.</source>
+        <target state="new">The GUID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Guid|DisplayName">
+        <source>CLSID</source>
+        <target state="new">CLSID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Identity|DisplayName">
         <source>Identity</source>
         <target state="translated">Identität</target>
@@ -65,6 +90,16 @@
       <trans-unit id="StringProperty|Identity|Description">
         <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
         <target state="translated">Sicherheits-ID der referenzierten Assembly (siehe System.Reflection.Assembly.Evidence oder System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|Description">
+        <source>The LCID of the COM server.</source>
+        <target state="new">The LCID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|DisplayName">
+        <source>Locale</source>
+        <target state="new">Locale</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">
@@ -85,6 +120,11 @@
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of reference.</source>
         <target state="translated">Verweisversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.es.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../ResolvedCOMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
         <source>COM Reference</source>
         <target state="needs-review-translation">Referencia COM resuelta</target>
@@ -57,6 +72,16 @@
         <target state="translated">Ensamblado nativo</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Guid|Description">
+        <source>The GUID of the COM server.</source>
+        <target state="new">The GUID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Guid|DisplayName">
+        <source>CLSID</source>
+        <target state="new">CLSID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Identity|DisplayName">
         <source>Identity</source>
         <target state="translated">Identidad</target>
@@ -65,6 +90,16 @@
       <trans-unit id="StringProperty|Identity|Description">
         <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
         <target state="translated">Identidad de seguridad del ensamblado al que se hace referencia (vea System.Reflection.Assembly.Evidence o System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|Description">
+        <source>The LCID of the COM server.</source>
+        <target state="new">The LCID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|DisplayName">
+        <source>Locale</source>
+        <target state="new">Locale</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">
@@ -85,6 +120,11 @@
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of reference.</source>
         <target state="translated">Versión de referencia.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.fr.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../ResolvedCOMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
         <source>COM Reference</source>
         <target state="needs-review-translation">Référence COM résolue</target>
@@ -57,6 +72,16 @@
         <target state="translated">Assembly natif</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Guid|Description">
+        <source>The GUID of the COM server.</source>
+        <target state="new">The GUID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Guid|DisplayName">
+        <source>CLSID</source>
+        <target state="new">CLSID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Identity|DisplayName">
         <source>Identity</source>
         <target state="translated">Identité</target>
@@ -65,6 +90,16 @@
       <trans-unit id="StringProperty|Identity|Description">
         <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
         <target state="translated">Identité de sécurité de l'assembly référencé (consultez System.Reflection.Assembly.Evidence ou System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|Description">
+        <source>The LCID of the COM server.</source>
+        <target state="new">The LCID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|DisplayName">
+        <source>Locale</source>
+        <target state="new">Locale</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">
@@ -85,6 +120,11 @@
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of reference.</source>
         <target state="translated">Version de référence.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.it.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../ResolvedCOMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
         <source>COM Reference</source>
         <target state="needs-review-translation">Riferimento COM risolto</target>
@@ -57,6 +72,16 @@
         <target state="translated">Assembly nativo</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Guid|Description">
+        <source>The GUID of the COM server.</source>
+        <target state="new">The GUID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Guid|DisplayName">
+        <source>CLSID</source>
+        <target state="new">CLSID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Identity|DisplayName">
         <source>Identity</source>
         <target state="translated">Identità</target>
@@ -65,6 +90,16 @@
       <trans-unit id="StringProperty|Identity|Description">
         <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
         <target state="translated">Identità di sicurezza dell'assembly a cui viene fatto riferimento (vedere System.Reflection.Assembly.Evidence o System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|Description">
+        <source>The LCID of the COM server.</source>
+        <target state="new">The LCID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|DisplayName">
+        <source>Locale</source>
+        <target state="new">Locale</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">
@@ -85,6 +120,11 @@
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of reference.</source>
         <target state="translated">Versione del riferimento.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.ja.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../ResolvedCOMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
         <source>COM Reference</source>
         <target state="needs-review-translation">解決された COM 参照</target>
@@ -57,6 +72,16 @@
         <target state="translated">ネイティブ アセンブリ</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Guid|Description">
+        <source>The GUID of the COM server.</source>
+        <target state="new">The GUID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Guid|DisplayName">
+        <source>CLSID</source>
+        <target state="new">CLSID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Identity|DisplayName">
         <source>Identity</source>
         <target state="translated">ID</target>
@@ -65,6 +90,16 @@
       <trans-unit id="StringProperty|Identity|Description">
         <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
         <target state="translated">参照されたアセンブリのセキュリティ ID です。System.Reflection.Assembly.Evidence または System.Security.Policy.Evidence を参照してください。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|Description">
+        <source>The LCID of the COM server.</source>
+        <target state="new">The LCID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|DisplayName">
+        <source>Locale</source>
+        <target state="new">Locale</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">
@@ -85,6 +120,11 @@
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of reference.</source>
         <target state="translated">参照のバージョンです。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.ko.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../ResolvedCOMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
         <source>COM Reference</source>
         <target state="needs-review-translation">확인된 COM 참조</target>
@@ -57,6 +72,16 @@
         <target state="translated">네이티브 어셈블리</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Guid|Description">
+        <source>The GUID of the COM server.</source>
+        <target state="new">The GUID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Guid|DisplayName">
+        <source>CLSID</source>
+        <target state="new">CLSID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Identity|DisplayName">
         <source>Identity</source>
         <target state="translated">ID</target>
@@ -65,6 +90,16 @@
       <trans-unit id="StringProperty|Identity|Description">
         <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
         <target state="translated">참조된 어셈블리의 보안 ID입니다(System.Reflection.Assembly.Evidence 또는 System.Security.Policy.Evidence 참조).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|Description">
+        <source>The LCID of the COM server.</source>
+        <target state="new">The LCID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|DisplayName">
+        <source>Locale</source>
+        <target state="new">Locale</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">
@@ -85,6 +120,11 @@
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of reference.</source>
         <target state="translated">참조의 버전입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.pl.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../ResolvedCOMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
         <source>COM Reference</source>
         <target state="needs-review-translation">Rozpoznane odwołanie COM</target>
@@ -57,6 +72,16 @@
         <target state="translated">Zestaw natywny</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Guid|Description">
+        <source>The GUID of the COM server.</source>
+        <target state="new">The GUID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Guid|DisplayName">
+        <source>CLSID</source>
+        <target state="new">CLSID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Identity|DisplayName">
         <source>Identity</source>
         <target state="translated">Tożsamość</target>
@@ -65,6 +90,16 @@
       <trans-unit id="StringProperty|Identity|Description">
         <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
         <target state="translated">Tożsamość zabezpieczeń zestawu, do którego się odwoływano (zobacz System.Reflection.Assembly.Evidence lub System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|Description">
+        <source>The LCID of the COM server.</source>
+        <target state="new">The LCID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|DisplayName">
+        <source>Locale</source>
+        <target state="new">Locale</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">
@@ -85,6 +120,11 @@
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of reference.</source>
         <target state="translated">Wersja odwołania.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.pt-BR.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ResolvedCOMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
         <source>COM Reference</source>
         <target state="needs-review-translation">Referência COM resolvida</target>
@@ -57,6 +72,16 @@
         <target state="translated">Assembly Nativo</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Guid|Description">
+        <source>The GUID of the COM server.</source>
+        <target state="new">The GUID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Guid|DisplayName">
+        <source>CLSID</source>
+        <target state="new">CLSID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Identity|DisplayName">
         <source>Identity</source>
         <target state="translated">Identidade</target>
@@ -65,6 +90,16 @@
       <trans-unit id="StringProperty|Identity|Description">
         <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
         <target state="translated">Identidade de segurança do assembly referenciado (veja System.Reflection.Assembly.Evidence ou System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|Description">
+        <source>The LCID of the COM server.</source>
+        <target state="new">The LCID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|DisplayName">
+        <source>Locale</source>
+        <target state="new">Locale</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">
@@ -85,6 +120,11 @@
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of reference.</source>
         <target state="translated">Versão de referência.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.ru.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../ResolvedCOMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
         <source>COM Reference</source>
         <target state="needs-review-translation">Разрешенная ссылка COM</target>
@@ -57,6 +72,16 @@
         <target state="translated">Машинная сборка</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Guid|Description">
+        <source>The GUID of the COM server.</source>
+        <target state="new">The GUID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Guid|DisplayName">
+        <source>CLSID</source>
+        <target state="new">CLSID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Identity|DisplayName">
         <source>Identity</source>
         <target state="translated">Идентификатор</target>
@@ -65,6 +90,16 @@
       <trans-unit id="StringProperty|Identity|Description">
         <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
         <target state="translated">Идентификатор безопасности сборки, на которую указывает ссылка (см System.Reflection.Assembly.Evidence или System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|Description">
+        <source>The LCID of the COM server.</source>
+        <target state="new">The LCID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|DisplayName">
+        <source>Locale</source>
+        <target state="new">Locale</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">
@@ -85,6 +120,11 @@
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of reference.</source>
         <target state="translated">Версия ссылочной сборки.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.tr.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../ResolvedCOMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
         <source>COM Reference</source>
         <target state="needs-review-translation">Çözümlenen COM Başvurusu</target>
@@ -57,6 +72,16 @@
         <target state="translated">Yerel Bütünleştirilmiş Kod</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Guid|Description">
+        <source>The GUID of the COM server.</source>
+        <target state="new">The GUID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Guid|DisplayName">
+        <source>CLSID</source>
+        <target state="new">CLSID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Identity|DisplayName">
         <source>Identity</source>
         <target state="translated">Kimlik</target>
@@ -65,6 +90,16 @@
       <trans-unit id="StringProperty|Identity|Description">
         <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
         <target state="translated">Başvurulan bütünleştirilmiş kodun güvenlik kimliği (bkz. System.Reflection.Assembly.Evidence veya System.Security.Policy.Evidence).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|Description">
+        <source>The LCID of the COM server.</source>
+        <target state="new">The LCID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|DisplayName">
+        <source>Locale</source>
+        <target state="new">Locale</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">
@@ -85,6 +120,11 @@
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of reference.</source>
         <target state="translated">Başvurunun sürümü.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.zh-Hans.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ResolvedCOMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
         <source>COM Reference</source>
         <target state="needs-review-translation">解析的 COM 引用</target>
@@ -57,6 +72,16 @@
         <target state="translated">本机程序集</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Guid|Description">
+        <source>The GUID of the COM server.</source>
+        <target state="new">The GUID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Guid|DisplayName">
+        <source>CLSID</source>
+        <target state="new">CLSID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Identity|DisplayName">
         <source>Identity</source>
         <target state="translated">标识</target>
@@ -65,6 +90,16 @@
       <trans-unit id="StringProperty|Identity|Description">
         <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
         <target state="translated">所引用程序集的安全标识(参见 System.Reflection.Assembly.Evidence 或 System.Security.Policy.Evidence)。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|Description">
+        <source>The LCID of the COM server.</source>
+        <target state="new">The LCID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|DisplayName">
+        <source>Locale</source>
+        <target state="new">Locale</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">
@@ -85,6 +120,11 @@
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of reference.</source>
         <target state="translated">引用的版本。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedCOMReference.xaml.zh-Hant.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ResolvedCOMReference.xaml">
     <body>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
         <source>COM Reference</source>
         <target state="needs-review-translation">已解析的 COM 參考</target>
@@ -57,6 +72,16 @@
         <target state="translated">原生組譯碼</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Guid|Description">
+        <source>The GUID of the COM server.</source>
+        <target state="new">The GUID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Guid|DisplayName">
+        <source>CLSID</source>
+        <target state="new">CLSID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|Identity|DisplayName">
         <source>Identity</source>
         <target state="translated">識別</target>
@@ -65,6 +90,16 @@
       <trans-unit id="StringProperty|Identity|Description">
         <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
         <target state="translated">參考組件的安全性識別 (請參閱 System.Reflection.Assembly.Evidence 或 System.Security.Policy.Evidence)。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|Description">
+        <source>The LCID of the COM server.</source>
+        <target state="new">The LCID of the COM server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Lcid|DisplayName">
+        <source>Locale</source>
+        <target state="new">Locale</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">
@@ -85,6 +120,11 @@
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of reference.</source>
         <target state="translated">參考的版本。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.cs.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Generovat vlastnost cesty</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Generovat vlastnost cesty</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.de.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Pfadeigenschaft generieren</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Pfadeigenschaft generieren</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.es.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Generar la propiedad path</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Generar la propiedad path</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.fr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Générer la propriété path</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Générer la propriété path</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.it.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Genera la proprietà Path</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Genera la proprietà Path</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ja.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">パス プロパティを生成します</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">パス プロパティを生成します</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ko.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">경로 속성 생성</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">경로 속성 생성</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pl.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Generuj właściwość ścieżki</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Generuj właściwość ścieżki</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">Uwzględnij zasoby</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">Uwzględnij zasoby</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">Wyklucz zasoby</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">Wyklucz zasoby</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.pt-BR.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Gerar propriedade do caminho</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Gerar propriedade do caminho</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.ru.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Создать свойство пути</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Создать свойство пути</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.tr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">Yol özelliği oluştur</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">Yol özelliği oluştur</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hans.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">生成路径属性</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">生成路径属性</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedPackageReference.xaml.zh-Hant.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
-        <source>Generate path property</source>
-        <target state="translated">產生路徑屬性</target>
+        <source>Generate Path Property</source>
+        <target state="needs-review-translation">產生路徑屬性</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Suppress Warnings</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included Assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded Assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/XamlRuleTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/XamlRuleTestBase.cs
@@ -78,5 +78,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
                 }
             }
         }
+
+        protected static IEnumerable<XElement> GetVisibleProperties(XElement rule)
+        {
+            foreach (var property in GetProperties(rule))
+            {
+                if (!string.Equals(property.Attribute("Visible")?.Value, "False", StringComparison.OrdinalIgnoreCase))
+                {
+                    yield return property;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
For every dependency type, we have a resolved and unresolved rule.

This PR ensures that both rules in every pair have the same visible properties, and that those properties have the same display name and description.

Long term we should split this so we have a single rule for the browse object with all-visible properties, and other rules for internal processing with no visible properties. That work is tracked by #5076.

Adds a unit test to ensure consistency.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6229)