### PR TITLE
[16.7] Protect against exception due to empty string

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyAttachedCollectionSourceProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyAttachedCollectionSourceProvider.cs
@@ -38,7 +38,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                 EnvDTE.Properties? props = projectItem?.Properties;
 
                 if (props?.Item("TargetingPackPath")?.Value is string path &&
-                    props?.Item("OriginalItemSpec")?.Value is string name)
+                    props?.Item("OriginalItemSpec")?.Value is string name &&
+                    !string.IsNullOrWhiteSpace(path) &&
+                    !string.IsNullOrWhiteSpace(name))
                 {
                     string? profile = props?.Item("Profile").Value as string;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceIdentity.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceIdentity.cs
@@ -10,8 +10,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public FrameworkReferenceIdentity(string path, string? profile, string name)
         {
-            Requires.NotNullOrEmpty(path, nameof(path));
-            Requires.NotNullOrEmpty(name, nameof(name));
+            Requires.NotNullOrWhiteSpace(path, nameof(path));
+            Requires.NotNullOrWhiteSpace(name, nameof(name));
 
             Path = path;
             Profile = profile;


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1151765

Applying this fix to `dev16.7.x`. It must merge forward to `master` (automation should do this).

---

We have received Watson data showing the value of `TargetingPackPath` or `OriginalItemSpec` can be empty, based on stack traces where these value are validated during the construction of `FrameworkReferenceIdentity`. This change prevents items from being attached in such a case.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6365)