### PR TITLE
Enable/resource editor codespaces client

### DIFF
--- a/setup/VisualStudioEditorsSetup/source.extension.vsixmanifest
+++ b/setup/VisualStudioEditorsSetup/source.extension.vsixmanifest
@@ -5,6 +5,7 @@
     <DisplayName>VisualStudio Editors</DisplayName>
     <Description>Microsoft VisualStudio Editors</Description>
     <PackageId>Microsoft.VisualStudio.Editors</PackageId>
+    <AllowClientRole>true</AllowClientRole>
   </Metadata>
   <Installation SystemComponent="true" Experimental="true">
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.Pro" />


### PR DESCRIPTION
This fixes [AzDO 114688](https://dev.azure.com/devdiv/DevDiv/_queries/edit/1146188/)  

To open a resource file using the resx designer, `CreateEditorInstance `in  DotNet ProjectSystem Microsoft.VisualStudio.Editors uses the service `DesignerActivationService `provided by `VSDesignerActivationPackage`. For this, another pr in VS is needed to make the service (Microsoft.VisualStudio.Design.dll) available for codespaces client.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6429)