### PR TITLE
BuildUpToDateCheck subscribes for updates lazily

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
@@ -500,7 +500,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     CopyReferenceInputs,
                     AdditionalDependentFileTimes,
                     LastAdditionalDependentFileTimesChangedAtUtc,
-                    LastItemsChangedAtUtc, lastCheckedAtUtc);
+                    LastItemsChangedAtUtc,
+                    lastCheckedAtUtc);
             }
 
             /// <summary>
@@ -527,7 +528,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     CopyReferenceInputs,
                     AdditionalDependentFileTimes,
                     LastAdditionalDependentFileTimesChangedAtUtc,
-                    lastItemsChangedAtUtc, LastCheckedAtUtc);
+                    lastItemsChangedAtUtc,
+                    LastCheckedAtUtc);
             }
 
             /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Subscription.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Subscription.cs
@@ -1,0 +1,170 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
+{
+    internal sealed partial class BuildUpToDateCheck
+    {
+        /// <summary>
+        /// Contains and tracks state related to a lifetime instance of <see cref="BuildUpToDateCheck"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// As the parent <see cref="BuildUpToDateCheck"/> is an <see cref="IProjectDynamicLoadComponent"/>, it may have multiple lifetimes.
+        /// This class contains all the state associated with such a lifetime: it's Dataflow subscription, tracking the first value to arrive,
+        /// and the <see cref="BuildUpToDateCheck.State"/> instance.
+        /// </para>
+        /// <para>
+        /// Initialization of the Dataflow subscription happens lazily, upon the first up-to-date check request.
+        /// </para>
+        /// </remarks>
+        private sealed class Subscription : IDisposable
+        {
+            /// <summary>
+            /// Completes when the first project update is received. Cancelled if the subscription is disposed.
+            /// </summary>
+            /// <remarks>
+            /// This field is also used to synchronise some operations.
+            /// </remarks>
+            private readonly TaskCompletionSource<byte> _dataReceived = new TaskCompletionSource<byte>();
+
+            /// <summary>
+            /// Prevent overlapping requests.
+            /// </summary>
+            private readonly AsyncSemaphore _semaphore = new AsyncSemaphore(1);
+
+            /// <summary>
+            /// Current <see cref="BuildUpToDateCheck.State"/> of the instance.
+            /// </summary>
+            /// <remarks>
+            /// Internal to support unit testing only.
+            /// </remarks>
+            internal State State { get; set; } = State.Empty;
+
+            /// <summary>
+            /// Lazily constructed Dataflow subscription. Set back to <see langword="null"/> in <see cref="Dispose"/>.
+            /// </summary>
+            private IDisposable? _link;
+
+            /// <summary>
+            /// Cancelled when this instance is disposed.
+            /// </summary>
+            private readonly CancellationTokenSource _disposeTokenSource = new CancellationTokenSource();
+
+            public async Task<bool> RunAsync(Func<State, CancellationToken, Task<bool>> func, ConfiguredProject configuredProject, IProjectItemSchemaService projectItemSchemaService, CancellationToken cancellationToken)
+            {
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposeTokenSource.Token);
+
+                CancellationToken token = cts.Token;
+
+                token.ThrowIfCancellationRequested();
+
+                // Note that we defer subscription until an actual request is made in order to
+                // prevent redundant work/allocation for inactive project configurations.
+                // https://github.com/dotnet/project-system/issues/6327
+                //
+                // We don't pass the cancellation token here as initialization must be atomic.
+                EnsureInitialized();
+
+                token.ThrowIfCancellationRequested();
+
+                // Wait for the first state to be computed
+                await _dataReceived.Task.WithCancellation(token);
+
+                // Prevent overlapping requests
+                using AsyncSemaphore.Releaser _ = await _semaphore.EnterAsync(token);
+
+                bool result = await func(State, token);
+
+                lock (_dataReceived)
+                {
+                    State = State.WithLastCheckedAtUtc(DateTime.UtcNow);
+                }
+
+                return result;
+
+                void EnsureInitialized()
+                {
+                    if (_link != null)
+                    {
+                        // Already initialized (or disposed)
+                        return;
+                    }
+
+                    lock (_dataReceived)
+                    {
+                        // Double check within lock
+                        if (_link == null)
+                        {
+                            Assumes.Present(configuredProject.Services.ProjectSubscription);
+
+                            _link = ProjectDataSources.SyncLinkTo(
+                                configuredProject.Services.ProjectSubscription.JointRuleSource.SourceBlock.SyncLinkOptions(DataflowOption.WithRuleNames(ProjectPropertiesSchemas)),
+                                configuredProject.Services.ProjectSubscription.SourceItemsRuleSource.SourceBlock.SyncLinkOptions(),
+                                configuredProject.Services.ProjectSubscription.ProjectSource.SourceBlock.SyncLinkOptions(),
+                                projectItemSchemaService.SourceBlock.SyncLinkOptions(),
+                                configuredProject.Services.ProjectSubscription.ProjectCatalogSource.SourceBlock.SyncLinkOptions(),
+                                target: DataflowBlockFactory.CreateActionBlock<IProjectVersionedValue<ValueTuple<IProjectSubscriptionUpdate, IProjectSubscriptionUpdate, IProjectSnapshot, IProjectItemSchema, IProjectCatalogSnapshot>>>(OnChanged, configuredProject.UnconfiguredProject),
+                                linkOptions: DataflowOption.PropagateCompletion);
+                        }
+                    }
+                }
+            }
+
+            internal void OnChanged(IProjectVersionedValue<ValueTuple<IProjectSubscriptionUpdate, IProjectSubscriptionUpdate, IProjectSnapshot, IProjectItemSchema, IProjectCatalogSnapshot>> e)
+            {
+                var snapshot = e.Value.Item3 as IProjectSnapshot2;
+                Assumes.NotNull(snapshot);
+
+                lock (_dataReceived)
+                {
+                    if (_disposeTokenSource.IsCancellationRequested)
+                    {
+                        // We've been disposed, so don't update State (which will be empty)
+                        return;
+                    }
+
+                    State = State.Update(
+                        jointRuleUpdate: e.Value.Item1,
+                        sourceItemsUpdate: e.Value.Item2,
+                        projectSnapshot: snapshot,
+                        projectItemSchema: e.Value.Item4,
+                        projectCatalogSnapshot: e.Value.Item5,
+                        configuredProjectVersion: e.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion]);
+                }
+
+                _dataReceived.TrySetResult(0);
+            }
+
+            /// <summary>
+            /// Tear down any Dataflow subscription and cancel any ongoing query.
+            /// </summary>
+            public void Dispose()
+            {
+                if (_disposeTokenSource.IsCancellationRequested)
+                {
+                    // Already disposed
+                    return;
+                }
+
+                lock (_dataReceived)
+                {
+                    _link?.Dispose();
+                    _link = null;
+
+                    State = State.Empty;
+
+                    _disposeTokenSource.Cancel();
+                    _disposeTokenSource.Dispose();
+                }
+
+                _dataReceived.TrySetCanceled();
+            }
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -87,15 +87,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _fileSystem.AddFolder(_msBuildProjectDirectory);
             _fileSystem.AddFolder(_outputPath);
 
-            var threadingService = IProjectThreadingServiceFactory.Create();
-
             _buildUpToDateCheck = new BuildUpToDateCheck(
                 projectSystemOptions.Object,
                 configuredProject.Object,
                 projectAsynchronousTasksService.Object,
                 IProjectItemSchemaServiceFactory.Create(),
                 ITelemetryServiceFactory.Create(telemetryParameters => _telemetryEvents.Add(telemetryParameters)),
-                threadingService,
                 _fileSystem);
         }
 
@@ -152,7 +149,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 identity: ProjectDataSources.ConfiguredProjectVersion,
                 version: _projectVersion);
 
-            _buildUpToDateCheck.OnChanged(value);
+            _buildUpToDateCheck.TestAccess.OnChanged(value);
 
             return;
 


### PR DESCRIPTION
Previously this component would subscribe for project updates as soon as it was initialised. As Lifeng points out in #6327, this can result in unnecessary work and allocation during solution load, especially for inactive project configurations.

This change pulls all lifetime-coupled objects out to the new `Subscription` nested type. Dataflow subscriptions are delayed until the first call to `IsUpToDateAsync`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6329)