### PR TITLE
Avoid starting restore dataflow on inactive configurations

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreProgressTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreProgressTracker.cs
@@ -1,15 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.ComponentModel.Composition;
+using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 {
     /// <summary>
     ///     Responsible for reporting package restore progress to operation progress.
     /// </summary>
-    [Export(ExportContractNames.Scopes.ConfiguredProject, typeof(IProjectDynamicLoadComponent))]
+    [Export(typeof(IImplicitlyActiveService))]
     [AppliesTo(ProjectCapability.PackageReferences)]
-    internal partial class PackageRestoreProgressTracker : AbstractMultiLifetimeComponent<PackageRestoreProgressTracker.PackageRestoreProgressTrackerInstance>, IProjectDynamicLoadComponent
+    internal partial class PackageRestoreProgressTracker : AbstractMultiLifetimeComponent<PackageRestoreProgressTracker.PackageRestoreProgressTrackerInstance>, IImplicitlyActiveService
     {
         private readonly ConfiguredProject _project;
         private readonly IProjectThreadingService _threadingService;
@@ -34,6 +35,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             _dataProgressTrackerService = dataProgressTrackerService;
             _dataSource = dataSource;
             _projectSubscriptionService = projectSubscriptionService;
+        }
+
+        public Task ActivateAsync()
+        {
+            return LoadAsync();
+        }
+
+        public Task DeactivateAsync()
+        {
+            return UnloadAsync();
         }
 
         protected override PackageRestoreProgressTrackerInstance CreateInstance()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IImplicitlyActiveService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IImplicitlyActiveService.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.Composition;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     /// <summary>
-    ///     A configured-project service which will be activated when its configured project becomes implicitly active, or deactivated when it not.
+    ///     A configured-project service which will be activated when its configured project becomes implicitly active, or deactivated when it is not.
     /// </summary>
     [ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ZeroOrMore)]
     internal interface IImplicitlyActiveService


### PR DESCRIPTION
Fixes part of https://github.com/dotnet/project-system/issues/6327.

We were activating the PackageRestoreProgressTracker on configurations as they were loaded, instead of just active ones.

Export/implement IImplicitlyActiveService which handles this for us automatically.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6339)