### PR TITLE
Use Artifacts container instead of \\cpvsbuild\drops\Roslyn share on build pipeline

### DIFF
--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -65,7 +65,7 @@ steps:
 - task: CopyFiles@2
   inputs:
     SourceFolder: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\SymStore'
-    Contents: **
+    Contents: '**'
     TargetFolder: '$(Build.SourcesDirectory)\artifacts\s'
   displayName: Copy symbols
 

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -70,7 +70,7 @@ steps:
 #TODO change the targetfolder - perhaps use ArtifactStagingDirectory variable
 - task: CopyFiles@2
   inputs:
-    SourceFolder: 'artifacts\$(BuildConfiguration)\bin\obj'
+    SourceFolder: 'artifacts\$(BuildConfiguration)\obj'
     Contents: |
       **/Microsoft.VisualStudio.ProjectSystem.Managed?(*.pdb|*.dll|*.xml)
       **/Microsoft.VisualStudio.AppDesigner?(*.pdb|*.dll|*.xml)

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -16,7 +16,6 @@ variables:
   BuildConfiguration: Release
   TeamName: DotNet-Project-System
   BuildPlatform: any cpu
-  DropRoot: \\cpvsbuild\drops\Roslyn\project-system-tools
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   
 steps:
@@ -57,32 +56,51 @@ steps:
     testResultsFiles: 'artifacts/$(BuildConfiguration)/TestResults/*.xml'
     testRunTitle: 'Unit Test Results'
   condition: succeededOrFailed()
-    
-- task: PublishSymbols@1
-  displayName: Create Symbol Index
+
+#Might need to do a CopyFiles@2 before this publish symbols
+- task: PublishSymbols@2
+  displayName: Archive symbols to VSTS
   inputs:
-    SymbolsPath: '$(DropRoot)\$(TeamName)\$(Build.SourceBranchName)\$(Build.BuildNumber)\Symbols'
-    SearchPattern: '**/*.pdb;**/*.dll;**/*.exe'
     SymbolsFolder: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\SymStore'
+    SearchPattern: '**/*.pdb;**/*.dll;**/*.exe'
+    SymbolServerType: TeamServices
     SkipIndexing: true
     SymbolsProduct: 'Roslyn Project System'
     SymbolsVersion: '$(Build.BuildNumber)'
     SymbolsArtifactName: Symbols
   continueOnError: true
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\SymStore'
+    ArtifactName: symbols
+    publishLocation: Container
+  displayName: 'Publish Artifact: symbols'
   
 - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
   displayName: Publish Symbols to Artifact Services
   inputs:
     symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
     requestName: '$(system.teamProject)/$(Build.DefinitionName)/$(Build.BuildNumber)/$(Build.BuildId)'
-    sourcePath: '$(DropRoot)\$(TeamName)\$(Build.SourceBranchName)\$(Build.BuildNumber)\Symbols'
+    sourcePath: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\SymStore'
     usePat: false
     
 - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
   displayName: Upload VSTS Drop
   inputs:
     DropFolder: 'artifacts\$(BuildConfiguration)\VSSetup\Insertion'
-    
+
+#Is this how we publish to symweb??
+#TODO change vsMajorVersion to a variable so we don't have to change this every new release
+- task: ms-vseng.MicroBuildTasks.0e9d0d4d-71ec-4e4e-ae40-db9896f1ae74.MicroBuildBuildVSBootstrapper@2
+  inputs:
+    vsMajorVersion: 16
+    channelName: $(TestBootstrapperChannel)
+    manifests: $(SetupManifests)
+    outputFolder: $(Build.Repository.LocalPath)\bin\$(BuildConfiguration)\packages\vsix
+  displayName: Build VS bootstrapper
+
+#TODO deprecate this with PublishBuildArtifacts@1
 - task: CopyPublishBuildArtifacts@1
   displayName: Publish Drop
   inputs:
@@ -95,8 +113,7 @@ steps:
      artifacts\$(BuildConfiguration)\VSSetup
      artifacts\$(BuildConfiguration)\TestResults
     ArtifactName: '$(Build.BuildNumber)'
-    ArtifactType: FilePath
-    TargetPath: '$(DropRoot)\$(TeamName)\$(Build.SourceBranchName)'
+    ArtifactType: Container
   condition: succeededOrFailed()
 
 - task: NuGetPublisher@0
@@ -123,6 +140,5 @@ steps:
   inputs:
     PathtoPublish: '$(Build.StagingDirectory)\MicroBuild\Output'
     ArtifactName: '$(Build.BuildNumber)'
-    publishLocation: FilePath
-    TargetPath: '$(DropRoot)\$(TeamName)\$(Build.SourceBranchName)'
+    publishLocation: Container
   condition: succeededOrFailed()

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -16,19 +16,10 @@ variables:
   BuildConfiguration: Release
   TeamName: DotNet-Project-System
   BuildPlatform: any cpu
-  DropRoot: \\cpvsbuild\drops\Roslyn
+  DropRoot: \\cpvsbuild\drops\Roslyn\project-system-tools
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   
 steps:
-- task: PowerShell@2
-  inputs:
-    targetType: inline
-    script: |
-      rm \\cpvsbuild\drops\Roslyn\DotNet-Project-System\master\20180810.1
-
-      Write-Host "This share has been deleted"
-  displayName: Clean up cpvsbuild
-
 - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
   displayName: Install Signing Plugin
   inputs:

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -57,6 +57,12 @@ steps:
     testRunTitle: 'Unit Test Results'
   condition: succeededOrFailed()
 
+- task: PowerShell@2
+  inputs:
+    filePath: build\variables\_vsts.ps1
+    failOnStderr: true
+  displayName: Set VSTS variables based on source
+
 # Symbols is the one thing we cannot declare in the ps1 artifact scripts due to the extra steps
 # needed and the specific order it has to be performed in. Copy -> Publish Symbols -> Publish
 # Artifact -> publish to symweb
@@ -66,13 +72,13 @@ steps:
   inputs:
     SourceFolder: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\SymStore'
     Contents: '**'
-    TargetFolder: '$(Build.SourcesDirectory)\artifacts\s'
+    TargetFolder: $(Build.ArtifactStagingDirectory)/symbols'
   displayName: Copy symbols
 
 - task: PublishSymbols@2
   displayName: Archive symbols to VSTS
   inputs:
-    SymbolsFolder: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\SymStore'
+    SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols'
     SearchPattern: '**/*.pdb;**/*.dll;**/*.exe'
     SymbolServerType: TeamServices
     SkipIndexing: true
@@ -83,7 +89,7 @@ steps:
 
 - task: PublishBuildArtifacts@1
   inputs:
-    PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\SymStore'
+    PathtoPublish: $(Build.ArtifactStagingDirectory)/symbols'
     ArtifactName: symbols
     publishLocation: Container
   displayName: 'Publish Artifact: symbols'
@@ -93,7 +99,7 @@ steps:
   inputs:
     symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
     requestName: '$(system.teamProject)/$(Build.DefinitionName)/$(Build.BuildNumber)/$(Build.BuildId)'
-    sourcePath: '$(Build.SourcesDirectory)\artifacts\s'
+    sourcePath: $(Build.ArtifactStagingDirectory)/symbols'
     usePat: false
     
 - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -70,7 +70,7 @@ steps:
 #TODO change the targetfolder - perhaps use ArtifactStagingDirectory variable
 - task: CopyFiles@2
   inputs:
-    SourceFolder: 'artifacts\$(BuildConfiguration)\obj'
+    SourceFolder: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)'
     Contents: |
       **/Microsoft.VisualStudio.ProjectSystem.Managed?(*.pdb|*.dll|*.xml)
       **/Microsoft.VisualStudio.AppDesigner?(*.pdb|*.dll|*.xml)

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -61,7 +61,7 @@ steps:
 - task: PublishSymbols@1
   displayName: Create Symbol Index
   inputs:
-    SymbolsPath: '$(DropRoot)\$(TeamName)\$(Build.SourceBranchName)\$(Build.BuildNumber)\Symbols'
+    SymbolsPath: '$(DropRoot)\$(TeamName)\Temp\$(Build.SourceBranchName)\$(Build.BuildNumber)\Symbols'
     SearchPattern: '**/*.pdb;**/*.dll;**/*.exe'
     SymbolsFolder: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\SymStore'
     SkipIndexing: true
@@ -75,7 +75,7 @@ steps:
   inputs:
     symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
     requestName: '$(system.teamProject)/$(Build.DefinitionName)/$(Build.BuildNumber)/$(Build.BuildId)'
-    sourcePath: '$(DropRoot)\$(TeamName)\$(Build.SourceBranchName)\$(Build.BuildNumber)\Symbols'
+    sourcePath: '$(DropRoot)\$(TeamName)\Temp\$(Build.SourceBranchName)\$(Build.BuildNumber)\Symbols'
     usePat: false
     
 - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
@@ -96,7 +96,7 @@ steps:
      artifacts\$(BuildConfiguration)\TestResults
     ArtifactName: '$(Build.BuildNumber)'
     ArtifactType: FilePath
-    TargetPath: '$(DropRoot)\$(TeamName)\$(Build.SourceBranchName)'
+    TargetPath: '$(DropRoot)\$(TeamName)\Temp\$(Build.SourceBranchName)'
   condition: succeededOrFailed()
 
 - task: NuGetPublisher@0
@@ -124,5 +124,5 @@ steps:
     PathtoPublish: '$(Build.StagingDirectory)\MicroBuild\Output'
     ArtifactName: '$(Build.BuildNumber)'
     publishLocation: FilePath
-    TargetPath: '$(DropRoot)\$(TeamName)\$(Build.SourceBranchName)'
+    TargetPath: '$(DropRoot)\$(TeamName)\Temp\$(Build.SourceBranchName)'
   condition: succeededOrFailed()

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -61,7 +61,7 @@ steps:
   inputs:
     filePath: build\variables\_vsts.ps1
     failOnStderr: true
-  displayName: Set VSTS variables based on source
+  displayName: Set VSTS variables based on source 
 
 # Symbols is the one thing we cannot declare in the ps1 artifact scripts due to the extra steps
 # needed and the specific order it has to be performed in. Copy -> Publish Symbols -> Publish

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -57,7 +57,18 @@ steps:
     testRunTitle: 'Unit Test Results'
   condition: succeededOrFailed()
 
-#Might need to do a CopyFiles@2 before this publish symbols
+# Symbols is the one thing we cannot declare in the ps1 artifact scripts due to the extra steps
+# needed and the specific order it has to be performed in. Copy -> Publish Symbols -> Publish
+# Artifact -> publish to symweb
+
+#TODO change the targetfolder - perhaps use ArtifactStagingDirectory variable
+- task: CopyFiles@2
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\SymStore'
+    Contents: **
+    TargetFolder: '$(Build.SourcesDirectory)\artifacts\s'
+  displayName: Copy symbols
+
 - task: PublishSymbols@2
   displayName: Archive symbols to VSTS
   inputs:
@@ -82,7 +93,7 @@ steps:
   inputs:
     symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
     requestName: '$(system.teamProject)/$(Build.DefinitionName)/$(Build.BuildNumber)/$(Build.BuildId)'
-    sourcePath: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\SymStore'
+    sourcePath: '$(Build.SourcesDirectory)\artifacts\s'
     usePat: false
     
 - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -20,6 +20,15 @@ variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   
 steps:
+- task: PowerShell@2
+  inputs:
+    targetType: inline
+    script: |
+      rm \\cpvsbuild\drops\Roslyn\DotNet-Project-System\master\20180810.1
+
+      Write-Host "This share has been deleted"
+  displayName: Clean up cpvsbuild
+
 - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
   displayName: Install Signing Plugin
   inputs:
@@ -28,12 +37,6 @@ steps:
     
 - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
   displayName: Install Swix Plugin
-
-- task: PowerShell@2
-  inputs:
-    targetType: inline
-    script: rm \\cpvsbuild\drops\Roslyn\DotNet-Project-System\master\20180810.1
-  displayName: Clean up cpvsbuild
   
 - task: NuGetRestore@1
   displayName: Restore 'Microsoft.DotNet.IBCMerge' package

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -70,8 +70,11 @@ steps:
 #TODO change the targetfolder - perhaps use ArtifactStagingDirectory variable
 - task: CopyFiles@2
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\SymStore'
-    Contents: '**'
+    SourceFolder: 'artifacts\$(BuildConfiguration)\bin\obj'
+    Contents: |
+      **/Microsoft.VisualStudio.ProjectSystem.Managed?(*.pdb|*.dll|*.xml)
+      **/Microsoft.VisualStudio.AppDesigner?(*.pdb|*.dll|*.xml)
+      **/Microsoft.VisualStudio.Editors?(*.pdb|*.dll|*.xml)
     TargetFolder: $(Build.ArtifactStagingDirectory)/symbols'
   displayName: Copy symbols
 

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -16,7 +16,7 @@ variables:
   BuildConfiguration: Release
   TeamName: DotNet-Project-System
   BuildPlatform: any cpu
-  DropRoot: \\cpvsbuild\drops\Temp
+  DropRoot: \\cpvsbuild\drops\Roslyn
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   
 steps:
@@ -28,6 +28,12 @@ steps:
     
 - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
   displayName: Install Swix Plugin
+
+- task: PowerShell@2
+  inputs:
+    targetType: inline
+    script: rm \\cpvsbuild\drops\Roslyn\DotNet-Project-System\master\20180810.1
+  displayName: Clean up cpvsbuild
   
 - task: NuGetRestore@1
   displayName: Restore 'Microsoft.DotNet.IBCMerge' package

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -75,14 +75,17 @@ steps:
       **/Microsoft.VisualStudio.ProjectSystem.Managed?(*.pdb|*.dll|*.xml)
       **/Microsoft.VisualStudio.AppDesigner?(*.pdb|*.dll|*.xml)
       **/Microsoft.VisualStudio.Editors?(*.pdb|*.dll|*.xml)
-    TargetFolder: $(Build.ArtifactStagingDirectory)/symbols'
+    TargetFolder: $(Build.ArtifactStagingDirectory)/symbols
   displayName: Copy symbols
 
 - task: PublishSymbols@2
   displayName: Archive symbols to VSTS
   inputs:
-    SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols'
-    SearchPattern: '**/*.pdb;**/*.dll;**/*.exe'
+    SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols
+    SearchPattern: 
+      '**/*.pdb
+      **/*.dll
+      **/*.exe'
     SymbolServerType: TeamServices
     SkipIndexing: true
     SymbolsProduct: 'Roslyn Project System'
@@ -92,7 +95,7 @@ steps:
 
 - task: PublishBuildArtifacts@1
   inputs:
-    PathtoPublish: $(Build.ArtifactStagingDirectory)/symbols'
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/symbols'
     ArtifactName: symbols
     publishLocation: Container
   displayName: 'Publish Artifact: symbols'

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -90,16 +90,6 @@ steps:
   inputs:
     DropFolder: 'artifacts\$(BuildConfiguration)\VSSetup\Insertion'
 
-#Is this how we publish to symweb??
-#TODO change vsMajorVersion to a variable so we don't have to change this every new release
-- task: ms-vseng.MicroBuildTasks.0e9d0d4d-71ec-4e4e-ae40-db9896f1ae74.MicroBuildBuildVSBootstrapper@2
-  inputs:
-    vsMajorVersion: 16
-    channelName: $(TestBootstrapperChannel)
-    manifests: $(SetupManifests)
-    outputFolder: $(Build.Repository.LocalPath)\bin\$(BuildConfiguration)\packages\vsix
-  displayName: Build VS bootstrapper
-
 #TODO deprecate this with PublishBuildArtifacts@1
 - task: CopyPublishBuildArtifacts@1
   displayName: Publish Drop

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -78,7 +78,7 @@ steps:
   displayName: 'Publish Artifact: symbols'
   
 - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
-  displayName: Publish Symbols to Artifact Services
+  displayName: Publish Symbols to Artifact Services (symweb)
   inputs:
     symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
     requestName: '$(system.teamProject)/$(Build.DefinitionName)/$(Build.BuildNumber)/$(Build.BuildId)'

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -49,7 +49,7 @@ steps:
   condition: succeeded()
   continueOnError: true
 
-- task: PublishTestResults@1
+- task: PublishTestResults@2
   displayName: Publish Test Results
   inputs:
     testRunner: XUnit

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -105,7 +105,7 @@ steps:
   inputs:
     symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
     requestName: '$(system.teamProject)/$(Build.DefinitionName)/$(Build.BuildNumber)/$(Build.BuildId)'
-    sourcePath: $(Build.ArtifactStagingDirectory)/symbols'
+    sourcePath: $(Build.ArtifactStagingDirectory)/symbols
     usePat: false
     
 - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -16,7 +16,7 @@ variables:
   BuildConfiguration: Release
   TeamName: DotNet-Project-System
   BuildPlatform: any cpu
-  DropRoot: \\cpvsbuild\drops\Roslyn
+  DropRoot: \\cpvsbuild\drops\Temp
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   
 steps:
@@ -61,7 +61,7 @@ steps:
 - task: PublishSymbols@1
   displayName: Create Symbol Index
   inputs:
-    SymbolsPath: '$(DropRoot)\$(TeamName)\Temp\$(Build.SourceBranchName)\$(Build.BuildNumber)\Symbols'
+    SymbolsPath: '$(DropRoot)\$(TeamName)\$(Build.SourceBranchName)\$(Build.BuildNumber)\Symbols'
     SearchPattern: '**/*.pdb;**/*.dll;**/*.exe'
     SymbolsFolder: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\SymStore'
     SkipIndexing: true
@@ -75,7 +75,7 @@ steps:
   inputs:
     symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
     requestName: '$(system.teamProject)/$(Build.DefinitionName)/$(Build.BuildNumber)/$(Build.BuildId)'
-    sourcePath: '$(DropRoot)\$(TeamName)\Temp\$(Build.SourceBranchName)\$(Build.BuildNumber)\Symbols'
+    sourcePath: '$(DropRoot)\$(TeamName)\$(Build.SourceBranchName)\$(Build.BuildNumber)\Symbols'
     usePat: false
     
 - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
@@ -96,7 +96,7 @@ steps:
      artifacts\$(BuildConfiguration)\TestResults
     ArtifactName: '$(Build.BuildNumber)'
     ArtifactType: FilePath
-    TargetPath: '$(DropRoot)\$(TeamName)\Temp\$(Build.SourceBranchName)'
+    TargetPath: '$(DropRoot)\$(TeamName)\$(Build.SourceBranchName)'
   condition: succeededOrFailed()
 
 - task: NuGetPublisher@0
@@ -124,5 +124,5 @@ steps:
     PathtoPublish: '$(Build.StagingDirectory)\MicroBuild\Output'
     ArtifactName: '$(Build.BuildNumber)'
     publishLocation: FilePath
-    TargetPath: '$(DropRoot)\$(TeamName)\Temp\$(Build.SourceBranchName)'
+    TargetPath: '$(DropRoot)\$(TeamName)\$(Build.SourceBranchName)'
   condition: succeededOrFailed()

--- a/build/variables/_vsts.ps1
+++ b/build/variables/_vsts.ps1
@@ -1,0 +1,4 @@
+Write-Host "List of *.ps1 in PSScriptRoot:" $PSScriptRoot
+
+$RepoRoot = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..")
+$ArtifactStagingDirectory = "$RepoRoot\artifacts\"


### PR DESCRIPTION
Previously we used to publish our symbols to \\cpvsbuild\drops\Roslyn but the share got full after 3TB so moving the more modern way of uploading symbols through the Artifacts container. Now in each build under artifacts you should be able to see a folder titled "symbols"

Fixes #5265 
Partially completes some of #5905 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6310)