### PR TITLE
Track dependency diagnostic level at snapshot level

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -14,6 +14,7 @@ using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.References;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions;
 using Microsoft.VisualStudio.ProjectSystem.VS;
@@ -358,7 +359,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
                     if (_treeTelemetryService.IsActive)
                     {
-                        await _treeTelemetryService.ObserveTreeUpdateCompletedAsync(snapshot.HasVisibleUnresolvedDependency);
+                        await _treeTelemetryService.ObserveTreeUpdateCompletedAsync(snapshot.MaximumVisibleDiagnosticLevel != DiagnosticLevel.None);
                     }
                 }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
             dependenciesTree = CleanupOldNodes(dependenciesTree, currentNodes);
 
-            ProjectImageMoniker rootIcon = _viewModelFactory.GetDependenciesRootIcon(snapshot.HasVisibleUnresolvedDependency).ToProjectSystemType();
+            ProjectImageMoniker rootIcon = _viewModelFactory.GetDependenciesRootIcon(snapshot.MaximumVisibleDiagnosticLevel).ToProjectSystemType();
 
             return dependenciesTree.SetProperties(icon: rootIcon, expandedIcon: rootIcon);
 
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                     {
                         IProjectTree? node = dependenciesTree.FindChildWithCaption(targetFramework.ShortName);
                         bool shouldAddTargetNode = node == null;
-                        IDependencyViewModel targetViewModel = _viewModelFactory.CreateTargetViewModel(targetedSnapshot.TargetFramework, targetedSnapshot.HasVisibleUnresolvedDependency);
+                        IDependencyViewModel targetViewModel = _viewModelFactory.CreateTargetViewModel(targetedSnapshot.TargetFramework, targetedSnapshot.MaximumVisibleDiagnosticLevel);
 
                         node = CreateOrUpdateNode(
                             node,
@@ -200,7 +200,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             {
                 IDependencyViewModel? subTreeViewModel = _viewModelFactory.CreateGroupNodeViewModel(
                     providerType,
-                    targetedSnapshot.CheckForUnresolvedDependencies(providerType));
+                    targetedSnapshot.GetMaximumVisibleDiagnosticLevelForProvider(providerType));
 
                 if (subTreeViewModel == null)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependenciesViewModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependenciesViewModelFactory.cs
@@ -22,18 +22,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
         [ImportMany]
         protected OrderPrecedenceImportCollection<IProjectDependenciesSubTreeProvider> SubTreeProviders { get; }
 
-        public IDependencyViewModel CreateTargetViewModel(TargetFramework targetFramework, bool hasVisibleUnresolvedDependency)
+        public IDependencyViewModel CreateTargetViewModel(TargetFramework targetFramework, DiagnosticLevel maximumDiagnosticLevel)
         {
-            return new TargetDependencyViewModel(targetFramework, hasVisibleUnresolvedDependency);
+            return new TargetDependencyViewModel(targetFramework, maximumDiagnosticLevel);
         }
 
-        public IDependencyViewModel? CreateGroupNodeViewModel(string providerType, bool hasVisibleUnresolvedDependency)
+        public IDependencyViewModel? CreateGroupNodeViewModel(string providerType, DiagnosticLevel maximumDiagnosticLevel)
         {
             IProjectDependenciesSubTreeProvider? provider = GetProvider();
 
             IDependencyModel? dependencyModel = provider?.CreateRootDependencyNode();
 
-            return dependencyModel?.ToViewModel(hasVisibleUnresolvedDependency);
+            return dependencyModel?.ToViewModel(maximumDiagnosticLevel);
 
             IProjectDependenciesSubTreeProvider? GetProvider()
             {
@@ -43,11 +43,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             }
         }
 
-        public ImageMoniker GetDependenciesRootIcon(bool hasVisibleUnresolvedDependency)
+        public ImageMoniker GetDependenciesRootIcon(DiagnosticLevel maximumDiagnosticLevel)
         {
-            return hasVisibleUnresolvedDependency
-                ? ManagedImageMonikers.ReferenceGroupWarning
-                : ManagedImageMonikers.ReferenceGroup;
+            return maximumDiagnosticLevel switch
+            {
+                DiagnosticLevel.None => ManagedImageMonikers.ReferenceGroup,
+                _ => ManagedImageMonikers.ReferenceGroupWarning
+            };
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependencyModel.cs
@@ -68,6 +68,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
                 };
             }
 
+            if (diagnosticLevel == DiagnosticLevel.None && !isResolved)
+            {
+                // Treat unresolved state as a warning diagnostic
+                diagnosticLevel = DiagnosticLevel.Warning;
+            }
+
             DependencyFlags depFlags = 0;
             if (isResolved)
                 depFlags |= DependencyFlags.Resolved;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/IDependenciesViewModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/IDependenciesViewModelFactory.cs
@@ -9,16 +9,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
         /// <summary>
         /// Returns a view model for a node that represents a target framework.
         /// </summary>
-        IDependencyViewModel CreateTargetViewModel(TargetFramework targetFramework, bool hasVisibleUnresolvedDependency);
+        IDependencyViewModel CreateTargetViewModel(TargetFramework targetFramework, DiagnosticLevel maximumDiagnosticLevel);
 
         /// <summary>
         /// Returns a view model for a node that groups dependencies from a given provider.
         /// </summary>
-        IDependencyViewModel? CreateGroupNodeViewModel(string providerType, bool hasVisibleUnresolvedDependency);
+        IDependencyViewModel? CreateGroupNodeViewModel(string providerType, DiagnosticLevel maximumDiagnosticLevel);
 
         /// <summary>
         /// Returns the icon to use for the "Dependencies" root node.
         /// </summary>
-        ImageMoniker GetDependenciesRootIcon(bool hasVisibleUnresolvedDependency);
+        ImageMoniker GetDependenciesRootIcon(DiagnosticLevel maximumDiagnosticLevel);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/IDependencyModelExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/IDependencyModelExtensions.cs
@@ -12,28 +12,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             return new DependencyId(self.ProviderType, self.Id);
         }
 
-        public static IDependencyViewModel ToViewModel(this IDependencyModel self, bool hasUnresolvedDependency)
+        public static IDependencyViewModel ToViewModel(this IDependencyModel self, DiagnosticLevel diagnosticLevel)
         {
-            return new DependencyModelViewModel(self, hasUnresolvedDependency);
+            return new DependencyModelViewModel(self, diagnosticLevel);
         }
 
         private sealed class DependencyModelViewModel : IDependencyViewModel
         {
             private readonly IDependencyModel _model;
-            private readonly bool _hasUnresolvedDependency;
+            private readonly DiagnosticLevel _diagnosticLevel;
 
-            public DependencyModelViewModel(IDependencyModel model, bool hasUnresolvedDependency)
+            public DependencyModelViewModel(IDependencyModel model, DiagnosticLevel diagnosticLevel)
             {
                 _model = model;
-                _hasUnresolvedDependency = hasUnresolvedDependency;
+                _diagnosticLevel = diagnosticLevel;
             }
 
             public string Caption => _model.Caption;
             public string? FilePath => _model.Path;
             public string? SchemaName => _model.SchemaName;
             public string? SchemaItemType => _model.SchemaItemType;
-            public ImageMoniker Icon => _hasUnresolvedDependency ? _model.UnresolvedIcon : _model.Icon;
-            public ImageMoniker ExpandedIcon => _hasUnresolvedDependency ? _model.UnresolvedExpandedIcon : _model.ExpandedIcon;
+            public ImageMoniker Icon => _diagnosticLevel == DiagnosticLevel.None ? _model.Icon : _model.UnresolvedIcon;
+            public ImageMoniker ExpandedIcon => _diagnosticLevel == DiagnosticLevel.None ? _model.ExpandedIcon : _model.UnresolvedExpandedIcon;
             public ProjectTreeFlags Flags => _model.Flags;
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/TargetDependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/TargetDependencyViewModel.cs
@@ -13,13 +13,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
     {
         private static ImmutableDictionary<string, ProjectTreeFlags> s_configurationFlags = ImmutableDictionary<string, ProjectTreeFlags>.Empty.WithComparers(StringComparer.Ordinal);
 
-        private readonly bool _hasUnresolvedDependency;
+        private readonly DiagnosticLevel _diagnosticLevel;
 
-        public TargetDependencyViewModel(TargetFramework targetFramework, bool hasVisibleUnresolvedDependency)
+        public TargetDependencyViewModel(TargetFramework targetFramework, DiagnosticLevel diagnosticLevel)
         {
             Caption = targetFramework.ShortName;
             Flags = GetCachedFlags(targetFramework);
-            _hasUnresolvedDependency = hasVisibleUnresolvedDependency;
+            _diagnosticLevel = diagnosticLevel;
 
             static ProjectTreeFlags GetCachedFlags(TargetFramework targetFramework)
             {
@@ -34,8 +34,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
         public string? FilePath => null;
         public string? SchemaName => null;
         public string? SchemaItemType => null;
-        public ImageMoniker Icon => _hasUnresolvedDependency ? ManagedImageMonikers.LibraryWarning : KnownMonikers.Library;
-        public ImageMoniker ExpandedIcon => _hasUnresolvedDependency ? ManagedImageMonikers.LibraryWarning : KnownMonikers.Library;
+        public ImageMoniker Icon => _diagnosticLevel == DiagnosticLevel.None ? KnownMonikers.Library : ManagedImageMonikers.LibraryWarning;
+        public ImageMoniker ExpandedIcon => _diagnosticLevel == DiagnosticLevel.None ? KnownMonikers.Library : ManagedImageMonikers.LibraryWarning;
         public ProjectTreeFlags Flags { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filters;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 
@@ -191,9 +192,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         public ImmutableDictionary<TargetFramework, TargetedDependenciesSnapshot> DependenciesByTargetFramework { get; }
 
         /// <summary>
-        /// Gets whether this snapshot contains at least one visible unresolved dependency, for any target framework.
+        /// Gets the maximum diagnostic level across all dependencies and targets within the snapshot.
         /// </summary>
-        public bool HasVisibleUnresolvedDependency => DependenciesByTargetFramework.Any(x => x.Value.HasVisibleUnresolvedDependency);
+        public DiagnosticLevel MaximumVisibleDiagnosticLevel
+        {
+            get
+            {
+                DiagnosticLevel max = DiagnosticLevel.None;
+                
+                foreach ((_, TargetedDependenciesSnapshot snapshot) in DependenciesByTargetFramework)
+                {
+                    if (snapshot.MaximumVisibleDiagnosticLevel > max)
+                    {
+                        max = snapshot.MaximumVisibleDiagnosticLevel;
+                    }
+                }
+
+                return max;
+            }
+        }
 
         public override string ToString() => $"{DependenciesByTargetFramework.Count} target framework{(DependenciesByTargetFramework.Count == 1 ? "" : "s")}";
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
@@ -54,14 +54,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             {
                 IconSet = model.IconSet;
 
-                // For now we consider any non-empty DiagnosticLevel string as a warning. In future we
-                // may differentiate visually on the node between different grades of diagnostic,
-                // such as warnings and errors.
-                _hasDiagnostic = model.DiagnosticLevel != DiagnosticLevel.None;
+                DiagnosticLevel = model.DiagnosticLevel;
             }
             else
             {
                 IconSet = DependencyIconSetCache.Instance.GetOrAddIconSet(dependencyModel.Icon, dependencyModel.ExpandedIcon, dependencyModel.UnresolvedIcon, dependencyModel.UnresolvedExpandedIcon);
+
+                DiagnosticLevel = dependencyModel.Resolved ? DiagnosticLevel.None : DiagnosticLevel.Warning;
             }
 
             BrowseObjectProperties = dependencyModel.Properties
@@ -97,10 +96,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             SchemaName = schemaName ?? dependency.SchemaName;
             IconSet = iconSet != null ? DependencyIconSetCache.Instance.GetOrAddIconSet(iconSet) : dependency.IconSet;
             Implicit = isImplicit ?? dependency.Implicit;
-            _hasDiagnostic = dependency._hasDiagnostic;
+            DiagnosticLevel = dependency.DiagnosticLevel;
         }
 
-        private readonly bool _hasDiagnostic;
+        public DiagnosticLevel DiagnosticLevel { get; }
 
         #region IDependency
 
@@ -144,8 +143,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
         public string? FilePath { get; }
 
-        public ImageMoniker Icon => Resolved && !_hasDiagnostic ? IconSet.Icon : IconSet.UnresolvedIcon;
-        public ImageMoniker ExpandedIcon => Resolved && !_hasDiagnostic ? IconSet.ExpandedIcon : IconSet.UnresolvedExpandedIcon;
+        public ImageMoniker Icon => DiagnosticLevel == DiagnosticLevel.None ? IconSet.Icon : IconSet.UnresolvedIcon;
+        public ImageMoniker ExpandedIcon => DiagnosticLevel == DiagnosticLevel.None ? IconSet.ExpandedIcon : IconSet.UnresolvedExpandedIcon;
 
         #endregion
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependency.cs
@@ -63,6 +63,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         IImmutableDictionary<string, string> BrowseObjectProperties { get; }
 
         /// <summary>
+        /// Gets the level of any diagnostic associated with this dependency (e.g. <see cref="DiagnosticLevel.Error"/>,
+        /// <see cref="DiagnosticLevel.Warning"/> and <see cref="DiagnosticLevel.None"/>).
+        /// </summary>
+        DiagnosticLevel DiagnosticLevel { get; }
+
+        /// <summary>
         /// Specifies if dependency is resolved or not
         /// </summary>
         bool Resolved { get; }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             if (getDependenciesRootIcon.HasValue)
             {
-                mock.Setup(x => x.GetDependenciesRootIcon(It.IsAny<bool>())).Returns(getDependenciesRootIcon.Value);
+                mock.Setup(x => x.GetDependenciesRootIcon(It.IsAny<DiagnosticLevel>())).Returns(getDependenciesRootIcon.Value);
             }
 
             if (createRootViewModel != null)
@@ -30,12 +30,16 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 {
                     mock.Setup(x => x.CreateGroupNodeViewModel(
                             It.Is<string>(t => string.Equals(t, d.ProviderType, StringComparison.OrdinalIgnoreCase)),
-                            false))
-                        .Returns(d.ToViewModel(false));
+                            DiagnosticLevel.None))
+                        .Returns(d.ToViewModel(DiagnosticLevel.None));
                     mock.Setup(x => x.CreateGroupNodeViewModel(
                             It.Is<string>(t => string.Equals(t, d.ProviderType, StringComparison.OrdinalIgnoreCase)),
-                            true))
-                        .Returns(d.ToViewModel(true));
+                            DiagnosticLevel.Warning))
+                        .Returns(d.ToViewModel(DiagnosticLevel.Warning));
+                    mock.Setup(x => x.CreateGroupNodeViewModel(
+                            It.Is<string>(t => string.Equals(t, d.ProviderType, StringComparison.OrdinalIgnoreCase)),
+                            DiagnosticLevel.Error))
+                        .Returns(d.ToViewModel(DiagnosticLevel.Error));
                 }
             }
 
@@ -45,8 +49,16 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 {
                     mock.Setup(x => x.CreateTargetViewModel(
                             It.Is<TargetFramework>(t => string.Equals(t.FullName, d.Caption, StringComparison.OrdinalIgnoreCase)),
-                            false))
-                        .Returns(d.ToViewModel(false));
+                            DiagnosticLevel.None))
+                        .Returns(d.ToViewModel(DiagnosticLevel.None));
+                    mock.Setup(x => x.CreateTargetViewModel(
+                            It.Is<TargetFramework>(t => string.Equals(t.FullName, d.Caption, StringComparison.OrdinalIgnoreCase)),
+                            DiagnosticLevel.Warning))
+                        .Returns(d.ToViewModel(DiagnosticLevel.Warning));
+                    mock.Setup(x => x.CreateTargetViewModel(
+                            It.Is<TargetFramework>(t => string.Equals(t.FullName, d.Caption, StringComparison.OrdinalIgnoreCase)),
+                            DiagnosticLevel.Error))
+                        .Returns(d.ToViewModel(DiagnosticLevel.Error));
                 }
             }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 
             var factory = new DependenciesViewModelFactory(project);
 
-            var result = factory.CreateTargetViewModel(targetFramework, hasVisibleUnresolvedDependency: false);
+            var result = factory.CreateTargetViewModel(targetFramework, maximumDiagnosticLevel: DiagnosticLevel.None);
 
             Assert.NotNull(result);
             Assert.Equal(targetFramework.FullName, result.Caption);
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 
             var factory = new DependenciesViewModelFactory(project);
 
-            var result = factory.CreateTargetViewModel(targetFramework, hasVisibleUnresolvedDependency: true);
+            var result = factory.CreateTargetViewModel(targetFramework, maximumDiagnosticLevel: DiagnosticLevel.Warning);
 
             Assert.NotNull(result);
             Assert.Equal(targetFramework.FullName, result.Caption);
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 
             var factory = new TestableDependenciesViewModelFactory(project, new[] { subTreeProvider1, subTreeProvider2 });
 
-            var result = factory.CreateGroupNodeViewModel("MyProvider1", hasVisibleUnresolvedDependency: false);
+            var result = factory.CreateGroupNodeViewModel("MyProvider1", maximumDiagnosticLevel: DiagnosticLevel.None);
 
             Assert.NotNull(result);
             Assert.Equal("ZzzDependencyRoot", result!.Caption);
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 
             var factory = new TestableDependenciesViewModelFactory(project, new[] { subTreeProvider1 });
 
-            var result = factory.CreateGroupNodeViewModel("UnknownProviderType", hasVisibleUnresolvedDependency: false);
+            var result = factory.CreateGroupNodeViewModel("UnknownProviderType", maximumDiagnosticLevel: DiagnosticLevel.None);
 
             Assert.Null(result);
         }
@@ -96,8 +96,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             var project = UnconfiguredProjectFactory.Create();
             var factory = new DependenciesViewModelFactory(project);
 
-            Assert.Equal(ManagedImageMonikers.ReferenceGroup, factory.GetDependenciesRootIcon(hasVisibleUnresolvedDependency: false));
-            Assert.Equal(ManagedImageMonikers.ReferenceGroupWarning, factory.GetDependenciesRootIcon(hasVisibleUnresolvedDependency: true));
+            Assert.Equal(ManagedImageMonikers.ReferenceGroup, factory.GetDependenciesRootIcon(maximumDiagnosticLevel: DiagnosticLevel.None));
+            Assert.Equal(ManagedImageMonikers.ReferenceGroupWarning, factory.GetDependenciesRootIcon(maximumDiagnosticLevel: DiagnosticLevel.Warning));
         }
 
         private class TestableDependenciesViewModelFactory : DependenciesViewModelFactory

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filters;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions;
@@ -65,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             Assert.Same(targetFramework, snapshot.ActiveTargetFramework);
             Assert.Same(dependenciesByTargetFramework, snapshot.DependenciesByTargetFramework);
-            Assert.False(snapshot.HasVisibleUnresolvedDependency);
+            Assert.Equal(DiagnosticLevel.None, snapshot.MaximumVisibleDiagnosticLevel);
         }
 
         [Fact]
@@ -75,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             Assert.Same(TargetFramework.Empty, snapshot.ActiveTargetFramework);
             Assert.Empty(snapshot.DependenciesByTargetFramework);
-            Assert.False(snapshot.HasVisibleUnresolvedDependency);
+            Assert.Equal(DiagnosticLevel.None, snapshot.MaximumVisibleDiagnosticLevel);
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filters;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions;
@@ -37,9 +38,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             Assert.Same(targetFramework, snapshot.TargetFramework);
             Assert.Same(catalogs, snapshot.Catalogs);
-            Assert.False(snapshot.HasVisibleUnresolvedDependency);
+            Assert.Equal(DiagnosticLevel.None, snapshot.MaximumVisibleDiagnosticLevel);
             Assert.Empty(snapshot.Dependencies);
-            Assert.False(snapshot.CheckForUnresolvedDependencies("foo"));
+            Assert.Equal(DiagnosticLevel.None, snapshot.GetMaximumVisibleDiagnosticLevelForProvider("foo"));
         }
 
         [Fact]
@@ -52,9 +53,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             Assert.Same(targetFramework, snapshot.TargetFramework);
             Assert.Same(catalogs, snapshot.Catalogs);
-            Assert.False(snapshot.HasVisibleUnresolvedDependency);
+            Assert.Equal(DiagnosticLevel.None, snapshot.MaximumVisibleDiagnosticLevel);
             Assert.Empty(snapshot.Dependencies);
-            Assert.False(snapshot.CheckForUnresolvedDependencies("foo"));
+            Assert.Equal(DiagnosticLevel.None, snapshot.GetMaximumVisibleDiagnosticLevelForProvider("foo"));
         }
 
         [Fact]
@@ -99,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             {
                 Assert.Same(previousSnapshot.Dependencies[i], snapshot.Dependencies[i]);
             }
-            Assert.False(snapshot.HasVisibleUnresolvedDependency);
+            Assert.Equal(DiagnosticLevel.None, snapshot.MaximumVisibleDiagnosticLevel);
             Assert.Empty(snapshot.Dependencies);
         }
 
@@ -150,7 +151,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             Assert.NotSame(previousSnapshot, snapshot);
             Assert.Same(catalogs, snapshot.Catalogs);
-            Assert.True(snapshot.HasVisibleUnresolvedDependency);
+            Assert.Equal(DiagnosticLevel.Warning, snapshot.MaximumVisibleDiagnosticLevel);
             AssertEx.CollectionLength(snapshot.Dependencies, 2);
             Assert.Contains(snapshot.Dependencies, resolved.Matches);
             Assert.Contains(snapshot.Dependencies, unresolved.Matches);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 {
@@ -42,6 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         public string? OriginalItemSpec { get; set; }
         public string? SchemaName { get; set; }
         public string? SchemaItemType { get; set; }
+        public DiagnosticLevel DiagnosticLevel { get; set; } = DiagnosticLevel.None;
         public bool Resolved { get; set; } = false;
         public bool Implicit { get; set; } = false;
         public bool Visible { get; set; } = true;


### PR DESCRIPTION
The concept of 'diagnostic level' was introduced in #6288. Previously, warnings were only shown on dependencies when they were marked as unresolved. Now we can have multiple levels.

This commit tracks the maximum visible diagnostic level in a snapshot at the snapshot level (both targeted and cross-target), and passes that value to code that's responsible for placing an icon in the tree. This value replaces the "has visible unresolved dependency", and opens up the possibility of showing different severities in tree icons in future.

This fixes an issue where a child could have a warning icon visible, but the parent would not (seen in https://github.com/dotnet/project-system/issues/6275#issuecomment-653365600).



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6330)