### PR TITLE
Remove TODO

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/DependenciesContextMenuProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/DependenciesContextMenuProvider.cs
@@ -136,7 +136,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
 
                 if (!containsProhibited)
                 {
-                    // TODO when CPS inserts, use ContainsAny here instead
                     if (item.Flags.Contains(DependencyTreeFlags.DependencyGroup) ||
                         item.Flags.Contains(DependencyTreeFlags.TargetNode) ||
                         item.Flags.Contains(DependencyTreeFlags.DependenciesRootNode))


### PR DESCRIPTION
`ContainsAny` is available now, but it requires allocating the composite `ProjectTreeFlags` somewhere in order to use it, either as a temporary or on the stack. The change is not justifiable.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6236)