### PR TITLE
Posting to Teams workflow should also update PRs

### DIFF
--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -12,8 +12,6 @@ jobs:
     
     steps:
       - name: Notify
-        uses: davidwengier/PostAdaptiveCard@v1.0.1
+        uses: davidwengier/PostAdaptiveCard@v1.0.2
         env:
-          WEBHOOK_FROM_SECRET: ${{ secrets.TeamsWebhook }}
-        with:
-          webhook_uri: ${WEBHOOK_FROM_SECRET}
+          WEBHOOK_URI: ${{ secrets.TeamsWebhook }}

--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -13,5 +13,7 @@ jobs:
     steps:
       - name: Notify
         uses: davidwengier/PostAdaptiveCard@v1.0.1
+        env:
+          WEBHOOK_FROM_SECRET: ${{ secrets.TeamsWebhook }}
         with:
-          webhook_uri: ${{ secrets.TeamsWebhook }}
+          webhook_uri: ${WEBHOOK_FROM_SECRET}

--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -13,5 +13,6 @@ jobs:
     steps:
       - name: Notify
         uses: davidwengier/PostAdaptiveCard@v1.0.1
+        if: github.repository == 'dotnet/project-system'
         with:
           webhook_uri: https://outlook.office.com/webhook/4ba7372f-2799-4677-89f0-7a1aaea3706c@72f988bf-86f1-41af-91ab-2d7cd011db47/IncomingWebhook/461ee56585254d63b67f15afdf6a1513/b4e5dfd6-185f-4aed-90e3-aa15b6f398ba

--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -12,6 +12,6 @@ jobs:
     
     steps:
       - name: Notify
-        uses: davidwengier/PostAdaptiveCard@v1.0.0
+        uses: davidwengier/PostAdaptiveCard@v1.0.1
         with:
           webhook_uri: ${{ secrets.TeamsWebhook }}

--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -14,4 +14,4 @@ jobs:
       - name: Notify
         uses: davidwengier/PostAdaptiveCard@v1.0.0
         with:
-          webhook-uri: ${{ secrets.TeamsWebhook }}
+          webhook_uri: ${{ secrets.TeamsWebhook }}

--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -15,4 +15,4 @@ jobs:
         uses: davidwengier/PostAdaptiveCard@v1.0.1
         if: github.repository == 'dotnet/project-system'
         with:
-          webhook_uri: https://outlook.office.com/webhook/4ba7372f-2799-4677-89f0-7a1aaea3706c@72f988bf-86f1-41af-91ab-2d7cd011db47/IncomingWebhook/461ee56585254d63b67f15afdf6a1513/b4e5dfd6-185f-4aed-90e3-aa15b6f398ba
+          webhook-uri: https://outlook.office.com/webhook/4ba7372f-2799-4677-89f0-7a1aaea3706c@72f988bf-86f1-41af-91ab-2d7cd011db47/IncomingWebhook/461ee56585254d63b67f15afdf6a1513/b4e5dfd6-185f-4aed-90e3-aa15b6f398ba

--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -12,6 +12,6 @@ jobs:
     
     steps:
       - name: Notify
-        uses: davidwengier/PostAdaptiveCard@v1.0.2
-        env:
-          WEBHOOK_URI: ${{ secrets.TeamsWebhook }}
+        uses: davidwengier/PostAdaptiveCard@v1.0.1
+        with:
+          webhook_uri: https://outlook.office.com/webhook/4ba7372f-2799-4677-89f0-7a1aaea3706c@72f988bf-86f1-41af-91ab-2d7cd011db47/IncomingWebhook/461ee56585254d63b67f15afdf6a1513/b4e5dfd6-185f-4aed-90e3-aa15b6f398ba


### PR DESCRIPTION
Currently our workflow is only posting new issues in our teams channel. Since we moved to a secret we believe this is giving us problems with PRs.
This PR is a placeholder for now and it's also helping us test the changes (hence the closing and reopening of it)

Current status: Reached out to Github support for help

Fixes #6367

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6372)