### PR TITLE
BuildUpToDateCheck subscribes for updates lazily

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ConfiguredProjectImplicitActivationTracking.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ConfiguredProjectImplicitActivationTracking.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.Threading.Tasks;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     /// <summary>
-    ///     Provides an implementation of <see cref="IConfiguredProjectActivationTracking"/> that is based on the results of <see cref="IActiveConfigurationGroupService"/>.
+    ///     Provides an implementation of <see cref="IConfiguredProjectImplicitActivationTracking"/> that is based on the results of <see cref="IActiveConfigurationGroupService"/>.
     /// </summary>
     [Export(typeof(IConfiguredProjectImplicitActivationTracking))]
     [AppliesTo(ProjectCapability.DotNet)]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -657,7 +657,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             public State State => _check._state;
 
-            public Task InitializedTask => _check._initializedTask.Task;
+            public Task EnsureInitialized() => _check._initializedTask.Task;
 
             public void SetLastCheckedAtUtc(DateTime lastCheckedAtUtc)
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             Dictionary<string, IProjectRuleSnapshotModel>? sourceSnapshot = null,
             IEnumerable<(string FilePath, DateTime Time)>? dependentTimeFiles = null)
         {
-            await _buildUpToDateCheck.TestAccess.InitializedTask;
+            await _buildUpToDateCheck.TestAccess.EnsureInitialized();
 
             BroadcastChange(
                 projectRuleSnapshot: projectSnapshot,
@@ -503,7 +503,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 [Compile.SchemaName] = SimpleItems("ItemPath1", "ItemPath2")
             };
 
-            await _buildUpToDateCheck.TestAccess.InitializedTask;
+            await _buildUpToDateCheck.TestAccess.EnsureInitialized();
 
             Assert.Equal(DateTime.MinValue, _buildUpToDateCheck.TestAccess.State.LastItemsChangedAtUtc);
 
@@ -914,7 +914,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 [Content.SchemaName] = ItemWithMetadata("Item1", "CopyToOutputDirectory", "PreserveNewest")
             };
 
-            await _buildUpToDateCheck.TestAccess.InitializedTask;
+            await _buildUpToDateCheck.TestAccess.EnsureInitialized();
 
             BroadcastChange(outDir: outDirSnapshot, sourceRuleSnapshot: sourceSnapshot);
 
@@ -1102,7 +1102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         [Fact]
         public async Task IsUpToDateAsync_True_InitialItemDataDoesNotUpdateLastAdditionalDependentFileTimesChangedAtUtc()
         {
-            await _buildUpToDateCheck.TestAccess.InitializedTask;
+            await _buildUpToDateCheck.TestAccess.EnsureInitialized();
 
             Assert.Equal(DateTime.MinValue, _buildUpToDateCheck.TestAccess.State.LastAdditionalDependentFileTimesChangedAtUtc);
 


### PR DESCRIPTION
This PR replaces #6329.

---

Previously this component would subscribe for project updates as soon as it was initialised. As Lifeng points out in #6327, this can result in unnecessary work and allocation during solution load, especially for inactive project configurations.

This change uses `IConfiguredProjectActivationTracking` to trigger initialisation. Dataflow subscriptions are delayed until that point, or the first call to `IsUpToDateAsync`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6334)