### PR TITLE
Add mnemonics to debug page.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.Designer.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add.
+        ///   Looks up a localized string similar to _Add.
         /// </summary>
         public static string AddBtn {
             get {
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Application arguments:.
+        ///   Looks up a localized string similar to Application ar_guments:.
         /// </summary>
         public static string ApplicationArguments {
             get {
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Authentication mode:.
+        ///   Looks up a localized string similar to Au_thentication mode:.
         /// </summary>
         public static string AuthenticationMode {
             get {
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Browse....
+        ///   Looks up a localized string similar to _Browse....
         /// </summary>
         public static string BrowseBtn {
             get {
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enable native code debugging.
+        ///   Looks up a localized string similar to Enable nati_ve code debugging.
         /// </summary>
         public static string chkNativeCodeDebuggingText {
             get {
@@ -160,7 +160,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enable SQL Server debugging.
+        ///   Looks up a localized string similar to Enable _SQL Server debugging.
         /// </summary>
         public static string chkSqlCodeDebuggingText {
             get {
@@ -178,7 +178,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete.
+        ///   Looks up a localized string similar to _Delete.
         /// </summary>
         public static string DeleteBtn {
             get {
@@ -205,7 +205,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Environment variables:.
+        ///   Looks up a localized string similar to Environ_ment variables:.
         /// </summary>
         public static string EnvironmentVariables {
             get {
@@ -241,7 +241,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Executable:.
+        ///   Looks up a localized string similar to _Executable:.
         /// </summary>
         public static string Executable {
             get {
@@ -268,7 +268,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Find....
+        ///   Looks up a localized string similar to _Find....
         /// </summary>
         public static string FindBtn {
             get {
@@ -286,7 +286,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Launch:.
+        ///   Looks up a localized string similar to _Launch:.
         /// </summary>
         public static string Launch {
             get {
@@ -331,7 +331,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to New....
+        ///   Looks up a localized string similar to _New....
         /// </summary>
         public static string NewBtn {
             get {
@@ -385,7 +385,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Profile:.
+        ///   Looks up a localized string similar to _Profile:.
         /// </summary>
         public static string Profile {
             get {
@@ -457,7 +457,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use remote m_achine:.
+        ///   Looks up a localized string similar to _Use remote machine:.
         /// </summary>
         public static string RemoteDebug {
             get {
@@ -484,7 +484,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove.
+        ///   Looks up a localized string similar to _Remove.
         /// </summary>
         public static string RemoveBtn {
             get {
@@ -511,7 +511,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Working directory:.
+        ///   Looks up a localized string similar to _Working directory:.
         /// </summary>
         public static string WorkingDirectory {
             get {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.resx
@@ -181,25 +181,25 @@
     <value>The errors on the page must be corrected prior to saving your changes.</value>
   </data>
   <data name="AddBtn" xml:space="preserve">
-    <value>Add</value>
+    <value>_Add</value>
   </data>
   <data name="ApplicationArguments" xml:space="preserve">
-    <value>Application arguments:</value>
+    <value>Application ar_guments:</value>
   </data>
   <data name="BrowseBtn" xml:space="preserve">
-    <value>Browse...</value>
+    <value>_Browse...</value>
   </data>
   <data name="DeleteBtn" xml:space="preserve">
-    <value>Delete</value>
+    <value>_Delete</value>
   </data>
   <data name="EnvironmentVariables" xml:space="preserve">
-    <value>Environment variables:</value>
+    <value>Environ_ment variables:</value>
   </data>
   <data name="Executable" xml:space="preserve">
-    <value>Executable:</value>
+    <value>_Executable:</value>
   </data>
   <data name="Launch" xml:space="preserve">
-    <value>Launch:</value>
+    <value>_Launch:</value>
   </data>
   <data name="LaunchURL" xml:space="preserve">
     <value>Launch browser:</value>
@@ -208,19 +208,19 @@
     <value>Name</value>
   </data>
   <data name="NewBtn" xml:space="preserve">
-    <value>New...</value>
+    <value>_New...</value>
   </data>
   <data name="Profile" xml:space="preserve">
-    <value>Profile:</value>
+    <value>_Profile:</value>
   </data>
   <data name="RemoveBtn" xml:space="preserve">
-    <value>Remove</value>
+    <value>_Remove</value>
   </data>
   <data name="ValueHeader" xml:space="preserve">
     <value>Value</value>
   </data>
   <data name="WorkingDirectory" xml:space="preserve">
-    <value>Working directory:</value>
+    <value>_Working directory:</value>
   </data>
   <data name="CancelBtn" xml:space="preserve">
     <value>Cancel</value>
@@ -247,16 +247,16 @@
     <value>Create the profile and return to the debug property page with the new profile selected</value>
   </data>
   <data name="chkNativeCodeDebuggingText" xml:space="preserve">
-    <value>Enable native code debugging</value>
+    <value>Enable nati_ve code debugging</value>
   </data>
   <data name="chkSqlCodeDebuggingText" xml:space="preserve">
-    <value>Enable SQL Server debugging</value>
+    <value>Enable _SQL Server debugging</value>
   </data>
   <data name="chkRemoteDebugEnabledHelpText" xml:space="preserve">
     <value>Enable remote debugging</value>
   </data>
   <data name="RemoteDebug" xml:space="preserve">
-    <value>Use remote m_achine:</value>
+    <value>_Use remote machine:</value>
   </data>
   <data name="RemoteDebugMachineWatermark" xml:space="preserve">
     <value>Remote machine host name</value>
@@ -268,9 +268,9 @@
     <value>The host name is invalid.</value>
   </data>
   <data name="FindBtn" xml:space="preserve">
-    <value>Find...</value>
+    <value>_Find...</value>
   </data>
   <data name="AuthenticationMode" xml:space="preserve">
-    <value>Authentication mode:</value>
+    <value>Au_thentication mode:</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.cs.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AuthenticationMode">
-        <source>Authentication mode:</source>
-        <target state="translated">Režim ověřování:</target>
+        <source>Au_thentication mode:</source>
+        <target state="needs-review-translation">Režim ověřování:</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugPropertyPageTitle">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FindBtn">
-        <source>Find...</source>
-        <target state="translated">Najít:</target>
+        <source>_Find...</source>
+        <target state="needs-review-translation">Najít:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidHostName">
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ProfileKindExecutableName">
         <source>Executable</source>
-        <target state="translated">Spustitelný soubor</target>
+        <target state="needs-review-translation">Spustitelný soubor</target>
         <note />
       </trans-unit>
       <trans-unit id="ProfileKindIISExpressName">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebug">
-        <source>Use remote m_achine:</source>
-        <target state="translated">Použít vzdál_ený počítač:</target>
+        <source>_Use remote machine:</source>
+        <target state="needs-review-translation">Použít vzdál_ený počítač:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebugMachineWatermark">
@@ -138,38 +138,38 @@
         <note />
       </trans-unit>
       <trans-unit id="AddBtn">
-        <source>Add</source>
-        <target state="translated">Přidat</target>
+        <source>_Add</source>
+        <target state="needs-review-translation">Přidat</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationArguments">
-        <source>Application arguments:</source>
-        <target state="translated">Argumenty aplikace:</target>
+        <source>Application ar_guments:</source>
+        <target state="needs-review-translation">Argumenty aplikace:</target>
         <note />
       </trans-unit>
       <trans-unit id="BrowseBtn">
-        <source>Browse...</source>
-        <target state="translated">Procházet...</target>
+        <source>_Browse...</source>
+        <target state="needs-review-translation">Procházet...</target>
         <note />
       </trans-unit>
       <trans-unit id="DeleteBtn">
-        <source>Delete</source>
-        <target state="translated">Odstranit</target>
+        <source>_Delete</source>
+        <target state="needs-review-translation">Odstranit</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariables">
-        <source>Environment variables:</source>
-        <target state="translated">Proměnné prostředí:</target>
+        <source>Environ_ment variables:</source>
+        <target state="needs-review-translation">Proměnné prostředí:</target>
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable:</source>
-        <target state="translated">Spustitelný soubor:</target>
+        <source>_Executable:</source>
+        <target state="needs-review-translation">Spustitelný soubor:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">
-        <source>Launch:</source>
-        <target state="translated">Spustit:</target>
+        <source>_Launch:</source>
+        <target state="needs-review-translation">Spustit:</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchURL">
@@ -183,18 +183,18 @@
         <note />
       </trans-unit>
       <trans-unit id="NewBtn">
-        <source>New...</source>
-        <target state="translated">Nový...</target>
+        <source>_New...</source>
+        <target state="needs-review-translation">Nový...</target>
         <note />
       </trans-unit>
       <trans-unit id="Profile">
-        <source>Profile:</source>
-        <target state="translated">Profil:</target>
+        <source>_Profile:</source>
+        <target state="needs-review-translation">Profil:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveBtn">
-        <source>Remove</source>
-        <target state="translated">Odebrat</target>
+        <source>_Remove</source>
+        <target state="needs-review-translation">Odebrat</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueHeader">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirectory">
-        <source>Working directory:</source>
-        <target state="translated">Pracovní adresář:</target>
+        <source>_Working directory:</source>
+        <target state="needs-review-translation">Pracovní adresář:</target>
         <note />
       </trans-unit>
       <trans-unit id="CancelBtn">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkNativeCodeDebuggingText">
-        <source>Enable native code debugging</source>
-        <target state="translated">Povolit ladění nativního kódu</target>
+        <source>Enable nati_ve code debugging</source>
+        <target state="needs-review-translation">Povolit ladění nativního kódu</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRemoteDebugEnabledHelpText">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkSqlCodeDebuggingText">
-        <source>Enable SQL Server debugging</source>
-        <target state="translated">Povolit ladění SQL Serveru</target>
+        <source>Enable _SQL Server debugging</source>
+        <target state="needs-review-translation">Povolit ladění SQL Serveru</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.de.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AuthenticationMode">
-        <source>Authentication mode:</source>
-        <target state="translated">Authentifizierungsmodus:</target>
+        <source>Au_thentication mode:</source>
+        <target state="needs-review-translation">Authentifizierungsmodus:</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugPropertyPageTitle">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FindBtn">
-        <source>Find...</source>
-        <target state="translated">Suchen...</target>
+        <source>_Find...</source>
+        <target state="needs-review-translation">Suchen...</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidHostName">
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ProfileKindExecutableName">
         <source>Executable</source>
-        <target state="translated">Ausführbare Datei</target>
+        <target state="needs-review-translation">Ausführbare Datei</target>
         <note />
       </trans-unit>
       <trans-unit id="ProfileKindIISExpressName">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebug">
-        <source>Use remote m_achine:</source>
-        <target state="translated">Rem_otecomputer verwenden:</target>
+        <source>_Use remote machine:</source>
+        <target state="needs-review-translation">Rem_otecomputer verwenden:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebugMachineWatermark">
@@ -138,38 +138,38 @@
         <note />
       </trans-unit>
       <trans-unit id="AddBtn">
-        <source>Add</source>
-        <target state="translated">Hinzufügen</target>
+        <source>_Add</source>
+        <target state="needs-review-translation">Hinzufügen</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationArguments">
-        <source>Application arguments:</source>
-        <target state="translated">Anwendungsargumente:</target>
+        <source>Application ar_guments:</source>
+        <target state="needs-review-translation">Anwendungsargumente:</target>
         <note />
       </trans-unit>
       <trans-unit id="BrowseBtn">
-        <source>Browse...</source>
-        <target state="translated">Durchsuchen...</target>
+        <source>_Browse...</source>
+        <target state="needs-review-translation">Durchsuchen...</target>
         <note />
       </trans-unit>
       <trans-unit id="DeleteBtn">
-        <source>Delete</source>
-        <target state="translated">Löschen</target>
+        <source>_Delete</source>
+        <target state="needs-review-translation">Löschen</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariables">
-        <source>Environment variables:</source>
-        <target state="translated">Umgebungsvariablen:</target>
+        <source>Environ_ment variables:</source>
+        <target state="needs-review-translation">Umgebungsvariablen:</target>
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable:</source>
-        <target state="translated">Ausführbare Datei:</target>
+        <source>_Executable:</source>
+        <target state="needs-review-translation">Ausführbare Datei:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">
-        <source>Launch:</source>
-        <target state="translated">Start:</target>
+        <source>_Launch:</source>
+        <target state="needs-review-translation">Start:</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchURL">
@@ -183,18 +183,18 @@
         <note />
       </trans-unit>
       <trans-unit id="NewBtn">
-        <source>New...</source>
-        <target state="translated">Neu...</target>
+        <source>_New...</source>
+        <target state="needs-review-translation">Neu...</target>
         <note />
       </trans-unit>
       <trans-unit id="Profile">
-        <source>Profile:</source>
-        <target state="translated">Profil:</target>
+        <source>_Profile:</source>
+        <target state="needs-review-translation">Profil:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveBtn">
-        <source>Remove</source>
-        <target state="translated">Entfernen</target>
+        <source>_Remove</source>
+        <target state="needs-review-translation">Entfernen</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueHeader">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirectory">
-        <source>Working directory:</source>
-        <target state="translated">Arbeitsverzeichnis:</target>
+        <source>_Working directory:</source>
+        <target state="needs-review-translation">Arbeitsverzeichnis:</target>
         <note />
       </trans-unit>
       <trans-unit id="CancelBtn">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkNativeCodeDebuggingText">
-        <source>Enable native code debugging</source>
-        <target state="translated">Debuggen von nativem Code aktivieren</target>
+        <source>Enable nati_ve code debugging</source>
+        <target state="needs-review-translation">Debuggen von nativem Code aktivieren</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRemoteDebugEnabledHelpText">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkSqlCodeDebuggingText">
-        <source>Enable SQL Server debugging</source>
-        <target state="translated">SQL Server-Debuggen aktivieren</target>
+        <source>Enable _SQL Server debugging</source>
+        <target state="needs-review-translation">SQL Server-Debuggen aktivieren</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.es.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AuthenticationMode">
-        <source>Authentication mode:</source>
-        <target state="translated">Modo de autenticación:</target>
+        <source>Au_thentication mode:</source>
+        <target state="needs-review-translation">Modo de autenticación:</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugPropertyPageTitle">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FindBtn">
-        <source>Find...</source>
-        <target state="translated">Buscar...</target>
+        <source>_Find...</source>
+        <target state="needs-review-translation">Buscar...</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidHostName">
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ProfileKindExecutableName">
         <source>Executable</source>
-        <target state="translated">Archivo ejecutable</target>
+        <target state="needs-review-translation">Archivo ejecutable</target>
         <note />
       </trans-unit>
       <trans-unit id="ProfileKindIISExpressName">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebug">
-        <source>Use remote m_achine:</source>
-        <target state="translated">Usar _máquina remota:</target>
+        <source>_Use remote machine:</source>
+        <target state="needs-review-translation">Usar _máquina remota:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebugMachineWatermark">
@@ -138,38 +138,38 @@
         <note />
       </trans-unit>
       <trans-unit id="AddBtn">
-        <source>Add</source>
-        <target state="translated">Agregar</target>
+        <source>_Add</source>
+        <target state="needs-review-translation">Agregar</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationArguments">
-        <source>Application arguments:</source>
-        <target state="translated">Argumentos de aplicación:</target>
+        <source>Application ar_guments:</source>
+        <target state="needs-review-translation">Argumentos de aplicación:</target>
         <note />
       </trans-unit>
       <trans-unit id="BrowseBtn">
-        <source>Browse...</source>
-        <target state="translated">Examinar...</target>
+        <source>_Browse...</source>
+        <target state="needs-review-translation">Examinar...</target>
         <note />
       </trans-unit>
       <trans-unit id="DeleteBtn">
-        <source>Delete</source>
-        <target state="translated">Eliminar</target>
+        <source>_Delete</source>
+        <target state="needs-review-translation">Eliminar</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariables">
-        <source>Environment variables:</source>
-        <target state="translated">Variables de entorno:</target>
+        <source>Environ_ment variables:</source>
+        <target state="needs-review-translation">Variables de entorno:</target>
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable:</source>
-        <target state="translated">Ejecutable:</target>
+        <source>_Executable:</source>
+        <target state="needs-review-translation">Ejecutable:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">
-        <source>Launch:</source>
-        <target state="translated">Iniciar:</target>
+        <source>_Launch:</source>
+        <target state="needs-review-translation">Iniciar:</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchURL">
@@ -183,18 +183,18 @@
         <note />
       </trans-unit>
       <trans-unit id="NewBtn">
-        <source>New...</source>
-        <target state="translated">Nuevo...</target>
+        <source>_New...</source>
+        <target state="needs-review-translation">Nuevo...</target>
         <note />
       </trans-unit>
       <trans-unit id="Profile">
-        <source>Profile:</source>
-        <target state="translated">Perfil:</target>
+        <source>_Profile:</source>
+        <target state="needs-review-translation">Perfil:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveBtn">
-        <source>Remove</source>
-        <target state="translated">Quitar</target>
+        <source>_Remove</source>
+        <target state="needs-review-translation">Quitar</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueHeader">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirectory">
-        <source>Working directory:</source>
-        <target state="translated">Directorio de trabajo:</target>
+        <source>_Working directory:</source>
+        <target state="needs-review-translation">Directorio de trabajo:</target>
         <note />
       </trans-unit>
       <trans-unit id="CancelBtn">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkNativeCodeDebuggingText">
-        <source>Enable native code debugging</source>
-        <target state="translated">Habilitar depuración de código nativo</target>
+        <source>Enable nati_ve code debugging</source>
+        <target state="needs-review-translation">Habilitar depuración de código nativo</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRemoteDebugEnabledHelpText">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkSqlCodeDebuggingText">
-        <source>Enable SQL Server debugging</source>
-        <target state="translated">Habilitar depuración de SQL Server</target>
+        <source>Enable _SQL Server debugging</source>
+        <target state="needs-review-translation">Habilitar depuración de SQL Server</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.fr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AuthenticationMode">
-        <source>Authentication mode:</source>
-        <target state="translated">Mode d'authentification :</target>
+        <source>Au_thentication mode:</source>
+        <target state="needs-review-translation">Mode d'authentification :</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugPropertyPageTitle">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FindBtn">
-        <source>Find...</source>
-        <target state="translated">Rechercher...</target>
+        <source>_Find...</source>
+        <target state="needs-review-translation">Rechercher...</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidHostName">
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ProfileKindExecutableName">
         <source>Executable</source>
-        <target state="translated">Exécutable</target>
+        <target state="needs-review-translation">Exécutable</target>
         <note />
       </trans-unit>
       <trans-unit id="ProfileKindIISExpressName">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebug">
-        <source>Use remote m_achine:</source>
-        <target state="translated">Utiliser une m_achine distante :</target>
+        <source>_Use remote machine:</source>
+        <target state="needs-review-translation">Utiliser une m_achine distante :</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebugMachineWatermark">
@@ -138,38 +138,38 @@
         <note />
       </trans-unit>
       <trans-unit id="AddBtn">
-        <source>Add</source>
-        <target state="translated">Ajouter</target>
+        <source>_Add</source>
+        <target state="needs-review-translation">Ajouter</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationArguments">
-        <source>Application arguments:</source>
-        <target state="translated">Arguments de l'application :</target>
+        <source>Application ar_guments:</source>
+        <target state="needs-review-translation">Arguments de l'application :</target>
         <note />
       </trans-unit>
       <trans-unit id="BrowseBtn">
-        <source>Browse...</source>
-        <target state="translated">Parcourir...</target>
+        <source>_Browse...</source>
+        <target state="needs-review-translation">Parcourir...</target>
         <note />
       </trans-unit>
       <trans-unit id="DeleteBtn">
-        <source>Delete</source>
-        <target state="translated">Supprimer</target>
+        <source>_Delete</source>
+        <target state="needs-review-translation">Supprimer</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariables">
-        <source>Environment variables:</source>
-        <target state="translated">Variables d’environnement :</target>
+        <source>Environ_ment variables:</source>
+        <target state="needs-review-translation">Variables d’environnement :</target>
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable:</source>
-        <target state="translated">Exécutable :</target>
+        <source>_Executable:</source>
+        <target state="needs-review-translation">Exécutable :</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">
-        <source>Launch:</source>
-        <target state="translated">Lancer :</target>
+        <source>_Launch:</source>
+        <target state="needs-review-translation">Lancer :</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchURL">
@@ -183,18 +183,18 @@
         <note />
       </trans-unit>
       <trans-unit id="NewBtn">
-        <source>New...</source>
-        <target state="translated">Nouveau...</target>
+        <source>_New...</source>
+        <target state="needs-review-translation">Nouveau...</target>
         <note />
       </trans-unit>
       <trans-unit id="Profile">
-        <source>Profile:</source>
-        <target state="translated">Profil :</target>
+        <source>_Profile:</source>
+        <target state="needs-review-translation">Profil :</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveBtn">
-        <source>Remove</source>
-        <target state="translated">Supprimer</target>
+        <source>_Remove</source>
+        <target state="needs-review-translation">Supprimer</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueHeader">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirectory">
-        <source>Working directory:</source>
-        <target state="translated">Répertoire de travail :</target>
+        <source>_Working directory:</source>
+        <target state="needs-review-translation">Répertoire de travail :</target>
         <note />
       </trans-unit>
       <trans-unit id="CancelBtn">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkNativeCodeDebuggingText">
-        <source>Enable native code debugging</source>
-        <target state="translated">Permettre le débogage du code natif</target>
+        <source>Enable nati_ve code debugging</source>
+        <target state="needs-review-translation">Permettre le débogage du code natif</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRemoteDebugEnabledHelpText">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkSqlCodeDebuggingText">
-        <source>Enable SQL Server debugging</source>
-        <target state="translated">Activer le débogage SQL Server</target>
+        <source>Enable _SQL Server debugging</source>
+        <target state="needs-review-translation">Activer le débogage SQL Server</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.it.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AuthenticationMode">
-        <source>Authentication mode:</source>
-        <target state="translated">Modalità di autenticazione:</target>
+        <source>Au_thentication mode:</source>
+        <target state="needs-review-translation">Modalità di autenticazione:</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugPropertyPageTitle">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FindBtn">
-        <source>Find...</source>
-        <target state="translated">Trova:</target>
+        <source>_Find...</source>
+        <target state="needs-review-translation">Trova:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidHostName">
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ProfileKindExecutableName">
         <source>Executable</source>
-        <target state="translated">Eseguibile</target>
+        <target state="needs-review-translation">Eseguibile</target>
         <note />
       </trans-unit>
       <trans-unit id="ProfileKindIISExpressName">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebug">
-        <source>Use remote m_achine:</source>
-        <target state="translated">Us_a computer remoto:</target>
+        <source>_Use remote machine:</source>
+        <target state="needs-review-translation">Us_a computer remoto:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebugMachineWatermark">
@@ -138,38 +138,38 @@
         <note />
       </trans-unit>
       <trans-unit id="AddBtn">
-        <source>Add</source>
-        <target state="translated">Aggiungi</target>
+        <source>_Add</source>
+        <target state="needs-review-translation">Aggiungi</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationArguments">
-        <source>Application arguments:</source>
-        <target state="translated">Argomenti applicazione:</target>
+        <source>Application ar_guments:</source>
+        <target state="needs-review-translation">Argomenti applicazione:</target>
         <note />
       </trans-unit>
       <trans-unit id="BrowseBtn">
-        <source>Browse...</source>
-        <target state="translated">Sfoglia...</target>
+        <source>_Browse...</source>
+        <target state="needs-review-translation">Sfoglia...</target>
         <note />
       </trans-unit>
       <trans-unit id="DeleteBtn">
-        <source>Delete</source>
-        <target state="translated">Elimina</target>
+        <source>_Delete</source>
+        <target state="needs-review-translation">Elimina</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariables">
-        <source>Environment variables:</source>
-        <target state="translated">Variabili di ambiente:</target>
+        <source>Environ_ment variables:</source>
+        <target state="needs-review-translation">Variabili di ambiente:</target>
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable:</source>
-        <target state="translated">File eseguibile:</target>
+        <source>_Executable:</source>
+        <target state="needs-review-translation">File eseguibile:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">
-        <source>Launch:</source>
-        <target state="translated">Avvio:</target>
+        <source>_Launch:</source>
+        <target state="needs-review-translation">Avvio:</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchURL">
@@ -183,18 +183,18 @@
         <note />
       </trans-unit>
       <trans-unit id="NewBtn">
-        <source>New...</source>
-        <target state="translated">Nuovo...</target>
+        <source>_New...</source>
+        <target state="needs-review-translation">Nuovo...</target>
         <note />
       </trans-unit>
       <trans-unit id="Profile">
-        <source>Profile:</source>
-        <target state="translated">Profilo:</target>
+        <source>_Profile:</source>
+        <target state="needs-review-translation">Profilo:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveBtn">
-        <source>Remove</source>
-        <target state="translated">Rimuovi</target>
+        <source>_Remove</source>
+        <target state="needs-review-translation">Rimuovi</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueHeader">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirectory">
-        <source>Working directory:</source>
-        <target state="translated">Directory di lavoro:</target>
+        <source>_Working directory:</source>
+        <target state="needs-review-translation">Directory di lavoro:</target>
         <note />
       </trans-unit>
       <trans-unit id="CancelBtn">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkNativeCodeDebuggingText">
-        <source>Enable native code debugging</source>
-        <target state="translated">Attiva il debug di codice nativo</target>
+        <source>Enable nati_ve code debugging</source>
+        <target state="needs-review-translation">Attiva il debug di codice nativo</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRemoteDebugEnabledHelpText">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkSqlCodeDebuggingText">
-        <source>Enable SQL Server debugging</source>
-        <target state="translated">Abilita debug SQL Server</target>
+        <source>Enable _SQL Server debugging</source>
+        <target state="needs-review-translation">Abilita debug SQL Server</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ja.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AuthenticationMode">
-        <source>Authentication mode:</source>
-        <target state="translated">認証モード:</target>
+        <source>Au_thentication mode:</source>
+        <target state="needs-review-translation">認証モード:</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugPropertyPageTitle">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FindBtn">
-        <source>Find...</source>
-        <target state="translated">検索:</target>
+        <source>_Find...</source>
+        <target state="needs-review-translation">検索:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidHostName">
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ProfileKindExecutableName">
         <source>Executable</source>
-        <target state="translated">実行可能ファイル</target>
+        <target state="needs-review-translation">実行可能ファイル</target>
         <note />
       </trans-unit>
       <trans-unit id="ProfileKindIISExpressName">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebug">
-        <source>Use remote m_achine:</source>
-        <target state="translated">リモート マシンを使用する(_A):</target>
+        <source>_Use remote machine:</source>
+        <target state="needs-review-translation">リモート マシンを使用する(_A):</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebugMachineWatermark">
@@ -138,38 +138,38 @@
         <note />
       </trans-unit>
       <trans-unit id="AddBtn">
-        <source>Add</source>
-        <target state="translated">追加</target>
+        <source>_Add</source>
+        <target state="needs-review-translation">追加</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationArguments">
-        <source>Application arguments:</source>
-        <target state="translated">アプリケーション引数:</target>
+        <source>Application ar_guments:</source>
+        <target state="needs-review-translation">アプリケーション引数:</target>
         <note />
       </trans-unit>
       <trans-unit id="BrowseBtn">
-        <source>Browse...</source>
-        <target state="translated">参照...</target>
+        <source>_Browse...</source>
+        <target state="needs-review-translation">参照...</target>
         <note />
       </trans-unit>
       <trans-unit id="DeleteBtn">
-        <source>Delete</source>
-        <target state="translated">削除</target>
+        <source>_Delete</source>
+        <target state="needs-review-translation">削除</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariables">
-        <source>Environment variables:</source>
-        <target state="translated">環境変数:</target>
+        <source>Environ_ment variables:</source>
+        <target state="needs-review-translation">環境変数:</target>
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable:</source>
-        <target state="translated">実行可能ファイル:</target>
+        <source>_Executable:</source>
+        <target state="needs-review-translation">実行可能ファイル:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">
-        <source>Launch:</source>
-        <target state="translated">起動:</target>
+        <source>_Launch:</source>
+        <target state="needs-review-translation">起動:</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchURL">
@@ -183,18 +183,18 @@
         <note />
       </trans-unit>
       <trans-unit id="NewBtn">
-        <source>New...</source>
-        <target state="translated">新規...</target>
+        <source>_New...</source>
+        <target state="needs-review-translation">新規...</target>
         <note />
       </trans-unit>
       <trans-unit id="Profile">
-        <source>Profile:</source>
-        <target state="translated">プロファイル:</target>
+        <source>_Profile:</source>
+        <target state="needs-review-translation">プロファイル:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveBtn">
-        <source>Remove</source>
-        <target state="translated">削除</target>
+        <source>_Remove</source>
+        <target state="needs-review-translation">削除</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueHeader">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirectory">
-        <source>Working directory:</source>
-        <target state="translated">作業ディレクトリ:</target>
+        <source>_Working directory:</source>
+        <target state="needs-review-translation">作業ディレクトリ:</target>
         <note />
       </trans-unit>
       <trans-unit id="CancelBtn">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkNativeCodeDebuggingText">
-        <source>Enable native code debugging</source>
-        <target state="translated">ネイティブ コードのデバッグを有効にする</target>
+        <source>Enable nati_ve code debugging</source>
+        <target state="needs-review-translation">ネイティブ コードのデバッグを有効にする</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRemoteDebugEnabledHelpText">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkSqlCodeDebuggingText">
-        <source>Enable SQL Server debugging</source>
-        <target state="translated">SQL Server デバッグを有効にする</target>
+        <source>Enable _SQL Server debugging</source>
+        <target state="needs-review-translation">SQL Server デバッグを有効にする</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ko.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AuthenticationMode">
-        <source>Authentication mode:</source>
-        <target state="translated">인증 모드:</target>
+        <source>Au_thentication mode:</source>
+        <target state="needs-review-translation">인증 모드:</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugPropertyPageTitle">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FindBtn">
-        <source>Find...</source>
-        <target state="translated">찾기:</target>
+        <source>_Find...</source>
+        <target state="needs-review-translation">찾기:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidHostName">
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ProfileKindExecutableName">
         <source>Executable</source>
-        <target state="translated">실행 파일</target>
+        <target state="needs-review-translation">실행 파일</target>
         <note />
       </trans-unit>
       <trans-unit id="ProfileKindIISExpressName">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebug">
-        <source>Use remote m_achine:</source>
-        <target state="translated">원격 머신 사용(_A):</target>
+        <source>_Use remote machine:</source>
+        <target state="needs-review-translation">원격 머신 사용(_A):</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebugMachineWatermark">
@@ -138,38 +138,38 @@
         <note />
       </trans-unit>
       <trans-unit id="AddBtn">
-        <source>Add</source>
-        <target state="translated">추가</target>
+        <source>_Add</source>
+        <target state="needs-review-translation">추가</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationArguments">
-        <source>Application arguments:</source>
-        <target state="translated">애플리케이션 인수:</target>
+        <source>Application ar_guments:</source>
+        <target state="needs-review-translation">애플리케이션 인수:</target>
         <note />
       </trans-unit>
       <trans-unit id="BrowseBtn">
-        <source>Browse...</source>
-        <target state="translated">찾아보기...</target>
+        <source>_Browse...</source>
+        <target state="needs-review-translation">찾아보기...</target>
         <note />
       </trans-unit>
       <trans-unit id="DeleteBtn">
-        <source>Delete</source>
-        <target state="translated">삭제</target>
+        <source>_Delete</source>
+        <target state="needs-review-translation">삭제</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariables">
-        <source>Environment variables:</source>
-        <target state="translated">환경 변수:</target>
+        <source>Environ_ment variables:</source>
+        <target state="needs-review-translation">환경 변수:</target>
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable:</source>
-        <target state="translated">실행 파일:</target>
+        <source>_Executable:</source>
+        <target state="needs-review-translation">실행 파일:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">
-        <source>Launch:</source>
-        <target state="translated">시작:</target>
+        <source>_Launch:</source>
+        <target state="needs-review-translation">시작:</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchURL">
@@ -183,18 +183,18 @@
         <note />
       </trans-unit>
       <trans-unit id="NewBtn">
-        <source>New...</source>
-        <target state="translated">새로 만들기...</target>
+        <source>_New...</source>
+        <target state="needs-review-translation">새로 만들기...</target>
         <note />
       </trans-unit>
       <trans-unit id="Profile">
-        <source>Profile:</source>
-        <target state="translated">프로필:</target>
+        <source>_Profile:</source>
+        <target state="needs-review-translation">프로필:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveBtn">
-        <source>Remove</source>
-        <target state="translated">제거</target>
+        <source>_Remove</source>
+        <target state="needs-review-translation">제거</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueHeader">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirectory">
-        <source>Working directory:</source>
-        <target state="translated">작업 디렉터리:</target>
+        <source>_Working directory:</source>
+        <target state="needs-review-translation">작업 디렉터리:</target>
         <note />
       </trans-unit>
       <trans-unit id="CancelBtn">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkNativeCodeDebuggingText">
-        <source>Enable native code debugging</source>
-        <target state="translated">네이티브 코드 디버깅 사용</target>
+        <source>Enable nati_ve code debugging</source>
+        <target state="needs-review-translation">네이티브 코드 디버깅 사용</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRemoteDebugEnabledHelpText">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkSqlCodeDebuggingText">
-        <source>Enable SQL Server debugging</source>
-        <target state="translated">SQL Server 디버깅 사용</target>
+        <source>Enable _SQL Server debugging</source>
+        <target state="needs-review-translation">SQL Server 디버깅 사용</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pl.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AuthenticationMode">
-        <source>Authentication mode:</source>
-        <target state="translated">Tryb uwierzytelniania:</target>
+        <source>Au_thentication mode:</source>
+        <target state="needs-review-translation">Tryb uwierzytelniania:</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugPropertyPageTitle">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FindBtn">
-        <source>Find...</source>
-        <target state="translated">Znajdź:</target>
+        <source>_Find...</source>
+        <target state="needs-review-translation">Znajdź:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidHostName">
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ProfileKindExecutableName">
         <source>Executable</source>
-        <target state="translated">Plik wykonywalny</target>
+        <target state="needs-review-translation">Plik wykonywalny</target>
         <note />
       </trans-unit>
       <trans-unit id="ProfileKindIISExpressName">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebug">
-        <source>Use remote m_achine:</source>
-        <target state="translated">Użyj m_aszyny zdalnej:</target>
+        <source>_Use remote machine:</source>
+        <target state="needs-review-translation">Użyj m_aszyny zdalnej:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebugMachineWatermark">
@@ -138,38 +138,38 @@
         <note />
       </trans-unit>
       <trans-unit id="AddBtn">
-        <source>Add</source>
-        <target state="translated">Dodaj</target>
+        <source>_Add</source>
+        <target state="needs-review-translation">Dodaj</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationArguments">
-        <source>Application arguments:</source>
-        <target state="translated">Argumenty aplikacji:</target>
+        <source>Application ar_guments:</source>
+        <target state="needs-review-translation">Argumenty aplikacji:</target>
         <note />
       </trans-unit>
       <trans-unit id="BrowseBtn">
-        <source>Browse...</source>
-        <target state="translated">Przeglądaj...</target>
+        <source>_Browse...</source>
+        <target state="needs-review-translation">Przeglądaj...</target>
         <note />
       </trans-unit>
       <trans-unit id="DeleteBtn">
-        <source>Delete</source>
-        <target state="translated">Usuń</target>
+        <source>_Delete</source>
+        <target state="needs-review-translation">Usuń</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariables">
-        <source>Environment variables:</source>
-        <target state="translated">Zmienne środowiskowe:</target>
+        <source>Environ_ment variables:</source>
+        <target state="needs-review-translation">Zmienne środowiskowe:</target>
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable:</source>
-        <target state="translated">Plik wykonywalny:</target>
+        <source>_Executable:</source>
+        <target state="needs-review-translation">Plik wykonywalny:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">
-        <source>Launch:</source>
-        <target state="translated">Uruchom:</target>
+        <source>_Launch:</source>
+        <target state="needs-review-translation">Uruchom:</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchURL">
@@ -183,18 +183,18 @@
         <note />
       </trans-unit>
       <trans-unit id="NewBtn">
-        <source>New...</source>
-        <target state="translated">Nowy...</target>
+        <source>_New...</source>
+        <target state="needs-review-translation">Nowy...</target>
         <note />
       </trans-unit>
       <trans-unit id="Profile">
-        <source>Profile:</source>
-        <target state="translated">Profil:</target>
+        <source>_Profile:</source>
+        <target state="needs-review-translation">Profil:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveBtn">
-        <source>Remove</source>
-        <target state="translated">Usuń</target>
+        <source>_Remove</source>
+        <target state="needs-review-translation">Usuń</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueHeader">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirectory">
-        <source>Working directory:</source>
-        <target state="translated">Katalog roboczy:</target>
+        <source>_Working directory:</source>
+        <target state="needs-review-translation">Katalog roboczy:</target>
         <note />
       </trans-unit>
       <trans-unit id="CancelBtn">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkNativeCodeDebuggingText">
-        <source>Enable native code debugging</source>
-        <target state="translated">Włącz debugowanie kodu natywnego</target>
+        <source>Enable nati_ve code debugging</source>
+        <target state="needs-review-translation">Włącz debugowanie kodu natywnego</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRemoteDebugEnabledHelpText">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkSqlCodeDebuggingText">
-        <source>Enable SQL Server debugging</source>
-        <target state="translated">Włącz debugowanie programu SQL Server</target>
+        <source>Enable _SQL Server debugging</source>
+        <target state="needs-review-translation">Włącz debugowanie programu SQL Server</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pt-BR.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AuthenticationMode">
-        <source>Authentication mode:</source>
-        <target state="translated">Modo de autenticação:</target>
+        <source>Au_thentication mode:</source>
+        <target state="needs-review-translation">Modo de autenticação:</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugPropertyPageTitle">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FindBtn">
-        <source>Find...</source>
-        <target state="translated">Localizar:</target>
+        <source>_Find...</source>
+        <target state="needs-review-translation">Localizar:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidHostName">
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ProfileKindExecutableName">
         <source>Executable</source>
-        <target state="translated">Executável</target>
+        <target state="needs-review-translation">Executável</target>
         <note />
       </trans-unit>
       <trans-unit id="ProfileKindIISExpressName">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebug">
-        <source>Use remote m_achine:</source>
-        <target state="translated">Usar comput_ador remoto:</target>
+        <source>_Use remote machine:</source>
+        <target state="needs-review-translation">Usar comput_ador remoto:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebugMachineWatermark">
@@ -138,38 +138,38 @@
         <note />
       </trans-unit>
       <trans-unit id="AddBtn">
-        <source>Add</source>
-        <target state="translated">Adicionar</target>
+        <source>_Add</source>
+        <target state="needs-review-translation">Adicionar</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationArguments">
-        <source>Application arguments:</source>
-        <target state="translated">Argumentos do aplicativo:</target>
+        <source>Application ar_guments:</source>
+        <target state="needs-review-translation">Argumentos do aplicativo:</target>
         <note />
       </trans-unit>
       <trans-unit id="BrowseBtn">
-        <source>Browse...</source>
-        <target state="translated">Procurar...</target>
+        <source>_Browse...</source>
+        <target state="needs-review-translation">Procurar...</target>
         <note />
       </trans-unit>
       <trans-unit id="DeleteBtn">
-        <source>Delete</source>
-        <target state="translated">Excluir</target>
+        <source>_Delete</source>
+        <target state="needs-review-translation">Excluir</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariables">
-        <source>Environment variables:</source>
-        <target state="translated">Variáveis do ambiente:</target>
+        <source>Environ_ment variables:</source>
+        <target state="needs-review-translation">Variáveis do ambiente:</target>
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable:</source>
-        <target state="translated">Executável:</target>
+        <source>_Executable:</source>
+        <target state="needs-review-translation">Executável:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">
-        <source>Launch:</source>
-        <target state="translated">Inicializar:</target>
+        <source>_Launch:</source>
+        <target state="needs-review-translation">Inicializar:</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchURL">
@@ -183,18 +183,18 @@
         <note />
       </trans-unit>
       <trans-unit id="NewBtn">
-        <source>New...</source>
-        <target state="translated">Novo...</target>
+        <source>_New...</source>
+        <target state="needs-review-translation">Novo...</target>
         <note />
       </trans-unit>
       <trans-unit id="Profile">
-        <source>Profile:</source>
-        <target state="translated">Perfil:</target>
+        <source>_Profile:</source>
+        <target state="needs-review-translation">Perfil:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveBtn">
-        <source>Remove</source>
-        <target state="translated">Remover</target>
+        <source>_Remove</source>
+        <target state="needs-review-translation">Remover</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueHeader">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirectory">
-        <source>Working directory:</source>
-        <target state="translated">Diretório de trabalho:</target>
+        <source>_Working directory:</source>
+        <target state="needs-review-translation">Diretório de trabalho:</target>
         <note />
       </trans-unit>
       <trans-unit id="CancelBtn">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkNativeCodeDebuggingText">
-        <source>Enable native code debugging</source>
-        <target state="translated">Habilitar depuração de código nativo</target>
+        <source>Enable nati_ve code debugging</source>
+        <target state="needs-review-translation">Habilitar depuração de código nativo</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRemoteDebugEnabledHelpText">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkSqlCodeDebuggingText">
-        <source>Enable SQL Server debugging</source>
-        <target state="translated">Habilitar a depuração do SQL Server</target>
+        <source>Enable _SQL Server debugging</source>
+        <target state="needs-review-translation">Habilitar a depuração do SQL Server</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ru.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AuthenticationMode">
-        <source>Authentication mode:</source>
-        <target state="translated">Режим проверки подлинности:</target>
+        <source>Au_thentication mode:</source>
+        <target state="needs-review-translation">Режим проверки подлинности:</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugPropertyPageTitle">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FindBtn">
-        <source>Find...</source>
-        <target state="translated">Найти...</target>
+        <source>_Find...</source>
+        <target state="needs-review-translation">Найти...</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidHostName">
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ProfileKindExecutableName">
         <source>Executable</source>
-        <target state="translated">Исполняемый файл</target>
+        <target state="needs-review-translation">Исполняемый файл</target>
         <note />
       </trans-unit>
       <trans-unit id="ProfileKindIISExpressName">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebug">
-        <source>Use remote m_achine:</source>
-        <target state="translated">Использовать удаленный к_омпьютер:</target>
+        <source>_Use remote machine:</source>
+        <target state="needs-review-translation">Использовать удаленный к_омпьютер:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebugMachineWatermark">
@@ -138,38 +138,38 @@
         <note />
       </trans-unit>
       <trans-unit id="AddBtn">
-        <source>Add</source>
-        <target state="translated">Добавить</target>
+        <source>_Add</source>
+        <target state="needs-review-translation">Добавить</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationArguments">
-        <source>Application arguments:</source>
-        <target state="translated">Аргументы приложения:</target>
+        <source>Application ar_guments:</source>
+        <target state="needs-review-translation">Аргументы приложения:</target>
         <note />
       </trans-unit>
       <trans-unit id="BrowseBtn">
-        <source>Browse...</source>
-        <target state="translated">Обзор...</target>
+        <source>_Browse...</source>
+        <target state="needs-review-translation">Обзор...</target>
         <note />
       </trans-unit>
       <trans-unit id="DeleteBtn">
-        <source>Delete</source>
-        <target state="translated">Удалить</target>
+        <source>_Delete</source>
+        <target state="needs-review-translation">Удалить</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariables">
-        <source>Environment variables:</source>
-        <target state="translated">Переменные среды:</target>
+        <source>Environ_ment variables:</source>
+        <target state="needs-review-translation">Переменные среды:</target>
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable:</source>
-        <target state="translated">Исполняемый объект:</target>
+        <source>_Executable:</source>
+        <target state="needs-review-translation">Исполняемый объект:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">
-        <source>Launch:</source>
-        <target state="translated">Запустить:</target>
+        <source>_Launch:</source>
+        <target state="needs-review-translation">Запустить:</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchURL">
@@ -183,18 +183,18 @@
         <note />
       </trans-unit>
       <trans-unit id="NewBtn">
-        <source>New...</source>
-        <target state="translated">Создать...</target>
+        <source>_New...</source>
+        <target state="needs-review-translation">Создать...</target>
         <note />
       </trans-unit>
       <trans-unit id="Profile">
-        <source>Profile:</source>
-        <target state="translated">Профиль:</target>
+        <source>_Profile:</source>
+        <target state="needs-review-translation">Профиль:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveBtn">
-        <source>Remove</source>
-        <target state="translated">Удалить</target>
+        <source>_Remove</source>
+        <target state="needs-review-translation">Удалить</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueHeader">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirectory">
-        <source>Working directory:</source>
-        <target state="translated">Рабочий каталог:</target>
+        <source>_Working directory:</source>
+        <target state="needs-review-translation">Рабочий каталог:</target>
         <note />
       </trans-unit>
       <trans-unit id="CancelBtn">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkNativeCodeDebuggingText">
-        <source>Enable native code debugging</source>
-        <target state="translated">Включить отладку машинного кода</target>
+        <source>Enable nati_ve code debugging</source>
+        <target state="needs-review-translation">Включить отладку машинного кода</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRemoteDebugEnabledHelpText">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkSqlCodeDebuggingText">
-        <source>Enable SQL Server debugging</source>
-        <target state="translated">Включить отладку SQL Server</target>
+        <source>Enable _SQL Server debugging</source>
+        <target state="needs-review-translation">Включить отладку SQL Server</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.tr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AuthenticationMode">
-        <source>Authentication mode:</source>
-        <target state="translated">Kimlik doğrulaması modu:</target>
+        <source>Au_thentication mode:</source>
+        <target state="needs-review-translation">Kimlik doğrulaması modu:</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugPropertyPageTitle">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FindBtn">
-        <source>Find...</source>
-        <target state="translated">Bul...</target>
+        <source>_Find...</source>
+        <target state="needs-review-translation">Bul...</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidHostName">
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ProfileKindExecutableName">
         <source>Executable</source>
-        <target state="translated">Yürütülebilir</target>
+        <target state="needs-review-translation">Yürütülebilir</target>
         <note />
       </trans-unit>
       <trans-unit id="ProfileKindIISExpressName">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebug">
-        <source>Use remote m_achine:</source>
-        <target state="translated">Uzak m_akine kullanın:</target>
+        <source>_Use remote machine:</source>
+        <target state="needs-review-translation">Uzak m_akine kullanın:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebugMachineWatermark">
@@ -138,38 +138,38 @@
         <note />
       </trans-unit>
       <trans-unit id="AddBtn">
-        <source>Add</source>
-        <target state="translated">Ekle</target>
+        <source>_Add</source>
+        <target state="needs-review-translation">Ekle</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationArguments">
-        <source>Application arguments:</source>
-        <target state="translated">Uygulama bağımsız değişkenleri:</target>
+        <source>Application ar_guments:</source>
+        <target state="needs-review-translation">Uygulama bağımsız değişkenleri:</target>
         <note />
       </trans-unit>
       <trans-unit id="BrowseBtn">
-        <source>Browse...</source>
-        <target state="translated">Gözat...</target>
+        <source>_Browse...</source>
+        <target state="needs-review-translation">Gözat...</target>
         <note />
       </trans-unit>
       <trans-unit id="DeleteBtn">
-        <source>Delete</source>
-        <target state="translated">Sil</target>
+        <source>_Delete</source>
+        <target state="needs-review-translation">Sil</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariables">
-        <source>Environment variables:</source>
-        <target state="translated">Ortam değişkenleri:</target>
+        <source>Environ_ment variables:</source>
+        <target state="needs-review-translation">Ortam değişkenleri:</target>
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable:</source>
-        <target state="translated">Yürütülebilir:</target>
+        <source>_Executable:</source>
+        <target state="needs-review-translation">Yürütülebilir:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">
-        <source>Launch:</source>
-        <target state="translated">Başlatma:</target>
+        <source>_Launch:</source>
+        <target state="needs-review-translation">Başlatma:</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchURL">
@@ -183,18 +183,18 @@
         <note />
       </trans-unit>
       <trans-unit id="NewBtn">
-        <source>New...</source>
-        <target state="translated">Yeni...</target>
+        <source>_New...</source>
+        <target state="needs-review-translation">Yeni...</target>
         <note />
       </trans-unit>
       <trans-unit id="Profile">
-        <source>Profile:</source>
-        <target state="translated">Profil:</target>
+        <source>_Profile:</source>
+        <target state="needs-review-translation">Profil:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveBtn">
-        <source>Remove</source>
-        <target state="translated">Kaldır</target>
+        <source>_Remove</source>
+        <target state="needs-review-translation">Kaldır</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueHeader">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirectory">
-        <source>Working directory:</source>
-        <target state="translated">Çalışma dizini:</target>
+        <source>_Working directory:</source>
+        <target state="needs-review-translation">Çalışma dizini:</target>
         <note />
       </trans-unit>
       <trans-unit id="CancelBtn">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkNativeCodeDebuggingText">
-        <source>Enable native code debugging</source>
-        <target state="translated">Yerel kod üzerinde hata ayıklamayı etkinleştir</target>
+        <source>Enable nati_ve code debugging</source>
+        <target state="needs-review-translation">Yerel kod üzerinde hata ayıklamayı etkinleştir</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRemoteDebugEnabledHelpText">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkSqlCodeDebuggingText">
-        <source>Enable SQL Server debugging</source>
-        <target state="translated">SQL Server hata ayıklamasını etkinleştir</target>
+        <source>Enable _SQL Server debugging</source>
+        <target state="needs-review-translation">SQL Server hata ayıklamasını etkinleştir</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hans.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AuthenticationMode">
-        <source>Authentication mode:</source>
-        <target state="translated">身份验证模式:</target>
+        <source>Au_thentication mode:</source>
+        <target state="needs-review-translation">身份验证模式:</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugPropertyPageTitle">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FindBtn">
-        <source>Find...</source>
-        <target state="translated">查找:</target>
+        <source>_Find...</source>
+        <target state="needs-review-translation">查找:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidHostName">
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ProfileKindExecutableName">
         <source>Executable</source>
-        <target state="translated">可执行文件</target>
+        <target state="needs-review-translation">可执行文件</target>
         <note />
       </trans-unit>
       <trans-unit id="ProfileKindIISExpressName">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebug">
-        <source>Use remote m_achine:</source>
-        <target state="translated">使用远程计算机(_A):</target>
+        <source>_Use remote machine:</source>
+        <target state="needs-review-translation">使用远程计算机(_A):</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebugMachineWatermark">
@@ -138,38 +138,38 @@
         <note />
       </trans-unit>
       <trans-unit id="AddBtn">
-        <source>Add</source>
-        <target state="translated">添加</target>
+        <source>_Add</source>
+        <target state="needs-review-translation">添加</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationArguments">
-        <source>Application arguments:</source>
-        <target state="translated">应用程序参数:</target>
+        <source>Application ar_guments:</source>
+        <target state="needs-review-translation">应用程序参数:</target>
         <note />
       </trans-unit>
       <trans-unit id="BrowseBtn">
-        <source>Browse...</source>
-        <target state="translated">浏览...</target>
+        <source>_Browse...</source>
+        <target state="needs-review-translation">浏览...</target>
         <note />
       </trans-unit>
       <trans-unit id="DeleteBtn">
-        <source>Delete</source>
-        <target state="translated">删除</target>
+        <source>_Delete</source>
+        <target state="needs-review-translation">删除</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariables">
-        <source>Environment variables:</source>
-        <target state="translated">环境变量:</target>
+        <source>Environ_ment variables:</source>
+        <target state="needs-review-translation">环境变量:</target>
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable:</source>
-        <target state="translated">可执行文件:</target>
+        <source>_Executable:</source>
+        <target state="needs-review-translation">可执行文件:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">
-        <source>Launch:</source>
-        <target state="translated">启动:</target>
+        <source>_Launch:</source>
+        <target state="needs-review-translation">启动:</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchURL">
@@ -183,18 +183,18 @@
         <note />
       </trans-unit>
       <trans-unit id="NewBtn">
-        <source>New...</source>
-        <target state="translated">新建...</target>
+        <source>_New...</source>
+        <target state="needs-review-translation">新建...</target>
         <note />
       </trans-unit>
       <trans-unit id="Profile">
-        <source>Profile:</source>
-        <target state="translated">配置文件:</target>
+        <source>_Profile:</source>
+        <target state="needs-review-translation">配置文件:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveBtn">
-        <source>Remove</source>
-        <target state="translated">移除</target>
+        <source>_Remove</source>
+        <target state="needs-review-translation">移除</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueHeader">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirectory">
-        <source>Working directory:</source>
-        <target state="translated">工作目录:</target>
+        <source>_Working directory:</source>
+        <target state="needs-review-translation">工作目录:</target>
         <note />
       </trans-unit>
       <trans-unit id="CancelBtn">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkNativeCodeDebuggingText">
-        <source>Enable native code debugging</source>
-        <target state="translated">启用本机代码调试</target>
+        <source>Enable nati_ve code debugging</source>
+        <target state="needs-review-translation">启用本机代码调试</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRemoteDebugEnabledHelpText">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkSqlCodeDebuggingText">
-        <source>Enable SQL Server debugging</source>
-        <target state="translated">启用 SQL Server 调试</target>
+        <source>Enable _SQL Server debugging</source>
+        <target state="needs-review-translation">启用 SQL Server 调试</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hant.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AuthenticationMode">
-        <source>Authentication mode:</source>
-        <target state="translated">驗證模式:</target>
+        <source>Au_thentication mode:</source>
+        <target state="needs-review-translation">驗證模式:</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugPropertyPageTitle">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FindBtn">
-        <source>Find...</source>
-        <target state="translated">尋找:</target>
+        <source>_Find...</source>
+        <target state="needs-review-translation">尋找:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidHostName">
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ProfileKindExecutableName">
         <source>Executable</source>
-        <target state="translated">可執行檔</target>
+        <target state="needs-review-translation">可執行檔</target>
         <note />
       </trans-unit>
       <trans-unit id="ProfileKindIISExpressName">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebug">
-        <source>Use remote m_achine:</source>
-        <target state="translated">使用遠端電腦(_A):</target>
+        <source>_Use remote machine:</source>
+        <target state="needs-review-translation">使用遠端電腦(_A):</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoteDebugMachineWatermark">
@@ -138,38 +138,38 @@
         <note />
       </trans-unit>
       <trans-unit id="AddBtn">
-        <source>Add</source>
-        <target state="translated">新增</target>
+        <source>_Add</source>
+        <target state="needs-review-translation">新增</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationArguments">
-        <source>Application arguments:</source>
-        <target state="translated">應用程式引數:</target>
+        <source>Application ar_guments:</source>
+        <target state="needs-review-translation">應用程式引數:</target>
         <note />
       </trans-unit>
       <trans-unit id="BrowseBtn">
-        <source>Browse...</source>
-        <target state="translated">瀏覽...</target>
+        <source>_Browse...</source>
+        <target state="needs-review-translation">瀏覽...</target>
         <note />
       </trans-unit>
       <trans-unit id="DeleteBtn">
-        <source>Delete</source>
-        <target state="translated">刪除</target>
+        <source>_Delete</source>
+        <target state="needs-review-translation">刪除</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariables">
-        <source>Environment variables:</source>
-        <target state="translated">環境變數:</target>
+        <source>Environ_ment variables:</source>
+        <target state="needs-review-translation">環境變數:</target>
         <note />
       </trans-unit>
       <trans-unit id="Executable">
-        <source>Executable:</source>
-        <target state="translated">可執行檔:</target>
+        <source>_Executable:</source>
+        <target state="needs-review-translation">可執行檔:</target>
         <note />
       </trans-unit>
       <trans-unit id="Launch">
-        <source>Launch:</source>
-        <target state="translated">啟動:</target>
+        <source>_Launch:</source>
+        <target state="needs-review-translation">啟動:</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchURL">
@@ -183,18 +183,18 @@
         <note />
       </trans-unit>
       <trans-unit id="NewBtn">
-        <source>New...</source>
-        <target state="translated">新增...</target>
+        <source>_New...</source>
+        <target state="needs-review-translation">新增...</target>
         <note />
       </trans-unit>
       <trans-unit id="Profile">
-        <source>Profile:</source>
-        <target state="translated">設定檔:</target>
+        <source>_Profile:</source>
+        <target state="needs-review-translation">設定檔:</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveBtn">
-        <source>Remove</source>
-        <target state="translated">移除</target>
+        <source>_Remove</source>
+        <target state="needs-review-translation">移除</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueHeader">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirectory">
-        <source>Working directory:</source>
-        <target state="translated">工作目錄:</target>
+        <source>_Working directory:</source>
+        <target state="needs-review-translation">工作目錄:</target>
         <note />
       </trans-unit>
       <trans-unit id="CancelBtn">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkNativeCodeDebuggingText">
-        <source>Enable native code debugging</source>
-        <target state="translated">啟用機器碼偵錯</target>
+        <source>Enable nati_ve code debugging</source>
+        <target state="needs-review-translation">啟用機器碼偵錯</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRemoteDebugEnabledHelpText">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="chkSqlCodeDebuggingText">
-        <source>Enable SQL Server debugging</source>
-        <target state="translated">啟用 SQL Server 偵錯</target>
+        <source>Enable _SQL Server debugging</source>
+        <target state="needs-review-translation">啟用 SQL Server 偵錯</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
As noted in #5797, Debug page was missing the key accelerators, or mnemonics.

Visual Studio has already defined some menu mnemonics:
![screenshot_vs_menubar](https://user-images.githubusercontent.com/8518253/86972368-b1420280-c127-11ea-8a8d-a80aeae342fe.png)

To avoid overlaps, I eliminated the letters _B, D, E, F, H, N, P, S, T, V, W, X_ from the set. I was able to assign a key accelerator to the majority of the properties, as shown below.

**Before:**
![screenshot_before](https://user-images.githubusercontent.com/8518253/86972748-47762880-c128-11ea-91d4-1741d7e9d641.png)

**After:**
![screenshot_after](https://user-images.githubusercontent.com/8518253/86972755-49d88280-c128-11ea-99ea-34b62124b069.png)

You'll notice that buttons have no key accelerator assigned: I was left with 4 unique letters _(J, K, M, O)_ for the 6 different buttons. Any suggestion?

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6350)