### PR TITLE
Remove some target framework usages

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -257,42 +257,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
         }
 
         /// <summary>
-        /// Efficiently finds a descendent with the given path in the given tree.
-        /// </summary>
-        /// <param name="root">The root of the tree.</param>
-        /// <param name="path">The absolute or project-relative path to the item sought.</param>
-        /// <returns>The item in the tree if found; otherwise <see langword="null"/>.</returns>
-        public override IProjectTree? FindByPath(IProjectTree root, string path)
-        {
-            // We override this since we need to find children under either:
-            //
-            // - our dependencies root node
-            // - dependency sub tree nodes
-            // - dependency sub tree top level nodes
-            //
-            // Deeper levels will be attached items with additional info, not direct dependencies
-            // specified in the project file.
-
-            IProjectTree? projectTree = _viewProviders.FirstOrDefault()?.Value.FindByPath(root, path);
-            return projectTree;
-        }
-
-        /// <summary>
-        /// Gets the path to a given node that can later be provided to <see cref="IProjectTreeProvider.FindByPath" /> to locate the node again.
-        /// </summary>
-        /// <param name="node">The node whose path is sought.</param>
-        /// <returns>
-        /// A non-empty string, or <see langword="null"/> if searching is not supported.
-        /// For nodes that represent files on disk, this is the project-relative path to that file.
-        /// The root node of a project is the absolute path to the project file.
-        /// </returns>
-        public override string? GetPath(IProjectTree node)
-        {
-            // TODO this is apparently for graph nodes search -- do we still need it?
-            return node.FilePath;
-        }
-
-        /// <summary>
         /// Generates the original references directory tree.
         /// </summary>
         protected override void Initialize()
@@ -492,7 +456,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 flags: flags);
         }
 
-        public async Task<IRule?> GetBrowseObjectRuleAsync(IDependency dependency, IProjectCatalogSnapshot? catalogs)
+        public async Task<IRule?> GetBrowseObjectRuleAsync(IDependency dependency, ITargetFramework targetFramework, IProjectCatalogSnapshot? catalogs)
         {
             Requires.NotNull(dependency, nameof(dependency));
 
@@ -569,9 +533,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             {
                 Assumes.NotNull(ActiveConfiguredProject);
 
-                ConfiguredProject project = dependency.TargetFramework.Equals(TargetFramework.Any)
+                ConfiguredProject project = targetFramework.Equals(TargetFramework.Any)
                     ? ActiveConfiguredProject
-                    : _dependenciesSnapshotProvider.GetConfiguredProject(dependency.TargetFramework) ?? ActiveConfiguredProject;
+                    : _dependenciesSnapshotProvider.GetConfiguredProject(targetFramework) ?? ActiveConfiguredProject;
 
                 return GetActiveConfiguredProjectExports(project);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -298,7 +298,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
                 Assumes.NotNull(parent);
 
-                rootNode = parent!;
+                rootNode = parent;
             }
 
             return currentNodes != null // shouldCleanup

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -155,21 +155,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             }
         }
 
-        public IProjectTree? FindByPath(IProjectTree? root, string path)
-        {
-            if (root == null)
-            {
-                return null;
-            }
-
-            IProjectTree? dependenciesNode = root.Flags.Contains(DependencyTreeFlags.DependenciesRootNode)
-                ? root
-                : root.FindChildWithFlags(DependencyTreeFlags.DependenciesRootNode);
-
-            return dependenciesNode?.GetSelfAndDescendentsBreadthFirst()
-                .FirstOrDefault((node, p) => string.Equals(node.FilePath, p, StringComparisons.Paths), path);
-        }
-
         /// <summary>
         /// Builds all available sub trees under root: target framework or Dependencies node
         /// when there is only one target.
@@ -331,7 +316,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             ProjectTreeFlags? excludedFlags = null)
         {
             IRule? browseObjectProperties = dependency.Flags.Contains(DependencyTreeFlags.SupportsRuleProperties)
-                ? await _treeServices.GetBrowseObjectRuleAsync(dependency, targetedSnapshot.Catalogs)
+                ? await _treeServices.GetBrowseObjectRuleAsync(dependency, targetedSnapshot.TargetFramework, targetedSnapshot.Catalogs)
                 : null;
 
             return CreateOrUpdateNode(
@@ -356,11 +341,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 return UpdateTreeNode();
             }
 
-            string? filePath = viewModel.Dependency != null &&
-                               viewModel.Dependency.Resolved
-                ? viewModel.Dependency.GetTopLevelId()
-                : viewModel.FilePath;
-
             ProjectTreeFlags filteredFlags = FilterFlags(viewModel.Flags);
 
             return isProjectItem
@@ -371,7 +351,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             {
                 return _treeServices.CreateTree(
                     caption: viewModel.Caption,
-                    filePath,
+                    filePath: null,
                     browseObjectProperties: browseObjectProperties,
                     icon: viewModel.Icon.ToProjectSystemType(),
                     expandedIcon: viewModel.ExpandedIcon.ToProjectSystemType(),
@@ -381,13 +361,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
             IProjectTree CreateProjectItemTreeNode()
             {
-                Assumes.NotNull(filePath);
-
                 var itemContext = ProjectPropertiesContext.GetContext(
                     _commonServices.Project,
-                    file: filePath,
+                    file: null,
                     itemType: viewModel.SchemaItemType,
-                    itemName: filePath);
+                    itemName: null);
 
                 return _treeServices.CreateTree(
                     caption: viewModel.Caption,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeFlags.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeFlags.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         /// <summary>
         /// Dependencies having this flag support displaying a browse object, where the corresponding <see cref="IRule" />
-        /// is obtained by <see cref="IDependenciesTreeServices.GetBrowseObjectRuleAsync(IDependency, IProjectCatalogSnapshot)" />.
+        /// is obtained by <see cref="IDependenciesTreeServices.GetBrowseObjectRuleAsync(IDependency, ITargetFramework, IProjectCatalogSnapshot)" />.
         /// </summary>
         internal static readonly ProjectTreeFlags SupportsRuleProperties = ProjectTreeFlags.Create("SupportsRuleProperties");
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/IDependenciesTreeServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/IDependenciesTreeServices.cs
@@ -58,7 +58,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
         /// display browse object properties page.
         /// </summary>
         /// <param name="dependency"></param>
+        /// <param name="targetFramework"></param>
         /// <param name="catalogs"></param>
-        Task<IRule?> GetBrowseObjectRuleAsync(IDependency dependency, IProjectCatalogSnapshot? catalogs);
+        Task<IRule?> GetBrowseObjectRuleAsync(
+            IDependency dependency,
+            ITargetFramework targetFramework,
+            IProjectCatalogSnapshot? catalogs);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/IDependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/IDependenciesTreeViewProvider.cs
@@ -28,12 +28,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             IProjectTree dependenciesTree,
             DependenciesSnapshot snapshot,
             CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Finds node by path in current dependencies view hierarchy.
-        /// </summary>
-        /// <param name="root">Node where we start searching</param>
-        /// <param name="path">Path to find</param>
-        IProjectTree? FindByPath(IProjectTree? root, string path);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/IDependencyModelExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/IDependencyModelExtensions.cs
@@ -2,7 +2,6 @@
 
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
-using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
@@ -24,9 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
                 _hasUnresolvedDependency = hasUnresolvedDependency;
             }
 
-            public IDependency? Dependency => null;
             public string Caption => _model.Caption;
-            public string? FilePath => _model.Id;
             public string? SchemaName => _model.SchemaName;
             public string? SchemaItemType => _model.SchemaItemType;
             public ImageMoniker Icon => _hasUnresolvedDependency ? _model.UnresolvedIcon : _model.Icon;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/IDependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/IDependencyViewModel.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Microsoft.VisualStudio.Imaging.Interop;
-using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
@@ -21,12 +20,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
     internal interface IDependencyViewModel
     {
         string Caption { get; }
-        string? FilePath { get; }
         string? SchemaName { get; }
         string? SchemaItemType { get; }
         ImageMoniker Icon { get; }
         ImageMoniker ExpandedIcon { get; }
         ProjectTreeFlags Flags { get; }
-        IDependency? Dependency { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/TargetDependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/TargetDependencyViewModel.cs
@@ -6,7 +6,6 @@ using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
-using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
@@ -32,12 +31,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
         }
 
         public string Caption { get; }
-        public string? FilePath => null;
         public string? SchemaName => null;
         public string? SchemaItemType => null;
         public ImageMoniker Icon => _hasUnresolvedDependency ? ManagedImageMonikers.LibraryWarning : KnownMonikers.Library;
         public ImageMoniker ExpandedIcon => _hasUnresolvedDependency ? ManagedImageMonikers.LibraryWarning : KnownMonikers.Library;
         public ProjectTreeFlags Flags { get; }
-        public IDependency? Dependency => null;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/DeduplicateCaptionsSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/DeduplicateCaptionsSnapshotFilter.cs
@@ -20,7 +20,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
         public const int Order = 101;
 
         public override void BeforeAddOrUpdate(
-            ITargetFramework targetFramework,
             IDependency dependency,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviderByProviderType,
             IImmutableSet<string>? projectItemSpecs,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/DependenciesSnapshotFilterBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/DependenciesSnapshotFilterBase.cs
@@ -12,7 +12,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
     internal abstract class DependenciesSnapshotFilterBase : IDependenciesSnapshotFilter
     {
         public virtual void BeforeAddOrUpdate(
-            ITargetFramework targetFramework,
             IDependency dependency,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviderByProviderType,
             IImmutableSet<string>? projectItemSpecs,
@@ -22,7 +21,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
         }
 
         public virtual void BeforeRemove(
-            ITargetFramework targetFramework,
             IDependency dependency,
             RemoveDependencyContext context)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
@@ -32,13 +32,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
         /// In addition to the above operations, implementations of this method may also modify other
         /// dependencies in the snapshot. All these operations are performed via the <paramref name="context"/>.
         /// </remarks>
-        /// <param name="targetFramework">Target framework for which dependency was resolved.</param>
         /// <param name="dependency">The dependency to which filter should be applied.</param>
         /// <param name="subTreeProviderByProviderType">All dictionary of subtree providers keyed by <see cref="IProjectDependenciesSubTreeProvider.ProviderType"/>.</param>
         /// <param name="projectItemSpecs">List of all items contained in project's xml at given moment (non-imported items), otherwise, <see langword="null"/> if we do not have any data.</param>
         /// <param name="context">An object via which the filter must signal acceptance or rejection, in addition to making further changes to other dependencies.</param>
         void BeforeAddOrUpdate(
-            ITargetFramework targetFramework,
             IDependency dependency,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviderByProviderType,
             IImmutableSet<string>? projectItemSpecs,
@@ -47,11 +45,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
         /// <summary>
         /// Called before removing a dependency from a snapshot.
         /// </summary>
-        /// <param name="targetFramework">Target framework for which dependency was resolved.</param>
         /// <param name="dependency">The dependency to which filter should be applied.</param>
         /// <param name="context">An object via which the filter must signal acceptance or rejection, in addition to making further changes to other dependencies.</param>
         void BeforeRemove(
-            ITargetFramework targetFramework,
             IDependency dependency,
             RemoveDependencyContext context);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/ImplicitDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/ImplicitDependenciesSnapshotFilter.cs
@@ -22,7 +22,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
         public const int Order = 130;
 
         public override void BeforeAddOrUpdate(
-            ITargetFramework targetFramework,
             IDependency dependency,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviderByProviderType,
             IImmutableSet<string>? projectItemSpecs,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/RemoveDependencyContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/RemoveDependencyContext.cs
@@ -7,8 +7,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
 {
     /// <summary>
     /// Context used by <see cref="IDependenciesSnapshotFilter"/> implementations when filtering
-    /// a dependency that is being removed from a <see cref="DependenciesSnapshot"/> by
-    /// <see cref="DependenciesSnapshot.FromChanges"/>.
+    /// a dependency that is being removed from a <see cref="TargetedDependenciesSnapshot"/> by
+    /// <see cref="TargetedDependenciesSnapshot.FromChanges"/>.
     /// </summary>
     internal sealed class RemoveDependencyContext
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
@@ -23,7 +23,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
         public const int Order = 110;
 
         public override void BeforeAddOrUpdate(
-            ITargetFramework targetFramework,
             IDependency dependency,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviderByProviderType,
             IImmutableSet<string>? projectItemSpecs,
@@ -35,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
                 //
                 // Try to find a resolved package dependency with the same name.
 
-                string packageId = Dependency.GetID(targetFramework, PackageRuleHandler.ProviderTypeString, modelId: dependency.Name);
+                string packageId = Dependency.GetID(PackageRuleHandler.ProviderTypeString, modelId: dependency.Name);
 
                 if (context.TryGetDependency(packageId, out IDependency package) && package.Resolved)
                 {
@@ -52,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
                 //
                 // Try to find an SDK dependency with the same name.
 
-                string sdkId = Dependency.GetID(targetFramework, SdkRuleHandler.ProviderTypeString, modelId: dependency.Name);
+                string sdkId = Dependency.GetID(SdkRuleHandler.ProviderTypeString, modelId: dependency.Name);
 
                 if (context.TryGetDependency(sdkId, out IDependency sdk))
                 {
@@ -71,7 +70,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
         }
 
         public override void BeforeRemove(
-            ITargetFramework targetFramework,
             IDependency dependency,
             RemoveDependencyContext context)
         {
@@ -82,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
                 //
                 // Try to find an SDK dependency with the same name.
 
-                string sdkId = Dependency.GetID(targetFramework, SdkRuleHandler.ProviderTypeString, modelId: dependency.Name);
+                string sdkId = Dependency.GetID(SdkRuleHandler.ProviderTypeString, modelId: dependency.Name);
 
                 if (context.TryGetDependency(sdkId, out IDependency sdk))
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/UnresolvedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/UnresolvedDependenciesSnapshotFilter.cs
@@ -23,7 +23,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
         public const int Order = 100;
 
         public override void BeforeAddOrUpdate(
-            ITargetFramework targetFramework,
             IDependency dependency,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviderByProviderType,
             IImmutableSet<string>? projectItemSpecs,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependency.cs
@@ -6,16 +6,11 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 {
     /// <summary>
-    /// Represents internal immutable dependency entity that is stored in immutable
-    /// snapshot <see cref="TargetedDependenciesSnapshot"/>.
+    /// Represents internal immutable dependency entity that is stored in an immutable
+    /// <see cref="TargetedDependenciesSnapshot"/>.
     /// </summary>
     internal interface IDependency
     {
-        /// <summary>
-        /// Target framework of the snapshot dependency belongs to
-        /// </summary>
-        ITargetFramework TargetFramework { get; }
-
         /// <summary>
         /// Gets the set of icons to use for this dependency based on its state (e.g. resolved, expanded).
         /// </summary>
@@ -35,11 +30,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         #region Copied from IDependencyModel
 
         /// <summary>
-        /// Gets an composite identifier comprised of <see cref="TargetFramework"/>, <see cref="ProviderType"/>
+        /// Gets an composite identifier comprised of <see cref="ProviderType"/>
         /// and the originating <see cref="IDependencyModel"/>'s <see cref="IDependencyModel.Id"/>.
         /// </summary>
         /// <remarks>
-        /// This string has form <c>"tfm-name\provider-type\model-id"</c>.
+        /// This string has form <c>"provider-type\model-id"</c>.
         /// See <see cref="Dependency.GetID"/> for details on how this string is constructed.
         /// </remarks>
         string Id { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
@@ -38,19 +38,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             public ProjectTreeFlags Flags => _dependency.Flags;
         }
 
-        /// <summary>
-        /// Returns id having full path instead of OriginalItemSpec
-        /// </summary>
-        public static string GetTopLevelId(this IDependency self)
-        {
-            return string.IsNullOrEmpty(self.Path)
-                ? self.Id
-                : Dependency.GetID(self.ProviderType, self.Path);
-        }
-
-        /// <summary>
-        /// Returns id having full path instead of OriginalItemSpec
-        /// </summary>
         public static bool TopLevelIdEquals(this IDependency self, string id)
         {
             return string.IsNullOrEmpty(self.Path)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
@@ -30,9 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 _hasUnresolvedDependency = !dependency.Resolved;
             }
 
-            public IDependency? Dependency => _dependency;
             public string Caption => _dependency.Caption;
-            public string? FilePath => _dependency.Id;
             public string? SchemaName => _dependency.SchemaName;
             public string? SchemaItemType => _dependency.SchemaItemType;
             public ImageMoniker Icon => _hasUnresolvedDependency ? _dependency.IconSet.UnresolvedIcon : _dependency.IconSet.Icon;
@@ -47,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         {
             return string.IsNullOrEmpty(self.Path)
                 ? self.Id
-                : Dependency.GetID(self.TargetFramework, self.ProviderType, self.Path);
+                : Dependency.GetID(self.ProviderType, self.Path);
         }
 
         /// <summary>
@@ -57,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         {
             return string.IsNullOrEmpty(self.Path)
                 ? string.Equals(self.Id, id, StringComparisons.DependencyTreeIds)
-                : Dependency.IdEquals(id, self.TargetFramework, self.ProviderType, self.Path);
+                : Dependency.IdEquals(id, self.ProviderType, self.Path);
         }
 
         public static IDependency ToResolved(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -88,8 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             void Remove(RemoveDependencyContext context, IDependencyModel dependencyModel)
             {
-                string dependencyId = Dependency.GetID(
-                    targetFramework, dependencyModel.ProviderType, dependencyModel.Id);
+                string dependencyId = Dependency.GetID(dependencyModel.ProviderType, dependencyModel.Id);
 
                 if (!context.TryGetDependency(dependencyId, out IDependency dependency))
                 {
@@ -101,7 +100,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 foreach (IDependenciesSnapshotFilter filter in snapshotFilters)
                 {
                     filter.BeforeRemove(
-                        targetFramework,
                         dependency,
                         context);
 
@@ -121,14 +119,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             void Add(AddDependencyContext context, IDependencyModel dependencyModel)
             {
                 // Create the unfiltered dependency
-                IDependency? dependency = new Dependency(dependencyModel, targetFramework);
+                IDependency? dependency = new Dependency(dependencyModel);
 
                 context.Reset();
 
                 foreach (IDependenciesSnapshotFilter filter in snapshotFilters)
                 {
                     filter.BeforeAddOrUpdate(
-                        targetFramework,
                         dependency,
                         subTreeProviderByProviderType,
                         projectItemSpecs,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/MockIDependenciesTreeServices.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/MockIDependenciesTreeServices.cs
@@ -23,7 +23,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return new TestProjectTree
             {
                 Caption = caption,
-                FilePath = itemContext.File ?? caption,
                 BrowseObjectProperties = browseObjectProperties,
                 Icon = icon,
                 ExpandedIcon = expandedIcon,
@@ -45,7 +44,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return new TestProjectTree
             {
                 Caption = caption,
-                FilePath = filePath,
                 BrowseObjectProperties = browseObjectProperties,
                 Icon = icon,
                 ExpandedIcon = expandedIcon,
@@ -55,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             };
         }
 
-        public Task<IRule?> GetBrowseObjectRuleAsync(IDependency dependency, IProjectCatalogSnapshot? catalogs)
+        public Task<IRule?> GetBrowseObjectRuleAsync(IDependency dependency, ITargetFramework targetFramework, IProjectCatalogSnapshot? catalogs)
         {
             var mockRule = new Mock<IRule>(MockBehavior.Strict);
             mockRule.Setup(x => x.Name).Returns(dependency.SchemaItemType);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/TestDependencyModel.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/TestDependencyModel.cs
@@ -35,9 +35,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public string Id { get; set; }
 #pragma warning restore CS8618 // Non-nullable property is uninitialized
 
-        public bool Matches(IDependency dependency, ITargetFramework tfm)
+        public bool Matches(IDependency dependency)
         {
-            return Dependency.GetID(tfm, ProviderType, Id) == dependency.Id
+            return Dependency.GetID(ProviderType, Id) == dependency.Id
                    && ProviderType == dependency.ProviderType
                    && Flags == dependency.Flags
                    && (Name == null || Name == dependency.Name)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/TestProjectTree.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/TestProjectTree.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public bool Visible { get; set; }
         public ProjectImageMoniker ExpandedIcon { get; set; }
         public ProjectImageMoniker Icon { get; set; }
-        public string FilePath { get; set; } = "";
+        public string FilePath => null;
         public string Caption { get; set; }
         IReadOnlyList<IProjectTree> IProjectTree.Children => Children.ToList();
         public IProjectTree Root { get; }
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public IProjectTree Remove(IProjectTree subtree)
         {
-            var nodeToRemove = Children.FirstOrDefault(x => x.FilePath.Equals(subtree.FilePath));
+            var nodeToRemove = Children.FirstOrDefault(ReferenceEquals, subtree);
             if (nodeToRemove != null)
             {
                 Children.Remove(nodeToRemove);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             var resultTree = await CreateProvider().BuildTreeAsync(dependenciesRoot, snapshot);
 
             // Assert
-            var expectedFlatHierarchy = "Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=";
+            var expectedFlatHierarchy = "Caption=MyDependencies, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=";
             Assert.Equal(expectedFlatHierarchy, ToTestDataString((TestProjectTree)resultTree));
             Assert.Equal(s_rootImage.ToProjectSystemType(), resultTree.Icon);
             Assert.Equal(s_rootImage.ToProjectSystemType(), resultTree.ExpandedIcon);
@@ -60,37 +60,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             var dependencyXxx1 = new TestDependency
             {
                 ProviderType = "Xxx",
-                Id = "tfm1\\xxx\\dependency1",
+                Id = "xxx\\dependency1",
                 Name = "dependency1",
                 Path = "dependencyXxxpath",
                 Caption = "Dependency1",
                 SchemaItemType = "Xxx",
-                Resolved = true,
-                TargetFramework = _tfm1
+                Resolved = true
             };
 
             var dependencyYyy1 = new TestDependency
             {
                 ProviderType = "Yyy",
-                Id = "tfm1\\yyy\\dependency1",
+                Id = "yyy\\dependency1",
                 Name = "dependency1",
                 Path = "dependencyYyypath",
                 Caption = "Dependency1",
                 SchemaItemType = "Yyy",
-                Resolved = true,
-                TargetFramework = _tfm1
+                Resolved = true
             };
 
             var dependencyYyyExisting = new TestDependency
             {
                 ProviderType = "Yyy",
-                Id = "tfm1\\yyy\\dependencyExisting",
+                Id = "yyy\\dependencyExisting",
                 Name = "dependencyExisting",
                 Path = "dependencyExistingPath",
                 Caption = "DependencyExisting",
                 SchemaItemType = "Yyy",
-                Resolved = true,
-                TargetFramework = _tfm1
+                Resolved = true
             };
 
             var dependenciesRoot = new TestProjectTree
@@ -105,13 +102,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                     new TestProjectTree
                     {
                         Caption = "YyyDependencyRoot",
-                        FilePath = "YyyDependencyRoot",
                         Children =
                         {
                             new TestProjectTree
                             {
-                                Caption = "DependencyExisting",
-                                FilePath = "tfm1\\yyy\\dependencyExisting"
+                                Caption = "DependencyExisting"
                             }
                         }
                     }
@@ -126,13 +121,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             var resultTree = await provider.BuildTreeAsync(dependenciesRoot, snapshot);
 
             // Assert
-            var expectedFlatHierarchy =
-@"Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
-    Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
-        Caption=DependencyExisting, FilePath=tfm1\yyy\dependencyExisting, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=False, CustomTag=
-        Caption=Dependency1, FilePath=tfm1\Yyy\dependencyYyypath, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=True, CustomTag=
-    Caption=XxxDependencyRoot, FilePath=XxxDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
-        Caption=Dependency1, FilePath=tfm1\Xxx\dependencyXxxpath, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=True, CustomTag=";
+            const string expectedFlatHierarchy =
+@"Caption=MyDependencies, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
+    Caption=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
+        Caption=DependencyExisting, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=False, CustomTag=
+        Caption=Dependency1, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=True, CustomTag=
+    Caption=XxxDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
+        Caption=Dependency1, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=True, CustomTag=";
             Assert.Equal(expectedFlatHierarchy, ToTestDataString((TestProjectTree)resultTree));
         }
 
@@ -151,13 +146,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             var dependencyYyyExisting = new TestDependency
             {
                 ProviderType = "Yyy",
-                Id = "tfm1\\yyy\\dependencyExisting",
+                Id = "yyy\\dependencyExisting",
                 Name = "dependencyExisting",
                 Path = "dependencyExistingpath",
                 Caption = "DependencyExisting",
                 SchemaItemType = "Yyy",
-                Resolved = true,
-                TargetFramework = _tfm1
+                Resolved = true
             };
 
             var dependenciesRoot = new TestProjectTree
@@ -168,13 +162,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                     new TestProjectTree
                     {
                         Caption = "YyyDependencyRoot",
-                        FilePath = "YyyDependencyRoot",
                         Children =
                         {
                             new TestProjectTree
                             {
                                 Caption = "DependencyExisting",
-                                FilePath = "tfm1\\yyy\\dependencyExisting",
                                 CustomTag = "Untouched",
                                 Flags = DependencyTreeFlags.Unresolved
                             }
@@ -192,9 +184,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
             // Assert
             var expectedFlatHierarchy =
-@"Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
-    Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
-        Caption=DependencyExisting, FilePath=tfm1\yyy\dependencyExisting, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=False, CustomTag=Untouched";
+@"Caption=MyDependencies, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
+    Caption=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
+        Caption=DependencyExisting, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=False, CustomTag=Untouched";
             Assert.Equal(expectedFlatHierarchy, ToTestDataString((TestProjectTree)resultTree));
         }
 
@@ -213,7 +205,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             var dependencyYyyExisting = new TestDependency
             {
                 ProviderType = "Yyy",
-                Id = "tfm1\\yyy\\dependencyExisting",
+                Id = "yyy\\dependencyExisting",
                 Name = "dependencyExisting",
                 Caption = "DependencyExisting",
                 SchemaItemType = "Yyy",
@@ -228,13 +220,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                     new TestProjectTree
                     {
                         Caption = "YyyDependencyRoot",
-                        FilePath = "YyyDependencyRoot",
                         Children =
                         {
                             new TestProjectTree
                             {
                                 Caption = "DependencyExisting",
-                                FilePath = "tfm1\\yyy\\dependencyExisting",
                                 CustomTag = "Untouched",
                                 Flags = DependencyTreeFlags.Resolved
                             }
@@ -252,9 +242,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
             // Assert
             var expectedFlatHierarchy =
-@"Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
-    Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
-        Caption=DependencyExisting, FilePath=tfm1\yyy\dependencyExisting, IconHash=325248665, ExpandedIconHash=325248817, Rule=, IsProjectItem=False, CustomTag=Untouched";
+@"Caption=MyDependencies, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
+    Caption=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
+        Caption=DependencyExisting, IconHash=325248665, ExpandedIconHash=325248817, Rule=, IsProjectItem=False, CustomTag=Untouched";
             Assert.Equal(expectedFlatHierarchy, ToTestDataString((TestProjectTree)resultTree));
         }
 
@@ -273,7 +263,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             var dependencyYyyExisting = new TestDependency
             {
                 ProviderType = "Yyy",
-                Id = "tfm1\\yyy\\dependencyExisting",
+                Id = "yyy\\dependencyExisting",
                 Name = "dependencyExisting",
                 Caption = "DependencyExisting",
                 SchemaItemType = "Yyy",
@@ -289,13 +279,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                     new TestProjectTree
                     {
                         Caption = "YyyDependencyRoot",
-                        FilePath = "YyyDependencyRoot",
                         Children =
                         {
                             new TestProjectTree
                             {
                                 Caption = "DependencyExisting",
-                                FilePath = "tfm1\\yyy\\dependencyExisting",
                                 Flags = DependencyTreeFlags.Resolved
                             }
                         }
@@ -312,9 +300,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
             // Assert
             var expectedFlatHierarchy =
-@"Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
-    Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
-        Caption=DependencyExisting, FilePath=tfm1\yyy\dependencyExisting, IconHash=325248088, ExpandedIconHash=325248260, Rule=Yyy, IsProjectItem=False, CustomTag=";
+@"Caption=MyDependencies, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
+    Caption=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
+        Caption=DependencyExisting, IconHash=325248088, ExpandedIconHash=325248260, Rule=Yyy, IsProjectItem=False, CustomTag=";
             Assert.Equal(expectedFlatHierarchy, ToTestDataString((TestProjectTree)resultTree));
         }
 
@@ -348,8 +336,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 {
                     new TestProjectTree
                     {
-                        Caption = "YyyDependencyRoot",
-                        FilePath = "YyyDependencyRoot"
+                        Caption = "YyyDependencyRoot"
                     }
                 }
             };
@@ -363,8 +350,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
             // Assert
             var expectedFlatHierarchy =
-@"Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
-    Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=";
+@"Caption=MyDependencies, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
+    Caption=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=";
             Assert.Equal(expectedFlatHierarchy, ToTestDataString((TestProjectTree)resultTree));
         }
 
@@ -397,8 +384,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 {
                     new TestProjectTree
                     {
-                        Caption = "YyyDependencyRoot",
-                        FilePath = "YyyDependencyRoot"
+                        Caption = "YyyDependencyRoot"
                     }
                 }
             };
@@ -412,7 +398,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
             // Assert
             var expectedFlatHierarchy =
-@"Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=";
+@"Caption=MyDependencies, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=";
             Assert.Equal(expectedFlatHierarchy, ToTestDataString((TestProjectTree)resultTree));
         }
 
@@ -436,8 +422,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 Name = "dependency1",
                 Caption = "Dependency1",
                 SchemaItemType = "Xxx",
-                Resolved = true,
-                TargetFramework = _tfm1
+                Resolved = true
             };
 
             var dependencyModelRootYyy = new TestDependencyModel
@@ -456,8 +441,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 Name = "dependency1",
                 Caption = "Dependency1",
                 SchemaItemType = "Yyy",
-                Resolved = true,
-                TargetFramework = _tfm1
+                Resolved = true
             };
 
             var dependencyYyyExisting = new TestDependency
@@ -468,8 +452,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 Name = "dependencyExisting",
                 Caption = "DependencyExisting",
                 SchemaItemType = "Yyy",
-                Resolved = true,
-                TargetFramework = _tfm1
+                Resolved = true
             };
 
             var dependencyModelRootZzz = new TestDependencyModel
@@ -488,8 +471,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 Id = "ZzzDependencyAny1",
                 Path = "ZzzDependencyAny1path",
                 Name = "ZzzDependencyAny1",
-                Caption = "ZzzDependencyAny1",
-                TargetFramework = TargetFramework.Any
+                Caption = "ZzzDependencyAny1"
             };
 
             var dependenciesRoot = new TestProjectTree
@@ -504,13 +486,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                     new TestProjectTree
                     {
                         Caption = "YyyDependencyRoot",
-                        FilePath = "YyyDependencyRoot",
                         Children =
                         {
                             new TestProjectTree
                             {
                                 Caption = "DependencyExisting",
-                                FilePath = "yyy\\dependencyExisting"
                             }
                         }
                     }
@@ -544,232 +524,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             var resultTree = await provider.BuildTreeAsync(dependenciesRoot, snapshot);
 
             // Assert
-            var expectedFlatHierarchy =
-@"Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
-    Caption=ZzzDependencyRoot, FilePath=ZzzDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
-        Caption=ZzzDependencyAny1, FilePath=ZzzDependencyAny1, IconHash=325248665, ExpandedIconHash=325248817, Rule=, IsProjectItem=False, CustomTag=
-    Caption=tfm2, FilePath=tfm2, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=, BubbleUpFlag=True
-        Caption=XxxDependencyRoot, FilePath=XxxDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
-            Caption=Dependency1, FilePath=tfm1\Xxx\dependencyxxxpath, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=False, CustomTag=
-        Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
-            Caption=Dependency1, FilePath=tfm1\Yyy\dependencyyyypath, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=False, CustomTag=
-            Caption=DependencyExisting, FilePath=tfm1\Yyy\dependencyyyyExistingpath, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=False, CustomTag=
-    Caption=tfm1, FilePath=tfm1, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=, BubbleUpFlag=True
-        Caption=XxxDependencyRoot, FilePath=XxxDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
-            Caption=Dependency1, FilePath=tfm1\Xxx\dependencyxxxpath, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=True, CustomTag=
-        Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
-            Caption=Dependency1, FilePath=tfm1\Yyy\dependencyyyypath, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=True, CustomTag=
-            Caption=DependencyExisting, FilePath=tfm1\Yyy\dependencyyyyExistingpath, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=True, CustomTag=";
+            const string expectedFlatHierarchy =
+@"Caption=MyDependencies, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
+    Caption=ZzzDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
+        Caption=ZzzDependencyAny1, IconHash=325248665, ExpandedIconHash=325248817, Rule=, IsProjectItem=False, CustomTag=
+    Caption=tfm2, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=, BubbleUpFlag=True
+        Caption=XxxDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
+            Caption=Dependency1, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=False, CustomTag=
+        Caption=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
+            Caption=Dependency1, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=False, CustomTag=
+            Caption=DependencyExisting, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=False, CustomTag=
+    Caption=tfm1, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=, BubbleUpFlag=True
+        Caption=XxxDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
+            Caption=Dependency1, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=True, CustomTag=
+        Caption=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
+            Caption=Dependency1, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=True, CustomTag=
+            Caption=DependencyExisting, IconHash=325248088, ExpandedIconHash=325248260, Rule=, IsProjectItem=True, CustomTag=";
             Assert.Equal(expectedFlatHierarchy, ToTestDataString((TestProjectTree)resultTree));
-        }
-
-        [Fact]
-        public void WhenFindByPathAndNullNode_ShouldDoNothing()
-        {
-            // Arrange
-            var provider = CreateProvider();
-
-            // Act
-            var resultTree = provider.FindByPath(null, "SomePath");
-
-            // Assert
-            Assert.Null(resultTree);
-        }
-
-        [Fact]
-        public void WhenFindByPathAndNotDependenciesRoot_ShouldDoNothing()
-        {
-            // Arrange
-            var provider = CreateProvider();
-            var dependenciesRoot = new TestProjectTree { Caption = "MyDependencies" };
-
-            // Act
-            var resultTree = provider.FindByPath(dependenciesRoot, "SomePath");
-
-            // Assert
-            Assert.Null(resultTree);
-        }
-
-        [Fact]
-        public void WhenFindByPathAndAbsoluteNodePath_ShouldFind()
-        {
-            // Arrange
-            var provider = CreateProvider();
-
-            var dependenciesRoot = new TestProjectTree
-            {
-                Caption = "MyDependencies",
-                Flags = DependencyTreeFlags.DependenciesRootNode,
-                Children =
-                {
-                    new TestProjectTree
-                    {
-                        Caption = "level1Child1",
-                        FilePath = @"c:\folder\level1Child1"
-                    },
-                    new TestProjectTree
-                    {
-                        Caption = "level1Child2",
-                        FilePath = @"c:\folder\level1Child2",
-                        Children =
-                        {
-                            new TestProjectTree
-                            {
-                                Caption = "level2Child21",
-                                FilePath = @"c:\folder\level2Child21"
-                            },
-                            new TestProjectTree
-                            {
-                                Caption = "level1Child22",
-                                FilePath = @"c:\folder\level2Child22",
-                                Children =
-                                {
-                                    new TestProjectTree
-                                    {
-                                        Caption = "level3Child31",
-                                        FilePath = @"c:\folder\level3Child31"
-                                    },
-                                    new TestProjectTree
-                                    {
-                                        Caption = "level3Child32",
-                                        FilePath = @"c:\folder\level3Child32"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
-            // Act
-            var resultTree = provider.FindByPath(dependenciesRoot, @"c:\folder\level3Child32");
-
-            // Assert
-            Assert.NotNull(resultTree);
-            Assert.Equal("level3Child32", resultTree!.Caption);
-        }
-
-        [Fact]
-        public void WhenFindByPathAndRelativeNodePath_ShouldNotFind()
-        {
-            // Arrange
-            var provider = CreateProvider();
-
-            var dependenciesRoot = new TestProjectTree
-            {
-                Caption = "MyDependencies",
-                Flags = DependencyTreeFlags.DependenciesRootNode,
-                Children =
-                {
-                    new TestProjectTree
-                    {
-                        Caption = "level1Child1",
-                        FilePath = @"c:\folder\level1Child1"
-                    },
-                    new TestProjectTree
-                    {
-                        Caption = "level1Child2",
-                        FilePath = @"c:\folder\level1Child2",
-                        Children =
-                        {
-                            new TestProjectTree
-                            {
-                                Caption = "level2Child21",
-                                FilePath = @"c:\folder\level2Child21"
-                            },
-                            new TestProjectTree
-                            {
-                                Caption = "level1Child22",
-                                FilePath = @"c:\folder\level2Child22",
-                                Children =
-                                {
-                                    new TestProjectTree
-                                    {
-                                        Caption = "level3Child31",
-                                        FilePath = @"c:\folder\level3Child31"
-                                    },
-                                    new TestProjectTree
-                                    {
-                                        Caption = "level3Child32",
-                                        FilePath = @"level3Child32"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
-            // Act
-            var resultTree = provider.FindByPath(dependenciesRoot, "SomePath\\level3Child32");
-
-            // Assert
-            Assert.Null(resultTree);
-        }
-
-        [Fact]
-        public void WhenFindByPathAndNeedToFindDependenciesRoot_ShouldNotFind()
-        {
-            // Arrange
-            var provider = CreateProvider();
-
-            var projectRoot = new TestProjectTree
-            {
-                Caption = "myproject",
-                Children =
-                {
-                    new TestProjectTree
-                    {
-                        Caption = "MyDependencies",
-                        Flags = DependencyTreeFlags.DependenciesRootNode,
-                        Children =
-                        {
-                            new TestProjectTree
-                            {
-                                Caption = "level1Child1",
-                                FilePath = @"c:\folder\level1Child1"
-                            },
-                            new TestProjectTree
-                            {
-                                Caption = "level1Child2",
-                                FilePath = @"c:\folder\level1Child2",
-                                Children =
-                                {
-                                    new TestProjectTree
-                                    {
-                                        Caption = "level2Child21",
-                                        FilePath = @"c:\folder\level2Child21"
-                                    },
-                                    new TestProjectTree
-                                    {
-                                        Caption = "level1Child22",
-                                        FilePath = @"c:\folder\level2Child22",
-                                        Children =
-                                        {
-                                            new TestProjectTree
-                                            {
-                                                Caption = "level3Child31",
-                                                FilePath = @"c:\folder\level3Child31"
-                                            },
-                                            new TestProjectTree
-                                            {
-                                                Caption = "level3Child32",
-                                                FilePath = @"level3Child32"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
-            // Act
-            var result = provider.FindByPath(projectRoot, "SomePath\\level3Child32");
-
-            // Assert
-            Assert.Null(result);
         }
 
         private static DependenciesTreeViewProvider CreateProvider(
@@ -783,7 +554,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 createRootViewModel: rootModels,
                 createTargetViewModel: targetModels);
 
-            var commonServices = IUnconfiguredProjectCommonServicesFactory.Create();
+            var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(
+                project: UnconfiguredProjectFactory.Create());
 
             return new DependenciesTreeViewProvider(treeServices, treeViewModelFactory, commonServices);
         }
@@ -830,7 +602,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 {
                     builder.Append(' ', indent * 4);
                     builder.Append("Caption=").Append(tree.Caption).Append(", ");
-                    builder.Append("FilePath=").Append(tree.FilePath).Append(", ");
                     builder.Append("IconHash=").Append(tree.Icon.GetHashCode()).Append(", ");
                     builder.Append("ExpandedIconHash=").Append(tree.ExpandedIcon.GetHashCode()).Append(", ");
                     builder.Append("Rule=").Append(tree.BrowseObjectProperties?.Name ?? "").Append(", ");

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DeduplicateCaptionsSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DeduplicateCaptionsSnapshotFilterTests.cs
@@ -38,7 +38,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var filter = new DeduplicateCaptionsSnapshotFilter();
 
             filter.BeforeAddOrUpdate(
-                null!,
                 dependency,
                 null!,
                 null,
@@ -84,7 +83,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var filter = new DeduplicateCaptionsSnapshotFilter();
 
             filter.BeforeAddOrUpdate(
-                null!,
                 dependency,
                 null!,
                 null,
@@ -136,7 +134,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var filter = new DeduplicateCaptionsSnapshotFilter();
 
             filter.BeforeAddOrUpdate(
-                null!,
                 dependency,
                 null!,
                 null,
@@ -189,7 +186,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var filter = new DeduplicateCaptionsSnapshotFilter();
 
             filter.BeforeAddOrUpdate(
-                null!,
                 dependency,
                 null!,
                 null,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshotFilterTestsBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshotFilterTestsBase.cs
@@ -23,7 +23,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var filter = CreateFilter();
 
             filter.BeforeAddOrUpdate(
-                null!,
                 dependency,
                 null!,
                 projectItemSpecs,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
@@ -174,7 +174,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var (actualTfm, targetedSnapshot) = Assert.Single(snapshot.DependenciesByTargetFramework);
             Assert.Same(targetFramework, actualTfm);
             var dependency = Assert.Single(targetedSnapshot.Dependencies);
-            Assert.Equal(@"tfm1\Xxx\dependency1", dependency.Id);
+            Assert.Equal(@"Xxx\dependency1", dependency.Id);
             Assert.Equal("Xxx", dependency.ProviderType);
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
@@ -44,7 +44,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             Assert.Equal(dependencyResolved.Caption,               viewModelResolved.Caption);
             Assert.Equal(dependencyResolved.Flags,                 viewModelResolved.Flags);
-            Assert.Equal(dependencyResolved.Id,                    viewModelResolved.FilePath);
             Assert.Equal(dependencyResolved.SchemaName,            viewModelResolved.SchemaName);
             Assert.Equal(dependencyResolved.SchemaItemType,        viewModelResolved.SchemaItemType);
             Assert.Equal(iconSet.Icon,                             viewModelResolved.Icon);
@@ -54,7 +53,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             Assert.Equal(dependencyUnresolved.Caption,             viewModelUnresolved.Caption);
             Assert.Equal(dependencyUnresolved.Flags,               viewModelUnresolved.Flags);
-            Assert.Equal(dependencyUnresolved.Id,                  viewModelUnresolved.FilePath);
             Assert.Equal(dependencyUnresolved.SchemaName,          viewModelUnresolved.SchemaName);
             Assert.Equal(dependencyUnresolved.SchemaItemType,      viewModelUnresolved.SchemaItemType);
             Assert.Equal(iconSet.UnresolvedIcon,                   viewModelUnresolved.Icon);
@@ -76,11 +74,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             {
                 Id = "id1",
                 Path = "xxxxxxx",
-                ProviderType = "MyProvider",
-                TargetFramework = new TargetFramework("tfm1")
+                ProviderType = "MyProvider"
             };
 
-            Assert.Equal("tfm1\\MyProvider\\xxxxxxx", dependency2.GetTopLevelId());
+            Assert.Equal("MyProvider\\xxxxxxx", dependency2.GetTopLevelId());
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
@@ -58,26 +58,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             Assert.Equal(iconSet.UnresolvedIcon,                   viewModelUnresolved.Icon);
             Assert.Equal(iconSet.UnresolvedExpandedIcon,           viewModelUnresolved.ExpandedIcon);
         }
-
-        [Fact]
-        public void GetTopLevelId()
-        {
-            var dependency1 = new TestDependency
-            {
-                Id = "id1",
-                ProviderType = "MyProvider"
-            };
-
-            Assert.Equal("id1", dependency1.GetTopLevelId());
-
-            var dependency2 = new TestDependency
-            {
-                Id = "id1",
-                Path = "xxxxxxx",
-                ProviderType = "MyProvider"
-            };
-
-            Assert.Equal("MyProvider\\xxxxxxx", dependency2.GetTopLevelId());
-        }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -15,29 +15,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         [Fact]
         public void Dependency_Constructor_WhenRequiredParamsNotProvided_ShouldThrow()
         {
-            var targetFramework = new TargetFramework("tfm");
-
             Assert.Throws<ArgumentNullException>("dependencyModel", () =>
             {
-                new Dependency(null!, targetFramework);
+                new Dependency(null!);
             });
 
             Assert.Throws<ArgumentNullException>("ProviderType", () =>
             {
                 var dependencyModel = new TestDependencyModel { ProviderType = null!, Id = "Id" };
-                new Dependency(dependencyModel, targetFramework);
+                new Dependency(dependencyModel);
             });
 
             Assert.Throws<ArgumentNullException>("Id", () =>
             {
                 var dependencyModel = new TestDependencyModel { ProviderType = "providerType", Id = null! };
-                new Dependency(dependencyModel, targetFramework);
-            });
-
-            Assert.Throws<ArgumentNullException>("targetFramework", () =>
-            {
-                var dependencyModel = new TestDependencyModel { ProviderType = "providerType", Id = "id" };
-                new Dependency(dependencyModel, null!);
+                new Dependency(dependencyModel);
             });
         }
 
@@ -50,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 Id = "mymodel"
             };
 
-            var dependency = new Dependency(mockModel, new TargetFramework("tfm1"));
+            var dependency = new Dependency(mockModel);
 
             Assert.Equal(mockModel.ProviderType, dependency.ProviderType);
             Assert.Equal(string.Empty, dependency.Name);
@@ -88,9 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 Properties = new Dictionary<string, string> { { "prop1", "val1" } }.ToImmutableDictionary()
             };
 
-            var targetFramework = new TargetFramework("Tfm1");
-
-            var dependency = new Dependency(mockModel, targetFramework);
+            var dependency = new Dependency(mockModel);
 
             Assert.Equal(mockModel.ProviderType, dependency.ProviderType);
             Assert.Equal(mockModel.Name, dependency.Name);
@@ -108,29 +98,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         }
 
         [Theory]
-        [InlineData(@"../../somepath", @"tfm1\xxx\__\__\somepath")]
-        [InlineData(@"__\somepath..\", @"tfm1\xxx\__\somepath__")]
-        [InlineData(@"somepath", @"tfm1\xxx\somepath")]
+        [InlineData(@"../../somepath", @"xxx\__\__\somepath")]
+        [InlineData(@"__\somepath..\", @"xxx\__\somepath__")]
+        [InlineData(@"somepath", @"xxx\somepath")]
         public void Dependency_Id_NoSnapshotTargetFramework(string modelId, string expectedId)
         {
             var dependencyModel = new TestDependencyModel { ProviderType = "xxx", Id = modelId };
 
-            var dependency = new Dependency(dependencyModel, new TargetFramework("tfm1"));
+            var dependency = new Dependency(dependencyModel);
 
             Assert.Equal(dependencyModel.ProviderType, dependency.ProviderType);
             Assert.Equal(expectedId, dependency.Id);
         }
 
         [Theory]
-        [InlineData(@"../../somepath", @"tfm\providerType\__\__\somepath")]
-        [InlineData(@"__\somepath..\", @"tfm\providerType\__\somepath__")]
-        [InlineData(@"somepath", @"tfm\providerType\somepath")]
+        [InlineData(@"../../somepath", @"providerType\__\__\somepath")]
+        [InlineData(@"__\somepath..\", @"providerType\__\somepath__")]
+        [InlineData(@"somepath", @"providerType\somepath")]
         public void Dependency_Id(string modelId, string expectedId)
         {
             var dependencyModel = new TestDependencyModel { ProviderType = "providerType", Id = modelId };
-            var targetFramework = new TargetFramework("tfm");
 
-            var dependency = new Dependency(dependencyModel, targetFramework);
+            var dependency = new Dependency(dependencyModel);
 
             Assert.Equal(dependencyModel.ProviderType, dependency.ProviderType);
             Assert.Equal(expectedId, dependency.Id);
@@ -141,7 +130,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         {
             var dependencyModel = new TestDependencyModel { ProviderType = "providerType", Id = "someId" };
 
-            var dependency = new Dependency(dependencyModel, new TargetFramework("tfm1"));
+            var dependency = new Dependency(dependencyModel);
             var flags = ProjectTreeFlags.Create("TestFlag");
 
             var newDependency = dependency.SetProperties(
@@ -159,7 +148,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         {
             var dependencyModel = new TestDependencyModel { ProviderType = "providerType", Id = "someId" };
 
-            var dependency = (new Dependency(dependencyModel, new TargetFramework("tfm1")))
+            var dependency = (new Dependency(dependencyModel))
                 .SetProperties(iconSet: new DependencyIconSet(KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference));
 
             var dependencyWithUpdatedIconSet = dependency.SetProperties(iconSet: new DependencyIconSet(KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference));
@@ -175,7 +164,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                     "ItemSpec",
                     iconSet: new DependencyIconSet(KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference));
 
-            var dependency = new Dependency(dependencyModel, new TargetFramework("tfm2"));
+            var dependency = new Dependency(dependencyModel);
 
             Assert.Same(dependencyModel.IconSet, dependency.IconSet);
         }
@@ -216,10 +205,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 UnresolvedExpandedIcon = KnownMonikers.PathListBoxItem
             };
 
-            var targetFramework = new TargetFramework("Tfm1");
-
-            var dependency1 = new Dependency(model1, targetFramework);
-            var dependency2 = new Dependency(model2, targetFramework);
+            var dependency1 = new Dependency(model1);
+            var dependency2 = new Dependency(model2);
 
             Assert.Same(dependency1.IconSet, dependency2.IconSet);
         }
@@ -227,40 +214,38 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         [Fact]
         public void GetID_ThrowsForInvalidArguments()
         {
-            var tfm = TargetFramework.Any;
             var type = "providerType";
             var modelId = "modelId";
 
-            Assert.Throws<ArgumentNullException>(() => Dependency.GetID(null!, type, modelId));
-            Assert.Throws<ArgumentNullException>(() => Dependency.GetID(tfm, null!, modelId));
-            Assert.Throws<ArgumentNullException>(() => Dependency.GetID(tfm, type, null!));
+            Assert.Throws<ArgumentNullException>(() => Dependency.GetID(null!, modelId));
+            Assert.Throws<ArgumentNullException>(() => Dependency.GetID(type, null!));
 
-            Assert.Throws<ArgumentException>(() => Dependency.GetID(tfm, "", modelId));
-            Assert.Throws<ArgumentException>(() => Dependency.GetID(tfm, type, ""));
+            Assert.Throws<ArgumentException>(() => Dependency.GetID("", modelId));
+            Assert.Throws<ArgumentException>(() => Dependency.GetID(type, ""));
         }
 
         [Theory]
-        [InlineData(@"../../somepath", @"any\providerType\__\__\somepath")]
-        [InlineData(@"__\somepath..\", @"any\providerType\__\somepath__")]
-        [InlineData(@"somepath", @"any\providerType\somepath")]
+        [InlineData(@"../../somepath", @"providerType\__\__\somepath")]
+        [InlineData(@"__\somepath..\", @"providerType\__\somepath__")]
+        [InlineData(@"somepath", @"providerType\somepath")]
         public void GetID_CreatesCorrectString(string modelId, string expected)
         {
-            Assert.Equal(expected, Dependency.GetID(TargetFramework.Any, "providerType", modelId));
+            Assert.Equal(expected, Dependency.GetID("providerType", modelId));
         }
 
         [Fact]
         public void IdEquals()
         {
-            Assert.True(Dependency.IdEquals(@"any\providerType\modelId", TargetFramework.Any, "providerType", "modelId"));
-            Assert.True(Dependency.IdEquals(@"any\providerType\modelId", TargetFramework.Any, "providerType", "modelId/"));
-            Assert.True(Dependency.IdEquals(@"any\providerType\__\__\modelId", TargetFramework.Any, "providerType", "../../modelId"));
-            Assert.True(Dependency.IdEquals(@"any\providerType\__\__\modelId", TargetFramework.Any, "providerType", "..\\..\\modelId"));
-            Assert.True(Dependency.IdEquals(@"any\providerType\__\__\modelId", TargetFramework.Any, "providerType", "../../modelId/"));
-            Assert.True(Dependency.IdEquals(@"ANY\PROVIDERTYPE\MODELID", TargetFramework.Any, "providerType", "modelId"));
-            Assert.False(Dependency.IdEquals(@"any/providerType/modelId", TargetFramework.Any, "providerType", "modelId"));
-            Assert.False(Dependency.IdEquals(@"any/providerType/modelId/", TargetFramework.Any, "providerType", "modelId"));
-            Assert.False(Dependency.IdEquals(@"XXX\providerType\modelId", TargetFramework.Any, "providerType", "modelId"));
-            Assert.False(Dependency.IdEquals(@"any\XXX\modelId", TargetFramework.Any, "providerType", "modelId"));
+            Assert.True(Dependency.IdEquals(@"providerType\modelId", "providerType", "modelId"));
+            Assert.True(Dependency.IdEquals(@"providerType\modelId", "providerType", "modelId/"));
+            Assert.True(Dependency.IdEquals(@"providerType\__\__\modelId", "providerType", "../../modelId"));
+            Assert.True(Dependency.IdEquals(@"providerType\__\__\modelId", "providerType", "..\\..\\modelId"));
+            Assert.True(Dependency.IdEquals(@"providerType\__\__\modelId", "providerType", "../../modelId/"));
+            Assert.True(Dependency.IdEquals(@"PROVIDERTYPE\MODELID", "providerType", "modelId"));
+            Assert.False(Dependency.IdEquals(@"providerType/modelId", "providerType", "modelId"));
+            Assert.False(Dependency.IdEquals(@"providerType/modelId/", "providerType", "modelId"));
+            Assert.False(Dependency.IdEquals(@"XXX\providerType\modelId", "providerType", "modelId"));
+            Assert.False(Dependency.IdEquals(@"XXX\modelId", "providerType", "modelId"));
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/ImplicitDependenciesSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/ImplicitDependenciesSnapshotFilterTests.cs
@@ -124,7 +124,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 implicitIcon: implicitIcon);
 
             filter.BeforeAddOrUpdate(
-                null!,
                 dependency,
                 new Dictionary<string, IProjectDependenciesSubTreeProvider> { { providerType, subTreeProvider } },
                 ImmutableHashSet<string>.Empty,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             var packageDependency = new TestDependency
             {
-                Id = Dependency.GetID(targetFramework, PackageRuleHandler.ProviderTypeString, sdkName),
+                Id = Dependency.GetID(PackageRuleHandler.ProviderTypeString, sdkName),
                 Resolved = true,
                 Flags = DependencyTreeFlags.PackageDependency
             };
@@ -41,7 +41,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var filter = new SdkAndPackagesDependenciesSnapshotFilter();
 
             filter.BeforeAddOrUpdate(
-                targetFramework,
                 sdkDependency,
                 null!,
                 null,
@@ -77,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             var packageDependency = new TestDependency
             {
-                Id = Dependency.GetID(targetFramework, PackageRuleHandler.ProviderTypeString, sdkName),
+                Id = Dependency.GetID(PackageRuleHandler.ProviderTypeString, sdkName),
                 Resolved = false,
                 Flags = DependencyTreeFlags.PackageDependency
             };
@@ -89,7 +88,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var filter = new SdkAndPackagesDependenciesSnapshotFilter();
 
             filter.BeforeAddOrUpdate(
-                targetFramework,
                 sdkDependency,
                 null!,
                 null,
@@ -111,7 +109,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             var sdkDependency = new TestDependency
             {
-                Id = Dependency.GetID(targetFramework, SdkRuleHandler.ProviderTypeString, packageName),
+                Id = Dependency.GetID(SdkRuleHandler.ProviderTypeString, packageName),
                 Resolved = true,
                 Flags = DependencyTreeFlags.PackageDependency.Union(DependencyTreeFlags.Unresolved) // to see if unresolved is fixed
             };
@@ -131,7 +129,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var filter = new SdkAndPackagesDependenciesSnapshotFilter();
 
             filter.BeforeAddOrUpdate(
-                targetFramework,
                 packageDependency,
                 null!,
                 null,
@@ -158,7 +155,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             var sdkDependency = new TestDependency
             {
-                Id = Dependency.GetID(targetFramework, SdkRuleHandler.ProviderTypeString, packageName),
+                Id = Dependency.GetID(SdkRuleHandler.ProviderTypeString, packageName),
                 Resolved = true,
                 Flags = DependencyTreeFlags.SdkDependency.Union(DependencyTreeFlags.Resolved)
             };
@@ -178,7 +175,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var filter = new SdkAndPackagesDependenciesSnapshotFilter();
 
             filter.BeforeRemove(
-                targetFramework: targetFramework,
                 dependency: packageDependency,
                 context);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -152,8 +152,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             Assert.Same(catalogs, snapshot.Catalogs);
             Assert.True(snapshot.HasVisibleUnresolvedDependency);
             AssertEx.CollectionLength(snapshot.Dependencies, 2);
-            Assert.Contains(snapshot.Dependencies, dep => resolved.Matches(dep, targetFramework));
-            Assert.Contains(snapshot.Dependencies, dep => unresolved.Matches(dep, targetFramework));
+            Assert.Contains(snapshot.Dependencies, resolved.Matches);
+            Assert.Contains(snapshot.Dependencies, unresolved.Matches);
         }
 
         [Fact]
@@ -164,7 +164,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var dependency1 = new TestDependency
             {
                 ProviderType = "Xxx",
-                Id = Dependency.GetID(targetFramework, "Xxx", "dependency1"),
+                Id = Dependency.GetID("Xxx", "dependency1"),
                 Name = "Dependency1",
                 Caption = "Dependency1",
                 SchemaItemType = "Xxx",
@@ -174,7 +174,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var dependency2 = new TestDependency
             {
                 ProviderType = "Xxx",
-                Id = Dependency.GetID(targetFramework, "Xxx", "dependency2"),
+                Id = Dependency.GetID("Xxx", "dependency2"),
                 Name = "Dependency1",
                 Caption = "Dependency1",
                 SchemaItemType = "Xxx",
@@ -212,7 +212,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var dependency1 = new TestDependency
             {
                 ProviderType = "Xxx",
-                Id = "tfm1\\xxx\\dependency1",
+                Id = "xxx\\dependency1",
                 Name = "Dependency1",
                 Caption = "Dependency1",
                 SchemaItemType = "Xxx",
@@ -222,7 +222,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var dependency2 = new TestDependency
             {
                 ProviderType =  "Xxx",
-                Id = "tfm1\\xxx\\dependency2",
+                Id = "xxx\\dependency2",
                 Name = "Dependency2",
                 Caption = "Dependency2",
                 SchemaItemType = "Xxx",
@@ -241,7 +241,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var addedOnRemove = new TestDependency { Id = "SomethingElse" };
 
             var snapshotFilter = new TestDependenciesSnapshotFilter()
-                .BeforeRemoveReject(@"tfm1\xxx\dependency1", addOrUpdate: addedOnRemove);
+                .BeforeRemoveReject(@"xxx\dependency1", addOrUpdate: addedOnRemove);
 
             var snapshot = TargetedDependenciesSnapshot.FromChanges(
                 previousSnapshot,
@@ -269,7 +269,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var dependency1 = new TestDependency
             {
                 ProviderType = "Xxx",
-                Id = Dependency.GetID(targetFramework, "Xxx", "dependency1"),
+                Id = Dependency.GetID("Xxx", "dependency1"),
                 Name = "Dependency1",
                 Caption = "Dependency1",
                 SchemaItemType = "Xxx",
@@ -298,7 +298,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             changes.Added(dependencyModelNew1);
 
             var snapshotFilter = new TestDependenciesSnapshotFilter()
-                .BeforeAddReject(@"tfm1\xxx\newdependency1");
+                .BeforeAddReject(@"xxx\newdependency1");
 
             var snapshot = TargetedDependenciesSnapshot.FromChanges(
                 previousSnapshot,
@@ -321,7 +321,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var dependency1 = new TestDependency
             {
                 ProviderType = "Xxx",
-                Id = "tfm1\\xxx\\dependency1",
+                Id = "xxx\\dependency1",
                 Name = "Dependency1",
                 Caption = "Dependency1",
                 SchemaItemType = "Xxx",
@@ -331,7 +331,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var dependency2 = new TestDependency
             {
                 ProviderType = "Xxx",
-                Id = "tfm1\\xxx\\dependency2",
+                Id = "xxx\\dependency2",
                 Name = "Dependency2",
                 Caption = "Dependency2",
                 SchemaItemType = "Xxx",
@@ -362,7 +362,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var filterAddedDependency = new TestDependency { Id = "unexpected" };
 
             var snapshotFilter = new TestDependenciesSnapshotFilter()
-                .BeforeAddReject(@"tfm1\xxx\newdependency1", addOrUpdate: filterAddedDependency);
+                .BeforeAddReject(@"xxx\newdependency1", addOrUpdate: filterAddedDependency);
 
             var snapshot = TargetedDependenciesSnapshot.FromChanges(
                 previousSnapshot,
@@ -393,7 +393,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var dependency1 = new TestDependency
             {
                 ProviderType = "Xxx",
-                Id = "tfm1\\xxx\\dependency1",
+                Id = "xxx\\dependency1",
                 Name = "Dependency1",
                 Caption = "Dependency1",
                 SchemaItemType = "Xxx",
@@ -403,7 +403,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var dependency2 = new TestDependency
             {
                 ProviderType = "Xxx",
-                Id = "tfm1\\xxx\\dependency2",
+                Id = "xxx\\dependency2",
                 Name = "Dependency2",
                 Caption = "Dependency2",
                 SchemaItemType = "Xxx",
@@ -449,7 +449,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var dependencyAdded2Changed = new TestDependency
             {
                 ProviderType = "Xxx",
-                Id = "tfm1\\xxx\\addeddependency2",
+                Id = "xxx\\addeddependency2",
                 Name = "AddedDependency2Changed",
                 Caption = "AddedDependency2Changed",
                 SchemaItemType = "Xxx",
@@ -459,7 +459,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var dependencyRemoved1 = new TestDependency
             {
                 ProviderType = "Xxx",
-                Id = "tfm1\\xxx\\Removeddependency1",
+                Id = "xxx\\Removeddependency1",
                 Name = "RemovedDependency1",
                 Caption = "RemovedDependency1",
                 SchemaItemType = "Xxx",
@@ -469,7 +469,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var dependencyInsteadRemoved1 = new TestDependency
             {
                 ProviderType = "Xxx",
-                Id = "tfm1\\xxx\\InsteadRemoveddependency1",
+                Id = "xxx\\InsteadRemoveddependency1",
                 Name = "InsteadRemovedDependency1",
                 Caption = "InsteadRemovedDependency1",
                 SchemaItemType = "Xxx",
@@ -489,10 +489,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             changes.Removed("Xxx", "Removeddependency1");
 
             var snapshotFilter = new TestDependenciesSnapshotFilter()
-                .BeforeAddReject(@"tfm1\xxx\addeddependency1")
-                .BeforeAddAccept(@"tfm1\xxx\addeddependency2", dependencyAdded2Changed)
-                .BeforeAddAccept(@"tfm1\xxx\addeddependency3")
-                .BeforeRemoveAccept(@"tfm1\xxx\Removeddependency1", dependencyInsteadRemoved1);
+                .BeforeAddReject(@"xxx\addeddependency1")
+                .BeforeAddAccept(@"xxx\addeddependency2", dependencyAdded2Changed)
+                .BeforeAddAccept(@"xxx\addeddependency3")
+                .BeforeRemoveAccept(@"xxx\Removeddependency1", dependencyInsteadRemoved1);
 
             var snapshot = TargetedDependenciesSnapshot.FromChanges(
                 previousSnapshot,
@@ -509,11 +509,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             Assert.Same(previousSnapshot.TargetFramework, snapshot.TargetFramework);
             Assert.Same(catalogs, snapshot.Catalogs);
             AssertEx.CollectionLength(snapshot.Dependencies, 5);
-            Assert.Contains(snapshot.Dependencies, dep => dep.Id == @"tfm1\xxx\dependency1");
-            Assert.Contains(snapshot.Dependencies, dep => dep.Id == @"tfm1\xxx\dependency2");
-            Assert.Contains(snapshot.Dependencies, dep => dep.Id == @"tfm1\xxx\addeddependency2");
-            Assert.Contains(snapshot.Dependencies, dep => dep.Id == @"tfm1\xxx\InsteadRemoveddependency1");
-            Assert.Contains(snapshot.Dependencies, dep => dep.Id == @"tfm1\Xxx\addeddependency3");
+            Assert.Contains(snapshot.Dependencies, dep => dep.Id == @"xxx\dependency1");
+            Assert.Contains(snapshot.Dependencies, dep => dep.Id == @"xxx\dependency2");
+            Assert.Contains(snapshot.Dependencies, dep => dep.Id == @"xxx\addeddependency2");
+            Assert.Contains(snapshot.Dependencies, dep => dep.Id == @"xxx\InsteadRemoveddependency1");
+            Assert.Contains(snapshot.Dependencies, dep => dep.Id == @"Xxx\addeddependency3");
         }
 
         [Fact]
@@ -524,7 +524,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var dependencyPrevious = new TestDependency
             {
                 ProviderType = "Xxx",
-                Id = "tfm1\\xxx\\dependency1",
+                Id = "xxx\\dependency1",
                 Name = "Dependency1",
                 Caption = "Dependency1",
                 SchemaItemType = "Xxx",
@@ -546,7 +546,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var dependencyUpdated = new TestDependency
             {
                 ProviderType = "Xxx",
-                Id = "tfm1\\xxx\\dependency1",
+                Id = "xxx\\dependency1",
                 Name = "Dependency1",
                 Caption = "Dependency1",
                 SchemaItemType = "Xxx",
@@ -563,7 +563,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             changes.Added(dependencyModelAdded);
 
             var snapshotFilter = new TestDependenciesSnapshotFilter()
-                    .BeforeAddAccept(@"tfm1\xxx\dependency1", dependencyUpdated);
+                    .BeforeAddAccept(@"xxx\dependency1", dependencyUpdated);
 
             var snapshot = TargetedDependenciesSnapshot.FromChanges(
                 previousSnapshot,
@@ -611,7 +611,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             }
 
             public void BeforeAddOrUpdate(
-                ITargetFramework targetFramework,
                 IDependency dependency,
                 IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviderByProviderType,
                 IImmutableSet<string>? projectItemSpecs,
@@ -646,7 +645,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             }
 
             public void BeforeRemove(
-                ITargetFramework targetFramework,
                 IDependency dependency,
                 RemoveDependencyContext context)
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -33,7 +33,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 BrowseObjectProperties = value.BrowseObjectProperties;
                 Flags = value.Flags;
                 Id = value.Id;
-                TargetFramework = value.TargetFramework;
             }
         }
 
@@ -51,7 +50,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         public IImmutableDictionary<string, string> BrowseObjectProperties { get; set; }
         public ProjectTreeFlags Flags { get; set; } = ProjectTreeFlags.Empty;
         public string Id { get; set; }
-        public ITargetFramework TargetFramework { get; set; }
         public DependencyIconSet IconSet { get; set; } = s_defaultIconSet;
 #pragma warning restore CS8618 // Non-nullable property is uninitialized
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependencyExtensions.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependencyExtensions.cs
@@ -23,7 +23,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             Xunit.Assert.Equal(expected.BrowseObjectProperties, actual.BrowseObjectProperties);
             Xunit.Assert.Equal(expected.Flags, actual.Flags);
             Xunit.Assert.Equal(expected.Id, actual.Id);
-            Xunit.Assert.Equal(expected.TargetFramework, actual.TargetFramework);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/UnresolvedDependenciesSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/UnresolvedDependenciesSnapshotFilterTests.cs
@@ -24,7 +24,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var filter = new UnresolvedDependenciesSnapshotFilter();
 
             filter.BeforeAddOrUpdate(
-                null!,
                 unresolvedDependency,
                 null!,
                 null,
@@ -49,7 +48,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var filter = new UnresolvedDependenciesSnapshotFilter();
 
             filter.BeforeAddOrUpdate(
-                null!,
                 unresolvedDependency,
                 null!,
                 null,
@@ -74,7 +72,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var filter = new UnresolvedDependenciesSnapshotFilter();
 
             filter.BeforeAddOrUpdate(
-                null!,
                 resolvedDependency,
                 null!,
                 null,


### PR DESCRIPTION
Relates to #5051.

`IDependency` instances are always accessed within the context of a `TargetedDependenciesSnapshot` which determines their `TargetFramework`.

Dependency IDs previously also included the TFM as a prefix. This change removes that prefix. This will further reduce memory consumption by the dependencies node.

The dependency ID (now of form `ProviderType/ModelId`) is no longer used as the `FilePath` for created `IProjectTree` items. This means `DependenciesProjectTreeProvider` no longer overrides `GetPath` and `FindByPath`, resulting in these tree items having a pseudo path of form `>123`, where the number is the project tree node's identity.

Collectively these changes allow removal of target framework parameters in several places, as well as the simplification of `IDependencyViewModel`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6276)