### PR TITLE
Unify analyzer packages

### DIFF
--- a/build/import/HostAgnostic.props
+++ b/build/import/HostAgnostic.props
@@ -40,13 +40,9 @@
     
     <!-- Analyzers-->
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" />
-    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" />
-    <PackageReference Include="Microsoft.NetCore.Analyzers" />
-    <PackageReference Include="Microsoft.NetFramework.Analyzers" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" />
 
     <!-- MSBuild -->

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -106,17 +106,11 @@
     <PackageReference Update="Microsoft.CSharp"                                                       Version="4.7.0" />
 
     <!-- Analyzers -->
-    <!-- Note: analyzers from github.com/dotnet/roslyn-analyzers are built together and share the same version -->
     <PackageReference Update="Microsoft.CodeAnalysis.Analyzers"                                       Version="3.3.0-beta1.final" />
-    <!-- Roslyn.Diagnostics.Analyzers has bad reference to a version of BannedApiAnalyzers that doesn't exist -->
-    <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers"                              Version="3.0.0" NoWarn="NU1605" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle"                                Version="3.6.0-2.20157.5" />
-    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers"                              Version="3.3.0-beta1.final" />
     <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"                           Version="3.6.0-2.20157.5" />
-    <PackageReference Update="Microsoft.CodeQuality.Analyzers"                                        Version="3.3.0-beta1.final" />
-    <PackageReference Update="Microsoft.NetCore.Analyzers"                                            Version="3.3.0-beta1.final" />
-    <PackageReference Update="Microsoft.NetFramework.Analyzers"                                       Version="3.3.0-beta1.final" />
-    <PackageReference Update="Roslyn.Diagnostics.Analyzers"                                           Version="3.3.0-beta1.final" />
+    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers"                                  Version="3.3.0-beta2.final" />
+    <PackageReference Update="Roslyn.Diagnostics.Analyzers"                                           Version="3.3.0-beta2.final" />
 
     <!-- NuGet -->
     <PackageReference Update="NuGet.SolutionRestoreManager.Interop"                                   Version="5.6.0-preview.2.6554" />


### PR DESCRIPTION
This references the root packages and stops reference individual packages. Also works around the bad reference to BannedApiAnalyzers which has since been fixed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6388)