### PR TITLE
Workaround WPF temp project bug

### DIFF
--- a/build/import/Workarounds.targets
+++ b/build/import/Workarounds.targets
@@ -19,4 +19,32 @@
       <SourceRoot Remove="@(SourceRoot)" Condition="'%(SourceRoot.SourceLinkUrl)' == ''" />
     </ItemGroup>
   </Target>
+
+
+  <!-- WORKAROUND: https://github.com/dotnet/wpf/issues/810
+       WPF temp-projects do not import .props and .targets files from NuGet packages. -->
+  
+  
+  <PropertyGroup Condition="'$(IsWpfTempProject)' == ''">
+    <IsWpfTempProject>false</IsWpfTempProject>
+    <IsWpfTempProject Condition="$(MSBuildProjectName.EndsWith('_wpftmp'))">true</IsWpfTempProject>
+  </PropertyGroup>
+
+  
+  <!-- Property _TargetAssemblyProjectName is set by GenerateTemporaryTargetAssembly task.
+       Disable Source Link and Xliff in WPF temp projects to avoid generating non-deterministic file names to obj dir.
+       The project name is non-deterministic and is included in the Source Link json file name and xlf directory names.
+       It's also not necessary to generate these assets. -->
+  
+  <PropertyGroup Condition="'$(IsWpfTempProject)' == 'true'">
+    <_WpfTempProjectNuGetFilePathNoExt>$(ArtifactsObjDir)$(_TargetAssemblyProjectName)\$(_TargetAssemblyProjectName)$(MSBuildProjectExtension).nuget.g</_WpfTempProjectNuGetFilePathNoExt>
+
+    <EnableSourceLink>false</EnableSourceLink>
+    <EmbedUntrackedSources>false</EmbedUntrackedSources>
+    <DeterministicSourcePaths>false</DeterministicSourcePaths>
+    <EnableXlfLocalization>false</EnableXlfLocalization>
+  </PropertyGroup>
+
+  <Import Project="$(_WpfTempProjectNuGetFilePathNoExt).targets" Condition="'$(_WpfTempProjectNuGetFilePathNoExt)' != '' and Exists('$(_WpfTempProjectNuGetFilePathNoExt).targets')"/>
+
 </Project>


### PR DESCRIPTION
This fixes the reason these warnings were seen at command-line build time: https://github.com/dotnet/project-system/pull/6464.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6469)