### PR TITLE
Test if we can cancel Teams notifications going to a certain branch

### DIFF
--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Notify
         uses: davidwengier/PostAdaptiveCard@v1.0.1
-        if: github.repository == 'dotnet/project-system' && github.base_ref == 'refs/heads/dotnet/master'
+        if: github.repository == 'dotnet/project-system' && github.base_ref == '*master*'
         with:
           webhook-uri: https://outlook.office.com/webhook/4ba7372f-2799-4677-89f0-7a1aaea3706c@72f988bf-86f1-41af-91ab-2d7cd011db47/IncomingWebhook/461ee56585254d63b67f15afdf6a1513/b4e5dfd6-185f-4aed-90e3-aa15b6f398ba
 

--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Notify
         uses: davidwengier/PostAdaptiveCard@v1.0.1
-        if: github.repository == 'dotnet/project-system' && github.base_ref != 'refs/heads/dotnet:master'
+        if: github.repository == 'dotnet/project-system' && github.base_ref == 'refs/heads/dotnet/master'
         with:
           webhook-uri: https://outlook.office.com/webhook/4ba7372f-2799-4677-89f0-7a1aaea3706c@72f988bf-86f1-41af-91ab-2d7cd011db47/IncomingWebhook/461ee56585254d63b67f15afdf6a1513/b4e5dfd6-185f-4aed-90e3-aa15b6f398ba
 

--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Notify
         uses: davidwengier/PostAdaptiveCard@v1.0.1
-        if: github.repository == 'dotnet/project-system' && github.base_ref == '*master*'
+        if: github.repository == 'dotnet/project-system' && github.event.base.ref == "master"
         with:
           webhook-uri: https://outlook.office.com/webhook/4ba7372f-2799-4677-89f0-7a1aaea3706c@72f988bf-86f1-41af-91ab-2d7cd011db47/IncomingWebhook/461ee56585254d63b67f15afdf6a1513/b4e5dfd6-185f-4aed-90e3-aa15b6f398ba
 

--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - name: Notify
         uses: davidwengier/PostAdaptiveCard@v1.0.1
-        if: github.repository == 'dotnet/project-system'
+        #TODO this ref should target feature branch --> or maybe I need to use github.ref != 'refs/heads/feature/*' (this is just to test out)
+        if: github.repository == 'dotnet/project-system' && github.ref != 'refs/heads/master' #github.ref != 'refs/heads/feature/*' #we don't want to notify when the PR is coming
         with:
           webhook-uri: https://outlook.office.com/webhook/4ba7372f-2799-4677-89f0-7a1aaea3706c@72f988bf-86f1-41af-91ab-2d7cd011db47/IncomingWebhook/461ee56585254d63b67f15afdf6a1513/b4e5dfd6-185f-4aed-90e3-aa15b6f398ba

--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Notify
         uses: davidwengier/PostAdaptiveCard@v1.0.1
-        if: github.repository == 'dotnet/project-system' && github.ref == 'refs/heads/master' && github.base_ref == 'refs/heads/master'
+        if: github.repository == 'dotnet/project-system' && github.base_ref != 'refs/heads/master'
         with:
           webhook-uri: https://outlook.office.com/webhook/4ba7372f-2799-4677-89f0-7a1aaea3706c@72f988bf-86f1-41af-91ab-2d7cd011db47/IncomingWebhook/461ee56585254d63b67f15afdf6a1513/b4e5dfd6-185f-4aed-90e3-aa15b6f398ba
 

--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -13,7 +13,8 @@ jobs:
     steps:
       - name: Notify
         uses: davidwengier/PostAdaptiveCard@v1.0.1
-        #TODO this ref should target feature branch --> or maybe I need to use github.ref != 'refs/heads/feature/*' (this is just to test out)
-        if: github.repository == 'dotnet/project-system' && github.base_ref != 'refs/heads/master' #github.ref != 'refs/heads/feature/*' #we don't want to notify when the PR is coming
+        if: github.repository == 'dotnet/project-system' && github.ref == 'refs/heads/master' && github.base_ref == 'refs/heads/master'
         with:
           webhook-uri: https://outlook.office.com/webhook/4ba7372f-2799-4677-89f0-7a1aaea3706c@72f988bf-86f1-41af-91ab-2d7cd011db47/IncomingWebhook/461ee56585254d63b67f15afdf6a1513/b4e5dfd6-185f-4aed-90e3-aa15b6f398ba
+
+#TODO this ref should target feature branch --> or maybe I need to use github.ref != 'refs/heads/feature/*' (this is just to test out)

--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Notify
         uses: davidwengier/PostAdaptiveCard@v1.0.1
-        if: github.repository == 'dotnet/project-system' && github.base_ref != 'refs/heads/master'
+        if: github.repository == 'dotnet/project-system' && github.base_ref != 'refs/heads/dotnet:master'
         with:
           webhook-uri: https://outlook.office.com/webhook/4ba7372f-2799-4677-89f0-7a1aaea3706c@72f988bf-86f1-41af-91ab-2d7cd011db47/IncomingWebhook/461ee56585254d63b67f15afdf6a1513/b4e5dfd6-185f-4aed-90e3-aa15b6f398ba
 

--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Notify
         uses: davidwengier/PostAdaptiveCard@v1.0.1
         #TODO this ref should target feature branch --> or maybe I need to use github.ref != 'refs/heads/feature/*' (this is just to test out)
-        if: github.repository == 'dotnet/project-system' && github.ref != 'refs/heads/master' #github.ref != 'refs/heads/feature/*' #we don't want to notify when the PR is coming
+        if: github.repository == 'dotnet/project-system' && github.base_ref != 'refs/heads/master' #github.ref != 'refs/heads/feature/*' #we don't want to notify when the PR is coming
         with:
           webhook-uri: https://outlook.office.com/webhook/4ba7372f-2799-4677-89f0-7a1aaea3706c@72f988bf-86f1-41af-91ab-2d7cd011db47/IncomingWebhook/461ee56585254d63b67f15afdf6a1513/b4e5dfd6-185f-4aed-90e3-aa15b6f398ba


### PR DESCRIPTION
We'd like to avoid getting notifications from automatic merges going from master into feature/* branches

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6431)