### PR TITLE
Fire launch completion when there are no debug targets

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
@@ -165,6 +165,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             VsDebugTargetInfo4[] launchSettingsNative = launchSettings.Select(GetDebuggerStruct4).ToArray();
             if (launchSettingsNative.Length == 0)
             {
+                cb.OnComplete(0, 0, null);
                 return;
             }
 


### PR DESCRIPTION
Some scenarios do the launch entirely through the Before and After launch hooks, but have no actual debug targets to launch.
This updates the async launch implementation to manually invoke the after launch completion handler if there were no actual debug targets to launch.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6412)