### PR TITLE
Force import WinFX targets

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,5 +5,8 @@
   <PropertyGroup>
     <!-- Prevent vsix manifests from being copied to the shared output directory, makes build more deterministic -->
     <CopyVsixManifestToOutput>false</CopyVsixManifestToOutput>
+    
+    <!-- Workaround: https://github.com/dotnet/sdk/issues/12739 -->
+    <ImportFrameworkWinFXTargets>true</ImportFrameworkWinFXTargets>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
VS installs 5.0 SDK by default, which includes https://github.com/dotnet/sdk/pull/10998/files . This has broken WPF builds that did not import WinFx targets.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6458)