### PR TITLE
Upgrade to the latest version of VS SDK packages

### DIFF
--- a/build/import/HostAgnostic.props
+++ b/build/import/HostAgnostic.props
@@ -13,16 +13,16 @@
     <Reference Include="System.Xml.Linq" />
     
     <!-- Toolset -->
-    <PackageReference Include="MicroBuild.Core" ExcludeAssets="All" />
-    <PackageReference Include="MicroBuild.Core.Sentinel" ExcludeAssets="All" />
-    <PackageReference Include="MicroBuild.Plugins.SwixBuild" ExcludeAssets="All"/>
+    <PackageReference Include="MicroBuild.Core"                     ExcludeAssets="All" />
+    <PackageReference Include="MicroBuild.Core.Sentinel"            ExcludeAssets="All" />
+    <PackageReference Include="MicroBuild.Plugins.SwixBuild"        ExcludeAssets="All"/>
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
     <PackageReference Include="XliffTasks" />
     <PackageReference Include="RoslynTools.SignTool" />
-    <PackageReference Include="RoslynTools.RepoToolset" ExcludeAssets="all" />
-    <PackageReference Include="Codecov" ExcludeAssets="all" />
-    <PackageReference Include="OpenCover" ExcludeAssets="all" />
-    <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb" ExcludeAssets="all" />
+    <PackageReference Include="RoslynTools.RepoToolset"             ExcludeAssets="all" />
+    <PackageReference Include="Codecov"                             ExcludeAssets="all" />
+    <PackageReference Include="OpenCover"                           ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb"      ExcludeAssets="all" />
     
     <!-- CPS -->
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" />
@@ -45,19 +45,16 @@
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" />
 
-    <!-- MSBuild -->
-    <PackageReference Include="Microsoft.Build" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" />
-    <PackageReference Include="Microsoft.Build.Engine" />
-
+    <!-- Framework packages -->
+    <PackageReference Include="Microsoft.IO.Redist" />
+    
     <!-- 3rd party -->
     <PackageReference Include="Newtonsoft.Json" />
 
     <!-- Host-Agnostic Visual Studio -->
+    <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" />
     <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" />
     <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" />
-    <PackageReference Include="StreamJsonRpc" />
 
   </ItemGroup>
 
@@ -70,4 +67,52 @@
     <PackageReference Include="xunit.runner.visualstudio" GeneratePathProperty="true" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
+
+ <!--
+    Some of the VSSDK packages may pull in Microsoft.VisualStudio.SDK.EmbedInteropTypes which essentially
+    does the below but for all of the listed references. We can't just use what they have since they include
+    things like EnvDTE which is reasonable for consumers, but strange since we actually _implement_ DTE and
+    use it as an exchange type with generics in a few places. Instead, we run directly after the target declared
+    in the EmbedInteropTypes package and ensure only the dependencies we need are embedded and the others are
+    skipped.
+  -->
+  <Target Name="CustomLinkVSSDKEmbeddableAssemblies" AfterTargets="LinkVSSDKEmbeddableAssemblies">
+    <ItemGroup>
+      <ReferencePath Condition="
+              '%(FileName)' == 'Microsoft.VisualStudio.Setup.Configuration.Interop'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Embeddable'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.12.0'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.7.DesignTime'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.8.DesignTime'
+           or '%(Filename)' == 'Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime'
+           or '%(FileName)' == 'Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime'
+           or '%(FileName)' == 'Microsoft.VisualStudio.ProjectSystem.Interop'
+           or '%(FileName)' == 'stdole'
+           or '%(FileName)' == 'Microsoft.VisualStudio.CommandBars'
+           or '%(FileName)' == 'NuGet.SolutionRestoreManager.Interop'
+           or '%(FileName)' == 'NuGet.VisualStudio'
+           or '%(FileName)' == 'VSLangProj110'
+           or '%(FileName)' == 'VSLangProj165'
+           ">
+        <EmbedInteropTypes>true</EmbedInteropTypes>
+      </ReferencePath>
+      <ReferencePath Condition="
+              '%(FileName)' == 'Microsoft.VisualStudio.Imaging.Interop.15.0.DesignTime'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.10.0'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.11.0'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Feedback.Interop.12.0.DesignTime'
+           or '%(FileName)' == 'microsoft.visualstudio.designer.interfaces'
+           or '%(FileName)' == 'EnvDTE80'
+           or '%(FileName)' == 'EnvDTE90'
+           or '%(FileName)' == 'EnvDTE100'
+           or '%(FileName)' == 'Microsoft.Internal.VisualStudio.Shell.Interop.14.1.DesignTime'
+           or '%(FileName)' == 'Microsoft.Internal.VisualStudio.Shell.Interop.14.2.DesignTime'">
+        <EmbedInteropTypes>false</EmbedInteropTypes>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -39,65 +39,66 @@
     <PackageReference Update="Microsoft.DevDiv.Validation.MediaRecorder"                              Version="15.0.199" />
 
     <!-- VS SDK -->
-    <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="16.7.2041" />
-    <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost"                              Version="16.0.198-g52de9c2988"/>
-    <PackageReference Update="Microsoft.VisualStudio.Composition"                                     Version="16.4.11"/>
-    <PackageReference Update="Microsoft.VisualStudio.Data.Core"                                       Version="9.0.21022" />
+    <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="16.7.3069" />
+    <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost"                              Version="16.6.255"/>
+    <PackageReference Update="Microsoft.VisualStudio.Composition"                                     Version="16.5.13"/>
+    <PackageReference Update="Microsoft.VisualStudio.Data.Core"                                       Version="9.0.21023" />
     <PackageReference Update="Microsoft.VisualStudio.DataDesign.Common"                               Version="16.0.28321-alpha"/>
-    <PackageReference Update="Microsoft.VisualStudio.Data.Services"                                   Version="9.0.21022" />
+    <PackageReference Update="Microsoft.VisualStudio.Data.Services"                                   Version="9.0.21023" />    
     <PackageReference Update="Microsoft.VisualStudio.DataTools.Interop"                               Version="16.0.28321-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces"                             Version="1.1.4322" />
-    <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="16.6.30107.105" />
-    <PackageReference Update="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime"                 Version="14.3.26930"/>
-    <PackageReference Update="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50727" />
-    <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="16.6.69" />
-    <PackageReference Update="Microsoft.VisualStudio.Telemetry"                                       Version="16.3.36" />
-    <PackageReference Update="Microsoft.VisualStudio.Settings.15.0"                                   Version="15.8.28010" />
-    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="1.16.30" />
-    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes"                           Version="15.0.29" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.15.0"                                      Version="16.6.30107.105" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Design"                                    Version="16.0.28316-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Framework"                                 Version="16.6.30107.105" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.9.0"                               Version="9.0.30730" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.10.0"                              Version="10.0.30320" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.11.0"                              Version="11.0.61031" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime"                   Version="12.1.30328" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime"                   Version="14.3.26929" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime"                   Version="15.0.26932" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime"                   Version="15.0.26929" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.7.DesignTime"                   Version="15.7.1" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.8.DesignTime"                   Version="15.8.1" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.16.6.DesignTime"                   Version="16.6.30107.105" />
-    <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="8.0.0-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="16.7.29-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="16.7.29-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="16.6.30107.105" />
-    <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="15.5.31" />
+    <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces"                             Version="1.1.4323" />
+    <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="16.8.30406.65-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime"                 Version="16.8.30406.65"/>
+    <PackageReference Update="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50728" />
+    <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="16.8.5-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Telemetry"                                       Version="16.3.59" />    
+    <PackageReference Update="Microsoft.VisualStudio.Settings.15.0"                                   Version="16.8.30406.155-pre" />    
+    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="2.3.2262-g94fae01e" />
+    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes"                           Version="15.0.34" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.15.0"                                      Version="16.8.30406.155-pre" />    
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Design"                                    Version="16.8.30406.155-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Framework"                                 Version="16.8.30406.155-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.9.0"                               Version="16.8.30406.65" />    
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.10.0"                              Version="16.8.30406.65" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.11.0"                              Version="16.8.30406.65" />    
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime"                   Version="16.8.30406.65" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime"                   Version="16.8.30406.65" />    
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime"                   Version="16.8.30406.65" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime"                   Version="16.8.30406.65" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.7.DesignTime"                   Version="16.8.30406.65" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.8.DesignTime"                   Version="16.8.30406.65" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.16.6.DesignTime"                   Version="16.8.30406.65-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="16.8.30403.137-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="16.8.16-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="16.8.16-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="16.8.30406.65-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="16.8.2-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.VSHelp"                                          Version="16.0.28321-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.WCFReference.Interop"                            Version="9.1.26606-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Workspace.VSIntegration"                         Version="16.3.43" />
+    <PackageReference Update="Microsoft.VisualStudio.Workspace.VSIntegration"                         Version="16.7.47-preview-0001" />
     <PackageReference Update="Microsoft.VisualStudio.XmlEditor"                                       Version="16.0.28321-alpha" />
     <PackageReference Update="Microsoft.VSDesigner"                                                   Version="16.0.28321-alpha" />
-    <PackageReference Update="VsWebSite.Interop"                                                      Version="8.0.0-alpha"/>
-    <PackageReference Update="VSLangProj"                                                             Version="7.0.3300" />
-    <PackageReference Update="VSLangProj2"                                                            Version="7.0.5000" />
-    <PackageReference Update="VSLangProj80"                                                           Version="8.0.50727" />
-    <PackageReference Update="VSLangProj90"                                                           Version="9.0.30729" />
-    <PackageReference Update="VSLangProj100"                                                          Version="10.0.30319" />
-    <PackageReference Update="VSLangProj110"                                                          Version="11.0.61030" />
-    <PackageReference Update="VSLangProj158"                                                          Version="15.8.0" />
+    <PackageReference Update="VsWebSite.Interop"                                                      Version="16.8.30406.65"/>
+    <PackageReference Update="VSLangProj"                                                             Version="16.8.30406.65" />
+    <PackageReference Update="VSLangProj2"                                                            Version="16.8.30406.65" />
+    <PackageReference Update="VSLangProj80"                                                           Version="16.8.30406.65" />
+    <PackageReference Update="VSLangProj90"                                                           Version="16.8.30406.65" />
+    <PackageReference Update="VSLangProj100"                                                          Version="16.8.30406.65" />
+    <PackageReference Update="VSLangProj110"                                                          Version="16.8.30406.65" />
+    <PackageReference Update="VSLangProj158"                                                          Version="16.8.30406.65" />
     <PackageReference Update="VSLangProj165"                                                          Version="16.5.0" />
-    <PackageReference Update="EnvDTE"                                                                 Version="8.0.1" />
-    <PackageReference Update="EnvDTE80"                                                               Version="8.0.1" />
-    <PackageReference Update="EnvDTE90"                                                               Version="9.0.1" />
-    <PackageReference Update="StreamJsonRpc"                                                          Version="2.4.34" />
+    <PackageReference Update="EnvDTE"                                                                 Version="16.8.30406.65" />
+    <PackageReference Update="EnvDTE80"                                                               Version="16.8.30406.65" />
+    <PackageReference Update="EnvDTE90"                                                               Version="16.8.30406.65" />
+    <PackageReference Update="StreamJsonRpc"                                                          Version="2.6.41-alpha" />
 
     <!-- Avoid double-writes, can remove when https://github.com/NuGet/Home/issues/8343 is fixed -->
     <PackageReference Include="VSSDK.DTE"                                                             Version="7.0.4"                           ExcludeAssets="All" />
     <PackageReference Include="VSSDK.TemplateWizardInterface"                                         Version="12.0.4"                          ExcludeAssets="All" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.7.232-pre" />
+    <!-- Analyzers have a different version due to https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/266100 -->
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.8.145-pre" />
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.7.232-pre" />
 
     <!-- Roslyn -->
@@ -114,16 +115,13 @@
     <PackageReference Update="Roslyn.Diagnostics.Analyzers"                                           Version="3.3.0-beta2.final" />
 
     <!-- NuGet -->
-    <PackageReference Update="NuGet.SolutionRestoreManager.Interop"                                   Version="5.6.0-preview.2.6554" />
-    <PackageReference Update="NuGet.VisualStudio"                                                     Version="5.6.0-preview.2.6554" />
+    <PackageReference Update="NuGet.SolutionRestoreManager.Interop"                                   Version="5.8.0-preview.2.6767" />
+    <PackageReference Update="NuGet.VisualStudio"                                                     Version="5.8.0-preview.2.6767" />
 
-    <!-- MSBuild -->
-    <PackageReference Update="Microsoft.Build"                                                        Version="16.4.0"/>
-    <PackageReference Update="Microsoft.Build.Utilities.Core"                                         Version="16.4.0"/>
-    <PackageReference Update="Microsoft.Build.Engine"                                                 Version="16.4.0"/>
-    <PackageReference Update="Microsoft.Build.Tasks.Core"                                             Version="16.4.0"/>
-
-    <!-- Libraries -->
+    <!-- Framework packages -->
+    <PackageReference Update="Microsoft.IO.Redist"                                                    Version="4.7.0" />
+    
+    <!-- 3rd party -->
     <PackageReference Update="Newtonsoft.Json"                                                        Version="12.0.2"/>
 
     <!-- Tests -->

--- a/build/import/VisualStudio.props
+++ b/build/import/VisualStudio.props
@@ -33,8 +33,7 @@
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" />
     <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" />
     <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" />
-    <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" />    
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" />
@@ -52,52 +51,5 @@
     <PackageReference Include="NuGet.SolutionRestoreManager.Interop" />
     <PackageReference Include="NuGet.VisualStudio" />    
   </ItemGroup>
-
-  <!--
-    Some of the VSSDK packages may pull in Microsoft.VisualStudio.SDK.EmbedInteropTypes which essentially
-    does the below but for all of the listed references. We can't just use what they have since they include
-    things like EnvDTE which is reasonable for consumers, but strange since we actually _implement_ DTE and
-    use it as an exchange type with generics in a few places. Instead, we run directly after the target declared
-    in the EmbedInteropTypes package and ensure only the dependencies we need are embedded and the others are
-    skipped.
-  -->
-  <Target Name="CustomLinkVSSDKEmbeddableAssemblies" AfterTargets="LinkVSSDKEmbeddableAssemblies">
-    <ItemGroup>
-      <ReferencePath Condition="
-              '%(FileName)' == 'Microsoft.VisualStudio.Setup.Configuration.Interop'
-           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Embeddable'
-           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.12.0'
-           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime'
-           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime'
-           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime'
-           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime'
-           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.7.DesignTime'
-           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.8.DesignTime'
-           or '%(Filename)' == 'Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime'
-           or '%(FileName)' == 'Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime'
-           or '%(FileName)' == 'Microsoft.VisualStudio.ProjectSystem.Interop'
-           or '%(FileName)' == 'stdole'
-           or '%(FileName)' == 'Microsoft.VisualStudio.CommandBars'
-           or '%(FileName)' == 'NuGet.SolutionRestoreManager.Interop'
-           or '%(FileName)' == 'NuGet.VisualStudio'
-           or '%(FileName)' == 'VSLangProj110'
-           or '%(FileName)' == 'VSLangProj165'
-           ">
-        <EmbedInteropTypes>true</EmbedInteropTypes>
-      </ReferencePath>
-      <ReferencePath Condition="
-              '%(FileName)' == 'Microsoft.VisualStudio.Imaging.Interop.15.0.DesignTime'
-           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.10.0'
-           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.11.0'
-           or '%(FileName)' == 'Microsoft.VisualStudio.Feedback.Interop.12.0.DesignTime'
-           or '%(FileName)' == 'microsoft.visualstudio.designer.interfaces'
-           or '%(FileName)' == 'EnvDTE80'
-           or '%(FileName)' == 'EnvDTE90'
-           or '%(FileName)' == 'EnvDTE100'
-           or '%(FileName)' == 'Microsoft.Internal.VisualStudio.Shell.Interop.14.1.DesignTime'
-           or '%(FileName)' == 'Microsoft.Internal.VisualStudio.Shell.Interop.14.2.DesignTime'">
-        <EmbedInteropTypes>false</EmbedInteropTypes>
-      </ReferencePath>
-    </ItemGroup>
-  </Target>
+ 
 </Project>

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerTypeDiscoveryService.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerTypeDiscoveryService.vb
@@ -1,6 +1,7 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 Imports Microsoft.VisualStudio.Shell.Interop
+Imports System.IO
 
 Namespace Microsoft.VisualStudio.Editors.DesignerFramework
 
@@ -142,9 +143,9 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                         Dim a As System.Reflection.Assembly = typeResolutionService.GetAssembly(an)
                         Return a
                     End If
-                Catch ex As IO.FileNotFoundException
+                Catch ex As FileNotFoundException
                     ' The assembly doesn't exist - it may not have been built yet
-                Catch ex As IO.IOException
+                Catch ex As IOException
                     ' Unknown error when trying to load the file...
                 Catch ex As Security.SecurityException
                     ' We didn't have permissions to load the file...

--- a/src/Microsoft.VisualStudio.Editors/GlobalSuppressions.vb
+++ b/src/Microsoft.VisualStudio.Editors/GlobalSuppressions.vb
@@ -1333,6 +1333,8 @@ Imports System.Diagnostics.CodeAnalysis
 <Assembly: SuppressMessage("Naming", "CA1713:Events should not have 'Before' or 'After' prefix", Justification:="<Pending>", Scope:="member", Target:="~E:Microsoft.VisualStudio.Editors.MyExtensibility.TrackProjectDocumentsEventsHelper.AfterRemoveFiles")>
 <Assembly: SuppressMessage("Naming", "CA1713:Events should not have 'Before' or 'After' prefix", Justification:="<Pending>", Scope:="member", Target:="~E:Microsoft.VisualStudio.Editors.MyExtensibility.TrackProjectDocumentsEventsHelper.AfterRenameDirectories")>
 <Assembly: SuppressMessage("Naming", "CA1713:Events should not have 'Before' or 'After' prefix", Justification:="<Pending>", Scope:="member", Target:="~E:Microsoft.VisualStudio.Editors.MyExtensibility.TrackProjectDocumentsEventsHelper.AfterRenameFiles")>
+<Assembly: SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Scope:="member", Target:="~M:Microsoft.VisualStudio.Editors.XmlIntellisense.XmlIntellisenseSchemas.CompileCallBack(Microsoft.VisualStudio.Editors.XmlIntellisense.XmlIntellisenseSchemasData)")>
 
 ' Bugs
 <Assembly: SuppressMessage("Style", "IDE0070:Use 'System.HashCode'", Justification:="https://github.com/dotnet/roslyn/issues/45995", Scope:="member", Target:="~M:Microsoft.VisualStudio.Editors.PropertyPages.WPF.ApplicationPropPageVBWPF.StartupObject.GetHashCode~System.Int32")>
+

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensionTemplate.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensionTemplate.vb
@@ -2,6 +2,7 @@
 
 Option Strict On
 Option Explicit On
+Imports System.IO
 Imports System.Xml
 
 Imports EnvDTE90
@@ -44,7 +45,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                 Dim xmlDocument As New XmlDocument With {
                     .XmlResolver = Nothing
                 }
-                Using reader As XmlReader = XmlReader.Create(New IO.StringReader(template.CustomData))
+                Using reader As XmlReader = XmlReader.Create(New StringReader(template.CustomData))
                     xmlDocument.Load(reader)
                 End Using
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageBase.vb
@@ -3,6 +3,7 @@
 Imports System.ComponentModel
 Imports System.Drawing
 Imports System.Drawing.Drawing2D
+Imports System.IO
 Imports System.Windows.Forms
 
 Imports EnvDTE
@@ -291,8 +292,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 '  which we don't want.  Make a copy of the file as a memory stream and use that to
                 '  create the Image.
                 Try
-                    Dim IconContents As Byte() = IO.File.ReadAllBytes(path)
-                    Dim IconStream As New IO.MemoryStream(IconContents, 0, IconContents.Length)
+                    Dim IconContents As Byte() = File.ReadAllBytes(path)
+                    Dim IconStream As New MemoryStream(IconContents, 0, IconContents.Length)
                     ApplicationIconPictureBox.Image = IconToImage(New Icon(IconStream), ApplicationIconPictureBox.ClientSize)
                 Catch ex As Exception When ReportWithoutCrash(ex, NameOf(SetIconImagePath), NameOf(ApplicationPropPageBase))
                     'This could mean a bad icon file, I/O problems, etc.  At any rate, it doesn't make sense to

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
@@ -2,6 +2,7 @@
 
 Imports System.CodeDom
 Imports System.CodeDom.Compiler
+Imports System.IO
 Imports System.Reflection
 
 Imports Microsoft.VisualStudio.Shell.Interop
@@ -293,7 +294,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
             Debug.Assert(AddTo IsNot Nothing, "Must have a project items collection to add new item to!")
 
             ' Create new document...
-            Using Writer As New IO.StreamWriter(NewFilePath, False, System.Text.Encoding.UTF8)
+            Using Writer As New StreamWriter(NewFilePath, False, System.Text.Encoding.UTF8)
                 Dim ExtendingNamespace As CodeNamespace = Nothing
                 If cc2.Namespace IsNot Nothing Then
                     Debug.Assert(cc2.Namespace.FullName IsNot Nothing, "Couldn't get a FullName from the CodeClass2.Namespace!?")
@@ -695,7 +696,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
             End If
 
             Dim sb As New System.Text.StringBuilder
-            Dim sw As New IO.StringWriter(sb)
+            Dim sw As New StringWriter(sb)
 
             generator.GenerateCodeFromStatement(statement, sw, New CodeGeneratorOptions())
             sw.Flush()

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
@@ -1,7 +1,7 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 Imports System.ComponentModel.Design
-
+Imports System.IO
 Imports Microsoft.VisualStudio.Editors.Interop
 Imports Microsoft.VisualStudio.Shell.Interop
 
@@ -194,7 +194,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                             ' No settings class provided - let's crack open the .settings file... 
                             '
                             Settings = New DesignTimeSettings()
-                            Using Reader As New IO.StreamReader(FullPath)
+                            Using Reader As New StreamReader(FullPath)
                                 SettingsSerializer.Deserialize(Settings, Reader, True)
                             End Using
                         End If

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
@@ -1,6 +1,7 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 Imports System.Drawing
+Imports System.IO
 Imports System.Reflection
 Imports System.Windows.Forms
 
@@ -345,7 +346,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 ' Let's report the error and keep the dialog open!
                 ReportError(My.Resources.Microsoft_VisualStudio_Editors_Designer.GetString(My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_ERR_InvalidTypeName_1Arg, TypeName))
                 Return False
-            Catch ex As IO.FileLoadException
+            Catch ex As FileLoadException
                 ' The type resolution may throw an argument exception if the type name contains an invalid assembly name 
                 ' (i.e. Foo,,)
                 ' Let's report the error and keep the dialog open!

--- a/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
@@ -1,6 +1,7 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 Imports System.ComponentModel.Design
+Imports System.IO
 Imports System.Runtime.InteropServices
 
 Imports Microsoft.VisualStudio.Editors.OptionPages
@@ -260,9 +261,9 @@ Namespace Microsoft.VisualStudio.Editors
         ''' </summary>
         ''' <param name="key">Added in the constructor using AddOptionKey </param>
         ''' <param name="stream">Stream to read from</param>
-        Protected Overrides Sub OnLoadOptions(key As String, stream As IO.Stream)
+        Protected Overrides Sub OnLoadOptions(key As String, stream As Stream)
             If String.Equals(key, ProjectDesignerSUOKey, StringComparison.Ordinal) Then
-                Dim reader As New IO.BinaryReader(stream)
+                Dim reader As New BinaryReader(stream)
                 Dim buf(15) As Byte ' Space enough for a GUID - 16 bytes...
                 Try
                     While reader.Read(buf, 0, buf.Length) = buf.Length
@@ -286,7 +287,7 @@ Namespace Microsoft.VisualStudio.Editors
         ''' </summary>
         ''' <param name="key">Added in the constructor using AddOptionKey</param>
         ''' <param name="stream">Stream to read data from</param>
-        Protected Overrides Sub OnSaveOptions(key As String, stream As IO.Stream)
+        Protected Overrides Sub OnSaveOptions(key As String, stream As Stream)
             If String.Equals(key, ProjectDesignerSUOKey, StringComparison.Ordinal) Then
                 ' This is the project designer's last active tab
                 If _lastViewedProjectDesignerTab IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public async Task<ICollection<IEnumValue>> GetListedValuesAsync()
         {
-            Project project = _workspace.CurrentSolution.Projects.First(p => PathHelper.IsSamePath(p.FilePath, _unconfiguredProject.FullPath));
+            Project project = _workspace.CurrentSolution.Projects.First(p => PathHelper.IsSamePath(p.FilePath!, _unconfiguredProject.FullPath));
             Compilation? compilation = await project.GetCompilationAsync();
 
             IEntryPointFinderService? entryPointFinderService = project.LanguageServices.GetService<IEntryPointFinderService>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
     /// <summary>
     /// Base project configuration dimension provider
     /// </summary>
-    internal abstract class BaseProjectConfigurationDimensionProvider : IProjectConfigurationDimensionsProvider4
+    internal abstract class BaseProjectConfigurationDimensionProvider : IProjectConfigurationDimensionsProvider5
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseProjectConfigurationDimensionProvider"/> class.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/IProjectConfigurationDimensionsProvider5.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/IProjectConfigurationDimensionsProvider5.cs
@@ -6,7 +6,7 @@ using Microsoft.Build.Construction;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal interface IProjectConfigurationDimensionsProvider4 : IProjectConfigurationDimensionsProvider3
+    internal interface IProjectConfigurationDimensionsProvider5 : IProjectConfigurationDimensionsProvider3
     {
         IEnumerable<string> GetBestGuessDimensionNames(ImmutableArray<ProjectPropertyElement> properties);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationManifestValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationManifestValueProvider.cs
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 await defaultProperties.DeletePropertyAsync(NoManifestMSBuildProperty);
                 // If we can make the path relative to the project folder do so. Otherwise just use the given path.
                 if (Path.IsPathRooted(unevaluatedPropertyValue) &&
-                    PathHelper.TryMakeRelativeToProjectDirectory(_unconfiguredProject, unevaluatedPropertyValue, out string relativePath))
+                    PathHelper.TryMakeRelativeToProjectDirectory(_unconfiguredProject, unevaluatedPropertyValue, out string? relativePath))
                 {
                     returnValue = relativePath;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/SigningPropertyPage/AssemblyOriginatorKeyFileValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/SigningPropertyPage/AssemblyOriginatorKeyFileValueProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
             if (Path.IsPathRooted(unevaluatedPropertyValue) &&
-                _unconfiguredProject.TryMakeRelativeToProjectDirectory(unevaluatedPropertyValue, out string relativePath))
+                _unconfiguredProject.TryMakeRelativeToProjectDirectory(unevaluatedPropertyValue, out string? relativePath))
             {
                 unevaluatedPropertyValue = relativePath;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Reload/ProjectReloadInterceptor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Reload/ProjectReloadInterceptor.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             // Look through the properties and find all declared dimensions (ie <Configurations>, <Platforms>, <TargetFrameworks>) 
             // and return their dimension name equivalents (Configuration, Platform, TargetFramework)
             return DimensionProviders.Select(v => v.Value)
-                                     .OfType<IProjectConfigurationDimensionsProvider4>()
+                                     .OfType<IProjectConfigurationDimensionsProvider5>()
                                      .SelectMany(p => p.GetBestGuessDimensionNames(properties));
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
@@ -67,6 +67,14 @@
     </StringProperty.Metadata>
   </StringProperty>
 
+  <StringProperty Name="NuGetPackageId"
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+
   <StringProperty Name="SubType"
                   Visible="false">
     <StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
@@ -67,6 +67,14 @@
     </StringProperty.Metadata>
   </StringProperty>
 
+  <StringProperty Name="NuGetPackageId"
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+
   <StringProperty Name="SubType"
                   Visible="false">
     <StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EditorConfigFiles.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EditorConfigFiles.xaml
@@ -67,6 +67,14 @@
     </StringProperty.Metadata>
   </StringProperty>
 
+  <StringProperty Name="NuGetPackageId"
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+  
   <StringProperty Name="SubType"
                   Visible="false">
     <StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
@@ -67,6 +67,14 @@
     </StringProperty.Metadata>
   </StringProperty>
 
+  <StringProperty Name="NuGetPackageId"
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+  
   <StringProperty Name="SubType"
                   Visible="false">
     <StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
@@ -67,6 +67,14 @@
     </StringProperty.Metadata>
   </StringProperty>
 
+  <StringProperty Name="NuGetPackageId"
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+
   <StringProperty Name="SubType"
                   Visible="false">
     <StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/PackageContentProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/PackageContentProjectTreePropertiesProvider.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.ComponentModel.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Tree
+{
+    /// <summary>
+    ///     Marks content items that come from packages as "user read-only".
+    /// </summary>
+    [Export(typeof(IProjectTreePropertiesProvider))]
+    [AppliesTo(ProjectCapability.PackageReferences)]
+    internal class PackageContentProjectTreePropertiesProvider : IProjectTreePropertiesProvider
+    {
+        public void CalculatePropertyValues(IProjectTreeCustomizablePropertyContext propertyContext, IProjectTreeCustomizablePropertyValues propertyValues)
+        {
+            // Package content items always come in as linked items, so to reduce
+            // the number of items we look at, we limit ourselves to them
+            if (propertyValues.Flags.Contains(ProjectTreeFlags.LinkedItem) && 
+                propertyContext.Metadata != null &&
+                propertyContext.Metadata.TryGetValue(None.NuGetPackageIdProperty, out string packageId) && packageId.Length > 0)
+            {
+                // TODO: Replace this with strongly typed value when we next update
+                propertyValues.Flags |= ProjectTreeFlags.Create("UserReadOnly");
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.ImplicitProjectCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.ImplicitProjectCheck.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                     if (!string.Equals(_nuGetPackageFoldersString, value, StringComparisons.Paths))
                     {
                         _nuGetPackageFoldersString = value;
-                        _nuGetPackageFolders = value.Split(';');
+                        _nuGetPackageFolders = value.Split(Delimiter.Semicolon);
                     }
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -439,7 +439,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             // here if the project actually produced a marker and we only check it against references that
             // actually produced a marker.
 
-            if (string.IsNullOrWhiteSpace(state.CopyUpToDateMarkerItem) || !state.CopyReferenceInputs.Any())
+            if (Strings.IsNullOrWhiteSpace(state.CopyUpToDateMarkerItem) || !state.CopyReferenceInputs.Any())
             {
                 return true;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringExtensions.cs
@@ -2,15 +2,15 @@
 
 using System;
 
-namespace Microsoft
+namespace Microsoft.VisualStudio
 {
     internal static class StringExtensions
     {
-        public static string[] SplitReturningEmptyIfEmpty(this string value, char separator)
+        public static string[] SplitReturningEmptyIfEmpty(this string value, params char[] separator)
         {
             string[] values = value.Split(separator);
 
-            if (values.Length == 1 && string.IsNullOrEmpty(value))
+            if (values.Length == 1 && string.IsNullOrEmpty(values[0]))
                 return Array.Empty<string>();
 
             return values;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsAsyncFileChangeExMock.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsAsyncFileChangeExMock.cs
@@ -59,5 +59,10 @@ namespace Microsoft.VisualStudio.Shell
         {
             throw new NotImplementedException();
         }
+
+        public System.Threading.Tasks.Task FilterDirectoryChangesAsync(uint cookie, string[] extensions, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
This updates all our package versions to latest available in master, and reacts to associated fallout:

- Needed to move interop embed down to HostAgnostic layer as there are dependencies on interop assemblies at that level.
- Needed to add a reference to Microsoft.IO.Redist which CPS runtime now has a dependency.
- Need to fix nullable warnings due to update references
- Need to fix VB's reference to namespace "IO" as it conflicts with "Microsoft.IO"

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6476)