### PR TITLE
Support Launch Browser and Launch URL properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileCommonValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileCommonValueProvider.cs
@@ -31,7 +31,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     {
         internal const string CommandLineArgumentsPropertyName = "CommandLineArguments";
         internal const string ExecutablePathPropertyName = "ExecutablePath";
+        internal const string LaunchBrowserPropertyName = "LaunchBrowser";
         internal const string LaunchTargetPropertyName = "LaunchTarget";
+        internal const string LaunchUrlPropertyName = "LaunchUrl";
         internal const string WorkingDirectoryPropertyName = "WorkingDirectory";
 
         private readonly UnconfiguredProject _project;
@@ -64,12 +66,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             {
                 CommandLineArgumentsPropertyName => launchSettings.ActiveProfile?.CommandLineArgs,
                 ExecutablePathPropertyName => launchSettings.ActiveProfile?.ExecutablePath,
+                LaunchBrowserPropertyName => ConvertBooleanToString(launchSettings.ActiveProfile?.LaunchBrowser),
                 LaunchTargetPropertyName => launchSettings.ActiveProfile?.CommandName,
+                LaunchUrlPropertyName => launchSettings.ActiveProfile?.LaunchUrl,
                 WorkingDirectoryPropertyName => launchSettings.ActiveProfile?.WorkingDirectory,
                 _ => throw new InvalidOperationException($"{nameof(ActiveLaunchProfileCommonValueProvider)} does not handle property '{propertyName}'.")
             };
 
             return activeProfilePropertyValue ?? string.Empty;
+        }
+
+        private static string? ConvertBooleanToString(bool? value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+            else if (value.Value)
+            {
+                return "true";
+            }
+            else
+            {
+                return "false";
+            }
         }
 
         public override Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
@@ -108,8 +128,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     activeProfile.ExecutablePath = newValue;
                     break;
 
+                case LaunchBrowserPropertyName:
+                    activeProfile.LaunchBrowser = bool.Parse(newValue);
+                    break;
+
                 case LaunchTargetPropertyName:
                     activeProfile.CommandName = newValue;
+                    break;
+
+                case LaunchUrlPropertyName:
+                    activeProfile.LaunchUrl = newValue;
                     break;
 
                 case WorkingDirectoryPropertyName:

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
@@ -254,6 +254,77 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         [Fact]
+        public async Task LaunchBrowser_OnGetEvaluatedPropertyValueAsync_GetsValueFromActiveProfile()
+        {
+            bool activeProfileLaunchBrowser = true;
+            var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileLaunchBrowser: activeProfileLaunchBrowser);
+
+            var project = UnconfiguredProjectFactory.Create();
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+
+            var actualValue = await workingDirectoryProvider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.LaunchBrowserPropertyName, string.Empty, Mock.Of<IProjectProperties>());
+
+            Assert.Equal(expected: "true", actual: actualValue);
+        }
+
+        [Fact]
+        public async Task LaunchBrowser_OnSetPropertyValueAsync_SetsValueInActiveProfile()
+        {
+            bool activeProfileLaunchBrowser = false;
+            var settingsProvider = SetupLaunchSettingsProvider(
+                activeProfileName: "Three",
+                activeProfileLaunchBrowser: activeProfileLaunchBrowser,
+                updateLaunchSettingsCallback: s =>
+                {
+                    activeProfileLaunchBrowser = s.ActiveProfile!.LaunchBrowser;
+                });
+
+            var project = UnconfiguredProjectFactory.Create();
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+
+            await workingDirectoryProvider.OnSetPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.LaunchBrowserPropertyName, "true", Mock.Of<IProjectProperties>());
+
+            Assert.True(activeProfileLaunchBrowser);
+        }
+
+        [Fact]
+        public async Task LaunchUrl_OnGetEvaluatedPropertyValueAsync_GetsUrlFromActiveProfile()
+        {
+            string activeProfileLaunchUrl = "https://microsoft.com";
+            var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileLaunchUrl: activeProfileLaunchUrl);
+
+            var project = UnconfiguredProjectFactory.Create();
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+
+            var actualValue = await workingDirectoryProvider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.LaunchUrlPropertyName, string.Empty, Mock.Of<IProjectProperties>());
+
+            Assert.Equal(expected: activeProfileLaunchUrl, actual: actualValue);
+        }
+
+        [Fact]
+        public async Task LaunchUrl_OnSetPropertyValueAsync_SetsUrlInActiveProfile()
+        {
+            string activeProfileLaunchUrl = "https://incorrect.com";
+            var settingsProvider = SetupLaunchSettingsProvider(
+                activeProfileName: "Three",
+                activeProfileLaunchUrl: activeProfileLaunchUrl,
+                updateLaunchSettingsCallback: s =>
+                {
+                    activeProfileLaunchUrl = s.ActiveProfile!.LaunchUrl;
+                });
+
+            var project = UnconfiguredProjectFactory.Create();
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+
+            await workingDirectoryProvider.OnSetPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.LaunchUrlPropertyName, "https://microsoft.com", Mock.Of<IProjectProperties>());
+
+            Assert.Equal(expected: "https://microsoft.com", actual: activeProfileLaunchUrl);
+        }
+        [Fact]
         public async Task AuthenticationMode_OnGetEvaluatedPropertyValueAsync_GetsModeFromActiveProfile()
         {
             string activeProfileAuthenticationMode = "Windows";
@@ -489,6 +560,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             string? activeProfileExecutablePath = null,
             string? activeProfileCommandLineArgs = null,
             string? activeProfileWorkingDirectory = null,
+            bool? activeProfileLaunchBrowser = null,
+            string? activeProfileLaunchUrl = null,
             Dictionary<string, object>? activeProfileOtherSettings = null,
             Action<string>? setActiveProfileCallback = null,
             Action<ILaunchSettings>? updateLaunchSettingsCallback = null)
@@ -518,6 +591,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             if (activeProfileWorkingDirectory != null)
             {
                 profile.WorkingDirectory = activeProfileWorkingDirectory;
+            }
+
+            if (activeProfileLaunchBrowser != null)
+            {
+                profile.LaunchBrowser = activeProfileLaunchBrowser.Value;
+            }
+
+            if (activeProfileLaunchUrl != null)
+            {
+                profile.LaunchUrl = activeProfileLaunchUrl;
             }
 
             if (activeProfileOtherSettings != null)


### PR DESCRIPTION
Add support for getting and setting the `ILaunchProfile.LaunchBrowser` and `ILaunchProfile.LaunchUrl` properties. We don't use these on our own property pages, but ASP.NET does.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6270)