### PR TITLE
Use CommandStatus member workaround

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/ReferenceManagerCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/ReferenceManagerCommandHandler.cs
@@ -19,9 +19,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
     [Order(ProjectSystem.Order.Default)]
     internal sealed class ReferenceManagerCommandHandler : ICommandGroupHandler
     {
-        // WORKAROUND: Until we can consume the new CommandStatus from CPS
-        public const CommandStatus InvisibleOnContextMenu = (CommandStatus)unchecked((int)0x20);
-
         private readonly IReferencesUI _referencesUI;
 
         [ImportingConstructor]
@@ -47,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
                 if (items.Any(tree => tree.IsFolder))
                 {   // Hide these commands for Folder -> Add
 
-                    progressiveStatus |= InvisibleOnContextMenu;
+                    progressiveStatus |= CommandStatus.InvisibleOnContextMenu;
                 }
 
                 return new CommandStatusResult(handled: true, commandText, progressiveStatus);


### PR DESCRIPTION
We now consume CPS packages that include `CommandStatus.InvisibleOnContextMenu`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6244)