### PR TITLE
Fix lingering warning icon on SDK references

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
@@ -79,7 +79,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             ProjectTreeFlags? flags,
             string? schemaName,
             DependencyIconSet? iconSet,
-            bool? isImplicit)
+            bool? isImplicit,
+            DiagnosticLevel? diagnosticLevel)
         {
             // Copy values as necessary to create a clone with any properties overridden
 
@@ -96,7 +97,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             SchemaName = schemaName ?? dependency.SchemaName;
             IconSet = iconSet != null ? DependencyIconSetCache.Instance.GetOrAddIconSet(iconSet) : dependency.IconSet;
             Implicit = isImplicit ?? dependency.Implicit;
-            DiagnosticLevel = dependency.DiagnosticLevel;
+            DiagnosticLevel = diagnosticLevel ?? dependency.DiagnosticLevel;
         }
 
         public DiagnosticLevel DiagnosticLevel { get; }
@@ -154,9 +155,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             ProjectTreeFlags? flags = null,
             string? schemaName = null,
             DependencyIconSet? iconSet = null,
-            bool? isImplicit = null)
+            bool? isImplicit = null,
+            DiagnosticLevel? diagnosticLevel = null)
         {
-            return new Dependency(this, caption, resolved, flags, schemaName, iconSet, isImplicit);
+            return new Dependency(this, caption, resolved, flags, schemaName, iconSet, isImplicit, diagnosticLevel);
         }
 
         public override string ToString()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
@@ -37,10 +37,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
 
                 if (context.TryGetDependency(new DependencyId(PackageRuleHandler.ProviderTypeString, dependency.Id), out IDependency package) && package.Resolved)
                 {
-                    // Set to resolved.
+                    // Set to resolved and clear any diagnostic.
 
                     context.Accept(dependency.ToResolved(
-                        schemaName: ResolvedSdkReference.SchemaName));
+                        schemaName: ResolvedSdkReference.SchemaName,
+                        diagnosticLevel: DiagnosticLevel.None));
                     return;
                 }
             }
@@ -56,10 +57,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
                     // as unresolved by SdkRuleHandler, and are only marked resolved here once we have resolved the
                     // corresponding package.
                     //
-                    // Set to resolved.
+                    // Set to resolved and clear any diagnostic.
 
                     context.AddOrUpdate(sdk.ToResolved(
-                        schemaName: ResolvedSdkReference.SchemaName));
+                        schemaName: ResolvedSdkReference.SchemaName,
+                        diagnosticLevel: DiagnosticLevel.None));
                 }
             }
 
@@ -82,10 +84,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
                     // We are removing the package dependency related to this SDK dependency
                     // and must undo the changes made above in BeforeAddOrUpdate.
                     //
-                    // Set to unresolved.
+                    // Set to unresolved and reinstate warning diagnostic.
 
                     context.AddOrUpdate(sdk.ToUnresolved(
-                        schemaName: SdkReference.SchemaName));
+                        schemaName: SdkReference.SchemaName,
+                        diagnosticLevel: DiagnosticLevel.Warning));
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependency.cs
@@ -26,7 +26,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             ProjectTreeFlags? flags = null,
             string? schemaName = null,
             DependencyIconSet? iconSet = null,
-            bool? isImplicit = null);
+            bool? isImplicit = null,
+            DiagnosticLevel? diagnosticLevel = null);
 
         /// <summary>
         /// Gets the originating <see cref="IDependencyModel"/>'s <see cref="IDependencyModel.Id"/>.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
@@ -14,22 +14,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
         public static IDependency ToResolved(
             this IDependency dependency,
-            string? schemaName = null)
+            string? schemaName = null,
+            DiagnosticLevel? diagnosticLevel = null)
         {
             return dependency.SetProperties(
                 resolved: true,
                 flags: dependency.GetResolvedFlags(),
-                schemaName: schemaName);
+                schemaName: schemaName,
+                diagnosticLevel: diagnosticLevel);
         }
 
         public static IDependency ToUnresolved(
             this IDependency dependency,
-            string? schemaName = null)
+            string? schemaName = null,
+            DiagnosticLevel? diagnosticLevel = null)
         {
             return dependency.SetProperties(
                 resolved: false,
                 flags: dependency.GetUnresolvedFlags(),
-                schemaName: schemaName);
+                schemaName: schemaName,
+                diagnosticLevel: diagnosticLevel);
         }
 
         private static ProjectTreeFlags GetResolvedFlags(this IDependency dependency)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Linq;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filters;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.RuleHandlers;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
@@ -51,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             Assert.NotNull(acceptedDependency);
             Assert.NotSame(sdkDependency, acceptedDependency);
             DependencyAssert.Equal(
-                sdkDependency.ToResolved(schemaName: ResolvedSdkReference.SchemaName),
+                sdkDependency.ToResolved(schemaName: ResolvedSdkReference.SchemaName, diagnosticLevel: DiagnosticLevel.None),
                 acceptedDependency!);
 
             // No changes other than the filtered dependency
@@ -140,7 +141,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             Assert.True(context.TryGetDependency(sdkDependency.GetDependencyId(), out IDependency sdkDependencyAfter));
             DependencyAssert.Equal(
-                sdkDependency.ToResolved(schemaName: ResolvedSdkReference.SchemaName),
+                sdkDependency.ToResolved(schemaName: ResolvedSdkReference.SchemaName, diagnosticLevel: DiagnosticLevel.None),
                 sdkDependencyAfter);
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -62,7 +62,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             ProjectTreeFlags? flags = null,
             string? schemaName = null,
             DependencyIconSet? iconSet = null,
-            bool? isImplicit = null)
+            bool? isImplicit = null,
+            DiagnosticLevel? diagnosticLevel = null)
         {
             return new TestDependency
             {
@@ -75,7 +76,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 Flags = flags ?? Flags,
                 SchemaName = schemaName ?? SchemaName,
                 IconSet = iconSet ?? IconSet,
-                Implicit = isImplicit ?? Implicit
+                Implicit = isImplicit ?? Implicit,
+                DiagnosticLevel = diagnosticLevel ?? DiagnosticLevel
             };
         }
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependencyExtensions.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependencyExtensions.cs
@@ -22,6 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             Xunit.Assert.Equal(expected.BrowseObjectProperties, actual.BrowseObjectProperties);
             Xunit.Assert.Equal(expected.Flags, actual.Flags);
             Xunit.Assert.Equal(expected.Id, actual.Id);
+            Xunit.Assert.Equal(expected.DiagnosticLevel, actual.DiagnosticLevel);
         }
     }
 }


### PR DESCRIPTION
In `netstandard2.0`, the framework is shown as an SDK reference. This is delivered via a package which is not shown in the tree. The project system has a filter which applies the resolved state of the package to the SDK item.

#6330 made a change where the diagnostic level determined whether a reference's icon showed a warning or not, rather than the resolved state. That PR did not update this SDK/package filter to correctly clear/apply the diagnostic level on the SDK node. This meant that a resolved SDK would appear with a warning icon.

### Before

![image](https://user-images.githubusercontent.com/350947/86704055-da935d80-c057-11ea-9239-af5c03dcef37.png)

### After

![image](https://user-images.githubusercontent.com/350947/86704084-e2530200-c057-11ea-8c5a-9198f3bb48f7.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6338)