### PR TITLE
Actually intercept launch properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileCommonValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileCommonValueProvider.cs
@@ -27,7 +27,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             CommandLineArgumentsPropertyName,
             ExecutablePathPropertyName,
+            LaunchBrowserPropertyName,
             LaunchTargetPropertyName,
+            LaunchUrlPropertyName,
             WorkingDirectoryPropertyName,
         },
         ExportInterceptingPropertyValueProviderFile.ProjectFile)]


### PR DESCRIPTION
Actually intercept the "LaunchBrowser" and "LaunchUrl" properties and redirect them to the `ILaunchSettingsProvider`. The code itself properly handles these properties (and we have unit tests verifying the behavior), but since we weren't exporting their names the code in question was never being called.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6344)