### PR TITLE
Only call OpenDocumentAsync when openDocumentService is not null.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeCommandHandler.cs
@@ -100,7 +100,8 @@ namespace Microsoft.VisualStudio.SolutionExplorer
                 {
                     Assumes.NotNull(openDocumentService);
 
-                    await openDocumentService.OpenDocumentAsync(node.NodeMoniker, cancellationToken: default);
+                    if (openDocumentService != null)
+                        await openDocumentService.OpenDocumentAsync(node.NodeMoniker, cancellationToken: default);
                 }
                 finally
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeCommandHandler.cs
@@ -102,6 +102,7 @@ namespace Microsoft.VisualStudio.SolutionExplorer
                         await openDocumentService.OpenDocumentAsync(node.NodeMoniker, cancellationToken: default);
                     //else
                         // TODO: figure out what to tell the user if we can't get the service
+                        // https://github.com/dotnet/project-system/issues/6306
                 }
                 finally
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeCommandHandler.cs
@@ -98,10 +98,10 @@ namespace Microsoft.VisualStudio.SolutionExplorer
 
                 try
                 {
-                    Assumes.NotNull(openDocumentService);
-
                     if (openDocumentService != null)
                         await openDocumentService.OpenDocumentAsync(node.NodeMoniker, cancellationToken: default);
+                    //else
+                        // TODO: figure out what to tell the user if we can't get the service
                 }
                 finally
                 {


### PR DESCRIPTION
This is the first step to ensure that when we call GetProxyAsync for CodeSpaces, we handle the case we get a null value. I'll create an issue to track how we want to handle when openDocumentService returns null.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6305)