### PR TITLE
Avoid failing when pushed the same version

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
@@ -291,7 +291,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         private void EnqueueProjectEvaluation(IComparable version, IProjectChangeDiff evaluationDifference)
         {
-            Assumes.False(_projectEvaluations.Count > 0 && version.IsEarlierThanOrEqualTo(_projectEvaluations.Peek().Version), "Attempted to push a project evaluation that regressed in version.");
+            Assumes.False(_projectEvaluations.Count > 0 && version.IsEarlierThan(_projectEvaluations.Peek().Version), "Attempted to push a project evaluation that regressed in version.");
 
             _projectEvaluations.Enqueue(new VersionedProjectChangeDiff(version, evaluationDifference));
         }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/6121

We can be pushed the same value of ConfiguredProjectVersion when other input data source versions change. Don't fail in this case. We should be tracking those versions, but I'll leave that for https://github.com/dotnet/project-system/issues/3425.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6304)