### PR TITLE
adding TargetPlatformMinVersion to configuration

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -138,6 +138,14 @@
                   Visible="False" />
 
 
+  <StringProperty Name="TargetPlatformMoniker"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="TargetPlatformMinVersion"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <StringProperty Name="TreatWarningsAsErrors"
                   ReadOnly="True"
                   Visible="False" />


### PR DESCRIPTION
See https://github.com/dotnet/designs/blob/master/accepted/2020/net5/net5.md#lighting-up-on-later-os-versions

I believe this is all that's needed to have the project system thread this value through? I think this covers everything we need, now. /cc @nkolev92 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6447)