### PR TITLE
Simplify LaunchSettingsProvider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
@@ -23,9 +23,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         ILaunchProfile? ActiveProfile { get; }
 
         /// <summary>
-        /// Replaces the current set of profiles with the contents of profiles. If changes were
-        /// made, the file will be checked out and updated. If the active profile is different, the
-        /// active profile property is updated.
+        /// Replaces the current set of profiles with the contents of <paramref name="profiles"/>.
+        /// If changes were made, the file will be checked out and updated. Note that the
+        /// active profile in <paramref name="profiles"/> is ignored; to change the active
+        /// profile use <see cref="SetActiveProfileAsync(string)"/> instead.
         /// </summary>
         Task UpdateAndSaveSettingsAsync(ILaunchSettings profiles);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -225,7 +225,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             }
 
             var newSnapshot = new LaunchSettings(snapshot.Profiles, snapshot.GlobalSettings, updatedActiveProfileName);
-            FinishUpdateAsync(newSnapshot);
+            FinishUpdate(newSnapshot);
         }
 
         /// <summary>
@@ -268,7 +268,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
                 var newSnapshot = new LaunchSettings(launchSettingData, updatedActiveProfileName);
 
-                FinishUpdateAsync(newSnapshot);
+                FinishUpdate(newSnapshot);
             }
             catch (Exception ex)
             {
@@ -286,7 +286,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                         OtherSettings = ImmutableStringDictionary<object>.EmptyOrdinal.Add("ErrorString", ex.Message)
                     };
                     var snapshot = new LaunchSettings(new[] { errorProfile }, null, errorProfile.Name);
-                    FinishUpdateAsync(snapshot);
+                    FinishUpdate(snapshot);
                 }
             }
         }
@@ -366,7 +366,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// <summary>
         /// Helper function to set the new snapshot and post the changes to consumers.
         /// </summary>
-        protected void FinishUpdateAsync(ILaunchSettings newSnapshot)
+        protected void FinishUpdate(ILaunchSettings newSnapshot)
         {
             CurrentSnapshot = newSnapshot;
 
@@ -711,7 +711,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 await SaveSettingsToDiskAsync(newSettings);
             }
 
-            FinishUpdateAsync(newSnapshot);
+            FinishUpdate(newSnapshot);
         }
 
         /// <summary>


### PR DESCRIPTION
The `LaunchSettingsProvider` type aggregates two separate sources of information:

1. Launch profile and global debugger settings from the launchSettings.json file.
2. The name of the _active_ profile from the `ProjectDebugger` rule (which ultimately reads it from the .user file).

It also allows updating all of this information and writes the changes back to the appropriate data source. As part of an update it almost always checks that the active profile specified in the current `ILaunchSettings` snapshot matches the value in the `ProjectDebugger` rule, and updates the latter if it does not. It turns out this is unnecessary and can be removed.

First, consider the only three public methods on `LaunchSettingsProvider` that could conceivably change the active profile:

1. `SetActiveProfileAsync`: Clearly, this one sets the active profile. However, it does _not_ update the current snapshot with the new profile name. Instead, it just delegates to the `ProjectDebugger` rule. We're already watching for changes to this rule via a data flow block, so we eventually get notified of the updated active profile (via the `ProjectRuleBlock_ChangedAsync` method) and can update the snapshot. There is no point in attempting to update the `ProjectDebugger` rule again, as it is the original source of the information.
2. `RemoveProfileAsync`: Conceivably, if we remove the active profile we may want to switch to another. However, the existing code doesn't do that; the new snapshot we create always copies the active profile name from the current snapshot. So in this case we know the active profile hasn't changed, and there is no need to try and update the `ProjectDebugger` rule.
3. `UpdateAndSaveSettingsAsync`: This methods takes a new `ILaunchSettings` as an argument, and entirely replaces the current snapshot with the new one--except for the active profile. While the documentation on the contract (`ILaunchSettingsProvider`) says it will update the active profile, the implementation specifically re-uses the active profile name from the current snapshot. In this case we clearly do not want to update `ProjectDebugger`.

None of the other public methods (for adding or updating profiles, and adding/updating/removing global settings) would be expected to change the active profile, so we don't need to check and update in those cases, either.

While I was at it I cleaned up some comments and updated some parameter names to clarify their intent.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6343)