### PR TITLE
Fix startup show only debuggable projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider3.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider3.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     /// Optional interface that is used to tell whether a project should appear in
     /// the Startup drop down list.
     /// </summary>
-    public interface IDebugProfileLaunchTargetsProvider3
+    internal interface IDebugProfileLaunchTargetsProvider3
     {
         Task<bool> CanBeStartupProjectAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider3.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider3.cs
@@ -6,10 +6,8 @@ using Microsoft.VisualStudio.ProjectSystem.Debug;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 {
     /// <summary>
-    /// Optional interface that can be cast from IDebugProfileLaunchTargetsProvider for those implementations which need to distinguish
-    /// calls to QueryDebugTargetsAsync that originate from IVsDebuggableProjectCfg:QueryDebugTargets, from calls that originate from 
-    /// IVsDebuggableProjectCfg:DebugLaunch. If this interface is implemented, calls that originate from a debugLaunch will call 
-    /// QueryDebugTargetsForDebugLaunchAsync(). Calls from QueryDebugTargets will call IDebugProfileLaunchTargetsProvider:QueryDebugTargetsAsync
+    /// Optional interface that is used to tell whether a project should appear in
+    /// the Startup drop down list.
     /// </summary>
     public interface IDebugProfileLaunchTargetsProvider3
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider3.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider3.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     /// Optional interface that is used to tell whether a project should appear in
     /// the Startup drop down list.
     /// </summary>
-    internal interface IDebugProfileLaunchTargetsProvider3
+    public interface IDebugProfileLaunchTargetsProvider3
     {
         Task<bool> CanBeStartupProjectAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider3.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider3.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
+{
+    /// <summary>
+    /// Optional interface that can be cast from IDebugProfileLaunchTargetsProvider for those implementations which need to distinguish
+    /// calls to QueryDebugTargetsAsync that originate from IVsDebuggableProjectCfg:QueryDebugTargets, from calls that originate from 
+    /// IVsDebuggableProjectCfg:DebugLaunch. If this interface is implemented, calls that originate from a debugLaunch will call 
+    /// QueryDebugTargetsForDebugLaunchAsync(). Calls from QueryDebugTargets will call IDebugProfileLaunchTargetsProvider:QueryDebugTargetsAsync
+    /// </summary>
+    public interface IDebugProfileLaunchTargetsProvider3
+    {
+        Task<bool> CanBeStartupProjectAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IStartupProjectProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IStartupProjectProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     /// Interface definition used by StartupProjectRegistrar to display only debuggable projects
     /// </summary>
     [ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Extension)]
-    public interface IStartupProjectProvider
+    internal interface IStartupProjectProvider
     {
         /// <summary>
         /// Returns true if this project can be selected as a startup project.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IStartupProjectProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IStartupProjectProvider.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
+{
+    /// <summary>
+    /// Interface definition used by StartupProjectRegistrar to display only debuggable projects
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Extension)]
+    public interface IStartupProjectProvider
+    {
+        /// <summary>
+        /// Returns true if this project can be selected as a startup project.
+        /// </summary>
+        Task<bool> CanBeStartupProjectAsync(DebugLaunchOptions launchOptions);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
@@ -63,8 +63,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 ILaunchProfile activeProfile = await GetActiveProfileAsync();
 
                 // Now find the DebugTargets provider for this profile
-                IDebugProfileLaunchTargetsProvider launchProvider =
-                    GetLaunchTargetsProvider(activeProfile) ?? throw new Exception();
+                IDebugProfileLaunchTargetsProvider? launchProvider = GetLaunchTargetsProvider(activeProfile);
+                if (launchProvider is null)
+                {
+                    return true;
+                }
 
                 if (launchProvider is IDebugProfileLaunchTargetsProvider3 provider3)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     /// </summary>
     [ExportDebugger(ProjectDebugger.SchemaName)]
     [AppliesTo(ProjectCapability.LaunchProfiles)]
-    internal class LaunchProfilesDebugLaunchProvider : DebugLaunchProviderBase, IDeployedProjectItemMappingProvider
+    internal class LaunchProfilesDebugLaunchProvider : DebugLaunchProviderBase, IDeployedProjectItemMappingProvider, IStartupProjectProvider
     {
         private readonly IVsService<IVsDebuggerLaunchAsync> _vsDebuggerService;
         private readonly ILaunchSettingsProvider _launchSettingsProvider;
@@ -54,19 +54,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         /// <summary>
-        /// This is called to query the list of debug targets  
+        /// Called by StartupProjectRegistrar to determine whether this project should appear in the Startup list.
         /// </summary>
-        public override Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsAsync(DebugLaunchOptions launchOptions)
+        public async Task<bool> CanBeStartupProjectAsync(DebugLaunchOptions launchOptions)
         {
-            return QueryDebugTargetsInternalAsync(launchOptions, fromDebugLaunch: false);
+            try
+            {
+                ILaunchProfile activeProfile = await GetActiveProfileAsync();
+
+                // Now find the DebugTargets provider for this profile
+                IDebugProfileLaunchTargetsProvider launchProvider =
+                    GetLaunchTargetsProvider(activeProfile) ?? throw new Exception();
+
+                if (launchProvider is IDebugProfileLaunchTargetsProvider3 provider3)
+                {
+                    return await provider3.CanBeStartupProjectAsync(launchOptions, activeProfile);
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            // Maintain backwards compat
+            return true;
         }
 
-        /// <summary>
-        /// This is called on F5 to return the list of debug targets. What is returned depends on the debug provider extensions
-        /// which understands how to launch the currently active profile type. 
-        /// </summary>
-        private async Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsInternalAsync(DebugLaunchOptions launchOptions, bool fromDebugLaunch)
+        private async Task<ILaunchProfile> GetActiveProfileAsync()
         {
+            // Launch providers to enforce requirements for debuggable projects
             // Get the active debug profile (timeout of 5s, though in reality is should never take this long as even in error conditions
             // a snapshot is produced).
             ILaunchSettings currentProfiles = await _launchSettingsProvider.WaitForFirstSnapshot(5000);
@@ -77,6 +92,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             {
                 throw new Exception(VSResources.ActiveLaunchProfileNotFound);
             }
+
+            return activeProfile;
+        }
+
+        /// <summary>
+        /// This is called to query the list of debug targets
+        /// </summary>
+        public override Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsAsync(DebugLaunchOptions launchOptions)
+        {
+            return QueryDebugTargetsInternalAsync(launchOptions, fromDebugLaunch: false);
+        }
+
+        /// <summary>
+        /// This is called on F5 to return the list of debug targets. What is returned depends on the debug provider extensions
+        /// which understands how to launch the currently active profile type.
+        /// </summary>
+        private async Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsInternalAsync(DebugLaunchOptions launchOptions, bool fromDebugLaunch)
+        {
+            ILaunchProfile activeProfile = await GetActiveProfileAsync();
 
             // Now find the DebugTargets provider for this profile
             IDebugProfileLaunchTargetsProvider launchProvider = GetLaunchTargetsProvider(activeProfile) ??

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -133,7 +133,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             return true;
         }
 
-
         public Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsForDebugLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile activeProfile)
         {
             return QueryDebugTargetsAsync(launchOptions, activeProfile, validateSettings: true);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     [Export(typeof(IDebugProfileLaunchTargetsProvider))]
     [AppliesTo(ProjectCapability.LaunchProfiles)]
     [Order(Order.Default)] // The higher the number the higher priority and we want this one last
-    internal class ProjectLaunchTargetsProvider : IDebugProfileLaunchTargetsProvider, IDebugProfileLaunchTargetsProvider2
+    internal class ProjectLaunchTargetsProvider : IDebugProfileLaunchTargetsProvider, IDebugProfileLaunchTargetsProvider2, IDebugProfileLaunchTargetsProvider3
     {
         private static readonly char[] s_escapedChars = new[] { '^', '<', '>', '&' };
         private readonly ConfiguredProject _project;
@@ -115,6 +115,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             return StringComparers.PropertyLiteralValues.Equals(actualOutputType.Name, outputType);
         }
+
+        public async Task<bool> CanBeStartupProjectAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile)
+        {
+            try
+            {
+                _ = await QueryDebugTargetsForDebugLaunchAsync(launchOptions, profile);
+            }
+            catch (ProjectNotRunnableDirectlyException)
+            {
+                return false;
+            }
+            catch (Exception)
+            {
+            }
+
+            return true;
+        }
+
 
         public Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsForDebugLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile activeProfile)
         {
@@ -433,7 +451,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 // If we're launching for debug purposes, prevent someone F5'ing a class library
                 if (validateSettings && await IsClassLibraryAsync())
                 {
-                    throw new Exception(VSResources.ProjectNotRunnableDirectly);
+                    throw new ProjectNotRunnableDirectlyException();
                 }
 
                 // Otherwise, fall back to "TargetPath"
@@ -641,6 +659,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         private enum StringState
         {
             NormalCharacter, EscapedCharacter, QuotedString, QuotedStringEscapedCharacter
+        }
+    }
+
+    internal class ProjectNotRunnableDirectlyException : Exception
+    {
+        public ProjectNotRunnableDirectlyException()
+            :this(VSResources.ProjectNotRunnableDirectly)
+        {
+        }
+
+        public ProjectNotRunnableDirectlyException(string message)
+            : base(message)
+        {
+        }
+
+        public ProjectNotRunnableDirectlyException(string message, Exception inner)
+            : base(message, inner)
+        {
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -97,7 +97,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             foreach (Lazy<IDebugLaunchProvider> provider in _launchProviders.Values)
             {
-                if (await provider.Value.CanLaunchAsync(DebugLaunchOptions.DesignTimeExpressionEvaluation))
+                if (provider.Value is IStartupProjectProvider startupProjectProvider &&
+                    await startupProjectProvider.CanBeStartupProjectAsync(DebugLaunchOptions.DesignTimeExpressionEvaluation))
                 {
                     return true;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugProfileLaunchTargetsProvider3
+Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugProfileLaunchTargetsProvider3.CanBeStartupProjectAsync(Microsoft.VisualStudio.ProjectSystem.Debug.DebugLaunchOptions launchOptions, Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile! profile) -> System.Threading.Tasks.Task<bool>!

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -111,6 +111,7 @@
                           UserSourceItems;
                           SupportAvailableItemName;
                           IntegratedConsoleDebugging;
+                          DisableBuiltInDebuggerServices;
                           PersistDesignTimeDataOutOfProject;" />
 
     <!-- COM references are not supported in .NET Core before 3.0 -->

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderFactory.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
     }
 
-    public interface IDebugLaunchProviderMock : IDebugLaunchProvider, IStartupProjectProvider
+    internal interface IDebugLaunchProviderMock : IDebugLaunchProvider, IStartupProjectProvider
     {
 
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderFactory.cs
@@ -1,20 +1,26 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
+using Microsoft.VisualStudio.ProjectSystem.VS.Debug;
 using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     public static class IDebugLaunchProviderFactory
     {
-        public static IDebugLaunchProvider ImplementCanLaunchAsync(Func<bool> action)
+        public static IDebugLaunchProvider ImplementIsProjectDebuggableAsync(Func<bool> action)
         {
-            var mock = new Mock<IDebugLaunchProvider>();
+            var mock = new Mock<IDebugLaunchProviderMock>();
 
-            mock.Setup(d => d.CanLaunchAsync(It.IsAny<DebugLaunchOptions>()))
+            mock.Setup(d => d.CanBeStartupProjectAsync(It.IsAny<DebugLaunchOptions>()))
                                 .ReturnsAsync(action);
 
             return mock.Object;
         }
+    }
+
+    public interface IDebugLaunchProviderMock : IDebugLaunchProvider, IStartupProjectProvider
+    {
+
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProviderTests.cs
@@ -16,6 +16,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         private readonly Mock<IDebugProfileLaunchTargetsProvider> _mockExeProvider = new Mock<IDebugProfileLaunchTargetsProvider>();
         private readonly OrderPrecedenceImportCollection<IDebugProfileLaunchTargetsProvider> _launchProviders =
             new OrderPrecedenceImportCollection<IDebugProfileLaunchTargetsProvider>(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst);
+
+        private readonly IProjectThreadingService _threadingService = IProjectThreadingServiceFactory.Create();
+
         private readonly Mock<ConfiguredProject> _configuredProjectMoq = new Mock<ConfiguredProject>();
         private readonly Mock<ILaunchSettingsProvider> _LaunchSettingsProviderMoq = new Mock<ILaunchSettingsProvider>();
         private readonly List<IDebugLaunchSettings> _webProviderSettings = new List<IDebugLaunchSettings>();
@@ -63,12 +66,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Fact]
-        public void GetLaunchTargetsProviderForProfileTests()
+        public void GetLaunchTargetsProviderForProfileTestsAsync()
         {
             var provider = CreateInstance();
-            Assert.Equal(_mockWebProvider.Object, provider.GetLaunchTargetsProvider(new LaunchProfile() { Name = "test", CommandName = "IISExpress" }));
-            Assert.Equal(_mockDockerProvider.Object, provider.GetLaunchTargetsProvider(new LaunchProfile() { Name = "test", CommandName = "Docker" }));
-            Assert.Equal(_mockExeProvider.Object, provider.GetLaunchTargetsProvider(new LaunchProfile() { Name = "test", CommandName = "Project" }));
+            Assert.Equal(_mockWebProvider.Object,  provider.GetLaunchTargetsProvider(new LaunchProfile() { Name = "test", CommandName = "IISExpress" }));
+            Assert.Equal(_mockDockerProvider.Object,  provider.GetLaunchTargetsProvider(new LaunchProfile() { Name = "test", CommandName = "Docker" }));
+            Assert.Equal(_mockExeProvider.Object,  provider.GetLaunchTargetsProvider(new LaunchProfile() { Name = "test", CommandName = "Project" }));
             Assert.Null(provider.GetLaunchTargetsProvider(new LaunchProfile() { Name = "test", CommandName = "IIS" }));
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -378,7 +378,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
 
-            await Assert.ThrowsAsync<Exception>(() =>
+            await Assert.ThrowsAsync<ProjectNotRunnableDirectlyException>(() =>
             {
                 return debugger.QueryDebugTargetsForDebugLaunchAsync(0, activeProfile);
             });

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public async Task OnProjectChanged_WhenNotDebuggable_ProjectNotRegistered()
         {
             var vsStartupProjectsListService = new VsStartupProjectsListService();
-            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => false);
+            var debugProvider = IDebugLaunchProviderFactory.ImplementIsProjectDebuggableAsync(() => false);
             var registrar = await CreateInitializedInstanceAsync(vsStartupProjectsListService, debugProvider);
 
             await registrar.OnProjectChangedAsync();
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             var projectGuid = Guid.NewGuid();
             var vsStartupProjectsListService = new VsStartupProjectsListService();
-            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => true);
+            var debugProvider = IDebugLaunchProviderFactory.ImplementIsProjectDebuggableAsync(() => true);
             var registrar = await CreateInitializedInstanceAsync(projectGuid, vsStartupProjectsListService, debugProvider);
 
             await registrar.OnProjectChangedAsync();
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             var projectGuid = Guid.NewGuid();
             var vsStartupProjectsListService = new VsStartupProjectsListService();
-            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => true);
+            var debugProvider = IDebugLaunchProviderFactory.ImplementIsProjectDebuggableAsync(() => true);
             var registrar = await CreateInitializedInstanceAsync(projectGuid, vsStartupProjectsListService, debugProvider);
 
             await registrar.OnProjectChangedAsync();
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public async Task OnProjectChanged_WhenProjectNotRegisteredAndNotDebuggable_RemainsUnregistered()
         {
             var vsStartupProjectsListService = new VsStartupProjectsListService();
-            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => false);
+            var debugProvider = IDebugLaunchProviderFactory.ImplementIsProjectDebuggableAsync(() => false);
             var registrar = await CreateInitializedInstanceAsync(vsStartupProjectsListService, debugProvider);
 
             await registrar.OnProjectChangedAsync();
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             bool isDebuggable = true;
             var projectGuid = Guid.NewGuid();
             var vsStartupProjectsListService = new VsStartupProjectsListService();
-            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => isDebuggable);
+            var debugProvider = IDebugLaunchProviderFactory.ImplementIsProjectDebuggableAsync(() => isDebuggable);
             var registrar = await CreateInitializedInstanceAsync(projectGuid, vsStartupProjectsListService, debugProvider);
 
             await registrar.OnProjectChangedAsync();
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             bool isDebuggable = false;
             var projectGuid = Guid.NewGuid();
             var vsStartupProjectsListService = new VsStartupProjectsListService();
-            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => isDebuggable);
+            var debugProvider = IDebugLaunchProviderFactory.ImplementIsProjectDebuggableAsync(() => isDebuggable);
             var registrar = await CreateInitializedInstanceAsync(projectGuid, vsStartupProjectsListService, debugProvider);
 
             await registrar.OnProjectChangedAsync();
@@ -129,8 +129,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             var projectGuid = Guid.NewGuid();
             var vsStartupProjectsListService = new VsStartupProjectsListService();
-            var debugProvider1 = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => false);
-            var debugProvider2 = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => true);
+            var debugProvider1 = IDebugLaunchProviderFactory.ImplementIsProjectDebuggableAsync(() => false);
+            var debugProvider2 = IDebugLaunchProviderFactory.ImplementIsProjectDebuggableAsync(() => true);
 
             var registrar = await CreateInitializedInstanceAsync(projectGuid, vsStartupProjectsListService, debugProvider1, debugProvider2);
 


### PR DESCRIPTION
This pr fixes #1308

The Startup project was showing NetCore Libraries which overwhelm users when using VS with large projects. This bug was not about whether Libraries should be in Startup or not, but to decide which projects are non-debuggable and only display debuggables.

Added the project capability `DisableBuiltInDebuggerServices `to disable CPS debuggers services for managed projects.

Implemented the missing functionality in `CanLaunch`() to decide which projects should appear in the Startup list.
The logic to decide if a project is non-debuggable is in `LaunchProfilesDebugLaunchProvider`

Fixed unit tests

By default, classes that do not implement `IDebugProfileLaunchTargetsProvider3 `will appear in the Startup drop down list.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6443)