### PR TITLE
Remove DotNetCliToolReference from BrowseObject context

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -346,7 +346,7 @@
 
     <!-- Tool references -->
     <PropertyPageSchema Include="$(ManagedXamlNeutralResourcesDirectory)DotNetCliToolReference.xaml">
-      <Context>ProjectSubscriptionService;BrowseObject</Context>
+      <Context>ProjectSubscriptionService</Context>
     </PropertyPageSchema>
 
     <!-- Analyzer references -->


### PR DESCRIPTION
DotNetCliToolReference do not show up in the project item, and hence does not need a browse object.

These will be caught by the new unit test rules that require BrowseObjects to be localized, which this rule is not.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6437)