### PR TITLE
Move URI to secret and remove if statement

### DIFF
--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -13,6 +13,5 @@ jobs:
     steps:
       - name: Notify
         uses: davidwengier/PostAdaptiveCard@v1.0.0
-        if: github.repository == 'dotnet/project-system'
         with:
-          webhook-uri: https://outlook.office.com/webhook/4ba7372f-2799-4677-89f0-7a1aaea3706c@72f988bf-86f1-41af-91ab-2d7cd011db47/IncomingWebhook/9a07b7d0343f4f25b1c138f52a38a2be/9dbc0cfc-eab3-42c9-838a-4879bef6875e
+          webhook-uri: ${{ secrets.TeamsWebhook }}


### PR DESCRIPTION
We used this if statement in order to avoid getting updates in our Teams only when PRs were created in the main repo (we didn't want them coming from forks).
Since we moved to using a different URI and it's now stored as a secret, secrets don't get copied to forks so we won't see this problem anymore.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6352)