### PR TITLE
Update page templates

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
@@ -3,7 +3,7 @@
 <Rule Name="ExecutableDebugPropertyPage"
       Description="Properties associated with launching and debugging a specified executable file."
       DisplayName="Executable"
-      PageTemplate="debugger"
+      PageTemplate="commandNameBasedDebugger"
       xmlns:sys="clr-namespace:System;assembly=mscorlib"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns="http://schemas.microsoft.com/build/2009/properties">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
@@ -3,7 +3,7 @@
 <Rule Name="ProjectDebugPropertyPage"
       Description="Properties associated with launching and debugging the project output."
       DisplayName="Project"
-      PageTemplate="debugger"
+      PageTemplate="commandNameBasedDebugger"
       xmlns:sys="clr-namespace:System;assembly=mscorlib"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns="http://schemas.microsoft.com/build/2009/properties">


### PR DESCRIPTION
Fixes #6225.

CPS assumes each "debugger" Rule (with `PageTemplate="debugger"`) should be shown in the launch target drop down in the toolbar, and expects that each provides the GUID and ID of the related VS debugger command in their metadata. Rules which do not are associated with default GUIDs and IDs.

Our debugger rules don't provide the GUID and IDs because they provide a debug target (e.g., Executable, Project, IIS, IISExpress, etc.) instead. For the purposes of the debugger they aren't directly "startable" on their own--they need to be associated with a launch profile that provides all the relevant settings. So we don't want them to appear on this menu.

I can't simply update CPS to filter out "debugger" pages that lack the GUID and ID, because in theory other pages are usable by the debugger with the default values and we want to keep showing those.

Instead I've updated the property page code in CPS ([PR 255874](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/CPS/pullrequest/255874)) to look for a new kind of page (`PageTemplate="commandNameBasedDebugger"`), and this commit updates the appropriate .xaml files in our repo to use this new page template.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6297)