### PR TITLE
Remove unneeded data sources from properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -110,64 +110,33 @@
                   Visible="False" />
 
   <StringProperty Name="TargetFramework"
-                  Visible="False">
-    <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False"
-                  PersistedName="TargetFramework"
-                  Persistence="ProjectFile"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+                  ReadOnly="True"
+                  Visible="False" />
+
 
   <StringProperty Name="TargetFrameworkIdentifier"
-                  Visible="False">
-    <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False"
-                  PersistedName="TargetFrameworkIdentifier"
-                  Persistence="ProjectFile"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+                  ReadOnly="True"
+                  Visible="False" />
+
 
   <StringProperty Name="TargetFrameworkMoniker"
-                  Visible="False">
-    <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False"
-                  PersistedName="TargetFrameworkMoniker"
-                  Persistence="ProjectFileWithInterceptionViaSnapshot"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+                  ReadOnly="True"
+                  Visible="False" />
+
 
   <StringProperty Name="TargetFrameworkProfile"
-                  Visible="False">
-    <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False"
-                  PersistedName="TargetFrameworkProfile"
-                  Persistence="ProjectFile"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+                  ReadOnly="True"
+                  Visible="False" />
 
   <StringProperty Name="TargetFrameworks"
-                  Visible="False">
-    <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False"
-                  PersistedName="TargetFrameworks"
-                  Persistence="ProjectFile"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+                  ReadOnly="True"
+                  Visible="False" />
+
 
   <StringProperty Name="TargetFrameworkVersion"
-                  Visible="False">
-    <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False"
-                  PersistedName="TargetFrameworkVersion"
-                  Persistence="ProjectFile"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+                  ReadOnly="True"
+                  Visible="False" />
+
 
   <StringProperty Name="TreatWarningsAsErrors"
                   ReadOnly="True"


### PR DESCRIPTION
These data sources are unneeded:

1) We don't use this rule for writing, so we don't need HasConfigurationCondition
2) We use this via snapshot model (and not live ProjectProperties) so don't need to set ProjectFileWithInterceptionViaSnapshot for the TargetFrameworkMoniker, as the data is already snapshot.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6450)