### PR TITLE
Fix priority ordering of attached tree children

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateRelationCollectionSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateRelationCollectionSource.cs
@@ -3,6 +3,8 @@
 using System;
 using System.Collections;
 using System.ComponentModel;
+using System.Windows.Data;
+using Microsoft.Internal.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Microsoft.VisualStudio.Shell;
 
@@ -73,8 +75,55 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                 PropertyChanged?.Invoke(this, KnownEventArgs.HasItemsPropertyChanged);
             };
 
+            // Work around inconsistent use of IPrioritizedComparable in the tree view control
+            // https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1158136
+            if (CollectionViewSource.GetDefaultView(_collection) is ListCollectionView view)
+            {
+                view.CustomSort = PrioritizedComparableComparer.Instance;
+            }
+
             PropertyChanged?.Invoke(this, KnownEventArgs.IsUpdatingItemsPropertyChanged);
             PropertyChanged?.Invoke(this, KnownEventArgs.HasItemsPropertyChanged);
+        }
+
+        private sealed class PrioritizedComparableComparer : IComparer
+        {
+            public static IComparer Instance { get; } = new PrioritizedComparableComparer();
+
+            public int Compare(object x, object y)
+            {
+                if (x == null || y == null)
+                {
+                    // We don't expect nulls
+                    return 0;
+                }
+
+                // Handle prioritized comparison
+                if (x is IPrioritizedComparable comparable1 && y is IPrioritizedComparable comparable2)
+                {
+                    int order = comparable1.Priority.CompareTo(comparable2.Priority);
+
+                    if (order != 0)
+                    {
+                        return order;
+                    }
+
+                    return comparable1.CompareTo(comparable2);
+                }
+
+                // Handle non-prioritized comparison
+                if (x is IComparable item1 && y is IComparable item2)
+                {
+                    int order = item1.CompareTo(item2);
+
+                    if (order != 0)
+                    {
+                        return order;
+                    }
+                }
+
+                return 0;
+            }
         }
     }
 }


### PR DESCRIPTION
Works around a limitation of Solution Explorer's tree view where the `IPrioritizedComparable` pattern is not used uniformly, and children can appear out of order.

---

Given:

```c#
    /// <summary>
    /// Specifies the order of attached items in the dependencies tree.
    /// </summary>
    /// <remarks>
    /// Used in conjunction with <see cref="IPrioritizedComparable"/>.
    /// </remarks>
    internal static class AttachedItemPriority
    {
        // Not all of these can be siblings.

        public const int Diagnostic               = 100;
        public const int Package                  = 200;
        public const int Project                  = 300;
        public const int CompileTimeAssemblyGroup = 400;
        public const int FrameworkAssemblyGroup   = 500;
        public const int ContentFilesGroup        = 600;
    }
```

Diagnostics should appear before any other kind of item.

## Before

Items appear alphabetically:

![image](https://user-images.githubusercontent.com/350947/87734775-f694bd00-c816-11ea-9d8b-4ee2ea069f1d.png)

## After

Priority is respected:

![image](https://user-images.githubusercontent.com/350947/87734758-e4b31a00-c816-11ea-979e-af48c1740739.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6385)