### PR TITLE
Fix debug target query in non-launch scenario

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             try
             {
                 // Launch providers to enforce requirements for debuggable projects
-                await QueryDebugTargetsInternalAsync(launchOptions, fromDebugLaunch: true);
+                await QueryDebugTargetsInternalAsync(launchOptions, fromDebugLaunch: false);
             }
             catch (ProjectNotRunnableDirectlyException)
             {
@@ -90,6 +90,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// This is called on F5 to return the list of debug targets. What is returned depends on the debug provider extensions
         /// which understands how to launch the currently active profile type. 
         /// </summary>
+        /// <param name="launchOptions"></param>
+        /// <param name="fromDebugLaunch">
+        /// <see langword="true"/> if the query is occurring as part of a launch operation, or <see langword="false"/> if no
+        /// launch will immediately follow this query.
+        /// </param>
         private async Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsInternalAsync(DebugLaunchOptions launchOptions, bool fromDebugLaunch)
         {
             // Get the active debug profile (timeout of 5s, though in reality is should never take this long as even in error conditions


### PR DESCRIPTION
Fixes [AB#1158301](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1158301).

Commit 5f85e2c5e5a9c8a3d00f64665b717a296092f803 introduced a bug where the querying of debug targets by `IsProjectDebuggableAsync` was passing a flag that indicated the query occurred as part of a debug launch operation.

This flag caused WebTools to launch a debugger on many actions which are unrelated to debugging:

![d0dec3c0-41b1-4557-b6f2-acb176722baa](https://user-images.githubusercontent.com/350947/87994358-16d2bd80-cb30-11ea-9a14-a79382f01c72.gif)

Thanks @BillHiebert for finding the root cause here.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6401)