### PR TITLE
Fix Startup Project to show only debuggable projects.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IStartupProjectProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IStartupProjectProvider.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
+{
+    /// <summary>
+    /// Interface definition used by StartupProjectRegistrar to display only debuggable projects
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Extension)]
+    internal interface IStartupProjectProvider
+    {
+        /// <summary>
+        /// Returns true if this is a project is debuggable and should appear in the startup list.
+        /// </summary>
+        Task<bool> IsProjectDebuggableAsync(DebugLaunchOptions launchOptions);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IStartupProjectProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IStartupProjectProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     /// Interface definition used by StartupProjectRegistrar to display only debuggable projects
     /// </summary>
     [ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Extension)]
-    internal interface IStartupProjectProvider
+    public interface IStartupProjectProvider
     {
         /// <summary>
         /// Returns true if this is a project is debuggable and should appear in the startup list.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Threading;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
@@ -56,17 +55,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             try
             {
                 // Launch providers to enforce requirements for debuggable projects
-                await QueryDebugTargetsInternalAsync(launchOptions, true);
+                await QueryDebugTargetsInternalAsync(launchOptions, fromDebugLaunch: true);
             }
-            catch(Exception e)
+            catch (ProjectNotRunnableDirectlyException)
             {
-                if (string.Compare(e.Message, VSResources.ProjectNotRunnableDirectly, StringComparison.OrdinalIgnoreCase) == 0)
-                {
-                    return await TplExtensions.FalseTask;
-                }
+                return false;
+            }
+            catch (Exception)
+            {
             }
 
-            return await TplExtensions.TrueTask;
+            return true;
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
@@ -19,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     /// </summary>
     [ExportDebugger(ProjectDebugger.SchemaName)]
     [AppliesTo(ProjectCapability.LaunchProfiles)]
-    internal class LaunchProfilesDebugLaunchProvider : DebugLaunchProviderBase, IDeployedProjectItemMappingProvider
+    internal class LaunchProfilesDebugLaunchProvider : DebugLaunchProviderBase, IDeployedProjectItemMappingProvider, IStartupProjectProvider
     {
         private readonly IVsService<IVsDebugger4> _vsDebuggerService;
         private readonly ILaunchSettingsProvider _launchSettingsProvider;
@@ -50,7 +51,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// <summary>
         /// Called by CPS to determine whether we can launch
         /// </summary>
-        public override async Task<bool> CanLaunchAsync(DebugLaunchOptions launchOptions)
+        public override Task<bool> CanLaunchAsync(DebugLaunchOptions launchOptions)
+        {
+            return TplExtensions.TrueTask;
+        }
+
+        /// <summary>
+        /// Called by StartupProjectRegistrar to determine whether this project should appear in the Startup list.
+        /// </summary>
+        public async Task<bool> IsProjectDebuggableAsync(DebugLaunchOptions launchOptions)
         {
             try
             {
@@ -63,6 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             }
             catch (Exception)
             {
+                // If other exception, just return true.
             }
 
             return true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -648,6 +648,4 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
         }
     }
-
-
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -428,7 +428,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 // If we're launching for debug purposes, prevent someone F5'ing a class library
                 if (validateSettings && await IsClassLibraryAsync())
                 {
-                    throw new ProjectNotRunnableDirectlyException(VSResources.ProjectNotRunnableDirectly);
+                    throw new ProjectNotRunnableDirectlyException();
                 }
 
                 // Otherwise, fall back to "TargetPath"
@@ -631,10 +631,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
     }
 
-    [Serializable]
     internal class ProjectNotRunnableDirectlyException : Exception
     {
         public ProjectNotRunnableDirectlyException()
+            :this(VSResources.ProjectNotRunnableDirectly)
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -428,7 +428,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 // If we're launching for debug purposes, prevent someone F5'ing a class library
                 if (validateSettings && await IsClassLibraryAsync())
                 {
-                    throw new Exception(VSResources.ProjectNotRunnableDirectly);
+                    throw new ProjectNotRunnableDirectlyException(VSResources.ProjectNotRunnableDirectly);
                 }
 
                 // Otherwise, fall back to "TargetPath"
@@ -630,4 +630,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             NormalCharacter, EscapedCharacter, QuotedString, QuotedStringEscapedCharacter
         }
     }
+
+    [Serializable]
+    internal class ProjectNotRunnableDirectlyException : Exception
+    {
+        public ProjectNotRunnableDirectlyException()
+        {
+        }
+
+        public ProjectNotRunnableDirectlyException(string message)
+            : base(message)
+        {
+        }
+
+        public ProjectNotRunnableDirectlyException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+
+
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -97,7 +97,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             foreach (Lazy<IDebugLaunchProvider> provider in _launchProviders.Values)
             {
-                if (await provider.Value.CanLaunchAsync(DebugLaunchOptions.DesignTimeExpressionEvaluation))
+                if (provider.Value is IStartupProjectProvider startupProjectProvider &&
+                    await startupProjectProvider.IsProjectDebuggableAsync(DebugLaunchOptions.DesignTimeExpressionEvaluation))
                 {
                     return true;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 Microsoft.VisualStudio.ProjectSystem.VS.Automation.VSProject.AuthenticationMode.get -> VSLangProj165.AuthenticationMode
 Microsoft.VisualStudio.ProjectSystem.VS.Automation.VSProject.AuthenticationMode.set -> void
+Microsoft.VisualStudio.ProjectSystem.VS.Debug.IStartupProjectProvider
+Microsoft.VisualStudio.ProjectSystem.VS.Debug.IStartupProjectProvider.IsProjectDebuggableAsync(Microsoft.VisualStudio.ProjectSystem.Debug.DebugLaunchOptions launchOptions) -> System.Threading.Tasks.Task<bool>!
 Microsoft.VisualStudio.ProjectSystem.VS.Properties.CSharp.CSharpProjectConfigurationProperties
 Microsoft.VisualStudio.ProjectSystem.VS.Properties.CSharp.CSharpProjectConfigurationProperties.ErrorReport.get -> string!
 Microsoft.VisualStudio.ProjectSystem.VS.Properties.CSharp.CSharpProjectConfigurationProperties.ErrorReport.set -> void

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -111,6 +111,7 @@
                           UserSourceItems;
                           SupportAvailableItemName;
                           IntegratedConsoleDebugging;
+                          DisableBuiltInDebuggerServices;
                           PersistDesignTimeDataOutOfProject;" />
 
     <!-- COM references are not supported in .NET Core before 3.0 -->

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectThreadingServiceFactory.ProjectThreadingService.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectThreadingServiceFactory.ProjectThreadingService.cs
@@ -67,11 +67,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
             {
                 JoinableTaskFactory.Run(asyncAction);
             }
-
-            public Task SwitchToUIThread()
-            {
-                return Task.CompletedTask;
-            }
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectThreadingServiceFactory.ProjectThreadingService.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectThreadingServiceFactory.ProjectThreadingService.cs
@@ -67,6 +67,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
             {
                 JoinableTaskFactory.Run(asyncAction);
             }
+
+            public Task SwitchToUIThread()
+            {
+                return Task.CompletedTask;
+            }
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderFactory.cs
@@ -1,20 +1,26 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
+using Microsoft.VisualStudio.ProjectSystem.VS.Debug;
 using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     public static class IDebugLaunchProviderFactory
     {
-        public static IDebugLaunchProvider ImplementCanLaunchAsync(Func<bool> action)
+        public static IDebugLaunchProvider ImplementIsProjectDebuggableAsync(Func<bool> action)
         {
-            var mock = new Mock<IDebugLaunchProvider>();
+            var mock = new Mock<IDebugLaunchProviderMock>();
 
-            mock.Setup(d => d.CanLaunchAsync(It.IsAny<DebugLaunchOptions>()))
+            mock.Setup(d => d.IsProjectDebuggableAsync(It.IsAny<DebugLaunchOptions>()))
                                 .ReturnsAsync(action);
 
             return mock.Object;
         }
+    }
+
+    public interface IDebugLaunchProviderMock : IDebugLaunchProvider, IStartupProjectProvider
+    {
+
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProviderTests.cs
@@ -16,6 +16,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         private readonly Mock<IDebugProfileLaunchTargetsProvider> _mockExeProvider = new Mock<IDebugProfileLaunchTargetsProvider>();
         private readonly OrderPrecedenceImportCollection<IDebugProfileLaunchTargetsProvider> _launchProviders =
             new OrderPrecedenceImportCollection<IDebugProfileLaunchTargetsProvider>(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst);
+
+        private readonly IProjectThreadingService _threadingService = IProjectThreadingServiceFactory.Create();
+
         private readonly Mock<ConfiguredProject> _configuredProjectMoq = new Mock<ConfiguredProject>();
         private readonly Mock<ILaunchSettingsProvider> _LaunchSettingsProviderMoq = new Mock<ILaunchSettingsProvider>();
         private readonly List<IDebugLaunchSettings> _webProviderSettings = new List<IDebugLaunchSettings>();
@@ -63,13 +66,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Fact]
-        public void GetLaunchTargetsProviderForProfileTests()
+        public async Task GetLaunchTargetsProviderForProfileTestsAsync()
         {
             var provider = CreateInstance();
-            Assert.Equal(_mockWebProvider.Object, provider.GetLaunchTargetsProvider(new LaunchProfile() { Name = "test", CommandName = "IISExpress" }));
-            Assert.Equal(_mockDockerProvider.Object, provider.GetLaunchTargetsProvider(new LaunchProfile() { Name = "test", CommandName = "Docker" }));
-            Assert.Equal(_mockExeProvider.Object, provider.GetLaunchTargetsProvider(new LaunchProfile() { Name = "test", CommandName = "Project" }));
-            Assert.Null(provider.GetLaunchTargetsProvider(new LaunchProfile() { Name = "test", CommandName = "IIS" }));
+            Assert.Equal(_mockWebProvider.Object, await provider.GetLaunchTargetsProviderAsync(new LaunchProfile() { Name = "test", CommandName = "IISExpress" }));
+            Assert.Equal(_mockDockerProvider.Object, await provider.GetLaunchTargetsProviderAsync(new LaunchProfile() { Name = "test", CommandName = "Docker" }));
+            Assert.Equal(_mockExeProvider.Object, await provider.GetLaunchTargetsProviderAsync(new LaunchProfile() { Name = "test", CommandName = "Project" }));
+            Assert.Null(await provider.GetLaunchTargetsProviderAsync(new LaunchProfile() { Name = "test", CommandName = "IIS" }));
         }
 
         [Fact]
@@ -116,7 +119,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
         private LaunchProfilesDebugLaunchProvider CreateInstance()
         {
-            var provider = new LaunchProfilesDebugLaunchProvider(_configuredProjectMoq.Object, _LaunchSettingsProviderMoq.Object, vsDebuggerService: null!);
+            var provider = new LaunchProfilesDebugLaunchProvider(_threadingService, _configuredProjectMoq.Object, _LaunchSettingsProviderMoq.Object, vsDebuggerService: null!);
 
             provider.LaunchTargetsProviders.Add(_mockWebProvider.Object);
             provider.LaunchTargetsProviders.Add(_mockDockerProvider.Object);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -378,7 +378,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
 
-            await Assert.ThrowsAsync<Exception>(() =>
+            await Assert.ThrowsAsync<ProjectNotRunnableDirectlyException>(() =>
             {
                 return debugger.QueryDebugTargetsForDebugLaunchAsync(0, activeProfile);
             });

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public async Task OnProjectChanged_WhenNotDebuggable_ProjectNotRegistered()
         {
             var vsStartupProjectsListService = new VsStartupProjectsListService();
-            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => false);
+            var debugProvider = IDebugLaunchProviderFactory.ImplementIsProjectDebuggableAsync(() => false);
             var registrar = await CreateInitializedInstanceAsync(vsStartupProjectsListService, debugProvider);
 
             await registrar.OnProjectChangedAsync();
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             var projectGuid = Guid.NewGuid();
             var vsStartupProjectsListService = new VsStartupProjectsListService();
-            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => true);
+            var debugProvider = IDebugLaunchProviderFactory.ImplementIsProjectDebuggableAsync(() => true);
             var registrar = await CreateInitializedInstanceAsync(projectGuid, vsStartupProjectsListService, debugProvider);
 
             await registrar.OnProjectChangedAsync();
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             var projectGuid = Guid.NewGuid();
             var vsStartupProjectsListService = new VsStartupProjectsListService();
-            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => true);
+            var debugProvider = IDebugLaunchProviderFactory.ImplementIsProjectDebuggableAsync(() => true);
             var registrar = await CreateInitializedInstanceAsync(projectGuid, vsStartupProjectsListService, debugProvider);
 
             await registrar.OnProjectChangedAsync();
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public async Task OnProjectChanged_WhenProjectNotRegisteredAndNotDebuggable_RemainsUnregistered()
         {
             var vsStartupProjectsListService = new VsStartupProjectsListService();
-            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => false);
+            var debugProvider = IDebugLaunchProviderFactory.ImplementIsProjectDebuggableAsync(() => false);
             var registrar = await CreateInitializedInstanceAsync(vsStartupProjectsListService, debugProvider);
 
             await registrar.OnProjectChangedAsync();
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             bool isDebuggable = true;
             var projectGuid = Guid.NewGuid();
             var vsStartupProjectsListService = new VsStartupProjectsListService();
-            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => isDebuggable);
+            var debugProvider = IDebugLaunchProviderFactory.ImplementIsProjectDebuggableAsync(() => isDebuggable);
             var registrar = await CreateInitializedInstanceAsync(projectGuid, vsStartupProjectsListService, debugProvider);
 
             await registrar.OnProjectChangedAsync();
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             bool isDebuggable = false;
             var projectGuid = Guid.NewGuid();
             var vsStartupProjectsListService = new VsStartupProjectsListService();
-            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => isDebuggable);
+            var debugProvider = IDebugLaunchProviderFactory.ImplementIsProjectDebuggableAsync(() => isDebuggable);
             var registrar = await CreateInitializedInstanceAsync(projectGuid, vsStartupProjectsListService, debugProvider);
 
             await registrar.OnProjectChangedAsync();
@@ -129,8 +129,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             var projectGuid = Guid.NewGuid();
             var vsStartupProjectsListService = new VsStartupProjectsListService();
-            var debugProvider1 = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => false);
-            var debugProvider2 = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => true);
+            var debugProvider1 = IDebugLaunchProviderFactory.ImplementIsProjectDebuggableAsync(() => false);
+            var debugProvider2 = IDebugLaunchProviderFactory.ImplementIsProjectDebuggableAsync(() => true);
 
             var registrar = await CreateInitializedInstanceAsync(projectGuid, vsStartupProjectsListService, debugProvider1, debugProvider2);
 


### PR DESCRIPTION
This pr fixes #1308 

The Startup project was showing NetCore Libraries which overwhelm users when using VS with large projects. This bug was not about whether Libraries should be in Startup or not, but to decide which projects are non-debuggable and only display debuggables.

- Added the project capability `DisableBuiltInDebuggerServices` to disable CPS debuggers services for managed projects.

- Implemented the missing functionality in `CanLaunch()` to decide which projects should appear in the Startup list.
  The logic to decide if a project is non-debuggable is in `LaunchProfilesDebugLaunchProvider`

-  Fixed unit tests

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6346)