### PR TITLE
Annotate code

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileEnumValuesGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileEnumValuesGenerator.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework.XamlTypes;
@@ -81,7 +82,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             return result;
         }
 
-        private static string? EscapeMnemonics(string text)
+        [return: NotNullIfNotNull("text")]
+        private static string? EscapeMnemonics(string? text)
         {
             return text?.Replace("&", "&&");
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ErrorProfileDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ErrorProfileDebugTargetsProvider.cs
@@ -58,7 +58,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// </summary>
         public Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsAsync(DebugLaunchOptions launchOptions, ILaunchProfile activeProfile)
         {
-            if (activeProfile.OtherSettings.TryGetValue("ErrorString", out object objErrorString) && objErrorString is string errorString)
+            if (activeProfile.OtherSettings != null &&
+                activeProfile.OtherSettings.TryGetValue("ErrorString", out object objErrorString) &&
+                objErrorString is string errorString)
             {
                 throw new Exception(string.Format(VSResources.ErrorInProfilesFile2, Path.GetFileNameWithoutExtension(_configuredProject.UnconfiguredProject.FullPath), errorString));
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -292,17 +292,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                     {
                         // Try to resolve against the current working directory (for compat) and failing that, the environment path.
                         string exeName = executable.EndsWith(".exe", StringComparisons.Paths) ? executable : executable + ".exe";
-                        string? fullPath = _fileSystem.GetFullPath(exeName);
+                        string fullPath = _fileSystem.GetFullPath(exeName);
                         if (_fileSystem.FileExists(fullPath))
                         {
                             executable = fullPath;
                         }
                         else
                         {
-                            fullPath = GetFullPathOfExeFromEnvironmentPath(exeName);
-                            if (fullPath != null)
+                            string? fullPathFromEnv = GetFullPathOfExeFromEnvironmentPath(exeName);
+                            if (fullPathFromEnv != null)
                             {
-                                executable = fullPath;
+                                executable = fullPathFromEnv;
                             }
                         }
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/IVsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/IVsContainedLanguageComponentsFactory.cs
@@ -24,8 +24,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         /// <param name="itemid">item id of the given file</param>
         /// <param name="containedLanguageFactory">an instance of IVsContainedLanguageFactory specific for current language service</param>
         int GetContainedLanguageFactoryForFile(string filePath,
-                                               out IVsHierarchy hierarchy,
+                                               out IVsHierarchy? hierarchy,
                                                out uint itemid,
-                                               out IVsContainedLanguageFactory containedLanguageFactory);
+                                               out IVsContainedLanguageFactory? containedLanguageFactory);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Shipped.txt
@@ -98,7 +98,7 @@ Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugProfileLaunchTargetsProvider
 Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugProfileLaunchTargetsProvider2
 Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugProfileLaunchTargetsProvider2.QueryDebugTargetsForDebugLaunchAsync(Microsoft.VisualStudio.ProjectSystem.Debug.DebugLaunchOptions launchOptions, Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile! profile) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugLaunchSettings!>!>!
 Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices.IVsContainedLanguageComponentsFactory
-Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices.IVsContainedLanguageComponentsFactory.GetContainedLanguageFactoryForFile(string! filePath, out Microsoft.VisualStudio.Shell.Interop.IVsHierarchy! hierarchy, out uint itemid, out Microsoft.VisualStudio.TextManager.Interop.IVsContainedLanguageFactory! containedLanguageFactory) -> int
+Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices.IVsContainedLanguageComponentsFactory.GetContainedLanguageFactoryForFile(string! filePath, out Microsoft.VisualStudio.Shell.Interop.IVsHierarchy? hierarchy, out uint itemid, out Microsoft.VisualStudio.TextManager.Interop.IVsContainedLanguageFactory? containedLanguageFactory) -> int
 Microsoft.VisualStudio.ProjectSystem.VS.Properties.AbstractProjectConfigurationProperties
 Microsoft.VisualStudio.ProjectSystem.VS.Properties.AbstractProjectConfigurationProperties.__id.get -> string!
 Microsoft.VisualStudio.ProjectSystem.VS.Properties.AbstractProjectConfigurationProperties.AllowUnsafeBlocks.get -> bool

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
@@ -39,22 +39,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public async Task<ILaunchProfile> ReplaceTokensInProfileAsync(ILaunchProfile profile)
         {
             var resolvedProfile = new LaunchProfile(profile);
-            if (!string.IsNullOrWhiteSpace(resolvedProfile.ExecutablePath))
+            if (!Strings.IsNullOrWhiteSpace(resolvedProfile.ExecutablePath))
             {
                 resolvedProfile.ExecutablePath = await ReplaceTokensInStringAsync(resolvedProfile.ExecutablePath, true);
             }
 
-            if (!string.IsNullOrWhiteSpace(resolvedProfile.CommandLineArgs))
+            if (!Strings.IsNullOrWhiteSpace(resolvedProfile.CommandLineArgs))
             {
                 resolvedProfile.CommandLineArgs = await ReplaceTokensInStringAsync(resolvedProfile.CommandLineArgs, true);
             }
 
-            if (!string.IsNullOrWhiteSpace(resolvedProfile.WorkingDirectory))
+            if (!Strings.IsNullOrWhiteSpace(resolvedProfile.WorkingDirectory))
             {
                 resolvedProfile.WorkingDirectory = await ReplaceTokensInStringAsync(resolvedProfile.WorkingDirectory, true);
             }
 
-            if (!string.IsNullOrWhiteSpace(resolvedProfile.LaunchUrl))
+            if (!Strings.IsNullOrWhiteSpace(resolvedProfile.LaunchUrl))
             {
                 resolvedProfile.LaunchUrl = await ReplaceTokensInStringAsync(resolvedProfile.LaunchUrl, true);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchProfile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchProfile.cs
@@ -9,14 +9,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     /// </summary>
     public interface ILaunchProfile
     {
-        string Name { get; }
-        string CommandName { get; }
-        string ExecutablePath { get; }
-        string CommandLineArgs { get; }
-        string WorkingDirectory { get; }
+        string? Name { get; }
+        string? CommandName { get; }
+        string? ExecutablePath { get; }
+        string? CommandLineArgs { get; }
+        string? WorkingDirectory { get; }
         bool LaunchBrowser { get; }
-        string LaunchUrl { get; }
-        ImmutableDictionary<string, string> EnvironmentVariables { get; } // TODO-NULLABLE in some contexts this is null
-        ImmutableDictionary<string, object> OtherSettings { get; }        // TODO-NULLABLE in some contexts this is null
+        string? LaunchUrl { get; }
+        ImmutableDictionary<string, string>? EnvironmentVariables { get; }
+        ImmutableDictionary<string, object>? OtherSettings { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IWritableLaunchProfile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IWritableLaunchProfile.cs
@@ -9,13 +9,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     /// </summary>
     public interface IWritableLaunchProfile
     {
-        string Name { get; set; }
-        string CommandName { get; set; }
-        string ExecutablePath { get; set; }
-        string CommandLineArgs { get; set; }
-        string WorkingDirectory { get; set; }
+        string? Name { get; set; }
+        string? CommandName { get; set; }
+        string? ExecutablePath { get; set; }
+        string? CommandLineArgs { get; set; }
+        string? WorkingDirectory { get; set; }
         bool LaunchBrowser { get; set; }
-        string LaunchUrl { get; set; }
+        string? LaunchUrl { get; set; }
         Dictionary<string, string> EnvironmentVariables { get; }
         Dictionary<string, object> OtherSettings { get; }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfile.cs
@@ -2,8 +2,6 @@
 
 using System.Collections.Immutable;
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     /// <summary>
@@ -62,22 +60,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             OtherSettings = writableProfile.OtherSettings.Count == 0 ? null : writableProfile.OtherSettings.ToImmutableDictionary();
         }
 
-        public string Name { get; set; }
-        public string CommandName { get; set; }
-        public string ExecutablePath { get; set; }
-        public string CommandLineArgs { get; set; }
-        public string WorkingDirectory { get; set; }
+        public string? Name { get; set; }
+        public string? CommandName { get; set; }
+        public string? ExecutablePath { get; set; }
+        public string? CommandLineArgs { get; set; }
+        public string? WorkingDirectory { get; set; }
         public bool LaunchBrowser { get; set; }
-        public string LaunchUrl { get; set; }
+        public string? LaunchUrl { get; set; }
         public bool DoNotPersist { get; set; }
 
-        public ImmutableDictionary<string, string> EnvironmentVariables { get; set; }
-        public ImmutableDictionary<string, object> OtherSettings { get; set; }
+        public ImmutableDictionary<string, string>? EnvironmentVariables { get; set; }
+        public ImmutableDictionary<string, object>? OtherSettings { get; set; }
 
         /// <summary>
         /// Compares two profile names. Using this function ensures case comparison consistency
         /// </summary>
-        public static bool IsSameProfileName(string name1, string name2)
+        public static bool IsSameProfileName(string? name1, string? name2)
         {
             return string.Equals(name1, name2, StringComparisons.LaunchProfileNames);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileData.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileData.cs
@@ -137,22 +137,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var data = new Dictionary<string, object>(StringComparers.LaunchProfileProperties);
 
             // Don't write out empty elements
-            if (!string.IsNullOrEmpty(profile.CommandName))
+            if (!Strings.IsNullOrEmpty(profile.CommandName))
             {
                 data.Add(Prop_commandName, profile.CommandName);
             }
 
-            if (!string.IsNullOrEmpty(profile.ExecutablePath))
+            if (!Strings.IsNullOrEmpty(profile.ExecutablePath))
             {
                 data.Add(Prop_executablePath, profile.ExecutablePath);
             }
 
-            if (!string.IsNullOrEmpty(profile.CommandLineArgs))
+            if (!Strings.IsNullOrEmpty(profile.CommandLineArgs))
             {
                 data.Add(Prop_commandLineArgs, profile.CommandLineArgs);
             }
 
-            if (!string.IsNullOrEmpty(profile.WorkingDirectory))
+            if (!Strings.IsNullOrEmpty(profile.WorkingDirectory))
             {
                 data.Add(Prop_workingDirectory, profile.WorkingDirectory);
             }
@@ -162,7 +162,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 data.Add(Prop_launchBrowser, profile.LaunchBrowser);
             }
 
-            if (!string.IsNullOrEmpty(profile.LaunchUrl))
+            if (!Strings.IsNullOrEmpty(profile.LaunchUrl))
             {
                 data.Add(Prop_launchUrl, profile.LaunchUrl);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -42,12 +42,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public const string ErrorProfileCommandName = "ErrorProfile";
 
         private readonly UnconfiguredProject _project;
-        private readonly IActiveConfiguredValue<IAppDesignerFolderSpecialFileProvider> _appDesignerSpecialFileProvider;
+        private readonly IActiveConfiguredValue<IAppDesignerFolderSpecialFileProvider?> _appDesignerSpecialFileProvider;
         private readonly IProjectFaultHandlerService _projectFaultHandler;
         private readonly AsyncLazy<string> _launchSettingsFilePath;
         private readonly IUnconfiguredProjectServices _projectServices;
         private readonly IUnconfiguredProjectCommonServices _commonProjectServices;
-        private readonly IActiveConfiguredProjectSubscriptionService _projectSubscriptionService;
+        private readonly IActiveConfiguredProjectSubscriptionService? _projectSubscriptionService;
         private readonly IFileSystem _fileSystem;
         private readonly TaskCompletionSource<bool> _firstSnapshotCompletionSource = new TaskCompletionSource<bool>();
         private readonly SequentialTaskExecutor _sequentialTaskQueue = new SequentialTaskExecutor();
@@ -62,8 +62,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             IUnconfiguredProjectServices projectServices,
             IFileSystem fileSystem,
             IUnconfiguredProjectCommonServices commonProjectServices,
-            IActiveConfiguredProjectSubscriptionService projectSubscriptionService,
-            IActiveConfiguredValue<IAppDesignerFolderSpecialFileProvider> appDesignerSpecialFileProvider,
+            IActiveConfiguredProjectSubscriptionService? projectSubscriptionService,
+            IActiveConfiguredValue<IAppDesignerFolderSpecialFileProvider?> appDesignerSpecialFileProvider,
             IProjectFaultHandlerService projectFaultHandler)
         {
             _project = project;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -16,8 +16,6 @@ using Microsoft.VisualStudio.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     /// <summary>
@@ -52,11 +50,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         private readonly IActiveConfiguredProjectSubscriptionService _projectSubscriptionService;
         private readonly IFileSystem _fileSystem;
         private readonly TaskCompletionSource<bool> _firstSnapshotCompletionSource = new TaskCompletionSource<bool>();
-        private SequentialTaskExecutor _sequentialTaskQueue = new SequentialTaskExecutor();
-        private IReceivableSourceBlock<ILaunchSettings> _changedSourceBlock;
-        private IBroadcastBlock<ILaunchSettings> _broadcastBlock;
-        private ILaunchSettings _currentSnapshot;
-        private IDisposable _projectRuleSubscriptionLink;
+        private readonly SequentialTaskExecutor _sequentialTaskQueue = new SequentialTaskExecutor();
+        private IReceivableSourceBlock<ILaunchSettings>? _changedSourceBlock;
+        private IBroadcastBlock<ILaunchSettings>? _broadcastBlock;
+        private ILaunchSettings? _currentSnapshot;
+        private IDisposable? _projectRuleSubscriptionLink;
 
         [ImportingConstructor]
         public LaunchSettingsProvider(
@@ -88,14 +86,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [ImportMany]
         protected OrderPrecedenceImportCollection<ISourceCodeControlIntegration> SourceControlIntegrations { get; set; }
 
-        protected SimpleFileWatcher FileWatcher { get; set; }
+        protected SimpleFileWatcher? FileWatcher { get; set; }
 
         // When we are saving the file we set this to minimize noise from the file change
         protected bool IgnoreFileChanges { get; set; }
 
         protected TimeSpan FileChangeProcessingDelay = TimeSpan.FromMilliseconds(500);
 
-        public ITaskDelayScheduler FileChangeScheduler { get; protected set; }
+        public ITaskDelayScheduler? FileChangeScheduler { get; protected set; }
 
         // Tracks when we last read or wrote to the file. Prevents picking up needless changes
         protected DateTime LastSettingsFileSyncTimeUtc { get; set; }
@@ -118,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// Returns the active profile. Looks up the value of the ActiveProfile property. If the value doesn't match the
         /// any of the profiles, the first one is returned
         /// </summary>
-        public ILaunchProfile ActiveProfile => CurrentSnapshot?.ActiveProfile;
+        public ILaunchProfile? ActiveProfile => CurrentSnapshot?.ActiveProfile;
 
         /// <summary>
         /// Link to this source block to be notified when the snapshot is changed.
@@ -128,7 +126,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             get
             {
                 EnsureInitialized();
-                return _changedSourceBlock;
+                return _changedSourceBlock!;
             }
         }
 
@@ -141,7 +139,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             get
             {
                 EnsureInitialized();
-                return _currentSnapshot;
+                return _currentSnapshot!;
             }
             protected set
             {
@@ -234,7 +232,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// a profile on disk has the same name as an in-memory profile, the one on disk wins. It tries to add the in-memory profiles
         /// in the same order they appeared prior to the disk change.
         /// </summary>
-        protected async Task UpdateProfilesAsync(string updatedActiveProfileName)
+        protected async Task UpdateProfilesAsync(string? updatedActiveProfileName)
         {
             try
             {
@@ -250,6 +248,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 }
 
                 LaunchSettingsData launchSettingData = await GetLaunchSettingsAsync();
+
+                Assumes.NotNull(launchSettingData.Profiles);
 
                 // If there are no profiles, we will add a default profile to run the project. W/o it our debugger
                 // won't be called on F5 and the user will see a poor error message
@@ -302,8 +302,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 ILaunchProfile profile = prevSnapshot.Profiles[i];
                 if (profile.IsInMemoryObject() && !string.Equals(profile.CommandName, ErrorProfileCommandName))
                 {
+                    Assumes.NotNull(newSnapshot.Profiles);
+
                     // Does it already have one with this name?
-                    if (newSnapshot.Profiles.FirstOrDefault(p => LaunchProfile.IsSameProfileName(p.Name, profile.Name)) == null)
+                    if (newSnapshot.Profiles.FirstOrDefault((p1, p2) => LaunchProfile.IsSameProfileName(p1.Name, p2.Name), profile) == null)
                     {
                         // Create a new one from the existing in-memory profile and insert it in the same location, or the end if it
                         // is beyond the end of the list
@@ -443,7 +445,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// Does a quick validation to make sure at least a name is present in each profile. Removes bad ones and
         /// logs errors. Returns the resultant profiles as a list
         /// </summary>
-        private static List<LaunchProfileData> FixUpProfilesAndLogErrors(Dictionary<string, LaunchProfileData> profilesData)
+        private static List<LaunchProfileData>? FixUpProfilesAndLogErrors(Dictionary<string, LaunchProfileData> profilesData)
         {
             if (profilesData == null)
             {
@@ -505,6 +507,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             {
                 if (ProfileShouldBePersisted(profile))
                 {
+                    Assumes.NotNull(profile.Name);
                     profileData.Add(profile.Name, LaunchProfileData.ToSerializableForm(profile));
                 }
             }
@@ -541,7 +544,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         protected async Task CheckoutSettingsFileAsync()
         {
-            Lazy<ISourceCodeControlIntegration, IOrderPrecedenceMetadataView> sourceControlIntegration = SourceControlIntegrations.FirstOrDefault();
+            Lazy<ISourceCodeControlIntegration, IOrderPrecedenceMetadataView>? sourceControlIntegration = SourceControlIntegrations.FirstOrDefault();
             if (sourceControlIntegration?.Value != null)
             {
                 string fileName = await GetLaunchSettingsFilePathAsync();
@@ -572,6 +575,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 // throttle.
                 if (_fileSystem.GetLastFileWriteTimeOrMinValueUtc(fileName) != LastSettingsFileSyncTimeUtc)
                 {
+                    Assumes.NotNull(FileChangeScheduler);
+
                     return FileChangeScheduler.ScheduleAsyncTask(token =>
                     {
                         if (token.IsCancellationRequested)
@@ -623,6 +628,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             {
                 FileChangeScheduler?.Dispose();
 
+                Assumes.Present(_projectServices.ProjectAsynchronousTasks);
+
                 // Create our scheduler for processing file changes
                 FileChangeScheduler = new TaskDelayScheduler(FileChangeProcessingDelay, _commonProjectServices.ThreadingService,
                     _projectServices.ProjectAsynchronousTasks.UnloadCancellationToken);
@@ -658,11 +665,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                     FileChangeScheduler = null;
                 }
 
-                if (_sequentialTaskQueue != null)
-                {
-                    _sequentialTaskQueue.Dispose();
-                    _sequentialTaskQueue = null;
-                }
+                _sequentialTaskQueue.Dispose();
 
                 if (_broadcastBlock != null)
                 {
@@ -703,7 +706,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             }
 
             // Make sure the profiles are copied. We don't want them to mutate.
-            string activeProfileName = ActiveProfile?.Name;
+            string? activeProfileName = ActiveProfile?.Name;
 
             ILaunchSettings newSnapshot = new LaunchSettings(newSettings.Profiles, newSettings.GlobalSettings, activeProfileName);
             if (persistToDisk)
@@ -726,6 +729,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             }
 
             await _firstSnapshotCompletionSource.Task.TryWaitForCompleteOrTimeout(timeout);
+            
+            Assumes.NotNull(CurrentSnapshot);
             return CurrentSnapshot;
         }
 
@@ -742,7 +747,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             return _sequentialTaskQueue.ExecuteTask(async () =>
             {
                 ILaunchSettings currentSettings = await GetSnapshotThrowIfErrors();
-                ILaunchProfile existingProfile = null;
+                ILaunchProfile? existingProfile = null;
                 int insertionIndex = 0;
                 foreach (ILaunchProfile p in currentSettings.Profiles)
                 {
@@ -885,7 +890,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // even though it can change over the lifetime of the project. We should fix this and convert to using dataflow
             // see: https://github.com/dotnet/project-system/issues/2316.
 
-            string folder = null;
+            string? folder = null;
             if (_appDesignerSpecialFileProvider.Value != null)
                 folder = await _appDesignerSpecialFileProvider.Value.GetFileAsync(SpecialFiles.AppDesigner, SpecialFileFlags.FullPath);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchProfile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchProfile.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Collections;
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     /// <summary>
@@ -40,13 +38,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             }
         }
 
-        public string Name { get; set; }
-        public string CommandName { get; set; }
-        public string ExecutablePath { get; set; }
-        public string CommandLineArgs { get; set; }
-        public string WorkingDirectory { get; set; }
+        public string? Name { get; set; }
+        public string? CommandName { get; set; }
+        public string? ExecutablePath { get; set; }
+        public string? CommandLineArgs { get; set; }
+        public string? WorkingDirectory { get; set; }
         public bool LaunchBrowser { get; set; }
-        public string LaunchUrl { get; set; }
+        public string? LaunchUrl { get; set; }
         public bool DoNotPersist { get; set; }
 
         public Dictionary<string, string> EnvironmentVariables { get; } = new Dictionary<string, string>(StringComparer.Ordinal);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AbstractProjectFileOrAssemblyInfoPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AbstractProjectFileOrAssemblyInfoPropertiesProvider.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
     /// <summary>
@@ -43,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// <summary>
         /// Gets the properties for a property or item.
         /// </summary>
-        public override IProjectProperties GetProperties(string file, string itemType, string item)
+        public override IProjectProperties GetProperties(string file, string? itemType, string? item)
         {
             IProjectProperties delegatedProperties = base.GetProperties(file, itemType, item);
             IProjectProperties assemblyInfoProperties = new AssemblyInfoProperties(delegatedProperties, _getActiveProjectId, _workspace, _threadingService);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/DelegatedProjectPropertiesBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/DelegatedProjectPropertiesBase.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     {
         protected readonly IProjectProperties DelegatedProperties;
 
-        public DelegatedProjectPropertiesBase(IProjectProperties properties)
+        protected DelegatedProjectPropertiesBase(IProjectProperties properties)
         {
             Requires.NotNull(properties, nameof(properties));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationManifestValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationManifestValueProvider.cs
@@ -6,8 +6,6 @@ using System.ComponentModel.Composition;
 using System.IO;
 using System.Threading.Tasks;
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
     [ExportInterceptingPropertyValueProvider("ApplicationManifest", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
@@ -58,16 +56,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// <summary>
         /// Sets the application manifest property
         /// </summary>
-        public override async Task<string> OnSetPropertyValueAsync(
+        public override async Task<string?> OnSetPropertyValueAsync(
             string propertyName,
-            string unevaluatedPropertyValue,
+            string? unevaluatedPropertyValue,
             IProjectProperties defaultProperties,
-            IReadOnlyDictionary<string, string> dimensionalConditions = null)
+            IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
-            string returnValue = null;
+            string? returnValue = null;
 
             // We treat NULL/empty value as reset to default and remove the two properties from the project.
-            if (string.IsNullOrEmpty(unevaluatedPropertyValue) || string.Equals(unevaluatedPropertyValue, DefaultManifestValue, StringComparison.InvariantCultureIgnoreCase))
+            if (Strings.IsNullOrEmpty(unevaluatedPropertyValue) || string.Equals(unevaluatedPropertyValue, DefaultManifestValue, StringComparison.InvariantCultureIgnoreCase))
             {
                 await defaultProperties.DeletePropertyAsync(ApplicationManifestMSBuildProperty);
                 await defaultProperties.DeletePropertyAsync(NoManifestMSBuildProperty);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectProperties.cs
@@ -6,8 +6,6 @@ using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework.XamlTypes;
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
     /// <summary>
@@ -54,27 +52,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             return evaluatedProperty;
         }
 
-        public override async Task<string> GetUnevaluatedPropertyValueAsync(string propertyName)
+        public override async Task<string?> GetUnevaluatedPropertyValueAsync(string propertyName)
         {
-            string unevaluatedProperty = await base.GetUnevaluatedPropertyValueAsync(propertyName);
+            string? unevaluatedProperty = await base.GetUnevaluatedPropertyValueAsync(propertyName);
             if (_valueProviders.TryGetValue(propertyName, out Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata> valueProvider))
             {
-                unevaluatedProperty = await valueProvider.Value.OnGetUnevaluatedPropertyValueAsync(propertyName, unevaluatedProperty, DelegatedProperties);
+                unevaluatedProperty = await valueProvider.Value.OnGetUnevaluatedPropertyValueAsync(propertyName, unevaluatedProperty ?? "", DelegatedProperties);
             }
 
             return unevaluatedProperty;
         }
 
-        public override async Task SetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IReadOnlyDictionary<string, string> dimensionalConditions = null)
+        public override async Task SetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
+            string? valueToSet;
             if (_valueProviders.TryGetValue(propertyName, out Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata> valueProvider))
             {
-                unevaluatedPropertyValue = await valueProvider.Value.OnSetPropertyValueAsync(propertyName, unevaluatedPropertyValue, DelegatedProperties, dimensionalConditions);
+                valueToSet = await valueProvider.Value.OnSetPropertyValueAsync(propertyName, unevaluatedPropertyValue, DelegatedProperties, dimensionalConditions);
+            }
+            else
+            {
+                valueToSet = unevaluatedPropertyValue;
             }
 
-            if (unevaluatedPropertyValue != null)
+            if (valueToSet != null)
             {
-                await base.SetPropertyValueAsync(propertyName, unevaluatedPropertyValue, dimensionalConditions);
+                await base.SetPropertyValueAsync(propertyName, valueToSet, dimensionalConditions);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Shipped.txt
@@ -57,22 +57,22 @@ Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsUIProvider.ShouldEnabl
 Microsoft.VisualStudio.ProjectSystem.Debug.IPersistOption
 Microsoft.VisualStudio.ProjectSystem.Debug.IPersistOption.DoNotPersist.get -> bool
 Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile
-Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.CommandLineArgs.get -> string!
+Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.CommandLineArgs.get -> string?
 Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.CommandLineArgs.set -> void
-Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.CommandName.get -> string!
+Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.CommandName.get -> string?
 Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.CommandName.set -> void
 Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.EnvironmentVariables.get -> System.Collections.Generic.Dictionary<string!, string!>!
-Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.ExecutablePath.get -> string!
+Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.ExecutablePath.get -> string?
 Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.ExecutablePath.set -> void
 Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.LaunchBrowser.get -> bool
 Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.LaunchBrowser.set -> void
-Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.LaunchUrl.get -> string!
+Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.LaunchUrl.get -> string?
 Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.LaunchUrl.set -> void
-Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.Name.get -> string!
+Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.Name.get -> string?
 Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.Name.set -> void
 Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.OtherSettings.get -> System.Collections.Generic.Dictionary<string!, object!>!
 Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.ToLaunchProfile() -> Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile!
-Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.WorkingDirectory.get -> string!
+Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.WorkingDirectory.get -> string?
 Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile.WorkingDirectory.set -> void
 Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchSettings
 Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchSettings.ActiveProfile.get -> Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile?

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Shipped.txt
@@ -19,15 +19,15 @@ Microsoft.VisualStudio.ProjectSystem.Debug.IJsonSection
 Microsoft.VisualStudio.ProjectSystem.Debug.IJsonSection.JsonSection.get -> string!
 Microsoft.VisualStudio.ProjectSystem.Debug.IJsonSection.SerializationType.get -> System.Type!
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile
-Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.CommandLineArgs.get -> string!
-Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.CommandName.get -> string!
-Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.EnvironmentVariables.get -> System.Collections.Immutable.ImmutableDictionary<string!, string!>!
-Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.ExecutablePath.get -> string!
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.CommandLineArgs.get -> string?
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.CommandName.get -> string?
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.EnvironmentVariables.get -> System.Collections.Immutable.ImmutableDictionary<string!, string!>?
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.ExecutablePath.get -> string?
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.LaunchBrowser.get -> bool
-Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.LaunchUrl.get -> string!
-Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.Name.get -> string!
-Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.OtherSettings.get -> System.Collections.Immutable.ImmutableDictionary<string!, object!>!
-Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.WorkingDirectory.get -> string!
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.LaunchUrl.get -> string?
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.Name.get -> string?
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.OtherSettings.get -> System.Collections.Immutable.ImmutableDictionary<string!, object!>?
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.WorkingDirectory.get -> string?
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettings
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettings.ActiveProfile.get -> Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile?
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettings.GetGlobalSetting(string! settingsName) -> object!

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/TestProjectTree.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/TestProjectTree.cs
@@ -6,8 +6,6 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal class TestProjectTree : IProjectTree
@@ -22,20 +20,20 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public bool IsProjectItem { get; set; }
 
         // for scenario where we need to see if it was recreated or not
-        public string CustomTag { get; set; }
+        public string? CustomTag { get; set; }
 
         public int Size { get; }
-        public IRule BrowseObjectProperties { get; set; }
+        public IRule? BrowseObjectProperties { get; set; }
         public ProjectTreeFlags Flags { get; set; } = ProjectTreeFlags.Empty;
         public bool IsFolder { get; }
         public bool Visible { get; set; }
-        public ProjectImageMoniker ExpandedIcon { get; set; }
-        public ProjectImageMoniker Icon { get; set; }
-        public string FilePath => null;
-        public string Caption { get; set; }
+        public ProjectImageMoniker? ExpandedIcon { get; set; }
+        public ProjectImageMoniker? Icon { get; set; }
+        public string? FilePath => null;
+        public string Caption { get; set; } = "Caption";
         IReadOnlyList<IProjectTree> IProjectTree.Children => Children.ToList();
-        public IProjectTree Root { get; }
-        public IProjectTree Parent { get; set; }
+        public IProjectTree Root { get; } = null!;
+        public IProjectTree? Parent { get; set; }
         public IntPtr Identity { get; }
 
         public IProjectTree Add(IProjectTree subtree)
@@ -47,26 +45,27 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public IProjectItemTree Add(IProjectItemTree subtree)
         {
-            return null;
+            throw new NotImplementedException();
         }
 
         public IEnumerable<IProjectTreeDiff> ChangesSince(IProjectTree priorVersion)
         {
-            return null;
+            throw new NotImplementedException();
         }
 
         public bool Contains(IntPtr nodeId)
         {
-            return false;
+            throw new NotImplementedException();
         }
 
         public IProjectTree Find(IntPtr nodeId)
         {
-            return null;
+            throw new NotImplementedException();
         }
 
         public IProjectTree Remove()
         {
+            Assumes.NotNull(Parent);
             return Parent.Remove(this);
         }
 
@@ -83,48 +82,48 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public IProjectItemTree Replace(IProjectItemTree subtree)
         {
-            return null;
+            throw new NotImplementedException();
         }
 
         public IProjectTree Replace(IProjectTree subtree)
         {
-            return null;
+            throw new NotImplementedException();
         }
 
-        public IProjectTree SetBrowseObjectProperties(IRule browseObjectProperties)
+        public IProjectTree SetBrowseObjectProperties(IRule? browseObjectProperties)
         {
-            return null;
+            throw new NotImplementedException();
         }
 
         public IProjectTree SetCaption(string caption)
         {
-            return null;
+            throw new NotImplementedException();
         }
 
-        public IProjectTree SetExpandedIcon(ProjectImageMoniker expandedIcon)
+        public IProjectTree SetExpandedIcon(ProjectImageMoniker? expandedIcon)
         {
-            return null;
+            throw new NotImplementedException();
         }
 
         public IProjectTree SetFlags(ProjectTreeFlags flags)
         {
-            return null;
+            throw new NotImplementedException();
         }
 
-        public IProjectTree SetIcon(ProjectImageMoniker icon)
+        public IProjectTree SetIcon(ProjectImageMoniker? icon)
         {
-            return null;
+            throw new NotImplementedException();
         }
 
-        public IProjectItemTree SetItem(IProjectPropertiesContext context, IPropertySheet propertySheet, bool isLinked)
+        public IProjectItemTree SetItem(IProjectPropertiesContext context, IPropertySheet? propertySheet, bool isLinked)
         {
-            return null;
+            throw new NotImplementedException();
         }
 
-        public IProjectTree SetProperties(string caption = null, string filePath = null, IRule browseObjectProperties = null,
-                                          ProjectImageMoniker icon = null, ProjectImageMoniker expandedIcon = null, bool?
-                                          visible = null, ProjectTreeFlags? flags = null, IProjectPropertiesContext context = null,
-                                          IPropertySheet propertySheet = null, bool? isLinked = null, bool resetFilePath = false,
+        public IProjectTree SetProperties(string? caption = null, string? filePath = null, IRule? browseObjectProperties = null,
+                                          ProjectImageMoniker? icon = null, ProjectImageMoniker? expandedIcon = null, bool? visible = null,
+                                          ProjectTreeFlags? flags = null, IProjectPropertiesContext? context = null,
+                                          IPropertySheet? propertySheet = null, bool? isLinked = null, bool resetFilePath = false,
                                           bool resetBrowseObjectProperties = false, bool resetIcon = false, bool resetExpandedIcon = false)
         {
             Icon = icon ?? Icon;
@@ -137,19 +136,17 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public IProjectTree SetVisible(bool visible)
         {
-            return null;
+            throw new NotImplementedException();
         }
 
         public bool TryFind(IntPtr nodeId, out IProjectTree subtree)
         {
-            subtree = null;
-            return false;
+            throw new NotImplementedException();
         }
 
         public bool TryFindImmediateChild(string caption, out IProjectTree subtree)
         {
-            subtree = null;
-            return false;
+            throw new NotImplementedException();
         }
 
         private sealed class ChildCollection : Collection<TestProjectTree>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
@@ -64,10 +64,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.False(resolvedProfile.LaunchBrowser);
             Assert.Equal("http://localhost:8080/", resolvedProfile.LaunchUrl);
             Assert.Equal("c:\\test\\Property6", resolvedProfile.WorkingDirectory);
-            Assert.Equal("envVariable1", resolvedProfile.EnvironmentVariables["var1"]);
-            Assert.Equal("Property3", resolvedProfile.EnvironmentVariables["var2"]);
-            Assert.Equal("envVariable1", resolvedProfile.OtherSettings["setting1"]);
-            Assert.True((bool)resolvedProfile.OtherSettings["setting2"]);
+            Assert.Equal("envVariable1", resolvedProfile.EnvironmentVariables?["var1"]);
+            Assert.Equal("Property3", resolvedProfile.EnvironmentVariables?["var2"]);
+            Assert.Equal("envVariable1", resolvedProfile.OtherSettings?["setting1"]);
+            Assert.True((bool?)resolvedProfile.OtherSettings?["setting2"]);
         }
 
         [Theory]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -660,7 +660,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             // Check snapshot
             AssertEx.CollectionLength(provider.CurrentSnapshot.Profiles, 2);
-            Assert.Null(provider.CurrentSnapshot.Profiles.FirstOrDefault(p => p.Name.Equals("test")));
+            Assert.Null(provider.CurrentSnapshot.Profiles.FirstOrDefault(p => p.Name!.Equals("test")));
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -33,7 +33,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var properties = ProjectPropertiesFactory.Create(project, new[] { debuggerData });
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(project, IProjectThreadingServiceFactory.Create(), null, properties);
             var projectServices = IUnconfiguredProjectServicesFactory.Create(IProjectAsynchronousTasksServiceFactory.Create());
-            var provider = new LaunchSettingsUnderTest(project, projectServices, fileSystem ?? new IFileSystemMock(), commonServices, null, specialFilesManager);
+            var projectFaultHandlerService = IProjectFaultHandlerServiceFactory.Create();
+            var provider = new LaunchSettingsUnderTest(project, projectServices, fileSystem ?? new IFileSystemMock(), commonServices, null, specialFilesManager, projectFaultHandlerService);
             return provider;
         }
 
@@ -84,7 +85,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.Null(provider.ActiveProfile);
 
             provider.SetCurrentSnapshot(testProfiles.Object);
-            Assert.Equal(activeProfile, provider.ActiveProfile.Name);
+            Assert.NotNull(provider.ActiveProfile);
+            Assert.Equal(activeProfile, provider.ActiveProfile?.Name);
         }
 
         [Fact]
@@ -876,7 +878,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     // Derives from base class to be able to set protected members
     internal class LaunchSettingsUnderTest : LaunchSettingsProvider
     {
-        // ECan pass null for all and a default will be created
         public LaunchSettingsUnderTest(
             UnconfiguredProject project,
             IUnconfiguredProjectServices projectServices,
@@ -884,7 +885,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             IUnconfiguredProjectCommonServices commonProjectServices,
             IActiveConfiguredProjectSubscriptionService? projectSubscriptionService,
             IActiveConfiguredValue<IAppDesignerFolderSpecialFileProvider?> appDesignerFolderSpecialFileProvider,
-            IProjectFaultHandlerService? projectFaultHandler = null)
+            IProjectFaultHandlerService projectFaultHandler)
           : base(project, projectServices, fileSystem, commonProjectServices, projectSubscriptionService, appDesignerFolderSpecialFileProvider, projectFaultHandler)
         {
             // Block the code from setting up one on the real file system. Since we block, it we need to set up the fileChange scheduler manually

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public void GetProperties_NotNull()
         {
             var provider = new TestProjectFileOrAssemblyInfoPropertiesProvider();
-            var properties = provider.GetProperties(null, null, null);
+            var properties = provider.GetProperties("file", null, null);
             Assert.NotNull(properties);
         }
 
@@ -137,6 +137,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             var provider = CreateProviderForSourceFileValidation(code, out Workspace workspace);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
+            Assumes.NotNull(projectFilePath);
 
             var properties = provider.GetProperties(projectFilePath, null, null);
             var propertyValue = await properties.GetEvaluatedPropertyValueAsync(propertyName);
@@ -159,6 +160,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             var provider = CreateProviderForProjectFileValidation(code, propertyName, propertyValueInProjectFile, out Workspace workspace);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
+            Assumes.NotNull(projectFilePath);
 
             var properties = provider.GetProperties(projectFilePath, null, null);
             var propertyValue = await properties.GetEvaluatedPropertyValueAsync(propertyName);
@@ -188,6 +190,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             var provider = CreateProviderForSourceFileValidation(code, out Workspace workspace);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
+            Assumes.NotNull(projectFilePath);
 
             var properties = provider.GetProperties(projectFilePath, null, null);
             await properties.SetPropertyValueAsync(propertyName, propertyValue);
@@ -206,6 +209,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var propertyValues = new Dictionary<string, string?>();
             var provider = CreateProviderForProjectFileValidation(code, propertyName, existingPropertyValue, out Workspace workspace, additionalProps: propertyValues);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
+            Assumes.NotNull(projectFilePath);
 
             var properties = provider.GetProperties(projectFilePath, null, null);
 
@@ -229,6 +233,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             var provider = CreateProviderForSourceFileValidation(code, out Workspace workspace);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
+            Assumes.NotNull(projectFilePath);
 
             var properties = provider.GetProperties(projectFilePath, null, null);
             var propertyValue = await properties.GetUnevaluatedPropertyValueAsync(propertyName);
@@ -243,6 +248,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             var provider = CreateProviderForProjectFileValidation(code, propertyName, propertyValueInProjectFile, out Workspace workspace);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
+            Assumes.NotNull(projectFilePath);
 
             var properties = provider.GetProperties(projectFilePath, null, null);
             var propertyValue = await properties.GetUnevaluatedPropertyValueAsync(propertyName);
@@ -284,6 +290,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 null;
             var provider = CreateProviderForSourceFileValidation(code, out Workspace workspace, interceptingProvider);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
+            Assumes.NotNull(projectFilePath);
 
             var properties = provider.GetProperties(projectFilePath, null, null);
             var propertyValue = await properties.GetEvaluatedPropertyValueAsync(propertyName);
@@ -311,6 +318,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             string code = "";
             var provider = CreateProviderForProjectFileValidation(code, propertyName, existingPropertyValue, out Workspace workspace, additionalProps: additionalProps);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
+            Assumes.NotNull(projectFilePath);
 
             var properties = provider.GetProperties(projectFilePath, null, null);
             var propertyValue = await properties.GetEvaluatedPropertyValueAsync(propertyName);
@@ -358,6 +366,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             string code = "";
             var provider = CreateProviderForProjectFileValidation(code, propertyName, existingPropertyValue, out Workspace workspace, interceptingProvider);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
+            Assumes.NotNull(projectFilePath);
 
             var properties = provider.GetProperties(projectFilePath, null, null);
             await properties.SetPropertyValueAsync(propertyName, propertyValueToSet);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
@@ -610,9 +610,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             if (activeProfileOtherSettings != null)
             {
-                foreach (var kvp in activeProfileOtherSettings)
+                Assumes.NotNull(profile.OtherSettings);
+
+                foreach ((string key, object value) in activeProfileOtherSettings)
                 {
-                    profile.OtherSettings.Add(kvp.Key, kvp.Value);
+                    profile.OtherSettings.Add(key, value);
                 }
             }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [Fact]
         public async Task ExecutablePath_OnSetPropertyValueAsync_SetsTargetInActiveProfile()
         {
-            string activeProfileExecutablePath = @"C:\user\bin\gamma.exe";
+            string? activeProfileExecutablePath = @"C:\user\bin\gamma.exe";
             var settingsProvider = SetupLaunchSettingsProvider(
                 activeProfileName: "Gamma",
                 activeProfileExecutablePath: activeProfileExecutablePath,
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [Fact]
         public async Task LaunchTarget_OnSetPropertyValueAsync_SetsTargetInActiveProfile()
         {
-            string activeProfileLaunchTarget = "GammaCommand";
+            string? activeProfileLaunchTarget = "GammaCommand";
             var settingsProvider = SetupLaunchSettingsProvider(
                 activeProfileName: "Gamma",
                 activeProfileLaunchTarget,
@@ -184,7 +184,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [Fact]
         public async Task CommandLineArguments_OnSetPropertyValueAsync_SetsArgumentsInActiveProfile()
         {
-            string activeProfileCommandLineArgs = "/orca:YES /bluewhale:NO";
+            string? activeProfileCommandLineArgs = "/orca:YES /bluewhale:NO";
             var settingsProvider = SetupLaunchSettingsProvider(
                 activeProfileName: "SeaMammals",
                 activeProfileCommandLineArgs: activeProfileCommandLineArgs,
@@ -235,7 +235,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [Fact]
         public async Task WorkingDirectory_OnSetPropertyValueAsync_SetsDirectoryInActiveProfile()
         {
-            string activeProfileWorkingDirectory = @"C:\one\two\three";
+            string? activeProfileWorkingDirectory = @"C:\one\two\three";
             var settingsProvider = SetupLaunchSettingsProvider(
                 activeProfileName: "Three",
                 activeProfileWorkingDirectory: activeProfileWorkingDirectory,
@@ -307,7 +307,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [Fact]
         public async Task LaunchUrl_OnSetPropertyValueAsync_SetsUrlInActiveProfile()
         {
-            string activeProfileLaunchUrl = "https://incorrect.com";
+            string? activeProfileLaunchUrl = "https://incorrect.com";
             var settingsProvider = SetupLaunchSettingsProvider(
                 activeProfileName: "Three",
                 activeProfileLaunchUrl: activeProfileLaunchUrl,
@@ -347,7 +347,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [Fact]
         public async Task AuthenticationMode_OnSetPropertyValueAsync_SetsDirectoryInActiveProfile()
         {
-            string activeProfileAuthenticationMode = "Windows";
+            string? activeProfileAuthenticationMode = "Windows";
             var activeProfileOtherSettings = new Dictionary<string, object>
             {
                 { LaunchProfileExtensions.RemoteAuthenticationModeProperty, activeProfileAuthenticationMode }
@@ -358,7 +358,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 activeProfileOtherSettings: activeProfileOtherSettings,
                 updateLaunchSettingsCallback: s =>
                 {
-                    activeProfileAuthenticationMode = (string)s.ActiveProfile!.OtherSettings[LaunchProfileExtensions.RemoteAuthenticationModeProperty];
+                    Assumes.NotNull(s.ActiveProfile?.OtherSettings);
+                    activeProfileAuthenticationMode = (string)s.ActiveProfile.OtherSettings[LaunchProfileExtensions.RemoteAuthenticationModeProperty];
                 });
 
             var project = UnconfiguredProjectFactory.Create();
@@ -404,7 +405,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 activeProfileOtherSettings: activeProfileOtherSettings,
                 updateLaunchSettingsCallback: s =>
                 {
-                    activeProfileNativeDebugging = (bool)s.ActiveProfile!.OtherSettings[LaunchProfileExtensions.NativeDebuggingProperty];
+                    Assumes.NotNull(s.ActiveProfile?.OtherSettings);
+                    activeProfileNativeDebugging = (bool)s.ActiveProfile.OtherSettings[LaunchProfileExtensions.NativeDebuggingProperty];
                 });
 
             var project = UnconfiguredProjectFactory.Create();
@@ -450,7 +452,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 activeProfileOtherSettings: activeProfileOtherSettings,
                 updateLaunchSettingsCallback: s =>
                 {
-                    activeProfileRemoteDebugEnabled = (bool)s.ActiveProfile!.OtherSettings[LaunchProfileExtensions.RemoteDebugEnabledProperty];
+                    Assumes.NotNull(s.ActiveProfile?.OtherSettings);
+                    activeProfileRemoteDebugEnabled = (bool)s.ActiveProfile.OtherSettings[LaunchProfileExtensions.RemoteDebugEnabledProperty];
                 });
 
             var project = UnconfiguredProjectFactory.Create();
@@ -496,7 +499,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 activeProfileOtherSettings: activeProfileOtherSettings,
                 updateLaunchSettingsCallback: s =>
                 {
-                    activeProfileRemoteMachineName = (string)s.ActiveProfile!.OtherSettings[LaunchProfileExtensions.RemoteDebugMachineProperty];
+                    Assumes.NotNull(s.ActiveProfile?.OtherSettings);
+                    activeProfileRemoteMachineName = (string)s.ActiveProfile.OtherSettings[LaunchProfileExtensions.RemoteDebugMachineProperty];
                 });
 
             var project = UnconfiguredProjectFactory.Create();
@@ -542,7 +546,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 activeProfileOtherSettings: activeProfileOtherSettings,
                 updateLaunchSettingsCallback: s =>
                 {
-                    activeProfileSqlDebugEnabled = (bool)s.ActiveProfile!.OtherSettings[LaunchProfileExtensions.SqlDebuggingProperty];
+                    Assumes.NotNull(s.ActiveProfile?.OtherSettings);
+                    activeProfileSqlDebugEnabled = (bool)s.ActiveProfile.OtherSettings[LaunchProfileExtensions.SqlDebuggingProperty];
                 });
 
             var project = UnconfiguredProjectFactory.Create();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchTargetPropertyPageValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchTargetPropertyPageValueProviderTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [Fact]
         public async Task  SetProperty_UpdatesActiveProfileCommand_WhenAPageWithAMatchingNameIsFound()
         {
-            string newLaunchTarget = string.Empty;
+            string? newLaunchTarget = string.Empty;
 
             var catalogProvider = GetCatalogProviderAndData();
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
@@ -628,8 +628,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                     {
                         builder.Append(' ', indent * 4);
                         builder.Append("Caption=").Append(tree.Caption).Append(", ");
-                        builder.Append("IconHash=").Append(tree.Icon.GetHashCode()).Append(", ");
-                        builder.Append("ExpandedIconHash=").Append(tree.ExpandedIcon.GetHashCode()).Append(", ");
+                        builder.Append("IconHash=").Append(tree.Icon?.GetHashCode()).Append(", ");
+                        builder.Append("ExpandedIconHash=").Append(tree.ExpandedIcon?.GetHashCode()).Append(", ");
                         builder.Append("Rule=").Append(tree.BrowseObjectProperties?.Name ?? "").Append(", ");
                         builder.Append("IsProjectItem=").Append(tree.IsProjectItem).Append(", ");
                         builder.Append("CustomTag=").Append(tree.CustomTag);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             string argsIn = "/foo /bar";
             string cmdExePath = Path.Combine(Environment.SystemDirectory, "cmd.exe");
 
-            ProjectLaunchTargetsProvider.GetExeAndArguments(false, exeIn, argsIn, out string finalExePath, out string? finalArguments);
+            ProjectLaunchTargetsProvider.GetExeAndArguments(false, exeIn, argsIn, out string? finalExePath, out string? finalArguments);
             Assert.Equal(finalExePath, exeIn);
             Assert.Equal(finalArguments, argsIn);
 
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             string argsInWithEscapes = "/foo /bar ^ < > &";
             string cmdExePath = Path.Combine(Environment.SystemDirectory, "cmd.exe");
 
-            ProjectLaunchTargetsProvider.GetExeAndArguments(true, exeIn, argsInWithEscapes, out string finalExePath, out string? finalArguments);
+            ProjectLaunchTargetsProvider.GetExeAndArguments(true, exeIn, argsInWithEscapes, out string? finalExePath, out string? finalArguments);
             Assert.Equal(cmdExePath, finalExePath);
             Assert.Equal("/c \"\"c:\\foo\\bar.exe\" /foo /bar ^^ ^< ^> ^& & pause\"", finalArguments);
 
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             string exeIn = @"c:\foo\bar.exe";
             string cmdExePath = Path.Combine(Environment.SystemDirectory, "cmd.exe");
 
-            ProjectLaunchTargetsProvider.GetExeAndArguments(true, exeIn, "", out string finalExePath, out string? finalArguments);
+            ProjectLaunchTargetsProvider.GetExeAndArguments(true, exeIn, "", out string? finalExePath, out string? finalArguments);
             Assert.Equal(cmdExePath, finalExePath);
             Assert.Equal("/c \"\"c:\\foo\\bar.exe\"  & pause\"", finalArguments);
         }
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             string cmdExePath = Path.Combine(Environment.SystemDirectory, "cmd.exe");
 
             // empty string args
-            ProjectLaunchTargetsProvider.GetExeAndArguments(true, exeIn, "", out string finalExePath, out string? finalArguments);
+            ProjectLaunchTargetsProvider.GetExeAndArguments(true, exeIn, "", out string? finalExePath, out string? finalArguments);
             Assert.Equal(cmdExePath, finalExePath);
             Assert.Equal("/c \"\"c:\\foo\\bar.exe\"  & pause\"", finalArguments);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             string exeIn = @"c:\foo\bar.exe";
             string cmdExePath = Path.Combine(Environment.SystemDirectory, "cmd.exe");
 
-            ProjectLaunchTargetsProvider.GetExeAndArguments(true, exeIn, null, out string finalExePath, out string? finalArguments);
+            ProjectLaunchTargetsProvider.GetExeAndArguments(true, exeIn, "", out string finalExePath, out string? finalArguments);
             Assert.Equal(cmdExePath, finalExePath);
             Assert.Equal("/c \"\"c:\\foo\\bar.exe\"  & pause\"", finalArguments);
         }
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             string cmdExePath = Path.Combine(Environment.SystemDirectory, "cmd.exe");
 
             // empty string args
-            ProjectLaunchTargetsProvider.GetExeAndArguments(true, exeIn, null, out string finalExePath, out string? finalArguments);
+            ProjectLaunchTargetsProvider.GetExeAndArguments(true, exeIn, "", out string finalExePath, out string? finalArguments);
             Assert.Equal(cmdExePath, finalExePath);
             Assert.Equal("/c \"\"c:\\foo\\bar.exe\"  & pause\"", finalArguments);
         }
@@ -542,7 +542,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             Assert.Throws<Exception>(() =>
             {
-                debugger.ValidateSettings(executable, workingDir, profileName);
+                debugger.ValidateSettings(executable!, workingDir!, profileName);
             });
         }
 
@@ -556,7 +556,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             Assert.Throws<Exception>(() =>
             {
-                debugger.ValidateSettings(executable, workingDir, profileName);
+                debugger.ValidateSettings(executable, workingDir!, profileName);
             });
         }
 
@@ -569,7 +569,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             var profileName = "run";
             _mockFS.WriteAllText(executable, "");
 
-            debugger.ValidateSettings(executable, workingDir, profileName);
+            debugger.ValidateSettings(executable, workingDir!, profileName);
             Assert.True(true);
         }
 
@@ -679,7 +679,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             IRemoteDebuggerAuthenticationService remoteDebuggerAuthenticationService = Mock.Of<IRemoteDebuggerAuthenticationService>();
 
-            return new ProjectLaunchTargetsProvider(unconfiguredProjectVsServices, configuredProject, tokenReplacer, fileSystem, environment, activeDebugFramework, properties, threadingService, IVsUIServiceFactory.Create<SVsShellDebugger, IVsDebugger10>(debugger), remoteDebuggerAuthenticationService);
+            return new ProjectLaunchTargetsProvider(unconfiguredProjectVsServices, configuredProject!, tokenReplacer, fileSystem!, environment, activeDebugFramework, properties!, threadingService, IVsUIServiceFactory.Create<SVsShellDebugger, IVsDebugger10>(debugger), remoteDebuggerAuthenticationService);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             Assert.Equal(1u, itemIdResult);
         }
 
-        private static void AssertFailed(int result, IVsHierarchy hierarchy, uint itemid, IVsContainedLanguageFactory containedLanguageFactory)
+        private static void AssertFailed(int result, IVsHierarchy? hierarchy, uint itemid, IVsContainedLanguageFactory? containedLanguageFactory)
         {
             Assert.Equal(VSConstants.E_FAIL, result);
             Assert.Null(hierarchy);


### PR DESCRIPTION
Reduces the number of un-annotated files from 14 to 5.

Includes annotations for `LaunchSettingsProvider`, which would have prevented bug [AB#1042733](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1042733) (fixed in #6389).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6392)