### PR TITLE
Replace ActiveConfiguredProject usage with new APIs

### DIFF
--- a/src/Common/BannedSymbols.txt
+++ b/src/Common/BannedSymbols.txt
@@ -89,3 +89,5 @@ M:Microsoft.VisualStudio.ProjectSystem.OnceInitializedOnceDisposedAsync.Initiali
 
 M:System.Diagnostics.Debugger.Break(); This should not be used in production code as the resulting dialog is not meant to be shown to users.
 M:System.Diagnostics.Debugger.Launch(); This should not be used in production code as the resulting dialog is not meant to be shown to users.
+
+T:Microsoft.VisualStudio.ProjectSystem.ActiveConfiguredProject`1; Use IActiveConfiguredValue<T>, and handle when Value returns null.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicVSImports.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicVSImports.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
     {
         private const string ImportItemTypeName = "Import";
 
-        private readonly ActiveConfiguredProject<ConfiguredProject> _activeConfiguredProject;
+        private readonly IActiveConfiguredValue<ConfiguredProject> _activeConfiguredProject;
         private readonly IProjectThreadingService _threadingService;
         private readonly IProjectAccessor _projectAccessor;
         private readonly VSLangProj.VSProject _vsProject;
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
         public VisualBasicVSImports(
             [Import(ExportContractNames.VsTypes.CpsVSProject)] VSLangProj.VSProject vsProject,
             IProjectThreadingService threadingService,
-            ActiveConfiguredProject<ConfiguredProject> activeConfiguredProject,
+            IActiveConfiguredValue<ConfiguredProject> activeConfiguredProject,
             IProjectAccessor projectAccessor,
             IUnconfiguredProjectVsServices unconfiguredProjectVSServices,
             VisualBasicNamespaceImportsList importsList)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject.cs
@@ -26,14 +26,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
     {
         private readonly VSLangProj.VSProject _vsProject;
         private readonly IProjectThreadingService _threadingService;
-        private readonly ActiveConfiguredProject<ProjectProperties> _projectProperties;
+        private readonly IActiveConfiguredValue<ProjectProperties> _projectProperties;
         private readonly BuildManager _buildManager;
 
         [ImportingConstructor]
         internal VSProject(
             [Import(ExportContractNames.VsTypes.CpsVSProject)] VSLangProj.VSProject vsProject,
             IProjectThreadingService threadingService,
-            ActiveConfiguredProject<ProjectProperties> projectProperties,
+            IActiveConfiguredValue<ProjectProperties> projectProperties,
             UnconfiguredProject project,
             BuildManager buildManager)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         private readonly IVsService<IVsStartupProjectsListService> _startupProjectsListService;
         private readonly ISafeProjectGuidService _projectGuidService;
         private readonly IActiveConfiguredProjectSubscriptionService _projectSubscriptionService;
-        private readonly ActiveConfiguredProject<DebuggerLaunchProviders> _launchProviders;
+        private readonly IActiveConfiguredValues<IDebugLaunchProvider> _launchProviders;
 
         private Guid _projectGuid;
         private IDisposable? _subscription;
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             IProjectThreadingService threadingService,
             ISafeProjectGuidService projectGuidService,
             IActiveConfiguredProjectSubscriptionService projectSubscriptionService,
-            ActiveConfiguredProject<DebuggerLaunchProviders> launchProviders)
+            IActiveConfiguredValues<IDebugLaunchProvider> launchProviders)
         : base(threadingService.JoinableTaskContext)
         {
             _project = project;
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             return _projectTasksService.LoadedProjectAsync(async () =>
             {
-                bool isDebuggable = await _launchProviders.Value.IsDebuggableAsync();
+                bool isDebuggable = await IsDebuggableAsync();
 
                 IVsStartupProjectsListService startupProjectsListService = await _startupProjectsListService.GetValueAsync();
 
@@ -93,30 +93,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             });
         }
 
-        [Export]
-        internal class DebuggerLaunchProviders
+        private async Task<bool> IsDebuggableAsync()
         {
-            [ImportingConstructor]
-            public DebuggerLaunchProviders(ConfiguredProject project)
+            foreach (Lazy<IDebugLaunchProvider> provider in _launchProviders.Values)
             {
-                Debuggers = new OrderPrecedenceImportCollection<IDebugLaunchProvider>(projectCapabilityCheckProvider: project);
-            }
-
-            [ImportMany]
-            public OrderPrecedenceImportCollection<IDebugLaunchProvider> Debuggers { get; }
-
-            public async Task<bool> IsDebuggableAsync()
-            {
-                foreach (Lazy<IDebugLaunchProvider> provider in Debuggers)
+                if (await provider.Value.CanLaunchAsync(DebugLaunchOptions.DesignTimeExpressionEvaluation))
                 {
-                    if (await provider.Value.CanLaunchAsync(DebugLaunchOptions.DesignTimeExpressionEvaluation))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
-
-                return false;
             }
+
+            return false;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/PasteOrdering.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/PasteOrdering.cs
@@ -20,13 +20,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
     {
         public const int OrderPrecedence = 10000;
 
-        private readonly ActiveConfiguredProject<ConfiguredProject> _configuredProject;
+        private readonly IActiveConfiguredValue<ConfiguredProject> _configuredProject;
         private readonly IProjectAccessor _accessor;
 
         private IProjectTree? _dropTarget;
 
         [ImportingConstructor]
-        public PasteOrdering(UnconfiguredProject unconfiguredProject, ActiveConfiguredProject<ConfiguredProject> configuredProject, IProjectAccessor accessor)
+        public PasteOrdering(UnconfiguredProject unconfiguredProject, IActiveConfiguredValue<ConfiguredProject> configuredProject, IProjectAccessor accessor)
         {
             _configuredProject = configuredProject;
             _accessor = accessor;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
     internal class BuildMacroInfo : IVsBuildMacroInfo, IDisposable
     {
         private IProjectThreadingService? _threadingService;
-        private ActiveConfiguredProject<ConfiguredProject>? _configuredProject;
+        private IActiveConfiguredValue<ConfiguredProject>? _configuredProject;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BuildMacroInfo"/> class.
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// <param name="threadingService">Project threading service.</param>
         [ImportingConstructor]
         public BuildMacroInfo(
-            ActiveConfiguredProject<ConfiguredProject> configuredProject,
+            IActiveConfiguredValue<ConfiguredProject> configuredProject,
             IProjectThreadingService threadingService)
         {
             _threadingService = threadingService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractActiveConfiguredValue.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractActiveConfiguredValue.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     Provides the base class for <see cref="ActiveConfiguredValue{T}"/> and <see cref="ActiveConfiguredValues{T}"/>.
+    /// </summary>
+    internal abstract class AbstractActiveConfiguredValue<T> : OnceInitializedOnceDisposed
+    {
+        private T _value = default!;
+        private readonly UnconfiguredProject _project;
+        private readonly IProjectThreadingService _threadingService;
+        private readonly IActiveConfiguredProjectProvider _activeConfiguredProjectProvider;
+
+        protected AbstractActiveConfiguredValue(UnconfiguredProject project, IActiveConfiguredProjectProvider activeConfiguredProjectProvider, IProjectThreadingService threadingService)
+        {
+            _project = project;            
+            _activeConfiguredProjectProvider = activeConfiguredProjectProvider;
+            _threadingService = threadingService;
+        }
+
+        public T Value
+        {
+            get
+            {
+                EnsureInitialized();
+
+                return _value!;
+            }
+        }
+
+        protected override void Initialize()
+        {
+            _activeConfiguredProjectProvider.Changed += OnActiveConfigurationChanged;
+
+            ConfiguredProject? configuredProject = _activeConfiguredProjectProvider.ActiveConfiguredProject;
+            if (configuredProject == null)
+            {
+                _threadingService.ExecuteSynchronously(async () =>
+                {
+                    configuredProject = await _project.GetSuggestedConfiguredProjectAsync();
+                });
+            }
+
+            Assumes.NotNull(configuredProject);
+
+            SetValueForConfiguration(configuredProject);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _activeConfiguredProjectProvider.Changed -= OnActiveConfigurationChanged;
+        }
+
+        protected abstract T GetValue(ConfiguredProject project);
+
+        private void OnActiveConfigurationChanged(object sender, ActiveConfigurationChangedEventArgs e)
+        {
+            SetValueForConfiguration(e.NowActive);
+        }
+
+        private void SetValueForConfiguration(ConfiguredProject project)
+        {
+            _value = GetValue(project);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredValue.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredValue.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.ComponentModel.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [Export(typeof(IActiveConfiguredValue<>))]
+    internal class ActiveConfiguredValue<T> : AbstractActiveConfiguredValue<T>, IActiveConfiguredValue<T>
+        where T : class?
+    {
+        [ImportingConstructor]
+        public ActiveConfiguredValue(
+            UnconfiguredProject project,
+            IActiveConfiguredProjectProvider activeConfiguredProjectProvider,
+            IProjectThreadingService threadingService)
+            : base(project, activeConfiguredProjectProvider, threadingService)
+        {
+        }
+
+        protected override T GetValue(ConfiguredProject project)
+        {
+            return project.Services.ExportProvider.GetExportedValueOrDefault<T>()!;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredValues.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredValues.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [Export(typeof(IActiveConfiguredValues<>))]
+    internal class ActiveConfiguredValues<T> : 
+        AbstractActiveConfiguredValue<object>,  // NOTE: Typed as 'object' because of https://github.com/microsoft/vs-mef/issues/180
+        IActiveConfiguredValues<T>
+        where T : class
+    {
+        [ImportingConstructor]
+        public ActiveConfiguredValues(
+            UnconfiguredProject project,
+            IActiveConfiguredProjectProvider activeConfiguredProjectProvider,
+            IProjectThreadingService threadingService)
+            : base(project, activeConfiguredProjectProvider, threadingService)
+        {
+        }
+
+        public IEnumerable<Lazy<T>> Values => (IEnumerable<Lazy<T>>)Value;
+
+        protected override object GetValue(ConfiguredProject project)
+        {
+            // Get the "natural" (unfiltered) export provider so that can we pull all the possible
+            // values, not just the ones that are applicable to the current set of capabilities when
+            // we call this.
+            //
+            // This so that when capabilities change over time, the resulting OrderPrecedenceImportCollection
+            // responds to the changes and filters the list based on the new set of capabilities.
+            //
+            // This basically mimics importing OrderPrecedenceImportCollection directly.
+            ExportProvider provider = project.Services.ExportProvider.GetExportedValue<ExportProvider>();
+
+            var values = new OrderPrecedenceImportCollection<T>(projectCapabilityCheckProvider: project);
+            foreach (Lazy<T, IOrderPrecedenceMetadataView> value in provider.GetExports<T, IOrderPrecedenceMetadataView>())
+            {
+                values.Add(value);
+            }
+
+            return values;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public const string ErrorProfileCommandName = "ErrorProfile";
 
         private readonly UnconfiguredProject _project;
-        private readonly ActiveConfiguredProject<IAppDesignerFolderSpecialFileProvider> _appDesignerSpecialFileProvider;
+        private readonly IActiveConfiguredValue<IAppDesignerFolderSpecialFileProvider> _appDesignerSpecialFileProvider;
         private readonly IProjectFaultHandlerService _projectFaultHandler;
         private readonly AsyncLazy<string> _launchSettingsFilePath;
         private readonly IUnconfiguredProjectServices _projectServices;
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             IFileSystem fileSystem,
             IUnconfiguredProjectCommonServices commonProjectServices,
             IActiveConfiguredProjectSubscriptionService projectSubscriptionService,
-            ActiveConfiguredProject<IAppDesignerFolderSpecialFileProvider> appDesignerSpecialFileProvider,
+            IActiveConfiguredValue<IAppDesignerFolderSpecialFileProvider> appDesignerSpecialFileProvider,
             IProjectFaultHandlerService projectFaultHandler)
         {
             _project = project;
@@ -897,7 +897,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // even though it can change over the lifetime of the project. We should fix this and convert to using dataflow
             // see: https://github.com/dotnet/project-system/issues/2316.
 
-            string folder = await _appDesignerSpecialFileProvider.Value.GetFileAsync(SpecialFiles.AppDesigner, SpecialFileFlags.FullPath);
+            string folder = await _appDesignerSpecialFileProvider.Value?.GetFileAsync(SpecialFiles.AppDesigner, SpecialFileFlags.FullPath);
 
             if (folder == null)  // AppDesigner capability not present, or the project has set AppDesignerFolder to empty
                 folder = Path.GetDirectoryName(_commonProjectServices.Project.FullPath);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredValue.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredValue.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+#pragma warning disable RS0030 // Do not used banned APIs (this wraps this API)
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     Provides an <see cref="UnconfiguredProject"/> access to an export from the active 
+    ///     <see cref="ConfiguredProject"/>. This is the singular version of <see cref="IActiveConfiguredValues{T}"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This replaces <see cref="ActiveConfiguredProject{T}"/> by returning <see langword="null"/>
+    ///         instead of throwing when the value does not exist.
+    ///     </para>
+    ///     <para>
+    ///         Consumers should specify a nullable type for <typeparamref name="T"/> if that import will be 
+    ///         satisfied by an export that will be applied to a particular capability.
+    ///     </para>
+    /// </remarks>
+    internal interface IActiveConfiguredValue<T>
+        where T : class?
+    {
+        /// <summary>
+        ///     Gets the value from the active <see cref="ConfiguredProject"/>; otherwise, 
+        ///     <see langword="null"/> if it does not exist.
+        /// </summary>
+        public T Value
+        {
+            get;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredValues.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredValues.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     Provides an <see cref="UnconfiguredProject"/> access to exports from the active 
+    ///     <see cref="ConfiguredProject"/>. This is the plural version of <see cref="IActiveConfiguredValue{T}"/>.
+    /// </summary>
+    internal interface IActiveConfiguredValues<T>
+        where T : class
+    {
+        /// <summary>
+        ///     Gets the applicable values from the active <see cref="ConfiguredProject"/>.
+        /// </summary>
+        public IEnumerable<Lazy<T>> Values
+        {
+            get;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ActiveWorkspaceProjectContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ActiveWorkspaceProjectContextHost.cs
@@ -16,13 +16,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     [AppliesTo(ProjectCapability.DotNetLanguageService)]
     internal class ActiveWorkspaceProjectContextHost : IActiveWorkspaceProjectContextHost
     {
-        private readonly ActiveConfiguredProject<IWorkspaceProjectContextHost> _activeHost;
+        private readonly IActiveConfiguredValue<IWorkspaceProjectContextHost?> _activeHost;
         private readonly IActiveConfiguredProjectProvider _activeConfiguredProjectProvider;
         private readonly IUnconfiguredProjectTasksService _tasksService;
 
         [ImportingConstructor]
         public ActiveWorkspaceProjectContextHost(
-            ActiveConfiguredProject<IWorkspaceProjectContextHost> activeHost,
+            IActiveConfiguredValue<IWorkspaceProjectContextHost?> activeHost,
             IActiveConfiguredProjectProvider activeConfiguredProjectProvider,
             IUnconfiguredProjectTasksService tasksService)
         {
@@ -46,7 +46,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                 try
                 {
-                    await _activeHost.Value.PublishAsync(tokenSource.Token);
+                    IWorkspaceProjectContextHost? host = _activeHost.Value;
+                    if (host != null)
+                    {
+                        await host.PublishAsync(tokenSource.Token);
+                    }
+
                     return;
                 }
                 catch (OperationCanceledException) when (activeConfigChangedToken.IsCancellationRequested)
@@ -61,7 +66,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 try
                 {
-                    await _activeHost.Value.OpenContextForWriteAsync(action);
+                    IWorkspaceProjectContextHost? host = _activeHost.Value;
+                    if (host != null)
+                    {
+                        await host.OpenContextForWriteAsync(action);
+                    }
+
                     return;
                 }
                 catch (ActiveProjectConfigurationChangedException)
@@ -76,7 +86,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 try
                 {
-                    return await _activeHost.Value.OpenContextForWriteAsync(action);
+                    IWorkspaceProjectContextHost? host = _activeHost.Value;
+                    if (host != null)
+                    {
+                        return await host.OpenContextForWriteAsync(action);
+                    }
+
+                    return default!;
                 }
                 catch (ActiveProjectConfigurationChangedException)
                 {   // Host was unloaded because configuration changed, retry on new config

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
@@ -13,14 +13,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private readonly UnconfiguredProject _project;
         private readonly IProjectTreeService _treeService;
         private readonly Lazy<IFileSystem> _fileSystem;
-        private readonly ActiveConfiguredProject<ConfiguredImports> _configuredImports;
+        private readonly IActiveConfiguredValue<ConfiguredImports> _configuredImports;
 
         [ImportingConstructor]
         public PhysicalProjectTreeStorage(
             UnconfiguredProject project,
             [Import(ExportContractNames.ProjectTreeProviders.PhysicalProjectTreeService)]IProjectTreeService treeService,
             Lazy<IFileSystem> fileSystem,
-            ActiveConfiguredProject<ConfiguredImports> configuredImports)
+            IActiveConfiguredValue<ConfiguredImports> configuredImports)
         {
             _project = project;
             _treeService = treeService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectCommonServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectCommonServices.cs
@@ -14,12 +14,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private readonly UnconfiguredProject _project;
         private readonly Lazy<IProjectThreadingService> _threadingService;
         private readonly Lazy<IProjectAccessor> _projectAccessor;
-        private readonly ActiveConfiguredProject<ConfiguredProject> _activeConfiguredProject;
-        private readonly ActiveConfiguredProject<ProjectProperties> _activeConfiguredProjectProperties;
+        private readonly IActiveConfiguredValue<ConfiguredProject> _activeConfiguredProject;
+        private readonly IActiveConfiguredValue<ProjectProperties> _activeConfiguredProjectProperties;
 
         [ImportingConstructor]
         public UnconfiguredProjectCommonServices(UnconfiguredProject project, Lazy<IProjectThreadingService> threadingService,
-                                                 ActiveConfiguredProject<ConfiguredProject> activeConfiguredProject, ActiveConfiguredProject<ProjectProperties> activeConfiguredProjectProperties,
+                                                 IActiveConfiguredValue<ConfiguredProject> activeConfiguredProject, IActiveConfiguredValue<ProjectProperties> activeConfiguredProjectProperties,
                                                  Lazy<IProjectAccessor> projectAccessor)
         {
             _project = project;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectFactory.cs
@@ -5,11 +5,12 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal static class ActiveConfiguredProjectFactory
+    internal static class IActiveConfiguredValueFactory
     {
-        public static ActiveConfiguredProject<T> ImplementValue<T>(Func<T> action)
+        public static IActiveConfiguredValue<T> ImplementValue<T>(Func<T> action)
+            where T : class?
         {
-            var mock = new Mock<ActiveConfiguredProject<T>>();
+            var mock = new Mock<IActiveConfiguredValue<T>>();
 
             mock.SetupGet(p => p.Value)
                 .Returns(action);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredValuesFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredValuesFactory.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IActiveConfiguredValuesFactory
+    {
+        public static IActiveConfiguredValues<T> ImplementValues<T>(Func<OrderPrecedenceImportCollection<T>> action)
+            where T : class
+        {
+            var mock = new Mock<IActiveConfiguredValues<T>>();
+
+            mock.SetupGet(p => p.Values)
+                .Returns(action);
+
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             activeProfileValue.Setup(s => s.Name).Returns(activeProfile);
             var debuggerData = new PropertyPageData(ProjectDebugger.SchemaName, ProjectDebugger.ActiveDebugProfileProperty, activeProfileValue.Object);
 
-            var specialFilesManager = ActiveConfiguredProjectFactory.ImplementValue(() => IAppDesignerFolderSpecialFileProviderFactory.ImplementGetFile(appDesignerFolder));
+            var specialFilesManager = IActiveConfiguredValueFactory.ImplementValue<IAppDesignerFolderSpecialFileProvider?>(() => IAppDesignerFolderSpecialFileProviderFactory.ImplementGetFile(appDesignerFolder));
             var project = UnconfiguredProjectFactory.Create(fullPath: @"c:\test\Project1\Project1.csproj");
             var properties = ProjectPropertiesFactory.Create(project, new[] { debuggerData });
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(project, IProjectThreadingServiceFactory.Create(), null, properties);
@@ -884,7 +884,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             IFileSystem fileSystem,
             IUnconfiguredProjectCommonServices commonProjectServices,
             IActiveConfiguredProjectSubscriptionService? projectSubscriptionService,
-            ActiveConfiguredProject<IAppDesignerFolderSpecialFileProvider> appDesignerFolderSpecialFileProvider,
+            IActiveConfiguredValue<IAppDesignerFolderSpecialFileProvider?> appDesignerFolderSpecialFileProvider,
             IProjectFaultHandlerService? projectFaultHandler = null)
           : base(project, projectServices, fileSystem, commonProjectServices, projectSubscriptionService, appDesignerFolderSpecialFileProvider, projectFaultHandler)
         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
@@ -324,7 +324,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 project,
                 projectTreeService,
                 new Lazy<IFileSystem>(() => fileSystem),
-                ActiveConfiguredProjectFactory.ImplementValue(() => new PhysicalProjectTreeStorage.ConfiguredImports(folderManager, sourceItemsProvider)));
+                IActiveConfiguredValueFactory.ImplementValue(() => new PhysicalProjectTreeStorage.ConfiguredImports(folderManager, sourceItemsProvider)));
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UnconfiguredProjectCommonServicesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UnconfiguredProjectCommonServicesTests.cs
@@ -13,8 +13,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var project = UnconfiguredProjectFactory.Create();
             var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
             var projectProperties = ProjectPropertiesFactory.Create(project);
-            var activeConfiguredProject = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
-            var activeConfiguredProjectProperties = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
+            var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties.ConfiguredProject);
+            var activeConfiguredProjectProperties = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
             var projectAccessor = new Lazy<IProjectAccessor>(() => IProjectAccessorFactory.Create());
 
             var services = new UnconfiguredProjectCommonServices(project, threadingService, activeConfiguredProject, activeConfiguredProjectProperties, projectAccessor);
@@ -28,8 +28,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var project = UnconfiguredProjectFactory.Create();
             var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
             var projectProperties = ProjectPropertiesFactory.Create(project);
-            var activeConfiguredProject = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
-            var activeConfiguredProjectProperties = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
+            var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties.ConfiguredProject);
+            var activeConfiguredProjectProperties = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
             var projectAccessor = new Lazy<IProjectAccessor>(() => IProjectAccessorFactory.Create());
 
             var services = new UnconfiguredProjectCommonServices(project, threadingService, activeConfiguredProject, activeConfiguredProjectProperties, projectAccessor);
@@ -43,8 +43,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var project = UnconfiguredProjectFactory.Create();
             var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
             var projectProperties = ProjectPropertiesFactory.Create(project);
-            var activeConfiguredProject = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
-            var activeConfiguredProjectProperties = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
+            var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties.ConfiguredProject);
+            var activeConfiguredProjectProperties = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
             var projectAccessor = new Lazy<IProjectAccessor>(() => IProjectAccessorFactory.Create());
 
             var services = new UnconfiguredProjectCommonServices(project, threadingService, activeConfiguredProject, activeConfiguredProjectProperties, projectAccessor);
@@ -58,8 +58,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var project = UnconfiguredProjectFactory.Create();
             var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
             var projectProperties = ProjectPropertiesFactory.Create(project);
-            var activeConfiguredProject = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
-            var activeConfiguredProjectProperties = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
+            var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties.ConfiguredProject);
+            var activeConfiguredProjectProperties = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
             var projectAccessor = new Lazy<IProjectAccessor>(() => IProjectAccessorFactory.Create());
 
             var services = new UnconfiguredProjectCommonServices(project, threadingService, activeConfiguredProject, activeConfiguredProjectProperties, projectAccessor);
@@ -73,8 +73,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var project = UnconfiguredProjectFactory.Create();
             var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
             var projectProperties = ProjectPropertiesFactory.Create(project);
-            var activeConfiguredProject = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
-            var activeConfiguredProjectProperties = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
+            var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties.ConfiguredProject);
+            var activeConfiguredProjectProperties = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
             var projectAccessor = new Lazy<IProjectAccessor>(() => IProjectAccessorFactory.Create());
 
             var services = new UnconfiguredProjectCommonServices(project, threadingService, activeConfiguredProject, activeConfiguredProjectProperties, projectAccessor);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/VisualBasicNamespaceImportsListFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/VisualBasicNamespaceImportsListFactory.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
             newList.VSImports = new Lazy<VisualBasicVSImports>(() => new TestVisualBasicVSImports(
                 Mock.Of<VSLangProj.VSProject>(),
                 IProjectThreadingServiceFactory.Create(),
-                ActiveConfiguredProjectFactory.ImplementValue<ConfiguredProject>(()=> ConfiguredProjectFactory.Create()),
+                IActiveConfiguredValueFactory.ImplementValue<ConfiguredProject>(()=> ConfiguredProjectFactory.Create()),
                 IProjectAccessorFactory.Create(),
                 IUnconfiguredProjectVsServicesFactory.Create(),
                 newList));
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
             private readonly TestVisualBasicNamespaceImportsList _testImportsList;
             public TestVisualBasicVSImports(VSLangProj.VSProject vsProject,
                                             IProjectThreadingService threadingService,
-                                            ActiveConfiguredProject<ConfiguredProject> activeConfiguredProject,
+                                            IActiveConfiguredValue<ConfiguredProject> activeConfiguredProject,
                                             IProjectAccessor projectAccessor,
                                             IUnconfiguredProjectVsServices unconfiguredProjectVSServices,
                                             TestVisualBasicNamespaceImportsList importsList)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VisualBasic/VsImportsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VisualBasic/VsImportsTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
             var vsimports = CreateInstance(
                                 Mock.Of<VSLangProj.VSProject>(),
                                 Mock.Of<IProjectThreadingService>(),
-                                Mock.Of<ActiveConfiguredProject<ConfiguredProject>>(),
+                                Mock.Of<IActiveConfiguredValue<ConfiguredProject>>(),
                                 Mock.Of<IProjectAccessor>(),
                                 Mock.Of<IUnconfiguredProjectVsServices>(),
                                 VisualBasicNamespaceImportsListFactory.CreateInstance());
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
             var vsimports = CreateInstance(
                                 vsProjectMock.Object,
                                 Mock.Of<IProjectThreadingService>(),
-                                Mock.Of<ActiveConfiguredProject<ConfiguredProject>>(),
+                                Mock.Of<IActiveConfiguredValue<ConfiguredProject>>(),
                                 Mock.Of<IProjectAccessor>(),
                                 Mock.Of<IUnconfiguredProjectVsServices>(),
                                 VisualBasicNamespaceImportsListFactory.CreateInstance());
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
             var vsimports = CreateInstance(
                     Mock.Of<VSLangProj.VSProject>(),
                     Mock.Of<IProjectThreadingService>(),
-                    Mock.Of<ActiveConfiguredProject<ConfiguredProject>>(),
+                    Mock.Of<IActiveConfiguredValue<ConfiguredProject>>(),
                     Mock.Of<IProjectAccessor>(),
                     Mock.Of<IUnconfiguredProjectVsServices>(),
                     VisualBasicNamespaceImportsListFactory.CreateInstance("A", "B"));
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
         private static VisualBasicVSImports CreateInstance(
             VSLangProj.VSProject vsProject,
             IProjectThreadingService threadingService,
-            ActiveConfiguredProject<ConfiguredProject> activeConfiguredProject,
+            IActiveConfiguredValue<ConfiguredProject> activeConfiguredProject,
             IProjectAccessor projectAccessor,
             IUnconfiguredProjectVsServices vsServices,
             VisualBasicNamespaceImportsList importList)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VsLangProjectPropertiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VsLangProjectPropertiesTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             var vsproject = CreateInstance(
                                 Mock.Of<VSLangProj.VSProject>(),
                                 threadingService: Mock.Of<IProjectThreadingService>(),
-                                projectProperties: Mock.Of<ActiveConfiguredProject<ProjectProperties>>());
+                                projectProperties: Mock.Of<IActiveConfiguredValue<ProjectProperties>>());
             Assert.NotNull(vsproject);
         }
 
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             var vsproject = CreateInstance(
                                 innerVSProjectMock.Object,
                                 threadingService: Mock.Of<IProjectThreadingService>(),
-                                projectProperties: Mock.Of<ActiveConfiguredProject<ProjectProperties>>());
+                                projectProperties: Mock.Of<IActiveConfiguredValue<ProjectProperties>>());
             Assert.NotNull(vsproject);
             Assert.True(imports.Equals(vsproject.Imports));
             Assert.Equal(events, vsproject.Events);
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             var vsproject = new VSProjectTestImpl(
                                 innerVSProjectMock.Object,
                                 threadingService: Mock.Of<IProjectThreadingService>(),
-                                projectProperties: Mock.Of<ActiveConfiguredProject<ProjectProperties>>(),
+                                projectProperties: Mock.Of<IActiveConfiguredValue<ProjectProperties>>(),
                                 project: unconfiguredProjectMock.Object,
                                 buildManager: Mock.Of<BuildManager>());
 
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             var data = new PropertyPageData(ConfigurationGeneralBrowseObject.SchemaName, ConfigurationGeneralBrowseObject.OutputTypeProperty, 4, setValues);
 
             var projectProperties = ProjectPropertiesFactory.Create(project, data);
-            var activeConfiguredProject = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
+            var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
 
             var vsLangProjectProperties = CreateInstance(Mock.Of<VSLangProj.VSProject>(), IProjectThreadingServiceFactory.Create(), activeConfiguredProject);
             Assert.Equal(prjOutputTypeEx.prjOutputTypeEx_AppContainerExe, vsLangProjectProperties.OutputTypeEx);
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             var data = new PropertyPageData(ConfigurationGeneralBrowseObject.SchemaName, ConfigurationGeneralBrowseObject.OutputTypeProperty, 1, setValues);
 
             var projectProperties = ProjectPropertiesFactory.Create(project, data);
-            var activeConfiguredProject = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
+            var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
 
             var vsLangProjectProperties = CreateInstance(Mock.Of<VSLangProj.VSProject>(), IProjectThreadingServiceFactory.Create(), activeConfiguredProject);
             Assert.Equal(prjOutputType.prjOutputTypeExe, vsLangProjectProperties.OutputType);
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             var data = new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.AssemblyNameProperty, "Blah", setValues);
 
             var projectProperties = ProjectPropertiesFactory.Create(project, data);
-            var activeConfiguredProject = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
+            var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
 
             var vsLangProjectProperties = CreateInstance(Mock.Of<VSLangProj.VSProject>(), IProjectThreadingServiceFactory.Create(), activeConfiguredProject);
             Assert.Equal("Blah", vsLangProjectProperties.AssemblyName);
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             var data = new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.ProjectDirProperty, "somepath");
 
             var projectProperties = ProjectPropertiesFactory.Create(project, data);
-            var activeConfiguredProject = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
+            var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
 
             var vsLangProjectProperties = CreateInstance(Mock.Of<VSLangProj.VSProject>(), IProjectThreadingServiceFactory.Create(), activeConfiguredProject);
             Assert.Equal("somepath", vsLangProjectProperties.FullPath);
@@ -155,7 +155,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             var data = new PropertyPageData(ConfigurationGeneralBrowseObject.SchemaName, ConfigurationGeneralBrowseObject.FullPathProperty, "testvalue");
 
             var projectProperties = ProjectPropertiesFactory.Create(project, data);
-            var activeConfiguredProject = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
+            var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
 
             var vsLangProjectProperties = CreateInstance(Mock.Of<VSLangProj.VSProject>(), IProjectThreadingServiceFactory.Create(), activeConfiguredProject);
             Assert.Equal("testvalue", vsLangProjectProperties.AbsoluteProjectDirectory);
@@ -167,7 +167,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             var vsproject = CreateInstance(
                 Mock.Of<VSLangProj.VSProject>(),
                 threadingService: Mock.Of<IProjectThreadingService>(),
-                projectProperties: Mock.Of<ActiveConfiguredProject<ProjectProperties>>(),
+                projectProperties: Mock.Of<IActiveConfiguredValue<ProjectProperties>>(),
                 buildManager: Mock.Of<BuildManager>());
             Assert.Null(vsproject.ExtenderCATID);
         }
@@ -175,7 +175,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
         private static VSProject CreateInstance(
             VSLangProj.VSProject vsproject,
             IProjectThreadingService threadingService,
-            ActiveConfiguredProject<ProjectProperties> projectProperties,
+            IActiveConfiguredValue<ProjectProperties> projectProperties,
             UnconfiguredProject? project = null,
             BuildManager? buildManager = null)
         {
@@ -189,7 +189,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             public VSProjectTestImpl(
                 VSLangProj.VSProject vsProject,
                 IProjectThreadingService threadingService,
-                ActiveConfiguredProject<ProjectProperties> projectProperties,
+                IActiveConfiguredValue<ProjectProperties> projectProperties,
                 UnconfiguredProject project,
                 BuildManager buildManager)
                 : base(vsProject, threadingService, projectProperties, project, buildManager)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/BuildMacroInfoTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/BuildMacroInfoTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
             var threadingService = IProjectThreadingServiceFactory.Create();
 
-            return new BuildMacroInfo(ActiveConfiguredProjectFactory.ImplementValue(() => configuredProject), threadingService);
+            return new BuildMacroInfo(IActiveConfiguredValueFactory.ImplementValue(() => configuredProject), threadingService);
         }
     }
 }


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1042733

ActiveConfiguredProject.Value throws a MEF exception when accessing a service that is not applicable to the capabilities of the ConfiguredProject. Rather than push MEF exceptions onto all callers of this, this replaces ActiveConfiguredProject usage with two new APIs that work similar to IVsService<T>, where it returns null when the configuration does not provide the service. The majority of usages of this API ask for a service that always exists so do not need this API.

This also simplifies another pattern; pulling a collection of values from the active ConfiguredProject, previously this needed an inner class to wrap the values.

Usage:
``` C#
public FooService(IActiveConfiguredValue<IService> service);

...

service.Value?.Method();
```
``` C#
public FooService(IActiveConfiguredValues<IService> services);

....

foreach (Lazy<T> service in services)
{
   service.Value.Method();
}

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6347)