### PR TITLE
Set initial AppliedValue to avoid hangs waiting on this

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridge.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridge.cs
@@ -106,6 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         /// </summary>
         protected override Task InitializeInnerCoreAsync(CancellationToken cancellationToken)
         {
+            AppliedValue = new ProjectVersionedValue<DesignTimeInputsDelta>(new DesignTimeInputsDelta(ImmutableHashSet.Create<string>(), ImmutableHashSet.Create<string>(), Enumerable.Empty<DesignTimeInputFileChange>(), ""), ImmutableDictionary.Create<NamedIdentity, IComparable>());
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
This pr adds a default initial value similar to [InitializeInnerCoreAsync](http://index/?leftProject=Microsoft.VisualStudio.ProjectSystem.VS&leftSymbol=faheqpyvnq9v&rightProject=Microsoft.VisualStudio.ProjectSystem.VS.Implementation&file=Package%5CReferencesHostBridge.cs&line=362)() in `ReferencesHostBridge`

Avoid [waiting](http://index/?rightProject=Microsoft.VisualStudio.ProjectSystem.VS&file=Package%5cProjectHostBridge.cs&line=271) in   `ReferencesHostBridge.InitializeInnerCoreAsync()` 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6415)