### PR TITLE
Add further debug properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AuthenticationModeEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AuthenticationModeEnumProvider.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.VS.Debug;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
+{
+    [ExportDynamicEnumValuesProvider(nameof(AuthenticationModeEnumProvider))]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+    internal class AuthenticationModeEnumProvider : IDynamicEnumValuesProvider
+    {
+        private readonly IRemoteDebuggerAuthenticationService _remoteDebuggerAuthenticationService;
+
+        [ImportingConstructor]
+        public AuthenticationModeEnumProvider(IRemoteDebuggerAuthenticationService remoteDebuggerAuthenticationService)
+        {
+            _remoteDebuggerAuthenticationService = remoteDebuggerAuthenticationService;
+        }
+
+        public Task<IDynamicEnumValuesGenerator> GetProviderAsync(IList<NameValuePair>? options)
+        {
+            return Task.FromResult<IDynamicEnumValuesGenerator>(new AuthenticationModeEnumValuesGenerator(_remoteDebuggerAuthenticationService));
+        }
+
+        private class AuthenticationModeEnumValuesGenerator : IDynamicEnumValuesGenerator
+        {
+            private readonly IRemoteDebuggerAuthenticationService _remoteDebuggerAuthenticationService;
+
+            public AuthenticationModeEnumValuesGenerator(IRemoteDebuggerAuthenticationService remoteDebuggerAuthenticationService)
+            {
+                _remoteDebuggerAuthenticationService = remoteDebuggerAuthenticationService;
+            }
+
+            public bool AllowCustomValues => false;
+
+            public Task<ICollection<IEnumValue>> GetListedValuesAsync()
+            {
+                var enumValues =_remoteDebuggerAuthenticationService
+                    .GetRemoteAuthenticationModes()
+                    .Select(i => new PageEnumValue(new EnumValue
+                    {
+                        Name = i.Name,
+                        DisplayName = i.DisplayName
+                    }))
+                    .ToArray<IEnumValue>();
+
+                return Task.FromResult<ICollection<IEnumValue>>(enumValues);
+            }
+
+            /// <summary>
+            /// The user can't add arbitrary authentication modes, so this method is unsupported.
+            /// </summary>
+            public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileExtensionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileExtensionValueProvider.cs
@@ -28,6 +28,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         internal const string RemoteDebugMachinePropertyName = "RemoteDebugMachine";
         internal const string SqlDebuggingPropertyName = "SqlDebugging";
 
+        // The CPS property system will map "true" and "false" to the localized versions of
+        // "Yes" and "No" for display purposes, but not other casings like "True" and
+        // "False". To ensure consistency we need to map booleans to these constants.
+        private const string True = "true";
+        private const string False = "false";
+
         private readonly UnconfiguredProject _project;
         private readonly ILaunchSettingsProvider _launchSettingsProvider;
         private readonly IProjectThreadingService _projectThreadingService;
@@ -58,10 +64,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             string? activeProfilePropertyValue = propertyName switch
             {
                 AuthenticationModePropertyName => GetOtherProperty(activeProfile, LaunchProfileExtensions.RemoteAuthenticationModeProperty, string.Empty),
-                NativeDebuggingPropertyName => GetOtherProperty(activeProfile, LaunchProfileExtensions.NativeDebuggingProperty, false).ToString(),
-                RemoteDebugEnabledPropertyName => GetOtherProperty(activeProfile, LaunchProfileExtensions.RemoteDebugEnabledProperty, false).ToString(),
+                NativeDebuggingPropertyName => GetOtherProperty(activeProfile, LaunchProfileExtensions.NativeDebuggingProperty, false) ? True : False,
+                RemoteDebugEnabledPropertyName => GetOtherProperty(activeProfile, LaunchProfileExtensions.RemoteDebugEnabledProperty, false) ? True : False,
                 RemoteDebugMachinePropertyName => GetOtherProperty(activeProfile, LaunchProfileExtensions.RemoteDebugMachineProperty, string.Empty),
-                SqlDebuggingPropertyName => GetOtherProperty(activeProfile, LaunchProfileExtensions.SqlDebuggingProperty, false).ToString(),
+                SqlDebuggingPropertyName => GetOtherProperty(activeProfile, LaunchProfileExtensions.SqlDebuggingProperty, false) ? True : False,
 
                 _ => throw new InvalidOperationException($"{nameof(ActiveLaunchProfileExtensionValueProvider)} does not handle property '{propertyName}'.")
             };
@@ -124,7 +130,8 @@ unconfiguredProject: _project);
 
         private static T GetOtherProperty<T>(ILaunchProfile? launchProfile, string propertyName, T defaultValue)
         {
-            if (launchProfile == null)
+            if (launchProfile == null
+                || launchProfile.OtherSettings == null)
             {
                 return defaultValue;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileExtensionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileExtensionValueProvider.cs
@@ -1,0 +1,173 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    [ExportInterceptingPropertyValueProvider(
+        new[]
+        {
+            AuthenticationModePropertyName,
+            NativeDebuggingPropertyName,
+            RemoteDebugEnabledPropertyName,
+            RemoteDebugMachinePropertyName,
+            SqlDebuggingPropertyName
+        },
+        ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    internal class ActiveLaunchProfileExtensionValueProvider : InterceptingPropertyValueProviderBase
+    {
+        internal const string AuthenticationModePropertyName = "AuthenticationMode";
+        internal const string NativeDebuggingPropertyName = "NativeDebugging";
+        internal const string RemoteDebugEnabledPropertyName = "RemoteDebugEnabled";
+        internal const string RemoteDebugMachinePropertyName = "RemoteDebugMachine";
+        internal const string SqlDebuggingPropertyName = "SqlDebugging";
+
+        private readonly UnconfiguredProject _project;
+        private readonly ILaunchSettingsProvider _launchSettingsProvider;
+        private readonly IProjectThreadingService _projectThreadingService;
+
+        [ImportingConstructor]
+        public ActiveLaunchProfileExtensionValueProvider(UnconfiguredProject project, ILaunchSettingsProvider launchSettingsProvider, IProjectThreadingService projectThreadingService)
+        {
+            _project = project;
+            _launchSettingsProvider = launchSettingsProvider;
+            _projectThreadingService = projectThreadingService;
+        }
+
+        public override Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        {
+            return GetPropertyValueAsync(propertyName);
+        }
+
+        public override Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+        {
+            return GetPropertyValueAsync(propertyName);
+        }
+
+        private async Task<string> GetPropertyValueAsync(string propertyName)
+        {
+            ILaunchSettings launchSettings = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            ILaunchProfile? activeProfile = launchSettings.ActiveProfile;
+
+            string? activeProfilePropertyValue = propertyName switch
+            {
+                AuthenticationModePropertyName => GetOtherProperty(activeProfile, LaunchProfileExtensions.RemoteAuthenticationModeProperty, string.Empty),
+                NativeDebuggingPropertyName => GetOtherProperty(activeProfile, LaunchProfileExtensions.NativeDebuggingProperty, false).ToString(),
+                RemoteDebugEnabledPropertyName => GetOtherProperty(activeProfile, LaunchProfileExtensions.RemoteDebugEnabledProperty, false).ToString(),
+                RemoteDebugMachinePropertyName => GetOtherProperty(activeProfile, LaunchProfileExtensions.RemoteDebugMachineProperty, string.Empty),
+                SqlDebuggingPropertyName => GetOtherProperty(activeProfile, LaunchProfileExtensions.SqlDebuggingProperty, false).ToString(),
+
+                _ => throw new InvalidOperationException($"{nameof(ActiveLaunchProfileExtensionValueProvider)} does not handle property '{propertyName}'.")
+            };
+
+            return activeProfilePropertyValue ?? string.Empty;
+        }
+
+        public override Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+        {
+            _projectThreadingService.RunAndForget(async () =>
+            {
+                ILaunchSettings launchSettings = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+
+                var writableLaunchSettings = launchSettings.ToWritableLaunchSettings();
+                var activeProfile = writableLaunchSettings.ActiveProfile;
+                if (activeProfile != null)
+                {
+                    UpdateActiveLaunchProfile(activeProfile, propertyName, unevaluatedPropertyValue);
+
+                    await _launchSettingsProvider.UpdateAndSaveSettingsAsync(writableLaunchSettings.ToLaunchSettings());
+                }
+            },
+options: ForkOptions.HideLocks,
+unconfiguredProject: _project);
+
+            // We've intercepted the "set" operation and redirected it to the launch settings.
+            // Return "null" to indicate that the value should _not_ be set in the project file
+            // as well.
+            return Task.FromResult<string?>(null);
+        }
+
+        private static void UpdateActiveLaunchProfile(IWritableLaunchProfile activeProfile, string propertyName, string unevaluatedPropertyValue)
+        {
+            switch (propertyName)
+            {
+                case AuthenticationModePropertyName:
+                    TrySetOtherProperty(activeProfile, LaunchProfileExtensions.RemoteAuthenticationModeProperty, unevaluatedPropertyValue, string.Empty);
+                    break;
+
+                case NativeDebuggingPropertyName:
+                    TrySetOtherProperty(activeProfile, LaunchProfileExtensions.NativeDebuggingProperty, bool.Parse(unevaluatedPropertyValue), false);
+                    break;
+
+                case RemoteDebugEnabledPropertyName:
+                    TrySetOtherProperty(activeProfile, LaunchProfileExtensions.RemoteDebugEnabledProperty, bool.Parse(unevaluatedPropertyValue), false);
+                    break;
+
+                case RemoteDebugMachinePropertyName:
+                    TrySetOtherProperty(activeProfile, LaunchProfileExtensions.RemoteDebugMachineProperty, unevaluatedPropertyValue, string.Empty);
+                    break;
+
+                case SqlDebuggingPropertyName:
+                    TrySetOtherProperty(activeProfile, LaunchProfileExtensions.SqlDebuggingProperty, bool.Parse(unevaluatedPropertyValue), false);
+                    break;
+
+                default:
+                    throw new InvalidOperationException($"{nameof(ActiveLaunchProfileExtensionValueProvider)} does not handle property '{propertyName}'.");
+            }
+        }
+
+        private static T GetOtherProperty<T>(ILaunchProfile? launchProfile, string propertyName, T defaultValue)
+        {
+            if (launchProfile == null)
+            {
+                return defaultValue;
+            }
+
+            if (launchProfile.OtherSettings.TryGetValue(propertyName, out object value) &&
+                value is T b)
+            {
+                return b;
+            }
+            else if (value is string s &&
+                TypeDescriptor.GetConverter(typeof(T)) is TypeConverter converter &&
+                converter.CanConvertFrom(typeof(string)))
+            {
+                try
+                {
+                    if (converter.ConvertFromString(s) is T o)
+                    {
+                        return o;
+                    }
+                }
+                catch (Exception)
+                {
+                    // ignore bad data in the json file and just let them have the default value
+                }
+            }
+
+            return defaultValue;
+        }
+
+        private static bool TrySetOtherProperty<T>(IWritableLaunchProfile launchProfile, string propertyName, T value, T defaultValue) where T : notnull
+        {
+            if (!launchProfile.OtherSettings.TryGetValue(propertyName, out object current))
+            {
+                current = defaultValue;
+            }
+
+            if (!(current is T currentTyped) || !Equals(currentTyped, value))
+            {
+                launchProfile.OtherSettings[propertyName] = value;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
@@ -22,13 +22,31 @@
                   Description="Path to the executable to run."
                   Subtype="file" />
 
+  <StringProperty Name="CommandLineArguments"
+                  DisplayName="Command line arguments"
+                  Description="Command line arguments to pass to the executable." />
+
   <StringProperty Name="WorkingDirectory"
                   DisplayName="Working directory"
                   Description="Path to the working directory where the process will be started."
                   Subtype="folder" />
 
-  <StringProperty Name="CommandLineArguments"
-                  DisplayName="Command line arguments"
-                  Description="Command line arguments to pass to the executable." />
-  
+  <BoolProperty Name="RemoteDebugEnabled"
+                DisplayName="Use remote machine"
+                Description="Indicates that the debugger should attach to a process on a remote machine."/>
+
+  <StringProperty Name="RemoteDebugMachine"
+                  DisplayName="Remote machine name"
+                  Description="The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled."/>
+
+  <StringProperty Name="AuthenticationMode"
+                  DisplayName="Authentication mode"
+                  Description="The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled."/>
+
+  <BoolProperty Name="NativeDebugging"
+                DisplayName="Enable native code debugging" />
+
+  <BoolProperty Name="SqlDebugging"
+                DisplayName="Enable SQL Server debugging" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
@@ -39,9 +39,10 @@
                   DisplayName="Remote machine name"
                   Description="The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled."/>
 
-  <StringProperty Name="AuthenticationMode"
-                  DisplayName="Authentication mode"
-                  Description="The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled."/>
+  <DynamicEnumProperty Name="AuthenticationMode"
+                       DisplayName="Authentication mode"
+                       Description="The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled."
+                       EnumProvider="AuthenticationModeEnumProvider" />
 
   <BoolProperty Name="NativeDebugging"
                 DisplayName="Enable native code debugging" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
@@ -17,13 +17,30 @@
                 HasConfigurationCondition="False" />
   </Rule.DataSource>
 
+  <StringProperty Name="CommandLineArguments"
+                  DisplayName="Command line arguments"
+                  Description="Command line arguments to pass to the executable." />
+
   <StringProperty Name="WorkingDirectory"
                   DisplayName="Working directory"
                   Description="Path to the working directory where the process will be started."
                   Subtype="folder" />
 
-  <StringProperty Name="CommandLineArguments"
-                  DisplayName="Command line arguments"
-                  Description="Command line arguments to pass to the executable." />
+  <BoolProperty Name="RemoteDebugEnabled"
+                DisplayName="Use remote machine"
+                Description="Indicates that the debugger should attach to a process on a remote machine."/>
 
+  <StringProperty Name="RemoteDebugMachine"
+                  DisplayName="Remote machine name"
+                  Description="The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled."/>
+
+  <StringProperty Name="AuthenticationMode"
+                  DisplayName="Authentication mode"
+                  Description="The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled."/>
+
+  <BoolProperty Name="NativeDebugging"
+                DisplayName="Enable native code debugging" />
+
+  <BoolProperty Name="SqlDebugging"
+                DisplayName="Enable SQL Server debugging" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
@@ -34,10 +34,10 @@
                   DisplayName="Remote machine name"
                   Description="The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled."/>
 
-  <StringProperty Name="AuthenticationMode"
-                  DisplayName="Authentication mode"
-                  Description="The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled."/>
-
+  <DynamicEnumProperty Name="AuthenticationMode"
+                       DisplayName="Authentication mode"
+                       Description="The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled."
+                       EnumProvider="AuthenticationModeEnumProvider" />
   <BoolProperty Name="NativeDebugging"
                 DisplayName="Enable native code debugging" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.cs.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.cs.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../ExecutableDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -10,6 +30,16 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
@@ -30,6 +60,16 @@
       <trans-unit id="StringProperty|ExecutablePath|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.de.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.de.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../ExecutableDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -10,6 +30,16 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
@@ -30,6 +60,16 @@
       <trans-unit id="StringProperty|ExecutablePath|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.es.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.es.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../ExecutableDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -10,6 +30,16 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
@@ -30,6 +60,16 @@
       <trans-unit id="StringProperty|ExecutablePath|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.fr.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.fr.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../ExecutableDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -10,6 +30,16 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
@@ -30,6 +60,16 @@
       <trans-unit id="StringProperty|ExecutablePath|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.it.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.it.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../ExecutableDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -10,6 +30,16 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
@@ -30,6 +60,16 @@
       <trans-unit id="StringProperty|ExecutablePath|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ja.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ja.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../ExecutableDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -10,6 +30,16 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
@@ -30,6 +60,16 @@
       <trans-unit id="StringProperty|ExecutablePath|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ko.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ko.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../ExecutableDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -10,6 +30,16 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
@@ -30,6 +60,16 @@
       <trans-unit id="StringProperty|ExecutablePath|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pl.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pl.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../ExecutableDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -10,6 +30,16 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
@@ -30,6 +60,16 @@
       <trans-unit id="StringProperty|ExecutablePath|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pt-BR.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ExecutableDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -10,6 +30,16 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
@@ -30,6 +60,16 @@
       <trans-unit id="StringProperty|ExecutablePath|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pt-BR.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ru.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ru.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../ExecutableDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -10,6 +30,16 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
@@ -30,6 +60,16 @@
       <trans-unit id="StringProperty|ExecutablePath|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.tr.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.tr.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../ExecutableDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -10,6 +30,16 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
@@ -30,6 +60,16 @@
       <trans-unit id="StringProperty|ExecutablePath|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hans.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ExecutableDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -10,6 +30,16 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
@@ -30,6 +60,16 @@
       <trans-unit id="StringProperty|ExecutablePath|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hans.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hant.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ExecutableDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -10,6 +30,16 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
@@ -30,6 +60,16 @@
       <trans-unit id="StringProperty|ExecutablePath|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hant.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ExecutableDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging a specified executable file.</source>
         <target state="new">Properties associated with launching and debugging a specified executable file.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ExecutableDebugPropertyPage|DisplayName">
         <source>Executable</source>
         <target state="new">Executable</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.cs.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../ProjectDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -12,6 +32,16 @@
         <target state="new">Project</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
         <source>Command line arguments to pass to the executable.</source>
         <target state="new">Command line arguments to pass to the executable.</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|CommandLineArguments|DisplayName">
         <source>Command line arguments</source>
         <target state="new">Command line arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.cs.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ProjectDebugPropertyPage|DisplayName">
         <source>Project</source>
         <target state="new">Project</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.de.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../ProjectDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -12,6 +32,16 @@
         <target state="new">Project</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
         <source>Command line arguments to pass to the executable.</source>
         <target state="new">Command line arguments to pass to the executable.</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|CommandLineArguments|DisplayName">
         <source>Command line arguments</source>
         <target state="new">Command line arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.de.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ProjectDebugPropertyPage|DisplayName">
         <source>Project</source>
         <target state="new">Project</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.es.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../ProjectDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -12,6 +32,16 @@
         <target state="new">Project</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
         <source>Command line arguments to pass to the executable.</source>
         <target state="new">Command line arguments to pass to the executable.</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|CommandLineArguments|DisplayName">
         <source>Command line arguments</source>
         <target state="new">Command line arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.es.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ProjectDebugPropertyPage|DisplayName">
         <source>Project</source>
         <target state="new">Project</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.fr.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../ProjectDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -12,6 +32,16 @@
         <target state="new">Project</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
         <source>Command line arguments to pass to the executable.</source>
         <target state="new">Command line arguments to pass to the executable.</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|CommandLineArguments|DisplayName">
         <source>Command line arguments</source>
         <target state="new">Command line arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.fr.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ProjectDebugPropertyPage|DisplayName">
         <source>Project</source>
         <target state="new">Project</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.it.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../ProjectDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -12,6 +32,16 @@
         <target state="new">Project</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
         <source>Command line arguments to pass to the executable.</source>
         <target state="new">Command line arguments to pass to the executable.</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|CommandLineArguments|DisplayName">
         <source>Command line arguments</source>
         <target state="new">Command line arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.it.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ProjectDebugPropertyPage|DisplayName">
         <source>Project</source>
         <target state="new">Project</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ja.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../ProjectDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -12,6 +32,16 @@
         <target state="new">Project</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
         <source>Command line arguments to pass to the executable.</source>
         <target state="new">Command line arguments to pass to the executable.</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|CommandLineArguments|DisplayName">
         <source>Command line arguments</source>
         <target state="new">Command line arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ja.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ProjectDebugPropertyPage|DisplayName">
         <source>Project</source>
         <target state="new">Project</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ko.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../ProjectDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -12,6 +32,16 @@
         <target state="new">Project</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
         <source>Command line arguments to pass to the executable.</source>
         <target state="new">Command line arguments to pass to the executable.</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|CommandLineArguments|DisplayName">
         <source>Command line arguments</source>
         <target state="new">Command line arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ko.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ProjectDebugPropertyPage|DisplayName">
         <source>Project</source>
         <target state="new">Project</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pl.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../ProjectDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -12,6 +32,16 @@
         <target state="new">Project</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
         <source>Command line arguments to pass to the executable.</source>
         <target state="new">Command line arguments to pass to the executable.</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|CommandLineArguments|DisplayName">
         <source>Command line arguments</source>
         <target state="new">Command line arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pl.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ProjectDebugPropertyPage|DisplayName">
         <source>Project</source>
         <target state="new">Project</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pt-BR.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ProjectDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -12,6 +32,16 @@
         <target state="new">Project</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
         <source>Command line arguments to pass to the executable.</source>
         <target state="new">Command line arguments to pass to the executable.</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|CommandLineArguments|DisplayName">
         <source>Command line arguments</source>
         <target state="new">Command line arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pt-BR.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ProjectDebugPropertyPage|DisplayName">
         <source>Project</source>
         <target state="new">Project</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ru.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../ProjectDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -12,6 +32,16 @@
         <target state="new">Project</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
         <source>Command line arguments to pass to the executable.</source>
         <target state="new">Command line arguments to pass to the executable.</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|CommandLineArguments|DisplayName">
         <source>Command line arguments</source>
         <target state="new">Command line arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ru.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ProjectDebugPropertyPage|DisplayName">
         <source>Project</source>
         <target state="new">Project</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.tr.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../ProjectDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -12,6 +32,16 @@
         <target state="new">Project</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
         <source>Command line arguments to pass to the executable.</source>
         <target state="new">Command line arguments to pass to the executable.</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|CommandLineArguments|DisplayName">
         <source>Command line arguments</source>
         <target state="new">Command line arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.tr.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ProjectDebugPropertyPage|DisplayName">
         <source>Project</source>
         <target state="new">Project</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hans.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ProjectDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -12,6 +32,16 @@
         <target state="new">Project</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
         <source>Command line arguments to pass to the executable.</source>
         <target state="new">Command line arguments to pass to the executable.</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|CommandLineArguments|DisplayName">
         <source>Command line arguments</source>
         <target state="new">Command line arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hans.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ProjectDebugPropertyPage|DisplayName">
         <source>Project</source>
         <target state="new">Project</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hant.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ProjectDebugPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|Description">
+        <source>Indicates that the debugger should attach to a process on a remote machine.</source>
+        <target state="new">Indicates that the debugger should attach to a process on a remote machine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
+        <source>Use remote machine</source>
+        <target state="new">Use remote machine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|DisplayName">
+        <source>Enable SQL Server debugging</source>
+        <target state="new">Enable SQL Server debugging</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -12,6 +32,16 @@
         <target state="new">Project</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">
         <source>Command line arguments to pass to the executable.</source>
         <target state="new">Command line arguments to pass to the executable.</target>
@@ -20,6 +50,16 @@
       <trans-unit id="StringProperty|CommandLineArguments|DisplayName">
         <source>Command line arguments</source>
         <target state="new">Command line arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|Description">
+        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">
+        <source>Remote machine name</source>
+        <target state="new">Remote machine name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WorkingDirectory|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hant.xlf
@@ -22,6 +22,16 @@
         <target state="new">Enable SQL Server debugging</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
+        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
+        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|ProjectDebugPropertyPage|Description">
         <source>Properties associated with launching and debugging the project output.</source>
         <target state="new">Properties associated with launching and debugging the project output.</target>
@@ -30,16 +40,6 @@
       <trans-unit id="Rule|ProjectDebugPropertyPage|DisplayName">
         <source>Project</source>
         <target state="new">Project</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="new">The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CommandLineArguments|Description">

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IRemoteAuthenticationProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IRemoteAuthenticationProviderFactory.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Moq;
+
+namespace Microsoft.VisualStudio.Mocks
+{
+    public class IRemoteAuthenticationProviderFactory
+    {
+        internal static IRemoteAuthenticationProvider Create(string name, string displayName)
+        {
+            var provider = new Mock<IRemoteAuthenticationProvider>();
+
+            provider.SetupGet(o => o.Name).Returns(name);
+            provider.SetupGet(o => o.DisplayName).Returns(displayName);
+
+            return provider.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Moq;
@@ -252,12 +253,243 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             Assert.Equal(expected: @"C:\four\five\six", actual: activeProfileWorkingDirectory);
         }
 
+        [Fact]
+        public async Task AuthenticationMode_OnGetEvaluatedPropertyValueAsync_GetsModeFromActiveProfile()
+        {
+            string activeProfileAuthenticationMode = "Windows";
+            var activeProfileOtherSettings = new Dictionary<string, object>
+            {
+                { LaunchProfileExtensions.RemoteAuthenticationModeProperty, activeProfileAuthenticationMode }
+            };
+
+            var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileOtherSettings: activeProfileOtherSettings);
+
+            var project = UnconfiguredProjectFactory.Create();
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+
+            var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.AuthenticationModePropertyName, string.Empty, Mock.Of<IProjectProperties>());
+
+            Assert.Equal(expected: activeProfileAuthenticationMode, actual: actualValue);
+        }
+
+        [Fact]
+        public async Task AuthenticationMode_OnSetPropertyValueAsync_SetsDirectoryInActiveProfile()
+        {
+            string activeProfileAuthenticationMode = "Windows";
+            var activeProfileOtherSettings = new Dictionary<string, object>
+            {
+                { LaunchProfileExtensions.RemoteAuthenticationModeProperty, activeProfileAuthenticationMode }
+            };
+
+            var settingsProvider = SetupLaunchSettingsProvider(
+                activeProfileName: "One",
+                activeProfileOtherSettings: activeProfileOtherSettings,
+                updateLaunchSettingsCallback: s =>
+                {
+                    activeProfileAuthenticationMode = (string)s.ActiveProfile!.OtherSettings[LaunchProfileExtensions.RemoteAuthenticationModeProperty];
+                });
+
+            var project = UnconfiguredProjectFactory.Create();
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+
+            await provider.OnSetPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.AuthenticationModePropertyName, "NotWindows", Mock.Of<IProjectProperties>());
+
+            Assert.Equal(expected: "NotWindows", actual: activeProfileAuthenticationMode);
+        }
+
+        [Fact]
+        public async Task NativeDebugging_OnGetEvaluatedPropertyValueAsync_GetsNativeDebuggingFromActiveProfile()
+        {
+            bool activeProfileNativeDebugging = true;
+            var activeProfileOtherSettings = new Dictionary<string, object>
+            {
+                { LaunchProfileExtensions.NativeDebuggingProperty, activeProfileNativeDebugging }
+            };
+
+            var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileOtherSettings: activeProfileOtherSettings);
+
+            var project = UnconfiguredProjectFactory.Create();
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+
+            var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.NativeDebuggingPropertyName, string.Empty, Mock.Of<IProjectProperties>());
+
+            Assert.Equal(expected: activeProfileNativeDebugging.ToString(), actual: actualValue);
+        }
+
+        [Fact]
+        public async Task NativeDebugging_OnSetPropertyValueAsync_SetsDirectoryInActiveProfile()
+        {
+            bool activeProfileNativeDebugging = false;
+            var activeProfileOtherSettings = new Dictionary<string, object>
+            {
+                { LaunchProfileExtensions.RemoteAuthenticationModeProperty, activeProfileNativeDebugging }
+            };
+
+            var settingsProvider = SetupLaunchSettingsProvider(
+                activeProfileName: "One",
+                activeProfileOtherSettings: activeProfileOtherSettings,
+                updateLaunchSettingsCallback: s =>
+                {
+                    activeProfileNativeDebugging = (bool)s.ActiveProfile!.OtherSettings[LaunchProfileExtensions.NativeDebuggingProperty];
+                });
+
+            var project = UnconfiguredProjectFactory.Create();
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+
+            await provider.OnSetPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.NativeDebuggingPropertyName, "true", Mock.Of<IProjectProperties>());
+
+            Assert.True(activeProfileNativeDebugging);
+        }
+
+        [Fact]
+        public async Task RemoteDebugEnabled_OnGetEvaluatedPropertyValueAsync_GetsNativeDebuggingFromActiveProfile()
+        {
+            bool activeProfileRemoteDebugEnabled = true;
+            var activeProfileOtherSettings = new Dictionary<string, object>
+            {
+                { LaunchProfileExtensions.RemoteDebugEnabledProperty, activeProfileRemoteDebugEnabled }
+            };
+
+            var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileOtherSettings: activeProfileOtherSettings);
+
+            var project = UnconfiguredProjectFactory.Create();
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+
+            var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.RemoteDebugEnabledPropertyName, string.Empty, Mock.Of<IProjectProperties>());
+
+            Assert.Equal(expected: activeProfileRemoteDebugEnabled.ToString(), actual: actualValue);
+        }
+
+        [Fact]
+        public async Task RemoveDebugEnabled_OnSetPropertyValueAsync_SetsDirectoryInActiveProfile()
+        {
+            bool activeProfileRemoteDebugEnabled = false;
+            var activeProfileOtherSettings = new Dictionary<string, object>
+            {
+                { LaunchProfileExtensions.RemoteDebugEnabledProperty, activeProfileRemoteDebugEnabled }
+            };
+
+            var settingsProvider = SetupLaunchSettingsProvider(
+                activeProfileName: "One",
+                activeProfileOtherSettings: activeProfileOtherSettings,
+                updateLaunchSettingsCallback: s =>
+                {
+                    activeProfileRemoteDebugEnabled = (bool)s.ActiveProfile!.OtherSettings[LaunchProfileExtensions.RemoteDebugEnabledProperty];
+                });
+
+            var project = UnconfiguredProjectFactory.Create();
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+
+            await provider.OnSetPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.RemoteDebugEnabledPropertyName, "true", Mock.Of<IProjectProperties>());
+
+            Assert.True(activeProfileRemoteDebugEnabled);
+        }
+
+        [Fact]
+        public async Task RemoteMachineName_OnGetEvaluatedPropertyValueAsync_GetsNameFromActiveProfile()
+        {
+            string activeProfileRemoteMachineName = "alphaMachine";
+            var activeProfileOtherSettings = new Dictionary<string, object>
+            {
+                { LaunchProfileExtensions.RemoteDebugMachineProperty, activeProfileRemoteMachineName }
+            };
+
+            var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileOtherSettings: activeProfileOtherSettings);
+
+            var project = UnconfiguredProjectFactory.Create();
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+
+            var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.RemoteDebugMachinePropertyName, string.Empty, Mock.Of<IProjectProperties>());
+
+            Assert.Equal(expected: activeProfileRemoteMachineName, actual: actualValue);
+        }
+
+        [Fact]
+        public async Task RemoteMachineName_OnSetPropertyValueAsync_SetsDirectoryInActiveProfile()
+        {
+            string activeProfileRemoteMachineName = "Tiger";
+            var activeProfileOtherSettings = new Dictionary<string, object>
+            {
+                { LaunchProfileExtensions.RemoteDebugMachineProperty, activeProfileRemoteMachineName }
+            };
+
+            var settingsProvider = SetupLaunchSettingsProvider(
+                activeProfileName: "One",
+                activeProfileOtherSettings: activeProfileOtherSettings,
+                updateLaunchSettingsCallback: s =>
+                {
+                    activeProfileRemoteMachineName = (string)s.ActiveProfile!.OtherSettings[LaunchProfileExtensions.RemoteDebugMachineProperty];
+                });
+
+            var project = UnconfiguredProjectFactory.Create();
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+
+            await provider.OnSetPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.RemoteDebugMachinePropertyName, "Cheetah", Mock.Of<IProjectProperties>());
+
+            Assert.Equal(expected: "Cheetah", actual: activeProfileRemoteMachineName);
+        }
+
+        [Fact]
+        public async Task SqlDebugEnabled_OnGetEvaluatedPropertyValueAsync_GetsSettingFromActiveProfile()
+        {
+            bool activeProfileSqlDebugEnabled = true;
+            var activeProfileOtherSettings = new Dictionary<string, object>
+            {
+                { LaunchProfileExtensions.SqlDebuggingProperty, activeProfileSqlDebugEnabled }
+            };
+
+            var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileOtherSettings: activeProfileOtherSettings);
+
+            var project = UnconfiguredProjectFactory.Create();
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+
+            var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.SqlDebuggingPropertyName, string.Empty, Mock.Of<IProjectProperties>());
+
+            Assert.Equal(expected: activeProfileSqlDebugEnabled.ToString(), actual: actualValue);
+        }
+
+        [Fact]
+        public async Task SqlDebugEnabled_OnSetPropertyValueAsync_SetsDirectoryInActiveProfile()
+        {
+            bool activeProfileSqlDebugEnabled = false;
+            var activeProfileOtherSettings = new Dictionary<string, object>
+            {
+                { LaunchProfileExtensions.SqlDebuggingProperty, activeProfileSqlDebugEnabled }
+            };
+
+            var settingsProvider = SetupLaunchSettingsProvider(
+                activeProfileName: "One",
+                activeProfileOtherSettings: activeProfileOtherSettings,
+                updateLaunchSettingsCallback: s =>
+                {
+                    activeProfileSqlDebugEnabled = (bool)s.ActiveProfile!.OtherSettings[LaunchProfileExtensions.SqlDebuggingProperty];
+                });
+
+            var project = UnconfiguredProjectFactory.Create();
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+
+            await provider.OnSetPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.SqlDebuggingPropertyName, "true", Mock.Of<IProjectProperties>());
+
+            Assert.True(activeProfileSqlDebugEnabled);
+        }
+
         private static ILaunchSettingsProvider SetupLaunchSettingsProvider(
             string activeProfileName,
             string? activeProfileLaunchTarget = null,
             string? activeProfileExecutablePath = null,
             string? activeProfileCommandLineArgs = null,
             string? activeProfileWorkingDirectory = null,
+            Dictionary<string, object>? activeProfileOtherSettings = null,
             Action<string>? setActiveProfileCallback = null,
             Action<ILaunchSettings>? updateLaunchSettingsCallback = null)
         {
@@ -286,6 +518,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             if (activeProfileWorkingDirectory != null)
             {
                 profile.WorkingDirectory = activeProfileWorkingDirectory;
+            }
+
+            if (activeProfileOtherSettings != null)
+            {
+                foreach (var kvp in activeProfileOtherSettings)
+                {
+                    profile.OtherSettings.Add(kvp.Key, kvp.Value);
+                }
             }
 
             var settingsProvider = ILaunchSettingsProviderFactory.Create(

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
@@ -316,7 +316,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.NativeDebuggingPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
-            Assert.Equal(expected: activeProfileNativeDebugging.ToString(), actual: actualValue);
+            Assert.Equal(expected: "true", actual: actualValue);
         }
 
         [Fact]
@@ -362,7 +362,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.RemoteDebugEnabledPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
-            Assert.Equal(expected: activeProfileRemoteDebugEnabled.ToString(), actual: actualValue);
+            Assert.Equal(expected: "true", actual: actualValue);
         }
 
         [Fact]
@@ -454,7 +454,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.SqlDebuggingPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
-            Assert.Equal(expected: activeProfileSqlDebugEnabled.ToString(), actual: actualValue);
+            Assert.Equal(expected: "true", actual: actualValue);
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IRemoteDebuggerAuthenticationServiceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IRemoteDebuggerAuthenticationServiceFactory.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Microsoft.VisualStudio.ProjectSystem.VS.Debug;
+using Moq;
+
+namespace Microsoft.VisualStudio.Mocks
+{
+    public class IRemoteDebuggerAuthenticationServiceFactory
+    {
+        internal static IRemoteDebuggerAuthenticationService Create(params IRemoteAuthenticationProvider[] providers)
+        {
+            var service = new Mock<IRemoteDebuggerAuthenticationService>();
+
+            service.Setup(s => s.GetRemoteAuthenticationModes()).Returns(providers);
+
+            return service.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/AuthenticationModeEnumProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/AuthenticationModeEnumProviderTests.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Mocks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
+{
+    public class AuthenticationModeEnumProviderTests
+    {
+        [Fact]
+        public async Task GetProviderAsync_ReturnsNonNullGenerator()
+        {
+            var remoteDebuggerAuthenticationService = IRemoteDebuggerAuthenticationServiceFactory.Create();
+
+            var provider = new AuthenticationModeEnumProvider(remoteDebuggerAuthenticationService);
+            var generator = await provider.GetProviderAsync(options: null);
+
+            Assert.NotNull(generator);
+        }
+
+        [Fact]
+        public async Task TryCreateEnumValueAsync_Throws()
+        {
+            var remoteDebuggerAuthenticationService = IRemoteDebuggerAuthenticationServiceFactory.Create();
+
+            var provider = new AuthenticationModeEnumProvider(remoteDebuggerAuthenticationService);
+            var generator = await provider.GetProviderAsync(options: null);
+
+            await Assert.ThrowsAsync<NotImplementedException>(() => generator.TryCreateEnumValueAsync("MyMode"));
+        }
+
+        [Fact]
+        public async Task GetListValuesAsync_ReturnsPageNamesAndDisplayNames()
+        {
+            var remoteDebuggerAuthenticationService = IRemoteDebuggerAuthenticationServiceFactory.Create(
+                IRemoteAuthenticationProviderFactory.Create("cheetah", "Fast authentication!"),
+                IRemoteAuthenticationProviderFactory.Create("tortoise", "Sloooow authentication..."));
+
+            var provider = new AuthenticationModeEnumProvider(remoteDebuggerAuthenticationService);
+            var generator = await provider.GetProviderAsync(options: null);
+
+            var values = await generator.GetListedValuesAsync();
+
+            Assert.Collection(values, new Action<IEnumValue>[]
+            {
+                ev => { Assert.Equal(expected: "cheetah", actual: ev.Name); Assert.Equal(expected: "Fast authentication!", actual: ev.DisplayName); },
+                ev => { Assert.Equal(expected: "tortoise", actual: ev.Name); Assert.Equal(expected: "Sloooow authentication...", actual: ev.DisplayName); }
+            });
+        }
+    }
+}


### PR DESCRIPTION
Fixes #6210.

This updates the ExecutableDebugPropertyPage and ProjectDebugPropertyPage to include the following properties:

- "Use remote machine" and the corresponding machine name
- "Authentication mode"
- "Enable native code debugging"
- "Enable SQL Server debugging"

To support this a new `ActiveLaunchProfileExtensionValueProvider` type has been added which knows how to read and write properties stored in `ILaunchProfile.OtherSettings`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6269)