### PR TITLE
Call new SetOptions API

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -13,6 +13,7 @@
       https://dotnet.myget.org/F/project-system-interop/api/v3/index.json;
       https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json;
       https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://api.nuget.org/v3/index.json;
       https://dotnet.myget.org/F/symreader-converter/api/v3/index.json;
@@ -68,8 +69,8 @@
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.8.DesignTime"                   Version="15.8.1" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.16.6.DesignTime"                   Version="16.6.30107.105" />
     <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="8.0.0-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="16.6.13" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="16.6.13" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="16.7.29-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="16.7.29-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="16.6.30107.105" />
     <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="15.5.31" />
     <PackageReference Update="Microsoft.VisualStudio.VSHelp"                                          Version="16.0.28321-alpha" />
@@ -100,8 +101,8 @@
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.7.232-pre" />
 
     <!-- Roslyn -->
-    <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="3.7.0-2.20256.8" />
-    <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="3.7.0-2.20256.8" />
+    <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="3.8.0-2.20402.1" />
+    <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="3.8.0-2.20402.1" />
     <PackageReference Update="Microsoft.VisualStudio.IntegrationTest.Utilities"                       Version="2.6.0-beta1-62113-02" />
     <PackageReference Update="Microsoft.CSharp"                                                       Version="4.7.0" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ErrorProfileDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ErrorProfileDebugTargetsProvider.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsAsync(DebugLaunchOptions launchOptions, ILaunchProfile activeProfile)
         {
             if (activeProfile.OtherSettings != null &&
-                activeProfile.OtherSettings.TryGetValue("ErrorString", out object objErrorString) &&
+                activeProfile.OtherSettings.TryGetValue("ErrorString", out object? objErrorString) &&
                 objErrorString is string errorString)
             {
                 throw new Exception(string.Format(VSResources.ErrorInProfilesFile2, Path.GetFileNameWithoutExtension(_configuredProject.UnconfiguredProject.FullPath), errorString));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeValueProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeValueProviderBase.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         {
             ConfigurationGeneral configuration = await _properties.GetConfigurationGeneralPropertiesAsync();
             string value = await configuration.OutputType.GetEvaluatedValueAtEndAsync();
-            if (GetMap.TryGetValue(value, out string returnValue))
+            if (GetMap.TryGetValue(value, out string? returnValue))
             {
                 return returnValue;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TargetFrameworkProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TargetFrameworkProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             }
 
             // Fast path for an exact name match
-            if (_targetFrameworkByName.TryGetValue(shortOrFullName, out TargetFramework existing))
+            if (_targetFrameworkByName.TryGetValue(shortOrFullName, out TargetFramework? existing))
             {
                 return existing;
             }
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     return null;
                 }
 
-                if (_targetFrameworkByName.TryGetValue(frameworkName.FullName, out TargetFramework exitingByFullName))
+                if (_targetFrameworkByName.TryGetValue(frameworkName.FullName, out TargetFramework? exitingByFullName))
                 {
                     // The full name was known, so cache by the provided (unknown) name too for next time
                     ImmutableInterlocked.TryAdd(ref _targetFrameworkByName, shortOrFullName, exitingByFullName);
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
                 string? shortName = _nuGetFrameworkParser.GetShortFrameworkName(frameworkName);
 
-                if (shortName != null && _targetFrameworkByName.TryGetValue(shortName, out TargetFramework exitingByShortName))
+                if (shortName != null && _targetFrameworkByName.TryGetValue(shortName, out TargetFramework? exitingByShortName))
                 {
                     // The short name was known, so cache by the provided (unknown) name too for next time
                     ImmutableInterlocked.TryAdd(ref _targetFrameworkByName, shortOrFullName, exitingByShortName);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
@@ -200,8 +200,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             string tempPEOutputPath;
             // Make sure we have the up to date output path. If either of these don't exist, they will be null and we'll handle the ArgumentException below
-            string basePath = configChanges.After.Properties.GetValueOrDefault(ConfigurationGeneral.ProjectDirProperty);
-            string objPath = configChanges.After.Properties.GetValueOrDefault(ConfigurationGeneral.IntermediateOutputPathProperty);
+            string? basePath = configChanges.After.Properties.GetValueOrDefault(ConfigurationGeneral.ProjectDirProperty);
+            string? objPath = configChanges.After.Properties.GetValueOrDefault(ConfigurationGeneral.IntermediateOutputPathProperty);
             try
             {
                 tempPEOutputPath = Path.Combine(basePath, objPath, "TempPE");

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.CompilationQueue.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.CompilationQueue.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                 {
                     foreach (DesignTimeInputFileChange item in addOrUpdateItems)
                     {
-                        if (queue.TryGetValue(item.File, out QueueItem existing))
+                        if (queue.TryGetValue(item.File, out QueueItem? existing))
                         {
                             // If the item exists, ensure that if anyone wanted us to ignore the file write time, we don't lose that info
                             // If the item doesn't need to be tracked, we'll clean it up later (we have to loop through everything then anyway)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/DictionaryEqualityComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/DictionaryEqualityComparer.cs
@@ -11,6 +11,7 @@ namespace Microsoft.VisualStudio.Collections
     /// <typeparam name="TKey">The type of key in the dictionaries to compare.</typeparam>
     /// <typeparam name="TValue">The type of value in the dictionaries to compare.</typeparam>
     internal class DictionaryEqualityComparer<TKey, TValue> : IEqualityComparer<IImmutableDictionary<TKey, TValue>>
+        where TKey : notnull
     {
         /// <summary>
         /// Initializes a new instance of the DictionaryEqualityComparer class.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ImmutableCollectionLinqExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ImmutableCollectionLinqExtensions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.VisualStudio
         // that don't box to IEnumerable<T> and can therefore avoid allocation.
 
         public static int Count<TKey, TValue>(this ImmutableDictionary<TKey, TValue> source, Func<KeyValuePair<TKey, TValue>, bool> predicate)
+            where TKey : notnull
         {
             int count = 0;
 
@@ -30,6 +31,7 @@ namespace Microsoft.VisualStudio
         }
 
         public static bool Any<TKey, TValue>(this ImmutableDictionary<TKey, TValue> source, Func<KeyValuePair<TKey, TValue>, bool> predicate)
+            where TKey : notnull
         {
             foreach (KeyValuePair<TKey, TValue> pair in source)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledDictionary.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledDictionary.cs
@@ -8,6 +8,7 @@ namespace Microsoft.VisualStudio.Buffers.PooledObjects
     // Dictionary that can be recycled via an object pool
     // NOTE: these dictionaries always have the default comparer.
     internal class PooledDictionary<K, V> : Dictionary<K, V>
+        where K : notnull
     {
         private readonly ObjectPool<PooledDictionary<K, V>> _pool;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             if (!Strings.IsNullOrWhiteSpace(activeFramework))
             {
-                if (configProjects.TryGetValue(activeFramework, out ConfiguredProject configuredProject))
+                if (configProjects.TryGetValue(activeFramework, out ConfiguredProject? configuredProject))
                 {
                     return configuredProject;
                 }
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             if (frameworks != null && frameworks.Count > 0)
             {
-                if (configProjects.TryGetValue(frameworks[0], out ConfiguredProject configuredProject))
+                if (configProjects.TryGetValue(frameworks[0], out ConfiguredProject? configuredProject))
                 {
                     return configuredProject;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettings.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// on the section being retrieved. The settingsName matches the section in the
         /// settings file.
         /// </summary>
-        object GetGlobalSetting(string settingsName);
+        object? GetGlobalSetting(string settingsName);
 
         /// <summary>
         /// Provides access to all the global settings.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public static bool IsNativeDebuggingEnabled(this ILaunchProfile profile)
         {
             if (profile.OtherSettings != null
-                && profile.OtherSettings.TryGetValue(NativeDebuggingProperty, out object value)
+                && profile.OtherSettings.TryGetValue(NativeDebuggingProperty, out object? value)
                 && value is bool b)
             {
                 return b;
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public static bool IsSqlDebuggingEnabled(this ILaunchProfile profile)
         {
             if (profile.OtherSettings != null
-                && profile.OtherSettings.TryGetValue(SqlDebuggingProperty, out object value)
+                && profile.OtherSettings.TryGetValue(SqlDebuggingProperty, out object? value)
                 && value is bool b)
             {
                 return b;
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public static bool IsRemoteDebugEnabled(this ILaunchProfile profile)
         {
             if (profile.OtherSettings != null
-                && profile.OtherSettings.TryGetValue(RemoteDebugEnabledProperty, out object value)
+                && profile.OtherSettings.TryGetValue(RemoteDebugEnabledProperty, out object? value)
                 && value is bool b)
             {
                 return b;
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public static string? RemoteDebugMachine(this ILaunchProfile profile)
         {
             if (profile.OtherSettings != null
-                && profile.OtherSettings.TryGetValue(RemoteDebugMachineProperty, out object value)
+                && profile.OtherSettings.TryGetValue(RemoteDebugMachineProperty, out object? value)
                 && value is string s)
             {
                 return s;
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public static string? RemoteAuthenticationMode(this ILaunchProfile profile)
         {
             if (profile?.OtherSettings != null
-               && profile.OtherSettings.TryGetValue(RemoteAuthenticationModeProperty, out object value)
+               && profile.OtherSettings.TryGetValue(RemoteAuthenticationModeProperty, out object? value)
                && value is string s)               
             {
                 return s;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
@@ -81,9 +81,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         public ImmutableDictionary<string, object> GlobalSettings { get; }
 
-        public object GetGlobalSetting(string settingName)
+        public object? GetGlobalSetting(string settingName)
         {
-            GlobalSettings.TryGetValue(settingName, out object o);
+            GlobalSettings.TryGetValue(settingName, out object? o);
             return o;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -822,7 +822,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             {
                 ILaunchSettings currentSettings = await GetSnapshotThrowIfErrors();
                 ImmutableDictionary<string, object> globalSettings = ImmutableStringDictionary<object>.EmptyOrdinal;
-                if (currentSettings.GlobalSettings.TryGetValue(settingName, out object currentValue))
+                if (currentSettings.GlobalSettings.TryGetValue(settingName, out object? currentValue))
                 {
                     globalSettings = currentSettings.GlobalSettings.Remove(settingName);
                 }
@@ -847,7 +847,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             return _sequentialTaskQueue.ExecuteTask(async () =>
             {
                 ILaunchSettings currentSettings = await GetSnapshotThrowIfErrors();
-                if (currentSettings.GlobalSettings.TryGetValue(settingName, out object currentValue))
+                if (currentSettings.GlobalSettings.TryGetValue(settingName, out object? currentValue))
                 {
                     bool saveToDisk = !currentValue.IsInMemoryObject();
                     ImmutableDictionary<string, object> globalSettings = currentSettings.GlobalSettings.Remove(settingName);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
@@ -172,7 +172,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             // We just pass all options to Roslyn
             string commandlineArguments = string.Join(" ", snapshot.Items.Keys);
 
+#pragma warning disable CS0618 // https://github.com/dotnet/project-system/issues/6470
             _context.SetOptions(commandlineArguments);
+#pragma warning restore CS0618
         }
 
         private Task ProcessCommandLineAsync(IComparable version, IProjectChangeDiff differences, bool isActiveContext, CancellationToken cancellationToken)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
@@ -170,11 +171,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             Assumes.NotNull(_context);
 
             // We just pass all options to Roslyn
-            string commandlineArguments = string.Join(" ", snapshot.Items.Keys);
-
-#pragma warning disable CS0618 // https://github.com/dotnet/project-system/issues/6470
-            _context.SetOptions(commandlineArguments);
-#pragma warning restore CS0618
+            _context.SetOptions(snapshot.Items.Keys.ToImmutableArray());
         }
 
         private Task ProcessCommandLineAsync(IComparable version, IProjectChangeDiff differences, bool isActiveContext, CancellationToken cancellationToken)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AssemblyInfoProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AssemblyInfoProperties.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// </summary>
         private async Task<string?> GetPropertyValueFromSourceAttributeAsync(string propertyName)
         {
-            if (_attributeValueProviderMap.TryGetValue(propertyName, out SourceAssemblyAttributePropertyValueProvider provider))
+            if (_attributeValueProviderMap.TryGetValue(propertyName, out SourceAssemblyAttributePropertyValueProvider? provider))
             {
                 return await provider.GetPropertyValueAsync();
             }
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// </summary>
         public override async Task SetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
-            if (_attributeValueProviderMap.TryGetValue(propertyName, out SourceAssemblyAttributePropertyValueProvider provider) &&
+            if (_attributeValueProviderMap.TryGetValue(propertyName, out SourceAssemblyAttributePropertyValueProvider? provider) &&
                 !await IsAssemblyInfoPropertyGeneratedByBuild(propertyName))
             {
                 await provider.SetPropertyValueAsync(unevaluatedPropertyValue);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileExtensionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileExtensionValueProvider.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override bool SetPropertyValue(string propertyName, string value, IWritableLaunchSettings launchSettings)
         {
-            var activeProfile = launchSettings.ActiveProfile;
+            IWritableLaunchProfile? activeProfile = launchSettings.ActiveProfile;
             if (activeProfile == null)
             {
                 return false;
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 return defaultValue;
             }
 
-            if (launchProfile.OtherSettings.TryGetValue(propertyName, out object value) &&
+            if (launchProfile.OtherSettings.TryGetValue(propertyName, out object? value) &&
                 value is T b)
             {
                 return b;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectProperties.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             {
                 string[] propertyNames = valueProvider.Metadata.PropertyNames;
 
-                foreach (var propertyName in propertyNames)
+                foreach (string propertyName in propertyNames)
                 {
                     Requires.Argument(!string.IsNullOrEmpty(propertyName), nameof(valueProvider), "A null or empty property name was found");
 
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public override async Task<string> GetEvaluatedPropertyValueAsync(string propertyName)
         {
             string evaluatedProperty = await base.GetEvaluatedPropertyValueAsync(propertyName);
-            if (_valueProviders.TryGetValue(propertyName, out Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata> valueProvider))
+            if (_valueProviders.TryGetValue(propertyName, out Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>? valueProvider))
             {
                 evaluatedProperty = await valueProvider.Value.OnGetEvaluatedPropertyValueAsync(propertyName, evaluatedProperty, DelegatedProperties);
             }
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public override async Task<string?> GetUnevaluatedPropertyValueAsync(string propertyName)
         {
             string? unevaluatedProperty = await base.GetUnevaluatedPropertyValueAsync(propertyName);
-            if (_valueProviders.TryGetValue(propertyName, out Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata> valueProvider))
+            if (_valueProviders.TryGetValue(propertyName, out Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>? valueProvider))
             {
                 unevaluatedProperty = await valueProvider.Value.OnGetUnevaluatedPropertyValueAsync(propertyName, unevaluatedProperty ?? "", DelegatedProperties);
             }
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public override async Task SetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
             string? valueToSet;
-            if (_valueProviders.TryGetValue(propertyName, out Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata> valueProvider))
+            if (_valueProviders.TryGetValue(propertyName, out Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>? valueProvider))
             {
                 valueToSet = await valueProvider.Value.OnSetPropertyValueAsync(propertyName, unevaluatedPropertyValue, DelegatedProperties, dimensionalConditions);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             var builder = previousSnapshot.DependenciesByTargetFramework.ToBuilder();
 
-            if (!builder.TryGetValue(changedTargetFramework, out TargetedDependenciesSnapshot previousTargetedSnapshot))
+            if (!builder.TryGetValue(changedTargetFramework, out TargetedDependenciesSnapshot? previousTargetedSnapshot))
             {
                 previousTargetedSnapshot = TargetedDependenciesSnapshot.CreateEmpty(changedTargetFramework, catalogs);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
             Requires.NotNull(changesBuilder, nameof(changesBuilder));
 
             DependenciesSnapshot snapshot = _dependenciesSnapshotProvider.CurrentSnapshot;
-            if (!snapshot.DependenciesByTargetFramework.TryGetValue(targetFramework, out TargetedDependenciesSnapshot targetedSnapshot))
+            if (!snapshot.DependenciesByTargetFramework.TryGetValue(targetFramework, out TargetedDependenciesSnapshot? targetedSnapshot))
             {
                 return;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -342,7 +342,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     }
                 }
 
-                if (state.UpToDateCheckInputItemsBySetName.TryGetValue(DefaultSetName, out ImmutableHashSet<string> upToDateCheckInputItems))
+                if (state.UpToDateCheckInputItemsBySetName.TryGetValue(DefaultSetName, out ImmutableHashSet<string>? upToDateCheckInputItems))
                 {
                     log.Verbose("Adding " + UpToDateCheckInput.SchemaName + " inputs:");
                     foreach (string input in upToDateCheckInputItems.Select(_configuredProject.UnconfiguredProject.MakeRooted))
@@ -368,7 +368,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             IEnumerable<string> CollectDefaultOutputs()
             {
-                if (state.UpToDateCheckOutputItemsBySetName.TryGetValue(DefaultSetName, out ImmutableHashSet<string> upToDateCheckOutputItems))
+                if (state.UpToDateCheckOutputItemsBySetName.TryGetValue(DefaultSetName, out ImmutableHashSet<string>? upToDateCheckOutputItems))
                 {
                     log.Verbose("Adding " + UpToDateCheckOutput.SchemaName + " outputs:");
 
@@ -379,7 +379,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     }
                 }
 
-                if (state.UpToDateCheckBuiltItemsBySetName.TryGetValue(DefaultSetName, out ImmutableHashSet<string> upToDateCheckBuiltItems))
+                if (state.UpToDateCheckBuiltItemsBySetName.TryGetValue(DefaultSetName, out ImmutableHashSet<string>? upToDateCheckBuiltItems))
                 {
                     log.Verbose("Adding " + UpToDateCheckBuilt.SchemaName + " outputs:");
 
@@ -393,7 +393,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             IEnumerable<(string Path, bool IsRequired)> CollectSetInputs(string setName)
             {
-                if (state.UpToDateCheckInputItemsBySetName.TryGetValue(setName, out ImmutableHashSet<string> upToDateCheckInputItems))
+                if (state.UpToDateCheckInputItemsBySetName.TryGetValue(setName, out ImmutableHashSet<string>? upToDateCheckInputItems))
                 {
                     log.Verbose("Adding " + UpToDateCheckInput.SchemaName + " inputs in set '{0}':", setName);
                     foreach (string input in upToDateCheckInputItems.Select(_configuredProject.UnconfiguredProject.MakeRooted))
@@ -406,7 +406,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             IEnumerable<string> CollectSetOutputs(string setName)
             {
-                if (state.UpToDateCheckOutputItemsBySetName.TryGetValue(setName, out ImmutableHashSet<string> upToDateCheckOutputItems))
+                if (state.UpToDateCheckOutputItemsBySetName.TryGetValue(setName, out ImmutableHashSet<string>? upToDateCheckOutputItems))
                 {
                     log.Verbose("Adding " + UpToDateCheckOutput.SchemaName + " outputs in set '{0}':", setName);
 
@@ -417,7 +417,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     }
                 }
 
-                if (state.UpToDateCheckBuiltItemsBySetName.TryGetValue(setName, out ImmutableHashSet<string> upToDateCheckBuiltItems))
+                if (state.UpToDateCheckBuiltItemsBySetName.TryGetValue(setName, out ImmutableHashSet<string>? upToDateCheckBuiltItems))
                 {
                     log.Verbose("Adding " + UpToDateCheckBuilt.SchemaName + " outputs in set '{0}':", setName);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/DisposableBag.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/DisposableBag.cs
@@ -16,14 +16,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         /// <summary>
         /// The set of disposable blocks. If <see langword="null" />, then this disposable bag has been disposed.
         /// </summary>
-        private ImmutableHashSet<IDisposable?>? _disposables = ImmutableHashSet.Create<IDisposable?>();
+        private ImmutableHashSet<IDisposable>? _disposables = ImmutableHashSet.Create<IDisposable>();
 
         /// <summary>
         /// Disposes of all contained disposable items.
         /// </summary>
         public void Dispose()
         {
-            ImmutableHashSet<IDisposable?>? disposables = Interlocked.Exchange(ref _disposables, null);
+            ImmutableHashSet<IDisposable>? disposables = Interlocked.Exchange(ref _disposables, null);
 
             if (disposables != null)
             {
@@ -49,8 +49,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
             }
 
             bool shouldDisposeArgument = false;
-
+#pragma warning disable CS8634 // https://github.com/dotnet/runtime/issues/40442
             ImmutableInterlocked.Update(
+#pragma warning restore CS8634
                 ref _disposables,
                 (set, item) =>
                 {
@@ -95,7 +96,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
                 return;
             }
 
+#pragma warning disable CS8634 // https://github.com/dotnet/runtime/issues/40442
             ImmutableInterlocked.Update(
+#pragma warning restore CS8634 
                 ref _disposables,
                 (set, item) => set?.Remove(item),
                 disposable);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Shipped.txt
@@ -30,7 +30,7 @@ Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.OtherSettings.get -> S
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile.WorkingDirectory.get -> string?
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettings
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettings.ActiveProfile.get -> Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile?
-Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettings.GetGlobalSetting(string! settingsName) -> object!
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettings.GetGlobalSetting(string! settingsName) -> object?
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettings.GlobalSettings.get -> System.Collections.Immutable.ImmutableDictionary<string!, object!>!
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettings.Profiles.get -> System.Collections.Immutable.ImmutableList<Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile!>!
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileDataTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileDataTests.cs
@@ -39,8 +39,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.Equal(data.WorkingDirectory, profile.WorkingDirectory);
             Assert.Equal(data.LaunchBrowser, profile.LaunchBrowser);
             Assert.Equal(data.LaunchUrl, profile.LaunchUrl);
-            Assert.Equal(data.EnvironmentVariables.ToImmutableDictionary(), profile.EnvironmentVariables, DictionaryEqualityComparer<string, string>.Instance);
-            Assert.True(DictionaryEqualityComparer<string, string>.Instance.Equals(data.EnvironmentVariables.ToImmutableDictionary(), profile.EnvironmentVariables));
+            Assert.Equal(data.EnvironmentVariables!.ToImmutableDictionary(), profile.EnvironmentVariables, DictionaryEqualityComparer<string, string>.Instance);
+            Assert.True(DictionaryEqualityComparer<string, string>.Instance.Equals(data.EnvironmentVariables!.ToImmutableDictionary(), profile.EnvironmentVariables));
             Assert.Equal(isInMemory, data.InMemoryProfile);
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.Equal(profile.LaunchBrowser, profile2.LaunchBrowser);
             Assert.Equal(profile.LaunchUrl, profile2.LaunchUrl);
             Assert.True(DictionaryEqualityComparer<string, string>.Instance.Equals(profile.EnvironmentVariables!, profile2.EnvironmentVariables!));
-            Assert.True(DictionaryEqualityComparer<string, object>.Instance.Equals(profile.OtherSettings.ToImmutableDictionary(), profile2.OtherSettings!));
+            Assert.True(DictionaryEqualityComparer<string, object>.Instance.Equals(profile.OtherSettings!.ToImmutableDictionary(), profile2.OtherSettings!));
             Assert.Equal(profile.DoNotPersist, profile2.DoNotPersist);
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -715,9 +715,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.Equal(!isInMemory, moqFS.FileExists(provider.LaunchSettingsFile));
             AssertEx.CollectionLength(provider.CurrentSnapshot.GlobalSettings, 2);
             // Check snapshot
-            Assert.True(provider.CurrentSnapshot.GlobalSettings.TryGetValue("iisSettings", out object updatedSettings));
+            Assert.True(provider.CurrentSnapshot.GlobalSettings.TryGetValue("iisSettings", out object? updatedSettings));
 
-            Assert.True(((IISSettingsData)updatedSettings).WindowsAuthentication);
+            Assert.True(((IISSettingsData)updatedSettings!).WindowsAuthentication);
         }
 
         [Theory]
@@ -750,9 +750,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             // Check snapshot
             AssertEx.CollectionLength(provider.CurrentSnapshot.GlobalSettings, 2);
-            Assert.True(provider.CurrentSnapshot.GlobalSettings.TryGetValue("iisSettings", out object updatedSettings));
+            Assert.True(provider.CurrentSnapshot.GlobalSettings.TryGetValue("iisSettings", out object? updatedSettings));
 
-            Assert.True(((IISSettingsData)updatedSettings).WindowsAuthentication);
+            Assert.True(((IISSettingsData)updatedSettings!).WindowsAuthentication);
         }
         [Fact]
         public async Task RemoveGlobalSettingAsync_SettingDoesntExist()


### PR DESCRIPTION
Includes https://github.com/dotnet/project-system/pull/6471, just review https://github.com/dotnet/project-system/commit/6c43cb59ffe24ac62f1cb5df77b4fc8beecd62c3.

Fixes: #6470

This avoids putting a large string on the LOH when we're dealing with large command-lines.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6472)