### PR TITLE
Fix crash in VS while searching in Solution Explorer

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateRelationCollectionSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateRelationCollectionSource.cs
@@ -3,8 +3,6 @@
 using System;
 using System.Collections;
 using System.ComponentModel;
-using System.Windows.Data;
-using Microsoft.Internal.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Microsoft.VisualStudio.Shell;
 
@@ -75,55 +73,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                 PropertyChanged?.Invoke(this, KnownEventArgs.HasItemsPropertyChanged);
             };
 
-            // Work around inconsistent use of IPrioritizedComparable in the tree view control
-            // https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1158136
-            if (CollectionViewSource.GetDefaultView(_collection) is ListCollectionView view)
-            {
-                view.CustomSort = PrioritizedComparableComparer.Instance;
-            }
-
             PropertyChanged?.Invoke(this, KnownEventArgs.IsUpdatingItemsPropertyChanged);
             PropertyChanged?.Invoke(this, KnownEventArgs.HasItemsPropertyChanged);
-        }
-
-        private sealed class PrioritizedComparableComparer : IComparer
-        {
-            public static IComparer Instance { get; } = new PrioritizedComparableComparer();
-
-            public int Compare(object x, object y)
-            {
-                if (x == null || y == null)
-                {
-                    // We don't expect nulls
-                    return 0;
-                }
-
-                // Handle prioritized comparison
-                if (x is IPrioritizedComparable comparable1 && y is IPrioritizedComparable comparable2)
-                {
-                    int order = comparable1.Priority.CompareTo(comparable2.Priority);
-
-                    if (order != 0)
-                    {
-                        return order;
-                    }
-
-                    return comparable1.CompareTo(comparable2);
-                }
-
-                // Handle non-prioritized comparison
-                if (x is IComparable item1 && y is IComparable item2)
-                {
-                    int order = item1.CompareTo(item2);
-
-                    if (order != 0)
-                    {
-                        return order;
-                    }
-                }
-
-                return 0;
-            }
         }
     }
 }


### PR DESCRIPTION
Fixes #6432.

Reverts #6385 (16.8) in which we attempted to work around a bug in Solution Explorer where `IPrioritizedComparable` does not behave consistently across siblings, meaning that attached tree items do not appear in the correct order.

Unfortunately that workaround introduced an exception here: http://index/?rightProject=Microsoft.VisualStudio.Shell.TreeNavigation.HierarchyProvider&file=Items%5CHierarchyItem.cs&line=2489

The Solution Explorer bug is tracked in [AB#1158136](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1158136)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6434)