### PR TITLE
Update LaunchTargetPropertyPageEnumProvider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchTargetPropertyPageEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchTargetPropertyPageEnumProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     /// launch target. 
     /// </summary>
     /// <remarks>
-    /// Specifically, we look for pages with a "debugger" <see cref="Rule.PageTemplate"/>
+    /// Specifically, we look for pages with a "commandNameBasedDebugger" <see cref="Rule.PageTemplate"/>
     /// and a CommandName property in their metadata.
     /// </remarks>
     [ExportDynamicEnumValuesProvider(nameof(LaunchTargetPropertyPageEnumProvider))]
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 return (ICollection<IEnumValue>)catalog.GetPropertyPagesSchemas()
                     .Select(name => catalog.GetSchema(name))
                     .WhereNotNull()
-                    .Where(rule => string.Equals(rule.PageTemplate, "Debugger", StringComparison.OrdinalIgnoreCase)
+                    .Where(rule => string.Equals(rule.PageTemplate, "CommandNameBasedDebugger", StringComparison.OrdinalIgnoreCase)
                             && rule.Metadata.TryGetValue("CommandName", out object pageCommandNameObj))
                     .Select(rule => new PageEnumValue(new EnumValue
                     {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/LaunchTargetPropertyPageEnumProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/LaunchTargetPropertyPageEnumProviderTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             var betaPage = IRuleFactory.Create(
                 name: "BetaCommandPageId",
                 displayName: "Beta",
-                pageTemplate: "Debugger",
+                pageTemplate: "CommandNameBasedDebugger",
                 metadata: new Dictionary<string, object>
                 {
                     { "CommandName", "BetaCommand" }
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             var gammaPage = IRuleFactory.Create(
                 name: "GammaCommandPageId",
                 displayName: "Gamma",
-                pageTemplate: "Debugger",
+                pageTemplate: "CommandNameBasedDebugger",
                 metadata: new Dictionary<string, object>
                 {
                     { "CommandName", "GammaCommand" }


### PR DESCRIPTION
Update `LaunchTargetPropertyPageEnumProvider` to look for pages that use the "CommandNamedBasedDebugger" template instead of the "Debugger" template; the former is what we actually use for managed projects.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6314)