### PR TITLE
Mark package content items as "user read-only"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
@@ -67,6 +67,14 @@
     </StringProperty.Metadata>
   </StringProperty>
 
+  <StringProperty Name="NuGetPackageId"
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+
   <StringProperty Name="SubType"
                   Visible="false">
     <StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
@@ -67,6 +67,14 @@
     </StringProperty.Metadata>
   </StringProperty>
 
+  <StringProperty Name="NuGetPackageId"
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+
   <StringProperty Name="SubType"
                   Visible="false">
     <StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EditorConfigFiles.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EditorConfigFiles.xaml
@@ -67,6 +67,14 @@
     </StringProperty.Metadata>
   </StringProperty>
 
+  <StringProperty Name="NuGetPackageId"
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+  
   <StringProperty Name="SubType"
                   Visible="false">
     <StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
@@ -67,6 +67,14 @@
     </StringProperty.Metadata>
   </StringProperty>
 
+  <StringProperty Name="NuGetPackageId"
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+  
   <StringProperty Name="SubType"
                   Visible="false">
     <StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
@@ -67,6 +67,14 @@
     </StringProperty.Metadata>
   </StringProperty>
 
+  <StringProperty Name="NuGetPackageId"
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+
   <StringProperty Name="SubType"
                   Visible="false">
     <StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/PackageContentProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/PackageContentProjectTreePropertiesProvider.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.ComponentModel.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Tree
+{
+    /// <summary>
+    ///     Marks content items that come from packages as "user read-only".
+    /// </summary>
+    [Export(typeof(IProjectTreePropertiesProvider))]
+    [AppliesTo(ProjectCapability.PackageReferences)]
+    internal class PackageContentProjectTreePropertiesProvider : IProjectTreePropertiesProvider
+    {
+        public void CalculatePropertyValues(IProjectTreeCustomizablePropertyContext propertyContext, IProjectTreeCustomizablePropertyValues propertyValues)
+        {
+            // Package content items always come in as linked items, so to reduce
+            // the number of items we look at, we limit ourselves to them
+            if (propertyValues.Flags.Contains(ProjectTreeFlags.LinkedItem) && 
+                propertyContext.Metadata != null &&
+                propertyContext.Metadata.TryGetValue(None.NuGetPackageIdProperty, out string packageId) && packageId.Length > 0)
+            {
+                // TODO: Replace this with strongly typed value when we next update
+                propertyValues.Flags |= ProjectTreeFlags.Create("UserReadOnly");
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.ImplicitProjectCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.ImplicitProjectCheck.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                     if (!string.Equals(_nuGetPackageFoldersString, value, StringComparisons.Paths))
                     {
                         _nuGetPackageFoldersString = value;
-                        _nuGetPackageFolders = value.Split(';');
+                        _nuGetPackageFolders = value.Split(Delimiter.Semicolon);
                     }
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringExtensions.cs
@@ -2,15 +2,15 @@
 
 using System;
 
-namespace Microsoft
+namespace Microsoft.VisualStudio
 {
     internal static class StringExtensions
     {
-        public static string[] SplitReturningEmptyIfEmpty(this string value, char separator)
+        public static string[] SplitReturningEmptyIfEmpty(this string value, params char[] separator)
         {
             string[] values = value.Split(separator);
 
-            if (values.Length == 1 && string.IsNullOrEmpty(value))
+            if (values.Length == 1 && string.IsNullOrEmpty(values[0]))
                 return Array.Empty<string>();
 
             return values;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/2141

This marks package content items as user read-only, which causes them to be opened read-only in the editor.

This depends on https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/266425.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6480)