### PR TITLE
Delete reference to unused/unshipped browse object

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -181,10 +181,6 @@
       <Context>File;ProjectSubscriptionService</Context>
     </PropertyPageSchema>
 
-    <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)Resource.BrowseObject.xaml">
-      <Context>BrowseObject</Context>
-    </PropertyPageSchema>
-
     <!-- Project related settings -->
     <PropertyPageSchema Include="$(ManagedXamlNeutralResourcesDirectory)AppDesigner.xaml">
       <Context>ProjectSubscriptionService</Context>


### PR DESCRIPTION
Note: That this and Page item types when chosen in a File -> New -> Console App cause the item to be hidden in the tree, which is unrelated to below. I'm still investigating this.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6340)