### PR TITLE
Use CPS_DiagnosticRuntime instead of PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED

### DIFF
--- a/Launch.cmd
+++ b/Launch.cmd
@@ -11,7 +11,6 @@ set VisualStudioXamlRulesDir=%Root%\artifacts\Debug\VSSetup\Rules\
 set VisualBasicDesignTimeTargetsPath=%VisualStudioXamlRulesDir%Microsoft.VisualBasic.DesignTime.targets
 set FSharpDesignTimeTargetsPath=%VisualStudioXamlRulesDir%Microsoft.FSharp.DesignTime.targets
 set CSharpDesignTimeTargetsPath=%VisualStudioXamlRulesDir%Microsoft.CSharp.DesignTime.targets
-set PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED=1
 set CPS_DiagnosticRuntime=1
 set CPS_MetricsCollection=1
 

--- a/docs/repo/debugging/logging.md
+++ b/docs/repo/debugging/logging.md
@@ -5,8 +5,14 @@ while debugging or when a certain environment variable is set.
 
 ## Enabling project system logs
 
+### 16.7 or earlier
 Setting the `PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED` environment variable to
 `1` enables project system logging.
+
+### 16.8 or later
+Setting the `CPS_DiagnosticRuntime` environment variable to
+`1` enables project system logging.
+
 
 This environment variable is set automatically when launching the
 `ProjectSystemSetup` project within Visual Studio, via its
@@ -15,7 +21,7 @@ This environment variable is set automatically when launching the
 To enable this logging in other situations you may, for example:
 
 1. Start a Developer Command Prompt
-2. Run: `set PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED=1`
+2. Run: `set CPS_DiagnosticRuntime=1`
 3. Run: `devenv`
 4. Open a solution
 5. Use "View.Output Window"

--- a/setup/ProjectSystemSetup/Properties/launchSettings.json
+++ b/setup/ProjectSystemSetup/Properties/launchSettings.json
@@ -8,7 +8,6 @@
         "VisualBasicDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.VisualBasic.DesignTime.targets",
         "FSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.FSharp.DesignTime.targets",
         "CSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.CSharp.DesignTime.targets",
-        "PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED": "1",
         "CPS_DiagnosticRuntime": "1",
         "CPS_MetricsCollection": "1"
       }
@@ -21,7 +20,6 @@
         "VisualBasicDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.VisualBasic.DesignTime.targets",
         "FSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.FSharp.DesignTime.targets",
         "CSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.CSharp.DesignTime.targets",
-        "PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED": "1",
         "CPS_DiagnosticRuntime": "1",
         "CPS_MetricsCollection": "1"
       },
@@ -35,7 +33,6 @@
         "VisualBasicDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.VisualBasic.DesignTime.targets",
         "FSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.FSharp.DesignTime.targets",
         "CSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.CSharp.DesignTime.targets",
-        "PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED": "1",
         "CPS_DiagnosticRuntime": "1",
         "CPS_MetricsCollection": "1",
         "COMPlus_ZapDisable": "1"
@@ -50,7 +47,6 @@
         "VisualBasicDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.VisualBasic.DesignTime.targets",
         "FSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.FSharp.DesignTime.targets",
         "CSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.CSharp.DesignTime.targets",
-        "PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED": "1",
         "CPS_DiagnosticRuntime": "1",
         "CPS_MetricsCollection": "1"
       }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectSystemOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     /// <summary>
     ///     Provides properties for retrieving options for the project system.
     /// </summary>
-    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    [ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IProjectSystemOptions
     {
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ServiceCapability.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ServiceCapability.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     Well-known <see cref="IProjectService"/> capabilities.
+    /// </summary>
+    internal static class ServiceCapability
+    {
+        /// <summary>
+        ///     Indicates that CPS has its diagnostic runtime enabled.
+        /// </summary>
+        public const string DiagnosticRuntimeServiceCapability = "Microsoft.VisualStudio.ProjectSystem.DiagnosticRuntime";
+    }
+}


### PR DESCRIPTION
This replaces PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED in lieu of checking for the diagnostic runtime which is turned on by CPS_DiagnosticRuntime environment variable. This is turned on by default on F5 for CPS and this repository.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6359)