### PR TITLE
[16.7.x] Restore case insensitive dependency ID comparison

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependencyId.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependencyId.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
+{
+    internal readonly struct DependencyId
+    {
+        public string ProviderId { get; }
+        public string ModelId { get; }
+
+        public DependencyId(string providerId, string modelId)
+        {
+            Requires.NotNull(providerId, nameof(providerId));
+            Requires.NotNull(modelId, nameof(modelId));
+
+            ProviderId = providerId;
+            ModelId = modelId;
+        }
+
+        public bool Equals(DependencyId other)
+        {
+            return StringComparers.DependencyProviderTypes.Equals(ProviderId, other.ProviderId) &&
+                   StringComparers.DependencyTreeIds.Equals(ModelId, other.ModelId);
+        }
+
+        public override bool Equals(object? obj) => obj is DependencyId other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            return unchecked(StringComparers.DependencyProviderTypes.GetHashCode(ProviderId) * 397) ^ StringComparers.DependencyTreeIds.GetHashCode(ModelId);
+        }
+
+        public static bool operator ==(DependencyId left, DependencyId right) => left.Equals(right);
+        public static bool operator !=(DependencyId left, DependencyId right) => !left.Equals(right);
+
+        public override string ToString() => $"({ProviderId}) {ModelId}";
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/IDependencyModelExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/IDependencyModelExtensions.cs
@@ -7,6 +7,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
     internal static class IDependencyModelExtensions
     {
+        public static DependencyId GetDependencyId(this IDependencyModel self)
+        {
+            return new DependencyId(self.ProviderType, self.Id);
+        }
+
         public static IDependencyViewModel ToViewModel(this IDependencyModel self, bool hasUnresolvedDependency)
         {
             return new DependencyModelViewModel(self, hasUnresolvedDependency);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/AddDependencyContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/AddDependencyContext.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filters
 {
@@ -12,14 +13,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
     /// </summary>
     internal sealed class AddDependencyContext
     {
-        private readonly Dictionary<(string ProviderType, string DependencyId), IDependency> _dependencyById;
+        private readonly Dictionary<DependencyId, IDependency> _dependencyById;
 
         private bool _acceptedOrRejected;
         private IDependency? _acceptedDependency;
 
         public bool Changed { get; private set; }
 
-        public AddDependencyContext(Dictionary<(string ProviderType, string DependencyId), IDependency> dependencyById)
+        public AddDependencyContext(Dictionary<DependencyId, IDependency> dependencyById)
         {
             _dependencyById = dependencyById;
         }
@@ -44,11 +45,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
         }
 
         /// <summary>
-        /// Attempts to find the dependency in the project's tree with specified <paramref name="providerType"/> and <paramref name="dependencyId"/>.
+        /// Attempts to find the dependency in the project's tree with specified <paramref name="dependencyId"/>.
         /// </summary>
-        public bool TryGetDependency(string providerType, string dependencyId, out IDependency dependency)
+        public bool TryGetDependency(DependencyId dependencyId, out IDependency dependency)
         {
-            return _dependencyById.TryGetValue((providerType, dependencyId), out dependency);
+            return _dependencyById.TryGetValue(dependencyId, out dependency);
         }
 
         /// <summary>
@@ -60,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
         /// </remarks>
         public void AddOrUpdate(IDependency dependency)
         {
-            (string ProviderType, string ModelId) key = (dependency.ProviderType, dependency.Id);
+            DependencyId key = dependency.GetDependencyId();
             _dependencyById.Remove(key);
             _dependencyById.Add(key, dependency);
             Changed = true;
@@ -69,15 +70,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
         /// <summary>
         /// Returns <see langword="true"/> if the project tree contains a dependency with specified <paramref name="dependencyId"/>.
         /// </summary>
-        public bool Contains(string providerType, string dependencyId)
+        public bool Contains(DependencyId dependencyId)
         {
-            return _dependencyById.ContainsKey((providerType, dependencyId));
+            return _dependencyById.ContainsKey(dependencyId);
         }
 
         /// <summary>
         /// Returns an enumerator over all dependencies in the project tree.
         /// </summary>
-        public Dictionary<(string ProviderType, string DependencyId), IDependency>.Enumerator GetEnumerator()
+        public Dictionary<DependencyId, IDependency>.Enumerator GetEnumerator()
         {
             return _dependencyById.GetEnumerator();
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/DeduplicateCaptionsSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/DeduplicateCaptionsSnapshotFilter.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filters
@@ -27,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
             IDependency? matchingDependency = null;
             bool shouldApplyAlias = false;
 
-            foreach (((string _, string _), IDependency other) in context)
+            foreach ((DependencyId _, IDependency other) in context)
             {
                 if (StringComparers.DependencyTreeIds.Equals(other.Id, dependency.Id) ||
                     !StringComparers.DependencyProviderTypes.Equals(other.ProviderType, dependency.ProviderType))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/RemoveDependencyContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/RemoveDependencyContext.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filters
 {
@@ -12,14 +13,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
     /// </summary>
     internal sealed class RemoveDependencyContext
     {
-        private readonly Dictionary<(string ProviderType, string ModelId), IDependency> _dependencyById;
+        private readonly Dictionary<DependencyId, IDependency> _dependencyById;
 
         private bool? _acceptedOrRejected;
         private IDependency? _acceptedDependency;
 
         public bool Changed { get; private set; }
 
-        public RemoveDependencyContext(Dictionary<(string ProviderType, string ModelId), IDependency> dependencyById)
+        public RemoveDependencyContext(Dictionary<DependencyId, IDependency> dependencyById)
         {
             _dependencyById = dependencyById;
         }
@@ -45,11 +46,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
         }
 
         /// <summary>
-        /// Attempts to find the dependency in the project's tree with specified <paramref name="providerType"/> and <paramref name="dependencyId"/>.
+        /// Attempts to find the dependency in the project's tree with specified <paramref name="dependencyId"/>.
         /// </summary>
-        public bool TryGetDependency(string providerType, string dependencyId, out IDependency dependency)
+        public bool TryGetDependency(DependencyId dependencyId, out IDependency dependency)
         {
-            return _dependencyById.TryGetValue((providerType, dependencyId), out dependency);
+            return _dependencyById.TryGetValue(dependencyId, out dependency);
         }
 
         /// <summary>
@@ -61,9 +62,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
         /// </remarks>
         public void AddOrUpdate(IDependency dependency)
         {
-            (string ProviderType, string ModelId) key = (dependency.ProviderType, dependency.Id);
-            _dependencyById.Remove(key);
-            _dependencyById.Add(key, dependency);
+            DependencyId dependencyId = dependency.GetDependencyId();
+            _dependencyById.Remove(dependencyId);
+            _dependencyById.Add(dependencyId, dependency);
             Changed = true;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.RuleHandlers;
 
@@ -34,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
                 //
                 // Try to find a resolved package dependency with the same name.
 
-                if (context.TryGetDependency(PackageRuleHandler.ProviderTypeString, dependencyId: dependency.Id, out IDependency package) && package.Resolved)
+                if (context.TryGetDependency(new DependencyId(PackageRuleHandler.ProviderTypeString, dependency.Id), out IDependency package) && package.Resolved)
                 {
                     // Set to resolved.
 
@@ -49,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
                 //
                 // Try to find an SDK dependency with the same name.
 
-                if (context.TryGetDependency(SdkRuleHandler.ProviderTypeString, dependencyId: dependency.Id, out IDependency sdk))
+                if (context.TryGetDependency(new DependencyId(SdkRuleHandler.ProviderTypeString, dependency.Id), out IDependency sdk))
                 {
                     // We have an SDK dependency for this package. Such dependencies, when implicit, are created
                     // as unresolved by SdkRuleHandler, and are only marked resolved here once we have resolved the
@@ -76,7 +77,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
                 //
                 // Try to find an SDK dependency with the same name.
 
-                if (context.TryGetDependency(SdkRuleHandler.ProviderTypeString, dependencyId: dependency.Id, out IDependency sdk))
+                if (context.TryGetDependency(new DependencyId(SdkRuleHandler.ProviderTypeString, dependency.Id), out IDependency sdk))
                 {
                     // We are removing the package dependency related to this SDK dependency
                     // and must undo the changes made above in BeforeAddOrUpdate.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/UnresolvedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/UnresolvedDependenciesSnapshotFilter.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
             AddDependencyContext context)
         {
             // TODO should this verify that the existing one is actually resolved?
-            if (!dependency.Resolved && context.Contains(dependency.ProviderType, dependency.Id))
+            if (!dependency.Resolved && context.Contains(dependency.GetDependencyId()))
             {
                 context.Reject();
                 return;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
@@ -1,11 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 {
     internal static class IDependencyExtensions
     {
+        public static DependencyId GetDependencyId(this IDependency dependency)
+        {
+            return new DependencyId(dependency.ProviderType, dependency.Id);
+        }
+
         public static IDependency ToResolved(
             this IDependency dependency,
             string? schemaName = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filters;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 
@@ -42,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             ITargetFramework targetFramework = previousSnapshot.TargetFramework;
 
-            var dependencyById = previousSnapshot.Dependencies.ToDictionary(d => (d.ProviderType, ModelId: d.Id));
+            var dependencyById = previousSnapshot.Dependencies.ToDictionary(IDependencyExtensions.GetDependencyId);
 
             if (changes != null && changes.RemovedNodes.Count != 0)
             {
@@ -88,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             void Remove(RemoveDependencyContext context, IDependencyModel dependencyModel)
             {
-                if (!context.TryGetDependency(dependencyModel.ProviderType, dependencyModel.Id, out IDependency dependency))
+                if (!context.TryGetDependency(dependencyModel.GetDependencyId(), out IDependency dependency))
                 {
                     return;
                 }
@@ -110,7 +111,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                     }
                 }
 
-                dependencyById.Remove((dependencyModel.ProviderType, dependencyModel.Id));
+                dependencyById.Remove(dependencyModel.GetDependencyId());
                 anyChanges = true;
             }
 
@@ -140,9 +141,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 if (dependency != null)
                 {
                     // A dependency was accepted
-                    (string ProviderType, string Id) key = (dependencyModel.ProviderType, dependencyModel.Id);
-                    dependencyById.Remove(key);
-                    dependencyById.Add(key, dependency);
+                    var id = dependencyModel.GetDependencyId();
+                    dependencyById.Remove(id);
+                    dependencyById.Add(id, dependency);
                     anyChanges = true;
                 }
                 else

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DeduplicateCaptionsSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DeduplicateCaptionsSnapshotFilterTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 ProviderType = providerType
             };
 
-            var dependencyById = new IDependency[] { dependency, otherDependency }.ToDictionary(d => (d.ProviderType, ModelId: d.Id));
+            var dependencyById = new IDependency[] { dependency, otherDependency }.ToDictionary(IDependencyExtensions.GetDependencyId);
 
             var context = new AddDependencyContext(dependencyById);
 
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 OriginalItemSpec = "originalItemSpec2"
             };
 
-            var dependencyById = new IDependency[] { dependency, otherDependency }.ToDictionary(d => (d.ProviderType, ModelId: d.Id));
+            var dependencyById = new IDependency[] { dependency, otherDependency }.ToDictionary(IDependencyExtensions.GetDependencyId);
 
             var context = new AddDependencyContext(dependencyById);
 
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             DependencyAssert.Equal(new TestDependency { ClonePropertiesFrom = dependency, Caption = "caption (originalItemSpec1)" }, dependencyAfter!);
 
             // The other dependency had its caption changed to its alias
-            Assert.True(context.TryGetDependency(otherDependency.ProviderType, otherDependency.Id, out IDependency otherDependencyAfter));
+            Assert.True(context.TryGetDependency(otherDependency.GetDependencyId(), out IDependency otherDependencyAfter));
             DependencyAssert.Equal(new TestDependency { ClonePropertiesFrom = otherDependency, Caption = "caption (originalItemSpec2)" }, otherDependencyAfter);
         }
 
@@ -127,7 +127,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 Caption = $"{caption} (originalItemSpec2)" // caption already includes alias
             };
 
-            var dependencyById = new IDependency[] { dependency, otherDependency }.ToDictionary(d => (d.ProviderType, ModelId: d.Id));
+            var dependencyById = new IDependency[] { dependency, otherDependency }.ToDictionary(IDependencyExtensions.GetDependencyId);
 
             var context = new AddDependencyContext(dependencyById);
 
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             DependencyAssert.Equal(new TestDependency { ClonePropertiesFrom = dependency, Caption = "caption (originalItemSpec1)" }, dependencyAfter!);
 
             // The other dependency had its caption changed to its alias
-            Assert.True(context.TryGetDependency(otherDependency.ProviderType, otherDependency.Id, out IDependency otherDependencyAfter));
+            Assert.True(context.TryGetDependency(otherDependency.GetDependencyId(), out IDependency otherDependencyAfter));
             DependencyAssert.Equal(new TestDependency { ClonePropertiesFrom = otherDependency, Caption = "caption (originalItemSpec2)" }, otherDependencyAfter);
         }
 
@@ -179,7 +179,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             // TODO test a longer suffix here -- looks like the implementation might not handle it correctly
 
-            var dependencyById = new IDependency[] { dependency, otherDependency }.ToDictionary(d => (d.ProviderType, ModelId: d.Id));
+            var dependencyById = new IDependency[] { dependency, otherDependency }.ToDictionary(IDependencyExtensions.GetDependencyId);
 
             var context = new AddDependencyContext(dependencyById);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshotFilterTestsBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshotFilterTestsBase.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filters;
 using Xunit;
 
@@ -13,9 +14,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
         private protected void VerifyUnchangedOnAdd(IDependency dependency, IImmutableSet<string>? projectItemSpecs = null)
         {
-            var dependencyById = new Dictionary<(string ProviderType, string ModelId), IDependency>
+            var dependencyById = new Dictionary<DependencyId, IDependency>
             {
-                { (dependency.ProviderType, dependency.Id), dependency }
+                { dependency.GetDependencyId(), dependency }
             };
 
             var context = new AddDependencyContext(dependencyById);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/ImplicitDependenciesSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/ImplicitDependenciesSnapshotFilterTests.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filters;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 using Xunit;
@@ -110,9 +111,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 IconSet = new DependencyIconSet(KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference)
             };
 
-            var dependencyById = new Dictionary<(string ProviderType, string ModelId), IDependency>
+            var dependencyById = new Dictionary<DependencyId, IDependency>
             {
-                { (dependency.ProviderType, dependency.Id), dependency }
+                { dependency.GetDependencyId(), dependency }
             };
 
             var context = new AddDependencyContext(dependencyById);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 Flags = DependencyTreeFlags.PackageDependency
             };
 
-            var builder = new IDependency[] { sdkDependency, packageDependency }.ToDictionary(d => (d.ProviderType, ModelId: d.Id));
+            var builder = new IDependency[] { sdkDependency, packageDependency }.ToDictionary(IDependencyExtensions.GetDependencyId);
 
             var context = new AddDependencyContext(builder);
 
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 Flags = DependencyTreeFlags.PackageDependency
             };
 
-            var builder = new IDependency[] { sdkDependency, packageDependency }.ToDictionary(d => (d.ProviderType, ModelId: d.Id));
+            var builder = new IDependency[] { sdkDependency, packageDependency }.ToDictionary(IDependencyExtensions.GetDependencyId);
 
             var context = new AddDependencyContext(builder);
 
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 Resolved = true
             };
 
-            var builder = new IDependency[] { packageDependency, sdkDependency }.ToDictionary(d => (d.ProviderType, ModelId: d.Id));
+            var builder = new IDependency[] { packageDependency, sdkDependency }.ToDictionary(IDependencyExtensions.GetDependencyId);
 
             var context = new AddDependencyContext(builder);
 
@@ -138,7 +138,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             // Other changes made
             Assert.True(context.Changed);
 
-            Assert.True(context.TryGetDependency(sdkDependency.ProviderType, sdkDependency.Id, out IDependency sdkDependencyAfter));
+            Assert.True(context.TryGetDependency(sdkDependency.GetDependencyId(), out IDependency sdkDependencyAfter));
             DependencyAssert.Equal(
                 sdkDependency.ToResolved(schemaName: ResolvedSdkReference.SchemaName),
                 sdkDependencyAfter);
@@ -165,7 +165,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 Resolved = true
             };
 
-            var builder = new IDependency[] { packageDependency, sdkDependency }.ToDictionary(d => (d.ProviderType, ModelId: d.Id));
+            var builder = new IDependency[] { packageDependency, sdkDependency }.ToDictionary(IDependencyExtensions.GetDependencyId);
 
             var context = new RemoveDependencyContext(builder);
 
@@ -181,10 +181,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             // Makes other changes too
             Assert.True(context.Changed);
 
-            Assert.True(builder.TryGetValue((packageDependency.ProviderType, packageDependency.Id), out var afterPackageDependency));
+            Assert.True(builder.TryGetValue(packageDependency.GetDependencyId(), out var afterPackageDependency));
             Assert.Same(packageDependency, afterPackageDependency);
 
-            Assert.True(builder.TryGetValue((sdkDependency.ProviderType, sdkDependency.Id), out var afterSdkDependency));
+            Assert.True(builder.TryGetValue(sdkDependency.GetDependencyId(), out var afterSdkDependency));
             DependencyAssert.Equal(
                 afterSdkDependency.ToUnresolved(SdkReference.SchemaName),
                 afterSdkDependency);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         }
 
 #pragma warning disable CS8618 // Non-nullable property is uninitialized
-        public string ProviderType { get; set; }
+        public string ProviderType { get; set; } = "provider";
         public string Caption { get; set; }
         public string? OriginalItemSpec { get; set; }
         public string? SchemaName { get; set; }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/UnresolvedDependenciesSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/UnresolvedDependenciesSnapshotFilterTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filters;
 using Xunit;
 
@@ -14,9 +15,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             var unresolvedDependency = new TestDependency { Id = "dependency", Resolved = false };
             var resolvedDependency   = new TestDependency { Id = "dependency", Resolved = true  };
 
-            var dependencyById = new Dictionary<(string ProviderType, string ModelId), IDependency>
+            var dependencyById = new Dictionary<DependencyId, IDependency>
             {
-                { (resolvedDependency.ProviderType, resolvedDependency.Id), resolvedDependency }
+                { resolvedDependency.GetDependencyId(), resolvedDependency }
             };
 
             var context = new AddDependencyContext(dependencyById);
@@ -41,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         {
             var unresolvedDependency = new TestDependency { Id = "dependency", Resolved = false };
 
-            var dependencyById = new Dictionary<(string ProviderType, string ModelId), IDependency>();
+            var dependencyById = new Dictionary<DependencyId, IDependency>();
 
             var context = new AddDependencyContext(dependencyById);
 
@@ -65,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         {
             var resolvedDependency = new TestDependency { Id = "dependency", Resolved = true };
 
-            var dependencyById = new Dictionary<(string ProviderType, string ModelId), IDependency>();
+            var dependencyById = new Dictionary<DependencyId, IDependency>();
 
             var context = new AddDependencyContext(dependencyById);
 


### PR DESCRIPTION
(This is a cherry-pick of #6323 to the 16.7.x branch to get the fix in, but needs QB approval.)

---

#6282 changed how dependencies were identified to avoid using a composite string. However, that string was forced to lower-case, which meant that comparisons on dependencies' IDs (item specs) was case insensitive.

Since that change the following project would result in two package references being shown in the tree:

```xml
<Project Sdk="Microsoft.NET.Sdk">

    <PropertyGroup>
        <TargetFramework>net5</TargetFramework>
    </PropertyGroup>

    <ItemGroup>
        <!-- NOTE invalid name casing, and invalid version number -->
        <PackageReference Include="Newtonsoft.JSON" Version="11.0.10" />
    </ItemGroup>

</Project>
```

This PR introduces a new `DependencyId` struct that provides proper hashing and equality.

### Before

![image](https://user-images.githubusercontent.com/350947/86318880-739c3000-bc76-11ea-881a-6a3501e2556a.png)

### After

![image](https://user-images.githubusercontent.com/350947/86318844-68e19b00-bc76-11ea-9608-5b18a7eb5a1f.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6325)