### PR TITLE
Allow resolved references to have diagnostics

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
@@ -37,6 +37,10 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <StringProperty Name="DiagnosticLevel"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <BoolProperty Name="GeneratePathProperty"
                 Description="Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'."
                 DisplayName="Generate Path Property">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedProjectReference.xaml
@@ -59,6 +59,10 @@
                   DisplayName="Description"
                   ReadOnly="True" />
 
+  <StringProperty Name="DiagnosticLevel"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <BoolProperty Name="EmbedInteropTypes"
                 Description="Indicates whether types defined in this assembly will be embedded into the target assembly."
                 DisplayName="Embed Interop Types">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependencyModel.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Caption = originalItemSpec;
             Flags = flags;
 
-            if (Properties.TryGetBoolProperty("Visible", out bool visibleProperty))
+            if (Properties.TryGetBoolProperty(ProjectItemMetadata.Visible, out bool visibleProperty))
             {
                 isVisible = visibleProperty;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
@@ -53,6 +53,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             if (dependencyModel is DependencyModel model)
             {
                 IconSet = model.IconSet;
+
+                // For now we consider any non-empty DiagnosticLevel string as a warning. In future we
+                // may differentiate visually on the node between different grades of diagnostic,
+                // such as warnings and errors.
+                _hasDiagnostic = model.DiagnosticLevel != DiagnosticLevel.None;
             }
             else
             {
@@ -92,7 +97,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             SchemaName = schemaName ?? dependency.SchemaName;
             IconSet = iconSet != null ? DependencyIconSetCache.Instance.GetOrAddIconSet(iconSet) : dependency.IconSet;
             Implicit = isImplicit ?? dependency.Implicit;
+            _hasDiagnostic = dependency._hasDiagnostic;
         }
+
+        private readonly bool _hasDiagnostic;
 
         #region IDependency
 
@@ -136,8 +144,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
         public string? FilePath { get; }
 
-        public ImageMoniker Icon => Resolved ? IconSet.Icon : IconSet.UnresolvedIcon;
-        public ImageMoniker ExpandedIcon => Resolved ? IconSet.ExpandedIcon : IconSet.UnresolvedExpandedIcon;
+        public ImageMoniker Icon => Resolved && !_hasDiagnostic ? IconSet.Icon : IconSet.UnresolvedIcon;
+        public ImageMoniker ExpandedIcon => Resolved && !_hasDiagnostic ? IconSet.ExpandedIcon : IconSet.UnresolvedExpandedIcon;
 
         #endregion
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             ProviderType = dependency.ProviderType;
             OriginalItemSpec = dependency.OriginalItemSpec;
             FilePath = dependency.FilePath;
-            _schemaItemType = dependency.SchemaItemType;
+            _schemaItemType = dependency._schemaItemType;
             Visible = dependency.Visible;
             BrowseObjectProperties = dependency.BrowseObjectProperties; // NOTE we explicitly do not update Identity in these properties if caption changes
             Caption = caption ?? dependency.Caption; // TODO if Properties contains "Folder.IdentityProperty" should we update it? (see public ctor)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/ProjectItemMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/ProjectItemMetadata.cs
@@ -11,5 +11,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
         public const string IsImplicitlyDefined = "IsImplicitlyDefined";
         public const string OriginalItemSpec = "OriginalItemSpec";
         public const string Visible = "Visible";
+        public const string DiagnosticLevel = "DiagnosticLevel";
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/ProjectItemMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/ProjectItemMetadata.cs
@@ -10,5 +10,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
         public const string Version = "Version";
         public const string IsImplicitlyDefined = "IsImplicitlyDefined";
         public const string OriginalItemSpec = "OriginalItemSpec";
+        public const string Visible = "Visible";
     }
 }


### PR DESCRIPTION
Fixes #6275.

Requires dotnet/sdk#12069.

Introduces a `DiagnosticLevel` metadata item for resolved references. Use it to show a warning icon on top-level dependencies which contain warning or error diagnostics.

In future this logic will likely change to support showing different icons based on the severity of the diagnostic.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6288)