### PR TITLE
Use short name for target nodes in dependencies tree

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/ITargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/ITargetFramework.cs
@@ -16,10 +16,5 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// Gets the short name.
         /// </summary>
         string ShortName { get; }
-
-        /// <summary>
-        /// Gets the display name. Can be an empty string.
-        /// </summary>
-        string FriendlyName { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
@@ -24,7 +24,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             FullName = frameworkName.FullName;
             ShortName = shortName ?? string.Empty;
-            FriendlyName = $"{frameworkName.Identifier} {frameworkName.Version}";
         }
 
         /// <summary>
@@ -38,14 +37,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             FullName = moniker;
             ShortName = moniker;
-            FriendlyName = moniker;
         }
 
         public string FullName { get; }
 
         public string ShortName { get; }
-
-        public string FriendlyName { get; }
 
         /// <summary>
         /// Override Equals to handle equivalency correctly. They are equal if the 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                     }
                     else
                     {
-                        IProjectTree? node = dependenciesTree.FindChildWithCaption(targetFramework.FriendlyName);
+                        IProjectTree? node = dependenciesTree.FindChildWithCaption(targetFramework.ShortName);
                         bool shouldAddTargetNode = node == null;
                         IDependencyViewModel targetViewModel = _viewModelFactory.CreateTargetViewModel(targetedSnapshot.TargetFramework, targetedSnapshot.HasVisibleUnresolvedDependency);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/TargetDependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/TargetDependencyViewModel.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 
         public TargetDependencyViewModel(ITargetFramework targetFramework, bool hasVisibleUnresolvedDependency)
         {
-            Caption = targetFramework.FriendlyName;
+            Caption = targetFramework.ShortName;
             Flags = GetCachedFlags(targetFramework);
             _hasUnresolvedDependency = hasVisibleUnresolvedDependency;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -217,6 +217,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             return false;
         }
 
-        public override string ToString() => $"{TargetFramework.FriendlyName} - {Dependencies.Length} dependencies";
+        public override string ToString() => $"{TargetFramework.ShortName} - {Dependencies.Length} dependencies";
     }
 }


### PR DESCRIPTION
This change was motivated by two factors:

1. For .NET 5, the target node showed ".NETCoreApp 5.0", but ".NETCoreApp" is not a concept in .NET 5.
2. We would one day like to support arbitrary user-defined names for TargetFrameworks (NuGet/Home#5154)

### Before

![image](https://user-images.githubusercontent.com/350947/86060711-abee1380-baa8-11ea-88f6-aa9de3c1e739.png)

### After

![image](https://user-images.githubusercontent.com/350947/86060688-9b3d9d80-baa8-11ea-9173-34090e2fb858.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6315)