### PR TITLE
Remove warnings of deprecated tasks on official build

### DIFF
--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -67,7 +67,6 @@ steps:
 # needed and the specific order it has to be performed in. Copy -> Publish Symbols -> Publish
 # Artifact -> publish to symweb
 
-#TODO change the targetfolder - perhaps use ArtifactStagingDirectory variable
 - task: CopyFiles@2
   inputs:
     SourceFolder: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)'

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -81,12 +81,10 @@ steps:
   displayName: Archive symbols to VSTS
   inputs:
     SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols
-    SearchPattern: 
-      '**/*.pdb
-      **/*.dll
-      **/*.exe'
+    SearchPattern: '**/*.pdb'
+    indexSources: false
+    publishSymbols: true
     SymbolServerType: TeamServices
-    SkipIndexing: true
     SymbolsProduct: 'Roslyn Project System'
     SymbolsVersion: '$(Build.BuildNumber)'
     SymbolsArtifactName: Symbols

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -110,11 +110,9 @@ steps:
   inputs:
     DropFolder: 'artifacts\$(BuildConfiguration)\VSSetup\Insertion'
 
-#TODO deprecate this with PublishBuildArtifacts@1
-- task: CopyPublishBuildArtifacts@1
-  displayName: Publish Drop
+- task: CopyFiles@2
   inputs:
-    CopyRoot: '$(Build.SourcesDirectory)'
+    SourceFolder: '$(Build.SourcesDirectory)'
     Contents: |
      artifacts\$(BuildConfiguration)\bin
      artifacts\$(BuildConfiguration)\DevDivInsertionFiles
@@ -122,8 +120,16 @@ steps:
      artifacts\$(BuildConfiguration)\packages
      artifacts\$(BuildConfiguration)\VSSetup
      artifacts\$(BuildConfiguration)\TestResults
+    TargetFolder: $(Build.ArtifactStagingDirectory)/drop
+  displayName: Copy Drop
+  condition: succeededOrFailed()
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/drop'
     ArtifactName: '$(Build.BuildNumber)'
-    ArtifactType: Container
+    publishLocation: Container
+  displayName: 'Publish Artifact: drop'
   condition: succeededOrFailed()
 
 - task: NuGetPublisher@0

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -81,7 +81,10 @@ steps:
   displayName: Archive symbols to VSTS
   inputs:
     SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols
-    SearchPattern: '**/*.pdb'
+    SearchPattern: 
+      '**/*.pdb
+      **/*.dll
+      **/*.exe'
     indexSources: false
     publishSymbols: true
     SymbolServerType: TeamServices

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -114,12 +114,12 @@ steps:
   inputs:
     SourceFolder: '$(Build.SourcesDirectory)'
     Contents: |
-     artifacts\$(BuildConfiguration)\bin
-     artifacts\$(BuildConfiguration)\DevDivInsertionFiles
-     artifacts\$(BuildConfiguration)\log
-     artifacts\$(BuildConfiguration)\packages
-     artifacts\$(BuildConfiguration)\VSSetup
-     artifacts\$(BuildConfiguration)\TestResults
+     artifacts\$(BuildConfiguration)\bin\**
+     artifacts\$(BuildConfiguration)\DevDivInsertionFiles\**
+     artifacts\$(BuildConfiguration)\log\**
+     artifacts\$(BuildConfiguration)\packages\**
+     artifacts\$(BuildConfiguration)\VSSetup\**
+     artifacts\$(BuildConfiguration)\TestResults\**
     TargetFolder: $(Build.ArtifactStagingDirectory)/drop
   displayName: Copy Drop
   condition: succeededOrFailed()

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -99,15 +99,15 @@ steps:
     ArtifactName: symbols
     publishLocation: Container
   displayName: 'Publish Artifact: symbols'
-  
-- task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
+
+- task: artifactDropTask@0
   displayName: Publish Symbols to Artifact Services (symweb)
   inputs:
-    symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
-    requestName: '$(system.teamProject)/$(Build.DefinitionName)/$(Build.BuildNumber)/$(Build.BuildId)'
-    sourcePath: $(Build.ArtifactStagingDirectory)/symbols
+    dropServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
+    buildNumber: '$(system.teamProject)/$(Build.DefinitionName)/$(Build.BuildNumber)/$(Build.BuildId)'
+    sourcePath: '$(Build.ArtifactStagingDirectory)/symbols'
     usePat: false
-    
+        
 - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
   displayName: Upload VSTS Drop
   inputs:


### PR DESCRIPTION
We were using tasks in our official build pipeline which had been deprecated which resulted in warnings showing up at the end of each build. The changes in this PR use the most up-to-date tasks and reduce the noise from the warnings.

## Before
![image](https://user-images.githubusercontent.com/3288375/91237029-5f146b00-e6ee-11ea-809e-c55d22d89b5e.png)

## After
![image](https://user-images.githubusercontent.com/3288375/91237060-73f0fe80-e6ee-11ea-9c61-fc06d771cc46.png)

This PR now uses the correct tasks.

Fixes #5905 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6478)