### PR TITLE
Register project properties editor with placeholder UI

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
@@ -15,8 +15,8 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
     ';ApplicationDesignerEditorFactory
     '
     'Remarks:
-    '   The editor factory for the resource editor.  The job of this class is
-    '   simply to create a new resource editor designer when requested by the
+    '   The editor factory for the application designer. The job of this class is
+    '   simply to create a new application designer when requested by the
     '   shell.
     '**************************************************************************
     <CLSCompliant(False),
@@ -212,7 +212,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
             ' The designer nominally supports VSConstants.LOGVIEWID.Designer_guid however it is also called with other GUIDs
             ' that are for the various sub-tabs of the property pages
-            ' Rather than hard code those here, we simply allow through everything TextView, as that is
+            ' Rather than hard code those here, we simply allow through everything except TextView, as that is
             ' used when opening files for text editing, and we want the project file to be editable as XML in that scenario
 
             If rguidLogicalView = VSConstants.LOGVIEWID.TextView_guid Then

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
@@ -233,11 +233,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             End If
             'Site is different - set it
             _site = Site
-            If TypeOf Site Is OLE.Interop.IServiceProvider Then
-                _siteProvider = New ServiceProvider(CType(Site, OLE.Interop.IServiceProvider))
-            Else
-                Debug.Fail("Site IsNot OLE.Interop.IServiceProvider")
-            End If
+            _siteProvider = New ServiceProvider(Site)
         End Function
 
     End Class

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
@@ -20,13 +20,15 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
     '   shell.
     '**************************************************************************
     <CLSCompliant(False),
-    Guid("04b8ab82-a572-4fef-95ce-5222444b6b64"),
+    Guid(ApplicationDesignerEditorFactory.EditorGuidString),
     ProvideView(LogicalView.Designer, "Design")>
     Public NotInheritable Class ApplicationDesignerEditorFactory
         Implements IVsEditorFactory
 
+        Friend Const EditorGuidString = "04b8ab82-a572-4fef-95ce-5222444b6b64"
+
         'The all important GUIDs 
-        Private Shared ReadOnly s_editorGuid As New Guid("{04b8ab82-a572-4fef-95ce-5222444b6b64}")
+        Private Shared ReadOnly s_editorGuid As New Guid(EditorGuidString)
         Private Shared ReadOnly s_commandUIGuid As New Guid("{d06cd5e3-d961-44dc-9d80-c89a1a8d9d56}")
 
         'Exposing the GUID for the rest of the assembly to see

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
     Public NotInheritable Class ApplicationDesignerEditorFactory
         Implements IVsEditorFactory
 
-        Friend Const EditorGuidString = "04b8ab82-a572-4fef-95ce-5222444b6b64"
+        Friend Const EditorGuidString = "990036EB-F67A-4B8A-93D4-4663DB2A1033"
 
         'The all important GUIDs 
         Private Shared ReadOnly s_editorGuid As New Guid(EditorGuidString)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.csproj
@@ -34,6 +34,10 @@
     <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\ProjectSystem\VS\Utilities\UIThreadHelper.cs" Link="Utilities\UIThreadHelper.cs" />
+    <Compile Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\ProjectSystem\VS\Utilities\UnitTestHelper.cs" Link="Utilities\UnitTestHelper.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Update="VSPackage.resx">
       <SubType>Designer</SubType>
       <MergeWithCTO>true</MergeWithCTO>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client.csproj
@@ -33,4 +33,10 @@
     <AdditionalFiles Include="PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="VSPackage.resx">
+      <SubType>Designer</SubType>
+      <MergeWithCTO>true</MergeWithCTO>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Packaging/ManagedProjectSystemClientPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Packaging/ManagedProjectSystemClientPackage.cs
@@ -25,6 +25,8 @@ namespace Microsoft.VisualStudio.Packaging
         {
             await base.InitializeAsync(cancellationToken, progress);
 
+            await JoinableTaskFactory.SwitchToMainThreadAsync();
+
             RegisterEditorFactory(new ProjectPropertiesEditorFactory());
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Packaging/ManagedProjectSystemClientPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Packaging/ManagedProjectSystemClientPackage.cs
@@ -2,15 +2,30 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.Packaging
 {
     [Guid(PackageGuid)]
     [PackageRegistration(AllowsBackgroundLoading = true, RegisterUsing = RegistrationMethod.CodeBase, UseManagedResourcesOnly = true)]
+    [ProvideEditorFactory(
+        typeof(ProjectPropertiesEditorFactory),
+        nameResourceID: 1100,
+        deferUntilIntellisenseIsReady: false,
+        TrustLevel = __VSEDITORTRUSTLEVEL.ETL_AlwaysTrusted)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
     internal sealed class ManagedProjectSystemClientPackage : AsyncPackage
     {
         public const string PackageGuid = "AE74FDFC-B9CE-4948-9E2F-F443B5BE8D37";
+
+        protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+        {
+            await base.InitializeAsync(cancellationToken, progress);
+
+            RegisterEditorFactory(new ProjectPropertiesEditorFactory());
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/ProjectProperties/ProjectPropertiesEditorFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/ProjectProperties/ProjectPropertiesEditorFactory.cs
@@ -29,6 +29,7 @@ namespace Microsoft.VisualStudio.Packaging
         /// <remarks>
         /// Triggered via menu item "Debug | [Project Name] Debug Properties".
         /// </remarks>
+        // TODO if we need this value, try and source it from VSHPROPID_ProjectPropertiesDebugPageArg
         internal static readonly Guid DebugPageLogicalViewGuid = new Guid("0273C280-1882-4ED0-9308-52914672E3AA");
 
         private ProjectPropertiesWindowPaneData? _paneData;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/ProjectProperties/ProjectPropertiesEditorFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/ProjectProperties/ProjectPropertiesEditorFactory.cs
@@ -1,0 +1,168 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Controls;
+using Microsoft.VisualStudio.ProjectSystem.VS;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using IServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
+
+namespace Microsoft.VisualStudio.Packaging
+{
+    [Guid(EditorFactoryGuidString)]
+    [ProvideView(LogicalView.Designer, "Design")]
+    internal sealed class ProjectPropertiesEditorFactory : IVsEditorFactory
+    {
+        private const string EditorFactoryGuidString = "04B8AB82-A572-4FEF-95CE-5222444B6B64";
+
+        // TODO if the new editor is not enabled, fall back to the legacy editor via this GUID
+        private const string LegacyEditorFactoryGuidString = "990036EB-F67A-4B8A-93D4-4663DB2A1033";
+        
+        private ProjectPropertiesWindowPaneData? _paneData;
+
+        public int SetSite(IServiceProvider site)
+        {
+            return HResult.OK;
+        }
+
+        public int CreateEditorInstance(
+            uint grfCreateDoc,
+            string pszMkDocument,
+            string pszPhysicalView,
+            IVsHierarchy pvHier,
+            uint itemid,
+            IntPtr punkDocDataExisting,
+            out IntPtr ppunkDocView,
+            out IntPtr ppunkDocData,
+            out string? pbstrEditorCaption,
+            out Guid pguidCmdUI,
+            out int pgrfCDW)
+        {
+            // TODO mouse wait cursor throughout this operation
+            // TODO try/catch all this (dispose designerLoader on catch, if not null)
+
+#pragma warning disable RS0030 // Do not used banned APIs
+            ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning restore RS0030 // Do not used banned APIs
+
+            ppunkDocView = IntPtr.Zero;
+            ppunkDocData = IntPtr.Zero;
+
+            // An empty caption allows the project name to be used as the caption.
+            pbstrEditorCaption = "";
+
+            pguidCmdUI = default;
+            pgrfCDW = default;
+
+            if ((grfCreateDoc & (VSConstants.CEF_OPENFILE | VSConstants.CEF_SILENT)) == 0)
+            {
+                Debug.Fail("Must be opening the file (not cloning it) and creating the editor silently");
+                return HResult.InvalidArg;
+            }
+
+            _paneData = new ProjectPropertiesWindowPaneData(pvHier, ServiceProvider.GlobalProvider);
+
+            ppunkDocData = Marshal.GetIUnknownForObject(_paneData);
+
+            var newEditor = new ProjectPropertiesWindowPane(pvHier);
+            ppunkDocView = Marshal.GetIUnknownForObject(newEditor);
+
+            const _VSRDTFLAGS windowFlags = _VSRDTFLAGS.RDT_DontAddToMRU |    // TODO review this
+                                            _VSRDTFLAGS.RDT_CantSave |        // TODO review this -- we do want to save
+                                            _VSRDTFLAGS.RDT_ProjSlnDocument |
+                                            _VSRDTFLAGS.RDT_VirtualDocument |
+                                            _VSRDTFLAGS.RDT_DontAutoOpen;     // TODO review this
+
+            pgrfCDW = (int)windowFlags;
+
+            pbstrEditorCaption = string.Empty; // no need to add anything to the caption
+                
+            return HResult.OK;
+        }
+
+        public int MapLogicalView(ref Guid rguidLogicalView, out string? pbstrPhysicalView)
+        {
+            // The default physical view for an editor must be null, and we only support one physical view.
+            pbstrPhysicalView = null;
+
+            // Disallow TextView, as that suggests the requested view is the XML editor.
+            if (rguidLogicalView == VSConstants.LOGVIEWID.TextView_guid)
+            {
+                return HResult.NotImplemented;
+            }
+
+            if (rguidLogicalView == VSConstants.LOGVIEWID.Primary_guid)
+            {
+                return HResult.OK;
+            }
+
+            if (rguidLogicalView == VSConstants.LOGVIEWID.Designer_guid)
+            {
+                return HResult.OK;
+            }
+
+            // We may also be called with other GUIDs for specific pages in the UI. Rather than list them all here,
+            // just return success.
+            // TODO determine whether we can handle those GUIDs in the new experience or not and potentially change this to return NotImplemented.
+            return HResult.OK;
+        }
+
+        public int Close()
+        {
+            return HResult.OK;
+        }
+
+        private sealed class ProjectPropertiesWindowPaneData
+        {
+            public ProjectPropertiesWindowPaneData(IVsHierarchy vsHierarchy, System.IServiceProvider serviceProvider)
+            {
+                
+            }
+        }
+
+        private sealed class ProjectPropertiesWindowPane : WindowPane
+        {
+            public ProjectPropertiesWindowPane(IVsHierarchy vsHierarchy)
+            {
+                
+            }
+
+            public override object? Content { get; set; }
+
+            protected override void OnCreate()
+            {
+#pragma warning disable RS0030 // Do not used banned APIs
+                ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning restore RS0030 // Do not used banned APIs
+
+                base.OnCreate();
+
+                // TODO provide the actual UI content here
+                Content = new TextBlock
+                {
+                    Text = "Hello world!",
+                    VerticalAlignment = VerticalAlignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Center
+                };
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+
+                if (disposing)
+                {
+                    if (Content != null)
+                    {
+                        FrameworkElement control = (FrameworkElement)Content;
+                        IDisposable? disposable = control.DataContext as IDisposable;
+                        disposable?.Dispose();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/ProjectProperties/ProjectPropertiesEditorFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/ProjectProperties/ProjectPropertiesEditorFactory.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.Packaging
             out int pgrfCDW)
         {
             // TODO mouse wait cursor throughout this operation
-            // TODO try/catch all this (dispose designerLoader on catch, if not null)
+            // TODO try/catch all this (dispose things created here as needed)
 
 #pragma warning disable RS0030 // Do not used banned APIs
             ThreadHelper.ThrowIfNotOnUIThread();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/ProjectProperties/ProjectPropertiesEditorFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/ProjectProperties/ProjectPropertiesEditorFactory.cs
@@ -16,10 +16,10 @@ namespace Microsoft.VisualStudio.Packaging
     [ProvideView(LogicalView.Designer, "Design")]
     internal sealed class ProjectPropertiesEditorFactory : IVsEditorFactory
     {
-        private const string EditorFactoryGuidString = "04B8AB82-A572-4FEF-95CE-5222444B6B64";
+        internal const string EditorFactoryGuidString = "04B8AB82-A572-4FEF-95CE-5222444B6B64";
 
         // TODO if the new editor is not enabled, fall back to the legacy editor via this GUID
-        private const string LegacyEditorFactoryGuidString = "990036EB-F67A-4B8A-93D4-4663DB2A1033";
+        internal const string LegacyEditorFactoryGuidString = "990036EB-F67A-4B8A-93D4-4663DB2A1033";
 
         /// <summary>
         /// Logical view identifier (passed to <see cref="MapLogicalView"/>) when the properties
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.Packaging
         /// <remarks>
         /// Triggered via menu item "Debug | [Project Name] Debug Properties".
         /// </remarks>
-        private static readonly Guid DebugPageLogicalViewGuid = new Guid("0273C280-1882-4ED0-9308-52914672E3AA");
+        internal static readonly Guid DebugPageLogicalViewGuid = new Guid("0273C280-1882-4ED0-9308-52914672E3AA");
 
         private ProjectPropertiesWindowPaneData? _paneData;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/ProjectProperties/ProjectPropertiesEditorFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/ProjectProperties/ProjectPropertiesEditorFactory.cs
@@ -20,7 +20,16 @@ namespace Microsoft.VisualStudio.Packaging
 
         // TODO if the new editor is not enabled, fall back to the legacy editor via this GUID
         private const string LegacyEditorFactoryGuidString = "990036EB-F67A-4B8A-93D4-4663DB2A1033";
-        
+
+        /// <summary>
+        /// Logical view identifier (passed to <see cref="MapLogicalView"/>) when the properties
+        /// pages are to be launched displaying the "debug" page.
+        /// </summary>
+        /// <remarks>
+        /// Triggered via menu item "Debug | [Project Name] Debug Properties".
+        /// </remarks>
+        private static readonly Guid DebugPageLogicalViewGuid = new Guid("0273C280-1882-4ED0-9308-52914672E3AA");
+
         private ProjectPropertiesWindowPaneData? _paneData;
 
         public int SetSite(IServiceProvider site)
@@ -104,8 +113,15 @@ namespace Microsoft.VisualStudio.Packaging
                 return HResult.OK;
             }
 
+            if (rguidLogicalView == DebugPageLogicalViewGuid)
+            {
+                // The UI should be launched with the "debug" page selected.
+                return HResult.OK;
+            }
+
             // We may also be called with other GUIDs for specific pages in the UI. Rather than list them all here,
             // just return success.
+
             // TODO determine whether we can handle those GUIDs in the new experience or not and potentially change this to return NotImplemented.
             return HResult.OK;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/ProjectProperties/ProjectPropertiesEditorFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/ProjectProperties/ProjectPropertiesEditorFactory.cs
@@ -51,8 +51,9 @@ namespace Microsoft.VisualStudio.Packaging
             out Guid pguidCmdUI,
             out int pgrfCDW)
         {
-            // TODO mouse wait cursor throughout this operation
             // TODO try/catch all this (dispose things created here as needed)
+
+            using var _ = new WaitCursor();
 
             UIThreadHelper.VerifyOnUIThread();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/ProjectProperties/ProjectPropertiesEditorFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/ProjectProperties/ProjectPropertiesEditorFactory.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using Microsoft.VisualStudio.ProjectSystem.VS;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using IServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
@@ -53,9 +54,7 @@ namespace Microsoft.VisualStudio.Packaging
             // TODO mouse wait cursor throughout this operation
             // TODO try/catch all this (dispose things created here as needed)
 
-#pragma warning disable RS0030 // Do not used banned APIs
-            ThreadHelper.ThrowIfNotOnUIThread();
-#pragma warning restore RS0030 // Do not used banned APIs
+            UIThreadHelper.VerifyOnUIThread();
 
             ppunkDocView = IntPtr.Zero;
             ppunkDocData = IntPtr.Zero;
@@ -150,9 +149,7 @@ namespace Microsoft.VisualStudio.Packaging
 
             protected override void OnCreate()
             {
-#pragma warning disable RS0030 // Do not used banned APIs
-                ThreadHelper.ThrowIfNotOnUIThread();
-#pragma warning restore RS0030 // Do not used banned APIs
+                UIThreadHelper.VerifyOnUIThread();
 
                 base.OnCreate();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Utilities/WaitCursor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/Utilities/WaitCursor.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Windows.Forms;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
+{
+    /// <summary>
+    /// Sets the mouse cursor to <see cref="Cursors.WaitCursor"/> within a given scope,
+    /// returning the cursor to its previous icon when disposed.
+    /// </summary>
+    internal sealed class WaitCursor : IDisposable
+    {
+        private Cursor? _previousCursor;
+
+        public WaitCursor()
+        {
+            _previousCursor = Cursor.Current;
+            Cursor.Current = Cursors.WaitCursor;
+        }
+
+        public void Dispose()
+        {
+            if (_previousCursor != null)
+            {
+                Cursor.Current = _previousCursor;
+                _previousCursor = null;
+            }
+            else
+            {
+                Cursor.Current = Cursors.Default;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/VSPackage.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/VSPackage.resx
@@ -1,0 +1,124 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="1100" xml:space="preserve">
+    <value>Project Properties Designer</value>
+    <comment>Used for the project properties designer in the shell UI.</comment>
+  </data>
+</root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.cs.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../VSPackage.resx">
+    <body>
+      <trans-unit id="1100">
+        <source>Project Properties Designer</source>
+        <target state="new">Project Properties Designer</target>
+        <note>Used for the project properties designer in the shell UI.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.de.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../VSPackage.resx">
+    <body>
+      <trans-unit id="1100">
+        <source>Project Properties Designer</source>
+        <target state="new">Project Properties Designer</target>
+        <note>Used for the project properties designer in the shell UI.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.es.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../VSPackage.resx">
+    <body>
+      <trans-unit id="1100">
+        <source>Project Properties Designer</source>
+        <target state="new">Project Properties Designer</target>
+        <note>Used for the project properties designer in the shell UI.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.fr.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../VSPackage.resx">
+    <body>
+      <trans-unit id="1100">
+        <source>Project Properties Designer</source>
+        <target state="new">Project Properties Designer</target>
+        <note>Used for the project properties designer in the shell UI.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.it.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../VSPackage.resx">
+    <body>
+      <trans-unit id="1100">
+        <source>Project Properties Designer</source>
+        <target state="new">Project Properties Designer</target>
+        <note>Used for the project properties designer in the shell UI.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.ja.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../VSPackage.resx">
+    <body>
+      <trans-unit id="1100">
+        <source>Project Properties Designer</source>
+        <target state="new">Project Properties Designer</target>
+        <note>Used for the project properties designer in the shell UI.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.ko.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../VSPackage.resx">
+    <body>
+      <trans-unit id="1100">
+        <source>Project Properties Designer</source>
+        <target state="new">Project Properties Designer</target>
+        <note>Used for the project properties designer in the shell UI.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.pl.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../VSPackage.resx">
+    <body>
+      <trans-unit id="1100">
+        <source>Project Properties Designer</source>
+        <target state="new">Project Properties Designer</target>
+        <note>Used for the project properties designer in the shell UI.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.pt-BR.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../VSPackage.resx">
+    <body>
+      <trans-unit id="1100">
+        <source>Project Properties Designer</source>
+        <target state="new">Project Properties Designer</target>
+        <note>Used for the project properties designer in the shell UI.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.ru.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../VSPackage.resx">
+    <body>
+      <trans-unit id="1100">
+        <source>Project Properties Designer</source>
+        <target state="new">Project Properties Designer</target>
+        <note>Used for the project properties designer in the shell UI.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.tr.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../VSPackage.resx">
+    <body>
+      <trans-unit id="1100">
+        <source>Project Properties Designer</source>
+        <target state="new">Project Properties Designer</target>
+        <note>Used for the project properties designer in the shell UI.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.zh-Hans.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../VSPackage.resx">
+    <body>
+      <trans-unit id="1100">
+        <source>Project Properties Designer</source>
+        <target state="new">Project Properties Designer</target>
+        <note>Used for the project properties designer in the shell UI.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/xlf/VSPackage.zh-Hant.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../VSPackage.resx">
+    <body>
+      <trans-unit id="1100">
+        <source>Project Properties Designer</source>
+        <target state="new">Project Properties Designer</target>
+        <note>Used for the project properties designer in the shell UI.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
Creates an editor factory that shows a placeholder UI when created.

This editor factory uses the well-known GUID for the project properties editor. The 'legacy' editor is given a new GUID. The intention is to introduce a feature flag or other mechanism to conditionally delegate to the legacy implementation.

![editor-factory](https://user-images.githubusercontent.com/350947/87895849-dae51d00-ca89-11ea-99d2-60696fac131f.gif)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6394)