### PR TITLE
Avoid deadlocks when firing events during initialization

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicNamespaceImportsList.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicNamespaceImportsList.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
         }
 
         [Import(typeof(VisualBasicVSImports))]
-        internal Lazy<VisualBasicVSImports>? VSImports { get; set; }
+        internal Lazy<VisualBasicVSImports> VSImports { get; set; } = null!;
 
         /// <summary>
         /// Get the global project collection version number, so we can make sure we are waiting for the latest build after a dependent project is updated.
@@ -84,24 +84,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
         {
             await JoinableFactory.SwitchToMainThreadAsync();
 
-            ImmutableList<string> current = AppliedValue?.Value ?? ImmutableList<string>.Empty;
-            ImmutableList<string> input = value.Value;
-
-            IEnumerable<string> removed = current.Except(input);
-            IEnumerable<string> added = input.Except(current);
+            IProjectVersionedValue<ImmutableList<string>>? previous = AppliedValue;
 
             AppliedValue = value;
 
-            VisualBasicVSImports? imports = VSImports?.Value;
-
-            if (imports != null)
+            // To avoid callers seeing an inconsistent state where there are no Imports,
+            // we use BlockInitializeOnFirstAppliedValue to block on the first value
+            // being applied.
+            //
+            // Due to that, and to avoid a deadlock when event handlers call back into us
+            // while we're still initializing, we avoid firing the events the first time 
+            // a value is applied.
+            if (previous != null)
             {
-                foreach (string import in removed)
+                VisualBasicVSImports imports = VSImports.Value;
+                ImmutableList<string> currentValue = value.Value;
+                ImmutableList<string> previousValue = previous.Value;
+
+                foreach (string import in previousValue.Except(currentValue))
                 {
                     imports.OnImportRemoved(import);
                 }
 
-                foreach (string import in added)
+                foreach (string import in currentValue.Except(previousValue))
                 {
                     imports.OnImportAdded(import);
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridge.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridge.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridgeTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridgeTests.cs
@@ -25,6 +25,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             await _bridge.ApplyAsync(new DesignTimeInputsDelta(
                 ImmutableHashSet.CreateRange(new string[] { "Resources1.Designer.cs" }),
                 ImmutableHashSet<string>.Empty,
+                ImmutableHashSet<DesignTimeInputFileChange>.Empty,
+                "C:\\TempPE"));
+
+            await _bridge.ApplyAsync(new DesignTimeInputsDelta(
+                ImmutableHashSet.CreateRange(new string[] { "Resources1.Designer.cs" }),
+                ImmutableHashSet<string>.Empty,
                 new DesignTimeInputFileChange[] { new DesignTimeInputFileChange("Resources1.Designer.cs", false) },
                 "C:\\TempPE"));
 


### PR DESCRIPTION
We were firing events during initialization, which resulted in listeners to call back into us and deadlock on Initialize because we're in the middle of initializing.

Fix both ImportsList and DesignTimeInputs to both avoid firing events the first time they set a value. This also makes sense; you don't fire "changed" events if the original state never changed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6454)