### PR TITLE
Fix hang in GetDesignTimeMoniker

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridge.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridge.cs
@@ -67,7 +67,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             DesignTimeInputsDelta value = AppliedValue.Value;
 
-            return await _designTimeInputsCompiler.GetDesignTimeInputXmlAsync(relativeFileName, value.TempPEOutputPath, value.SharedInputs);
+            return string.IsNullOrEmpty(value.TempPEOutputPath) ? string.Empty :
+                await _designTimeInputsCompiler.GetDesignTimeInputXmlAsync(relativeFileName, value.TempPEOutputPath, value.SharedInputs);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
@@ -9,8 +9,6 @@ using System.Linq;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 
-using EmptyCollections = Microsoft.VisualStudio.ProjectSystem.Empty;
-
 namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 {
     [Export(typeof(IDesignTimeInputsChangeTracker))]
@@ -147,17 +145,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             PublishDelta(delta);
         }
 
+        // Should always produce output data to avoid hangs.
         internal void ProcessDataflowChanges(IProjectVersionedValue<ValueTuple<DesignTimeInputs, IProjectSubscriptionUpdate>> input)
         {
-            _currentState = GenerateOutputData(_currentState, input);
-
-            // Processed bad input data
-            if (_currentState is null)
-            {
-                // Lets return a default value to avoid hangs waiting on this.
-                _currentState = new DesignTimeInputsDelta(EmptyCollections.OrdinalStringSet,
-                    EmptyCollections.OrdinalStringSet, Enumerable.Empty<DesignTimeInputFileChange>(), string.Empty);
-            }
+            _currentState = GenerateOutputData(_currentState, input) ?? DesignTimeInputsDelta.Empty;
 
             PublishDelta(_currentState);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsDelta.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsDelta.cs
@@ -2,6 +2,9 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
+
+using EmptyCollections = Microsoft.VisualStudio.ProjectSystem.Empty;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 {
@@ -11,6 +14,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         public ImmutableHashSet<string> SharedInputs { get; }
         public ImmutableArray<DesignTimeInputFileChange> ChangedInputs { get; }
         public string TempPEOutputPath { get; }
+        public static readonly  DesignTimeInputsDelta Empty = new DesignTimeInputsDelta(EmptyCollections.OrdinalStringSet,
+            EmptyCollections.OrdinalStringSet, Enumerable.Empty<DesignTimeInputFileChange>(), string.Empty);
 
         public DesignTimeInputsDelta(ImmutableHashSet<string> inputs, ImmutableHashSet<string> sharedInputs, IEnumerable<DesignTimeInputFileChange> changedInputs, string tempPEOutputPath)
         {


### PR DESCRIPTION
Fixes AzDO 1085702
DesignTimeOutputMonikers calls initializes DesignTimeInputsBuildManagerBridge
that waits (hangs) for AppliedValue to be generated/created.

AppliedValue was not generated when bad input data block arrives and
in here we are producing an empty value that will get assigned
to AppliedValue.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6442)