### PR TITLE
Do not auto-initialize VisualBasicNamespaceImportsList

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicNamespaceImportsList.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicNamespaceImportsList.cs
@@ -80,15 +80,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        [ProjectAutoLoad(startAfter: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
-        [AppliesTo(ProjectCapability.VisualBasic)]
-        internal Task OnProjectFactoryCompletedAsync()
-        {
-            TryInitialize();
-
-            return Task.CompletedTask;
-        }
-
         protected override async Task ApplyAsync(IProjectVersionedValue<ImmutableList<string>> value)
         {
             await JoinableFactory.SwitchToMainThreadAsync();


### PR DESCRIPTION
We don't need to auto-initialize this service, just do this the first time someone calls us. This initialize was causing thread-pool exchaustion because we were synchronously initializing an async method that required the UI thread.

Fixes: Part of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1146682.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6380)