### PR TITLE
Support environment variables in debugger property pages

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileCommonValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileCommonValueProvider.cs
@@ -1,10 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-using System.Linq;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
@@ -29,7 +26,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         new[]
         {
             CommandLineArgumentsPropertyName,
-            EnvironmentVariablesPropertyName,
             ExecutablePathPropertyName,
             LaunchBrowserPropertyName,
             LaunchTargetPropertyName,
@@ -40,7 +36,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     internal class ActiveLaunchProfileCommonValueProvider : LaunchSettingsValueProviderBase
     {
         internal const string CommandLineArgumentsPropertyName = "CommandLineArguments";
-        internal const string EnvironmentVariablesPropertyName = "EnvironmentVariables";
         internal const string ExecutablePathPropertyName = "ExecutablePath";
         internal const string LaunchBrowserPropertyName = "LaunchBrowser";
         internal const string LaunchTargetPropertyName = "LaunchTarget";
@@ -58,7 +53,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             string? activeProfilePropertyValue = propertyName switch
             {
                 CommandLineArgumentsPropertyName => launchSettings.ActiveProfile?.CommandLineArgs,
-                EnvironmentVariablesPropertyName => ConvertDictionaryToString(launchSettings.ActiveProfile?.EnvironmentVariables),
                 ExecutablePathPropertyName => launchSettings.ActiveProfile?.ExecutablePath,
                 LaunchBrowserPropertyName => ConvertBooleanToString(launchSettings.ActiveProfile?.LaunchBrowser),
                 LaunchTargetPropertyName => launchSettings.ActiveProfile?.CommandName,
@@ -99,90 +93,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             }
         }
 
-        private static string ConvertDictionaryToString(ImmutableDictionary<string, string>? value)
-        {
-            if (value == null)
-            {
-                return string.Empty;
-            }
-
-            return string.Join(",", value.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).Select(kvp => $"{encode(kvp.Key)}={encode(kvp.Value)}"));
-
-            static string encode(string value)
-            {
-                return value.Replace("/", "//").Replace(",", "/,").Replace("=", "/=");
-            }
-        }
-
-        private static void ParseStringIntoDictionary(string value, Dictionary<string, string> dictionary)
-        {
-            dictionary.Clear();
-
-            foreach (var entry in readEntries(value))
-            {
-                var (entryKey, entryValue) = splitEntry(entry);
-                var decodedEntryKey = decode(entryKey);
-                var decodedEntryValue = decode(entryValue);
-
-                if (!string.IsNullOrEmpty(decodedEntryKey))
-                {
-                    dictionary[decodedEntryKey] = decodedEntryValue;
-                }
-            }
-
-            static IEnumerable<string> readEntries(string rawText)
-            {
-                bool escaped = false;
-                int entryStart = 0;
-                for (int i = 0; i < rawText.Length; i++)
-                {
-                    if (rawText[i] == ',' && !escaped)
-                    {
-                        yield return rawText.Substring(entryStart, i - entryStart);
-                        entryStart = i + 1;
-                        escaped = false;
-                    }
-                    else if (rawText[i] == '/')
-                    {
-                        escaped = !escaped;
-                    }
-                    else
-                    {
-                        escaped = false;
-                    }
-                }
-
-                yield return rawText.Substring(entryStart);
-            }
-
-            static (string encodedKey, string encodedValue) splitEntry(string entry)
-            {
-                bool escaped = false;
-                for (int i = 0; i < entry.Length; i++)
-                {
-                    if (entry[i] == '=' && !escaped)
-                    {
-                        return (entry.Substring(0, i), entry.Substring(i + 1));
-                    }
-                    else if (entry[i] == '/')
-                    {
-                        escaped = !escaped;
-                    }
-                    else
-                    {
-                        escaped = false;
-                    }
-                }
-
-                return (string.Empty, string.Empty);
-            }
-
-            static string decode(string value)
-            {
-                return value.Replace("/=", "=").Replace("/,", ",").Replace("//", "/");
-            }
-        }
-
         private static void UpdateActiveLaunchProfile(IWritableLaunchProfile activeProfile, string propertyName, string newValue)
         {
             switch (propertyName)
@@ -193,10 +103,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
                 case ExecutablePathPropertyName:
                     activeProfile.ExecutablePath = newValue;
-                    break;
-
-                case EnvironmentVariablesPropertyName:
-                    ParseStringIntoDictionary(newValue, activeProfile.EnvironmentVariables);
                     break;
 
                 case LaunchBrowserPropertyName:

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileCommonValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileCommonValueProvider.cs
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 return string.Empty;
             }
 
-            return string.Join(",", value.Select(kvp => $"{encode(kvp.Key)}={encode(kvp.Value)}"));
+            return string.Join(",", value.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).Select(kvp => $"{encode(kvp.Key)}={encode(kvp.Value)}"));
 
             static string encode(string value)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileEnvironmentVariableValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileEnvironmentVariableValueProvider.cs
@@ -1,0 +1,143 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    /// <summary>
+    /// Reads and writes the <see cref="ILaunchProfile.EnvironmentVariables"/> property
+    /// of the active <see cref="ILaunchProfile"/> via the <see cref="ILaunchSettingsProvider"/>.
+    /// </summary>
+    /// <remarks>
+    /// Most of the properties of the <see cref="ILaunchProfile"/> are handled by <see cref="ActiveLaunchProfileCommonValueProvider"/>
+    /// and <see cref="ActiveLaunchProfileExtensionValueProvider"/>. Handling of <see cref="ILaunchProfile.EnvironmentVariables"/>
+    /// is complex enough to warrant its own value provider.
+    /// </remarks>
+    [ExportInterceptingPropertyValueProvider(EnvironmentVariablesPropertyName, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    internal class ActiveLaunchProfileEnvironmentVariableValueProvider : LaunchSettingsValueProviderBase
+    {
+        internal const string EnvironmentVariablesPropertyName = "EnvironmentVariables";
+
+        [ImportingConstructor]
+        public ActiveLaunchProfileEnvironmentVariableValueProvider(UnconfiguredProject project, ILaunchSettingsProvider launchSettingsProvider, IProjectThreadingService projectThreadingService)
+            : base(project, launchSettingsProvider, projectThreadingService)
+        {
+        }
+
+        public override string? GetPropertyValue(string propertyName, ILaunchSettings launchSettings)
+        {
+            if (propertyName != EnvironmentVariablesPropertyName)
+            {
+                throw new InvalidOperationException($"{nameof(ActiveLaunchProfileEnvironmentVariableValueProvider)} does not handle property '{propertyName}'.");
+            }
+
+            return ConvertDictionaryToString(launchSettings.ActiveProfile?.EnvironmentVariables);
+        }
+
+        public override bool SetPropertyValue(string propertyName, string value, IWritableLaunchSettings launchSettings)
+        {
+            if (propertyName != EnvironmentVariablesPropertyName)
+            {
+                throw new InvalidOperationException($"{nameof(ActiveLaunchProfileEnvironmentVariableValueProvider)} does not handle property '{propertyName}'.");
+            }
+
+            var activeProfile = launchSettings.ActiveProfile;
+            if (activeProfile == null)
+            {
+                return false;
+            }
+
+            ParseStringIntoDictionary(value, activeProfile.EnvironmentVariables);
+
+            return true;
+        }
+
+        private static string ConvertDictionaryToString(ImmutableDictionary<string, string>? value)
+        {
+            if (value == null)
+            {
+                return string.Empty;
+            }
+
+            return string.Join(",", value.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).Select(kvp => $"{encode(kvp.Key)}={encode(kvp.Value)}"));
+
+            static string encode(string value)
+            {
+                return value.Replace("/", "//").Replace(",", "/,").Replace("=", "/=");
+            }
+        }
+        private static void ParseStringIntoDictionary(string value, Dictionary<string, string> dictionary)
+        {
+            dictionary.Clear();
+
+            foreach (var entry in readEntries(value))
+            {
+                var (entryKey, entryValue) = splitEntry(entry);
+                var decodedEntryKey = decode(entryKey);
+                var decodedEntryValue = decode(entryValue);
+
+                if (!string.IsNullOrEmpty(decodedEntryKey))
+                {
+                    dictionary[decodedEntryKey] = decodedEntryValue;
+                }
+            }
+
+            static IEnumerable<string> readEntries(string rawText)
+            {
+                bool escaped = false;
+                int entryStart = 0;
+                for (int i = 0; i < rawText.Length; i++)
+                {
+                    if (rawText[i] == ',' && !escaped)
+                    {
+                        yield return rawText.Substring(entryStart, i - entryStart);
+                        entryStart = i + 1;
+                        escaped = false;
+                    }
+                    else if (rawText[i] == '/')
+                    {
+                        escaped = !escaped;
+                    }
+                    else
+                    {
+                        escaped = false;
+                    }
+                }
+
+                yield return rawText.Substring(entryStart);
+            }
+
+            static (string encodedKey, string encodedValue) splitEntry(string entry)
+            {
+                bool escaped = false;
+                for (int i = 0; i < entry.Length; i++)
+                {
+                    if (entry[i] == '=' && !escaped)
+                    {
+                        return (entry.Substring(0, i), entry.Substring(i + 1));
+                    }
+                    else if (entry[i] == '/')
+                    {
+                        escaped = !escaped;
+                    }
+                    else
+                    {
+                        escaped = false;
+                    }
+                }
+
+                return (string.Empty, string.Empty);
+            }
+
+            static string decode(string value)
+            {
+                return value.Replace("/=", "=").Replace("/,", ",").Replace("//", "/");
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
@@ -44,6 +44,10 @@
                        Description="The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled."
                        EnumProvider="AuthenticationModeEnumProvider" />
 
+  <StringProperty Name="EnvironmentVariables"
+                  DisplayName="Environment variables"
+                  Description="The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/)."/>
+
   <BoolProperty Name="NativeDebugging"
                 DisplayName="Enable native code debugging" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
@@ -38,6 +38,11 @@
                        DisplayName="Authentication mode"
                        Description="The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled."
                        EnumProvider="AuthenticationModeEnumProvider" />
+
+  <StringProperty Name="EnvironmentVariables"
+                  DisplayName="Environment variables"
+                  Description="The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/)."/>
+
   <BoolProperty Name="NativeDebugging"
                 DisplayName="Enable native code debugging" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.cs.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Argumenty příkazového řádku</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ExecutablePath|Description">
         <source>Path to the executable to run.</source>
         <target state="translated">Cesta ke spouštěnému souboru</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.de.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Befehlszeilenargumente</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ExecutablePath|Description">
         <source>Path to the executable to run.</source>
         <target state="translated">Pfad der zu startenden ausführbaren Datei.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.es.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Argumentos de la línea de comandos</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ExecutablePath|Description">
         <source>Path to the executable to run.</source>
         <target state="translated">Ruta de acceso al archivo ejecutable que debe ejecutarse.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.fr.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Arguments de ligne de commande</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ExecutablePath|Description">
         <source>Path to the executable to run.</source>
         <target state="translated">Chemin de l'exécutable à exécuter.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.it.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Argomenti della riga di comando</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ExecutablePath|Description">
         <source>Path to the executable to run.</source>
         <target state="translated">Percorso dell'eseguibile da avviare.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ja.xlf
@@ -52,6 +52,16 @@
         <target state="translated">コマンド ライン引数</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ExecutablePath|Description">
         <source>Path to the executable to run.</source>
         <target state="translated">実行する実行可能ファイルのパス。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ko.xlf
@@ -52,6 +52,16 @@
         <target state="translated">명령줄 인수</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ExecutablePath|Description">
         <source>Path to the executable to run.</source>
         <target state="translated">실행할 실행 파일 경로입니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pl.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Argumenty wiersza polecenia</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ExecutablePath|Description">
         <source>Path to the executable to run.</source>
         <target state="translated">Ścieżka pliku wykonywalnego do uruchomienia.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pt-BR.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Argumentos da linha de comando</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ExecutablePath|Description">
         <source>Path to the executable to run.</source>
         <target state="translated">Caminho para o executável ser executado.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ru.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Аргументы командной строки</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ExecutablePath|Description">
         <source>Path to the executable to run.</source>
         <target state="translated">Путь к исполняемому файлу для запуска.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.tr.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Komut satırı bağımsız değişkenleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ExecutablePath|Description">
         <source>Path to the executable to run.</source>
         <target state="translated">Çalıştırılacak yürütülebilir dosyanın yolu.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hans.xlf
@@ -52,6 +52,16 @@
         <target state="translated">命令行参数</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ExecutablePath|Description">
         <source>Path to the executable to run.</source>
         <target state="translated">要运行的可执行文件的路径。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hant.xlf
@@ -52,6 +52,16 @@
         <target state="translated">命令列引數</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ExecutablePath|Description">
         <source>Path to the executable to run.</source>
         <target state="translated">要執行之可執行檔的路徑。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.cs.xlf
@@ -52,6 +52,16 @@
         <target state="new">Command line arguments</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
         <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
         <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.de.xlf
@@ -52,6 +52,16 @@
         <target state="new">Command line arguments</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
         <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
         <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.es.xlf
@@ -52,6 +52,16 @@
         <target state="new">Command line arguments</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
         <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
         <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.fr.xlf
@@ -52,6 +52,16 @@
         <target state="new">Command line arguments</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
         <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
         <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.it.xlf
@@ -52,6 +52,16 @@
         <target state="new">Command line arguments</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
         <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
         <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ja.xlf
@@ -52,6 +52,16 @@
         <target state="new">Command line arguments</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
         <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
         <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ko.xlf
@@ -52,6 +52,16 @@
         <target state="new">Command line arguments</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
         <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
         <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pl.xlf
@@ -52,6 +52,16 @@
         <target state="new">Command line arguments</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
         <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
         <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pt-BR.xlf
@@ -52,6 +52,16 @@
         <target state="new">Command line arguments</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
         <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
         <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ru.xlf
@@ -52,6 +52,16 @@
         <target state="new">Command line arguments</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
         <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
         <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.tr.xlf
@@ -52,6 +52,16 @@
         <target state="new">Command line arguments</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
         <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
         <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hans.xlf
@@ -52,6 +52,16 @@
         <target state="new">Command line arguments</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
         <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
         <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hant.xlf
@@ -52,6 +52,16 @@
         <target state="new">Command line arguments</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|Description">
+        <source>The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</source>
+        <target state="new">The environment variables to set prior to running the process. Variables are separated by a comma (,) and variables names and values are separated with an equal sign (=). Example: var1=value1,var2=value2,var3=value3. Commas and equal signs appearing within a variable can be escaped using a forward slash (/).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|EnvironmentVariables|DisplayName">
+        <source>Environment variables</source>
+        <target state="new">Environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
         <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
         <target state="new">The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</target>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
@@ -581,6 +581,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         [Fact]
+        public async Task EnvironmentVariables_OnGetPropertyValueAsync_VariablesAreSorted()
+        {
+            var activeProfileEnvironmentVariables = new Dictionary<string, string>
+            {
+                { "var3", "value3" },
+                { "var2", "value2" },
+                { "var1", "value1" }
+            };
+
+            var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileEnvironmentVariables: activeProfileEnvironmentVariables);
+
+            var project = UnconfiguredProjectFactory.Create();
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var provider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+
+            var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.EnvironmentVariablesPropertyName, string.Empty, Mock.Of<IProjectProperties>());
+
+            Assert.Equal(expected: "var1=value1,var2=value2,var3=value3", actual: actualValue);
+        }
+
+        [Fact]
         public async Task EnvironmentVariables_OnSetPropertyValueAsync_HandlesEscapeCharactersProperly()
         {
             var activeProfileEnvironmentVariables = new Dictionary<string, string>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
@@ -573,9 +573,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var project = UnconfiguredProjectFactory.Create();
             var threadingService = IProjectThreadingServiceFactory.Create();
-            var provider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var provider = new ActiveLaunchProfileEnvironmentVariableValueProvider(project, settingsProvider, threadingService);
 
-            var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.EnvironmentVariablesPropertyName, string.Empty, Mock.Of<IProjectProperties>());
+            var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileEnvironmentVariableValueProvider.EnvironmentVariablesPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
             Assert.Equal(expected: "Alpha=Comma: /, Equals: /=,Beta=12345", actual: actualValue);
         }
@@ -594,9 +594,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var project = UnconfiguredProjectFactory.Create();
             var threadingService = IProjectThreadingServiceFactory.Create();
-            var provider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var provider = new ActiveLaunchProfileEnvironmentVariableValueProvider(project, settingsProvider, threadingService);
 
-            var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.EnvironmentVariablesPropertyName, string.Empty, Mock.Of<IProjectProperties>());
+            var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileEnvironmentVariableValueProvider.EnvironmentVariablesPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
             Assert.Equal(expected: "var1=value1,var2=value2,var3=value3", actual: actualValue);
         }
@@ -622,12 +622,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var project = UnconfiguredProjectFactory.Create();
             var threadingService = IProjectThreadingServiceFactory.Create();
-            var provider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var provider = new ActiveLaunchProfileEnvironmentVariableValueProvider(project, settingsProvider, threadingService);
 
-            await provider.OnSetPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.EnvironmentVariablesPropertyName, "Alpha=Equals: /= Comma: /,,Beta=two", Mock.Of<IProjectProperties>());
+            await provider.OnSetPropertyValueAsync(ActiveLaunchProfileEnvironmentVariableValueProvider.EnvironmentVariablesPropertyName, "Alpha=Equals: /= Comma: /, Slash: //,Beta=two", Mock.Of<IProjectProperties>());
 
             Assumes.NotNull(updatedEnvironmentVariables);
-            Assert.Equal(expected: "Equals: = Comma: ,", actual: updatedEnvironmentVariables["Alpha"]);
+            Assert.Equal(expected: "Equals: = Comma: , Slash: /", actual: updatedEnvironmentVariables["Alpha"]);
             Assert.Equal(expected: "two", actual: updatedEnvironmentVariables["Beta"]);
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Moq;
@@ -559,6 +560,56 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             Assert.True(activeProfileSqlDebugEnabled);
         }
 
+        [Fact]
+        public async Task EnvironmentVariables_OnGetPropertyValueAsync_GetsEscapedValuesFromActiveProfile()
+        {
+            var activeProfileEnvironmentVariables = new Dictionary<string, string>
+            {
+                { "Alpha", "Comma: , Equals: =" },
+                { "Beta", "12345" }
+            };
+
+            var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileEnvironmentVariables: activeProfileEnvironmentVariables);
+
+            var project = UnconfiguredProjectFactory.Create();
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var provider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+
+            var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.EnvironmentVariablesPropertyName, string.Empty, Mock.Of<IProjectProperties>());
+
+            Assert.Equal(expected: "Alpha=Comma: /, Equals: /=,Beta=12345", actual: actualValue);
+        }
+
+        [Fact]
+        public async Task EnvironmentVariables_OnSetPropertyValueAsync_HandlesEscapeCharactersProperly()
+        {
+            var activeProfileEnvironmentVariables = new Dictionary<string, string>
+            {
+                { "Alpha", "one" }
+            };
+
+            ImmutableDictionary<string, string>? updatedEnvironmentVariables = null;
+
+            var settingsProvider = SetupLaunchSettingsProvider(
+                activeProfileName: "One",
+                activeProfileEnvironmentVariables: activeProfileEnvironmentVariables,
+                updateLaunchSettingsCallback: s =>
+                {
+                    Assumes.NotNull(s.ActiveProfile?.EnvironmentVariables);
+                    updatedEnvironmentVariables = s.ActiveProfile?.EnvironmentVariables;
+                });
+
+            var project = UnconfiguredProjectFactory.Create();
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var provider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+
+            await provider.OnSetPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.EnvironmentVariablesPropertyName, "Alpha=Equals: /= Comma: /,,Beta=two", Mock.Of<IProjectProperties>());
+
+            Assumes.NotNull(updatedEnvironmentVariables);
+            Assert.Equal(expected: "Equals: = Comma: ,", actual: updatedEnvironmentVariables["Alpha"]);
+            Assert.Equal(expected: "two", actual: updatedEnvironmentVariables["Beta"]);
+        }
+
         private static ILaunchSettingsProvider SetupLaunchSettingsProvider(
             string activeProfileName,
             string? activeProfileLaunchTarget = null,
@@ -567,6 +618,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             string? activeProfileWorkingDirectory = null,
             bool? activeProfileLaunchBrowser = null,
             string? activeProfileLaunchUrl = null,
+            Dictionary<string, string>? activeProfileEnvironmentVariables = null,
             Dictionary<string, object>? activeProfileOtherSettings = null,
             Action<string>? setActiveProfileCallback = null,
             Action<ILaunchSettings>? updateLaunchSettingsCallback = null)
@@ -615,6 +667,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 foreach ((string key, object value) in activeProfileOtherSettings)
                 {
                     profile.OtherSettings.Add(key, value);
+                }
+            }
+
+            if (activeProfileEnvironmentVariables != null)
+            {
+                Assumes.NotNull(profile.EnvironmentVariables);
+
+                foreach ((string key, string value) in activeProfileEnvironmentVariables)
+                {
+                    profile.EnvironmentVariables.Add(key, value);
                 }
             }
 


### PR DESCRIPTION
Fixes #6268.

Add basic support for the "Environment variables" property as used by various debugger property pages. This changes adds 
 the `ActiveLaunchProfileEnvironmentVariableValueProvider` type to serialize the `ILaunchProfile.EnvironmentVariables` dictionary to a string when the value is retrieved, and deserialize it from a string back to a dictionary when it is set.

In serializing to a string we need some way to separate the environment variable name from its value, and also some way to separate one environment variable from the next. Here we use an equal sign `=` for the former, and a comma `,` for the latter. These were chosen as they were unlikely to appear in variable names or values and wouldn't need to be escaped. When we do need to escape them, we do so using a forward slash `/`.

The "Executable" and "Project" debug pages have also been updated to expose the serialized string as-is. This is functional but not a great user experience. In the future we will need to put a better editor in front of this data, but the specifics of that depend on the new property pages UI.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6474)