### PR TITLE
Use new context menus for transitive dependency tree items

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyItem.cs
@@ -1,11 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Microsoft.Internal.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.Implementation
 {
     internal sealed class FrameworkReferenceAssemblyItem : RelatableItemBase
     {
+        private const int IDM_VS_CTXT_TRANSITIVE_ASSEMBLY_REFERENCE = 0x04B1;
+
+        private static readonly IContextMenuController s_defaultMenuController = new MenuController(VsMenus.guidSHLMainMenu, IDM_VS_CTXT_TRANSITIVE_ASSEMBLY_REFERENCE);
+
         public string AssemblyName { get; }
         public string? Path { get; }
         public string? AssemblyVersion { get; }
@@ -26,6 +32,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         public override object Identity => Text;
         public override int Priority => 0;
         public override ImageMoniker IconMoniker => ManagedImageMonikers.ReferencePrivate;
+
+        protected override IContextMenuController? ContextMenuController => s_defaultMenuController;
 
         public override object? GetBrowseObject() => new BrowseObject(this);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/RelatableItemBase.DefaultContextMenuController.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/RelatableItemBase.DefaultContextMenuController.cs
@@ -12,9 +12,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 {
     public abstract partial class RelatableItemBase
     {
-        private sealed class DefaultContextMenuController : IContextMenuController
+        internal sealed class MenuController : IContextMenuController
         {
-            public static DefaultContextMenuController Instance { get; } = new DefaultContextMenuController();
+            private readonly Guid _menuGuid;
+            private readonly int _menuId;
+
+            public MenuController(Guid menuGuid, int menuId)
+            {
+                _menuGuid = menuGuid;
+                _menuId = menuId;
+            }
 
             public bool ShowContextMenu(IEnumerable<object> items, Point location)
             {
@@ -24,13 +31,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                 {
                     if (Package.GetGlobalService(typeof(SVsUIShell)) is IVsUIShell shell)
                     {
-                        const int MenuId = VsMenus.IDM_VS_CTXT_PROJWIN_FILECONTENTS;
-                        Guid guidContextMenu = VsMenus.guidSHLMainMenu;
+                        Guid guidContextMenu = _menuGuid;
 
                         int result = shell.ShowContextMenu(
                             dwCompRole: 0,
                             rclsidActive: ref guidContextMenu,
-                            nMenuId: MenuId,
+                            nMenuId: _menuId,
                             pos: new[] { new POINTS { x = (short)location.X, y = (short)location.Y } },
                             pCmdTrgtActive: null);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/RelatableItemBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/RelatableItemBase.cs
@@ -2,6 +2,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Internal.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections
 {
@@ -11,6 +12,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     /// </summary>
     public abstract partial class RelatableItemBase : AttachedCollectionItemBase, IRelatableItem
     {
+        private const int IDM_VS_CTXT_DEPENDENCY_TRANSITIVE_ITEM = 0x04B0;
+
+        private static readonly IContextMenuController s_defaultMenuController = new MenuController(VsMenus.guidSHLMainMenu, IDM_VS_CTXT_DEPENDENCY_TRANSITIVE_ITEM);
+
         private AggregateContainsRelationCollection? _containsCollection;
 
         protected RelatableItemBase(string name)
@@ -20,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public abstract object Identity { get; }
 
-        protected override IContextMenuController? ContextMenuController => DefaultContextMenuController.Instance;
+        protected override IContextMenuController? ContextMenuController => s_defaultMenuController;
 
         AggregateContainsRelationCollection? IRelatableItem.ContainsCollection => _containsCollection;
 


### PR DESCRIPTION
Relates to #5935.

https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/250942 adds new
context menus for various kinds of transitive dependencies.

This commit opts into the use of two of them:

1. `IDM_VS_CTXT_DEPENDENCY_TRANSITIVE_ITEM` for generic items
2. `IDM_VS_CTXT_TRANSITIVE_ASSEMBLY_REFERENCE` for framework reference assemblies

This unblocks further development of Fakes support for assemblies.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6248)