### PR TITLE
Fire hint to CPS to reevaluate on assets file changed

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectChangeHintSubmissionServiceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectChangeHintSubmissionServiceFactory.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IProjectChangeHintSubmissionServiceFactory
+    {
+        public static IProjectChangeHintSubmissionService Create()
+        {
+            var mock = new Mock<IProjectChangeHintSubmissionService>();
+            mock.Setup(s => s.HintAsync(It.IsAny<IProjectChangeHint>()))
+                .ReturnsAsync(() => { });
+
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/PackageRestoreDataSourceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/PackageRestoreDataSourceTests.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Logging;
@@ -93,13 +94,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             solutionRestoreService ??= IVsSolutionRestoreServiceFactory.Create();
             IProjectLogger logger = IProjectLoggerFactory.Create();
             IFileSystem fileSystem = IFileSystemFactory.Create();
-            
+            var hintService = new Lazy<IProjectChangeHintSubmissionService>(() => IProjectChangeHintSubmissionServiceFactory.Create());
+            var projectAccessor = IProjectAccessorFactory.Create();
+
             return new PackageRestoreDataSource(
                 project,
                 dataSource,
                 projectAsynchronousTasksService,
                 solutionRestoreService,
                 fileSystem,
+                hintService,
+                projectAccessor,
                 logger);
         }
     }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/6479

CPS can miss file changed events when there are lots of file changes (such as a branch switch via the command-line). Fire a hint specifically to tell it to that the file "might" changed, CPS itself will determine if it has.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6481)