### PR TITLE
Fix root graft tree provider GetPath logic

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -70,6 +70,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
             _unconfiguredProjectTasksService = unconfiguredProjectTasksService;
         }
 
+        public override string? GetPath(IProjectTree node)
+        {
+            // Only process nodes belonging to our tree.
+            // This test excludes the root which is fine as it doesn't have a file path.
+            if (node.Flags.Contains(ProjectImport))
+            {
+                return node.FilePath;
+            }
+
+            return null;
+        }
+
         public bool ShowAllFiles
         {
             get => _showAllFiles;


### PR DESCRIPTION
Fixes #6420.

Root graft project tree providers should only return a value for `GetPath` for tree nodes that they own. Previously the assumption was that this method was only passed its own descendants, but this is not the case.

This fixes a problem where, when the Dependencies tree was not enabled, the "Copy Full Path" command on import tree items would result in the pseudo-path (">123") being copied rather than the actual file path.

---

In a nanoFramework project:

## Before

![image](https://user-images.githubusercontent.com/350947/88283985-ece7e980-cd2f-11ea-89b7-7aaa87004e6a.png)

Note item appears expanded (by arrow direction) but no child is visible.

"Copy Full Path" produces: `D:\repos\NFApp1\NFApp1\>34`, where `>34` is the item ID

## After

![image](https://user-images.githubusercontent.com/350947/88284115-2f112b00-cd30-11ea-8fce-4c5e3f0a8be7.png)

"Copy Full Path" produces: `C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview-master\MSBuild\nanoFramework\v1.0\NFProjectSystem.Default.props`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6424)