### PR TITLE
Remove reference to non-existent rule

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -268,11 +268,6 @@
       <Context>Invisible</Context>
     </PropertyPageSchema>
 
-    <!-- .editorconfig files -->
-    <PropertyPageSchema Include="$(ManagedXamlNeutralResourcesDirectory)PotentialEditorConfigFiles.xaml">
-      <Context>ProjectSubscriptionService</Context>
-    </PropertyPageSchema>
-
   </ItemGroup>
 
   <ItemGroup Condition="'$(DefineCommonManagedReferenceSchemas)' == 'true'">


### PR DESCRIPTION
Usage of this rule was removed in https://github.com/dotnet/project-system/pull/6126.

This would make a good unit test catch, however, I've removed references to rules in the design-time targets in another branch (moving them to exports) and written a different set tests to catch this sort of thing.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6436)