### PR TITLE
Look for the correct page template

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/LaunchTargetPropertyPageValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/LaunchTargetPropertyPageValueProvider.cs
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             {
                 var rule = catalog.GetSchema(schemaName);
                 if (rule != null
-                    && string.Equals(rule.PageTemplate, "Debugger", StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(rule.PageTemplate, "CommandNameBasedDebugger", StringComparison.OrdinalIgnoreCase)
                     && rule.Metadata.TryGetValue("CommandName", out object pageCommandNameObj)
                     && pageCommandNameObj is string pageCommandName
                     && pageCommandName.Equals(commandName))

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchTargetPropertyPageValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchTargetPropertyPageValueProviderTests.cs
@@ -190,13 +190,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private static IPropertyPagesCatalogProvider GetCatalogProviderAndData()
         {
             var betaPage = ProjectSystem.IRuleFactory.Create(
-                pageTemplate: "Debugger",
+                pageTemplate: "CommandNameBasedDebugger",
                 metadata: new Dictionary<string, object>
                 {
                     { "CommandName", "BetaCommand" }
                 });
             var gammaPage = ProjectSystem.IRuleFactory.Create(
-                pageTemplate: "Debugger",
+                pageTemplate: "CommandNamedBasedDebugger",
                 metadata: new Dictionary<string, object>
                 {
                     { "CommandName", "GammaCommand" }


### PR DESCRIPTION
PR #6297 updated our debugger property pages to use the "commandNameBasedDebugger" page template instead of the "debugger" template (see the PR for more details). However, I forgot to update the `LaunchTargetPropertyPageValueProvider` which is responsible for determining the set of valid launch targets to show in the property page UI. It does this by looking for "debugger" pages with "CommandName" metadata. Once I changed the pages to use a different template, the value provider no longer found them, and they no longer appeared as options in the UI.

The fix here is to look for pages using the "CommandNameBasedDebugger" template.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6308)