### PR TITLE
Switch to the new LaunchAsync interface.

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -66,6 +66,7 @@
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime"                   Version="15.0.26929" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.7.DesignTime"                   Version="15.7.1" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.8.DesignTime"                   Version="15.8.1" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.16.6.DesignTime"                   Version="16.6.30107.105" />
     <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="8.0.0-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="16.6.13" />
     <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="16.6.13" />

--- a/build/import/VisualStudio.props
+++ b/build/import/VisualStudio.props
@@ -44,6 +44,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime"/>
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.7.DesignTime"/>
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.8.DesignTime"/>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.16.6.DesignTime"/>
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" />


### PR DESCRIPTION
This updates the debug launch to use the LaunchDebugTargetsAsync.
This provides a better guarantee that the debug targets have been launched/attached to
when the completion routine is invoked and thus OnAfterLaunchAsync is only called once
debugging has started.

@davkean @andrewcrawley

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6358)