### PR TITLE
[16.7] Fix integer overflow exception

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeSearchContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeSearchContext.cs
@@ -13,15 +13,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     internal sealed class DependenciesTreeSearchContext : IDisposable
     {
         private readonly string _searchString;
-        private readonly int _maximumResults;
+        private readonly uint _maximumResults;
         private readonly Action<ISearchResult> _resultAccumulator;
         private readonly CancellationTokenSource _cts;
-        private int _submittedResultCount;
+        private long _submittedResultCount; // long as there's no interlocked increment for uint32
 
         public DependenciesTreeSearchContext(IRelationshipSearchParameters parameters, Action<ISearchResult> resultAccumulator)
         {
             _searchString = parameters.SearchQuery.SearchString;
-            _maximumResults = checked((int)parameters.MaximumResults);
+            _maximumResults = parameters.MaximumResults;
             _resultAccumulator = resultAccumulator;
             _cts = CancellationTokenSource.CreateLinkedTokenSource(parameters.CancellationToken);
         }


### PR DESCRIPTION
[AB#1155051](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1155051)

Applying this fix to `dev16.7.x`. It must merge forward to `master` (automation should do this).

---

`Interlocked.Increment` does not have an overload that accepts `uint`, therefore `_submittedResultCount` was tracked as a (signed) `int`. The maximum number of results is specified as an `uint`, and the original code made a `checked` conversion from `uint` to `int`. During testing this worked fine, however there are scenarios where `uint.MaxValue` is provided here, which triggers an `OverflowException`. That exception would fault the search operation and surfaced during previews via NFE reporting.

The fix is to widen the type of `_submittedResultCount` to `long`, the domain of which includes all `uint` values, and which is a type that `Interlocked.Increment` supports.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6366)