### PR TITLE
Suppress build warnings

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitIndicator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitIndicator.cs
@@ -96,17 +96,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
             }
             catch (OperationCanceledException)
             {
-                // TODO track https://github.com/dotnet/roslyn/issues/37069 regarding these suppressions
-#pragma warning disable CS8653
+#pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type.
                 return (WaitIndicatorResult.Canceled, default);
-#pragma warning restore CS8653
+#pragma warning restore CS8619 // Nullability of reference types in value doesn't match target type.
             }
             catch (AggregateException aggregate) when (aggregate.InnerExceptions.All(e => e is OperationCanceledException))
             {
-                // TODO track https://github.com/dotnet/roslyn/issues/37069 regarding these suppressions
-#pragma warning disable CS8653
+#pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type.
                 return (WaitIndicatorResult.Canceled, default);
-#pragma warning restore CS8653
+#pragma warning restore CS8619 // Nullability of reference types in value doesn't match target type.
             }
         }
 


### PR DESCRIPTION
I believe this was introduced when updating the analyzers in #6374 

This also removes the suppression for warning CS8653 as it appears to no longer be necessary

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6464)