### PR TITLE
[16.7.x] Workaround SourceRoot without urls

### DIFF
--- a/build/import/Workarounds.targets
+++ b/build/import/Workarounds.targets
@@ -9,4 +9,14 @@
     <None Remove="$(Pkgxunit_runner_console)\**\xunit.abstractions.dll" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <InitializeSourceRootDependsOn>$(InitializeSourceRootDependsOn);RemoveSourceRootsWithoutSourceLinkUrl</InitializeSourceRootDependsOn>
+  </PropertyGroup>
+
+  <!-- WORKAROUND: https://github.com/NuGet/Home/issues/9431 -->
+  <Target Name="RemoveSourceRootsWithoutSourceLinkUrl">
+    <ItemGroup>
+      <SourceRoot Remove="@(SourceRoot)" Condition="'%(SourceRoot.SourceLinkUrl)' == ''" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
(ported to 16.7.x)

Works around: https://github.com/NuGet/Home/issues/9431, which resulted in:

```
C:\Users\vsagent\.nuget\packages\roslyntools.repotoolset\1.0.0-beta-62705-01\tools\SourceLink.targets(31,5): error : SourceRoot.SourceLinkUrl is empty: 'C:\Users\vsagent\.nuget\packages\' [F:\workspace\_work\1\s\src\Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client\Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.csproj]
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6393)