### PR TITLE
Make 'Resouce file' textbox accessible.

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -845,6 +845,9 @@
   </data>
   <data name="&gt;&gt;Win32ResourceRadioButton.ZOrder" xml:space="preserve">
     <value>9</value>
+  </data>
+  <data name="Win32ResourceFile.AccessibleName" xml:space="preserve">
+    <value>Resource file</value>
   </data>
   <data name="Win32ResourceFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.cs.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Manifest:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Win32ResourceFile.AccessibleName">
+        <source>Resource file</source>
+        <target state="new">Resource file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Win32ResourceRadioButton.Text">
         <source>Re&amp;source file:</source>
         <target state="translated">&amp;Soubor prostředku:</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.de.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Manifest:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Win32ResourceFile.AccessibleName">
+        <source>Resource file</source>
+        <target state="new">Resource file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Win32ResourceRadioButton.Text">
         <source>Re&amp;source file:</source>
         <target state="translated">Re&amp;ssourcendatei:</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.es.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Manifiesto:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Win32ResourceFile.AccessibleName">
+        <source>Resource file</source>
+        <target state="new">Resource file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Win32ResourceRadioButton.Text">
         <source>Re&amp;source file:</source>
         <target state="translated">Archivo de recur&amp;sos:</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.fr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Manifeste :</target>
         <note />
       </trans-unit>
+      <trans-unit id="Win32ResourceFile.AccessibleName">
+        <source>Resource file</source>
+        <target state="new">Resource file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Win32ResourceRadioButton.Text">
         <source>Re&amp;source file:</source>
         <target state="translated">Fichier de re&amp;ssources :</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.it.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Manifesto:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Win32ResourceFile.AccessibleName">
+        <source>Resource file</source>
+        <target state="new">Resource file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Win32ResourceRadioButton.Text">
         <source>Re&amp;source file:</source>
         <target state="translated">File di &amp;risorse:</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.ja.xlf
@@ -62,6 +62,11 @@
         <target state="translated">マニフェスト:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Win32ResourceFile.AccessibleName">
+        <source>Resource file</source>
+        <target state="new">Resource file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Win32ResourceRadioButton.Text">
         <source>Re&amp;source file:</source>
         <target state="translated">リソース ファイル(&amp;S):</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.ko.xlf
@@ -62,6 +62,11 @@
         <target state="translated">매니페스트:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Win32ResourceFile.AccessibleName">
+        <source>Resource file</source>
+        <target state="new">Resource file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Win32ResourceRadioButton.Text">
         <source>Re&amp;source file:</source>
         <target state="translated">리소스 파일(&amp;S):</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.pl.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Manifest:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Win32ResourceFile.AccessibleName">
+        <source>Resource file</source>
+        <target state="new">Resource file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Win32ResourceRadioButton.Text">
         <source>Re&amp;source file:</source>
         <target state="translated">Plik za&amp;sobów:</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.pt-BR.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Manifesto:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Win32ResourceFile.AccessibleName">
+        <source>Resource file</source>
+        <target state="new">Resource file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Win32ResourceRadioButton.Text">
         <source>Re&amp;source file:</source>
         <target state="translated">Arquivo de recur&amp;so:</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.ru.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Манифест:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Win32ResourceFile.AccessibleName">
+        <source>Resource file</source>
+        <target state="new">Resource file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Win32ResourceRadioButton.Text">
         <source>Re&amp;source file:</source>
         <target state="translated">&amp;Файл ресурсов:</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.tr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Bildirim:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Win32ResourceFile.AccessibleName">
+        <source>Resource file</source>
+        <target state="new">Resource file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Win32ResourceRadioButton.Text">
         <source>Re&amp;source file:</source>
         <target state="translated">Ka&amp;ynak dosyası:</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.zh-Hans.xlf
@@ -62,6 +62,11 @@
         <target state="translated">清单:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Win32ResourceFile.AccessibleName">
+        <source>Resource file</source>
+        <target state="new">Resource file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Win32ResourceRadioButton.Text">
         <source>Re&amp;source file:</source>
         <target state="translated">资源文件(&amp;S):</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.zh-Hant.xlf
@@ -62,6 +62,11 @@
         <target state="translated">資訊清單:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Win32ResourceFile.AccessibleName">
+        <source>Resource file</source>
+        <target state="new">Resource file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Win32ResourceRadioButton.Text">
         <source>Re&amp;source file:</source>
         <target state="translated">資源檔(&amp;S):</target>


### PR DESCRIPTION
In the Application page, this item's name couldn't be found by the Accessibility Insights tool.

After:
![image](https://user-images.githubusercontent.com/8518253/84198136-f48d5080-aa57-11ea-85ba-fea7a66cc5ef.png)

[Link ](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1132995)to the original AzDO ticket.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6271)