### PR TITLE
Tidying for target frameworks

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/ITargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/ITargetFramework.cs
@@ -4,8 +4,7 @@ using System;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal interface ITargetFramework : IEquatable<ITargetFramework?>,
-                                          IEquatable<string?>
+    internal interface ITargetFramework : IEquatable<ITargetFramework?>
     {
         /// <summary>
         /// Gets the full moniker (TFM).

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
@@ -57,12 +57,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return obj != null && FullName.Equals(obj.FullName, StringComparisons.FrameworkIdentifiers);
         }
 
-        public static bool operator ==(TargetFramework left, TargetFramework right)
+        public static bool operator ==(TargetFramework? left, TargetFramework? right)
         {
             return left is null ? right is null : left.Equals(right);
         }
 
-        public static bool operator !=(TargetFramework left, TargetFramework right)
+        public static bool operator !=(TargetFramework? left, TargetFramework? right)
         {
             return !(left == right);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
@@ -58,10 +58,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         public static bool operator ==(TargetFramework left, TargetFramework right)
-            => left is null ? right is null : left.Equals(right);
+        {
+            return left is null ? right is null : left.Equals(right);
+        }
 
         public static bool operator !=(TargetFramework left, TargetFramework right)
-            => !(left == right);
+        {
+            return !(left == right);
+        }
 
         public override int GetHashCode()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
@@ -49,33 +49,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// </summary>
         public override bool Equals(object obj)
         {
-            return obj switch
-            {
-                ITargetFramework targetFramework => Equals(targetFramework),
-                string s => Equals(s),
-                _ => false
-            };
+            return obj is ITargetFramework targetFramework && Equals(targetFramework);
         }
 
         public bool Equals(ITargetFramework? obj)
         {
-            if (obj != null)
-            {
-                return FullName.Equals(obj.FullName, StringComparisons.FrameworkIdentifiers);
-            }
-
-            return false;
-        }
-
-        public bool Equals(string? obj)
-        {
-            if (obj != null)
-            {
-                return string.Equals(FullName, obj, StringComparisons.FrameworkIdentifiers)
-                    || string.Equals(ShortName, obj, StringComparisons.FrameworkIdentifiers);
-            }
-
-            return false;
+            return obj != null && FullName.Equals(obj.FullName, StringComparisons.FrameworkIdentifiers);
         }
 
         public static bool operator ==(TargetFramework left, TargetFramework right)


### PR DESCRIPTION
- Remove `IEquatable<string>`
- Use statement bodies
- Annotate operator parameters correctly

A subsequent PR will remove `ITargetFramework` entirely as the abstraction adds no value.