### PR TITLE
Fix potentially invalid expression in props file

### DIFF
--- a/build/import/HostAgnostic.props
+++ b/build/import/HostAgnostic.props
@@ -1,7 +1,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Project>
   <PropertyGroup>
-    <BannedSymbolsOptOut Condition="$(IsTestProject)">true</BannedSymbolsOptOut>
+    <BannedSymbolsOptOut Condition="'$(IsTestProject)' == 'true'">true</BannedSymbolsOptOut>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
After upgrading to 16.6.3 and with a `global.json` pinning to 3.1.4xx (which requires MSBuild 16.7), opening this repo caused all projects to fail to load.

The problem is that when `IsTestProject` is undefined, we see the error:

> Specified condition "$(IsTestProject)" evaluates to "" instead of a boolean



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6328)