### PR TITLE
Remove call to RunAndForget

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileCommonValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileCommonValueProvider.cs
@@ -43,8 +43,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         internal const string WorkingDirectoryPropertyName = "WorkingDirectory";
 
         [ImportingConstructor]
-        public ActiveLaunchProfileCommonValueProvider(UnconfiguredProject project, ILaunchSettingsProvider launchSettingsProvider, IProjectThreadingService projectThreadingService)
-            : base(project, launchSettingsProvider, projectThreadingService)
+        public ActiveLaunchProfileCommonValueProvider(ILaunchSettingsProvider launchSettingsProvider)
+            : base(launchSettingsProvider)
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileEnvironmentVariableValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileEnvironmentVariableValueProvider.cs
@@ -24,8 +24,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         internal const string EnvironmentVariablesPropertyName = "EnvironmentVariables";
 
         [ImportingConstructor]
-        public ActiveLaunchProfileEnvironmentVariableValueProvider(UnconfiguredProject project, ILaunchSettingsProvider launchSettingsProvider, IProjectThreadingService projectThreadingService)
-            : base(project, launchSettingsProvider, projectThreadingService)
+        public ActiveLaunchProfileEnvironmentVariableValueProvider(ILaunchSettingsProvider launchSettingsProvider)
+            : base(launchSettingsProvider)
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileExtensionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileExtensionValueProvider.cs
@@ -47,8 +47,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private const string False = "false";
 
         [ImportingConstructor]
-        public ActiveLaunchProfileExtensionValueProvider(UnconfiguredProject project, ILaunchSettingsProvider launchSettingsProvider, IProjectThreadingService projectThreadingService)
-            : base(project, launchSettingsProvider, projectThreadingService)
+        public ActiveLaunchProfileExtensionValueProvider(ILaunchSettingsProvider launchSettingsProvider)
+            : base(launchSettingsProvider)
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Shipped.txt
@@ -101,7 +101,7 @@ Microsoft.VisualStudio.ProjectSystem.Properties.IInterceptingPropertyValueProvid
 Microsoft.VisualStudio.ProjectSystem.Properties.InterceptingPropertyValueProviderBase
 Microsoft.VisualStudio.ProjectSystem.Properties.InterceptingPropertyValueProviderBase.InterceptingPropertyValueProviderBase() -> void
 Microsoft.VisualStudio.ProjectSystem.Properties.LaunchSettingsValueProviderBase
-Microsoft.VisualStudio.ProjectSystem.Properties.LaunchSettingsValueProviderBase.LaunchSettingsValueProviderBase(Microsoft.VisualStudio.ProjectSystem.UnconfiguredProject! project, Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider! launchSettingsProvider, Microsoft.VisualStudio.ProjectSystem.IProjectThreadingService! projectThreadingService) -> void
+Microsoft.VisualStudio.ProjectSystem.Properties.LaunchSettingsValueProviderBase.LaunchSettingsValueProviderBase(Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider! launchSettingsProvider) -> void
 Microsoft.VisualStudio.ProjectSystem.VS.Extensibility.IProjectExportProvider
 Microsoft.VisualStudio.ProjectSystem.VS.Extensibility.IProjectExportProvider.GetExport<T>(string! projectFilePath) -> T?
 Microsoft.VisualStudio.ProjectSystem.VS.ManagedImageMonikers

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ActiveLaunchProfileValueProvidersTests.cs
@@ -56,9 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             string activeProfileExecutablePath = @"C:\user\bin\alpha.exe";
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "Alpha", activeProfileExecutablePath: activeProfileExecutablePath);
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var launchProfileProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var launchProfileProvider = new ActiveLaunchProfileCommonValueProvider(settingsProvider);
 
             var actualValue = await launchProfileProvider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.ExecutablePathPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
@@ -71,9 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             string activeProfileExecutablePath = @"C:\user\bin\beta.exe";
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "Beta", activeProfileExecutablePath: activeProfileExecutablePath);
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var launchProfileProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var launchProfileProvider = new ActiveLaunchProfileCommonValueProvider(settingsProvider);
 
             var actualValue = await launchProfileProvider.OnGetUnevaluatedPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.ExecutablePathPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
@@ -92,9 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     activeProfileExecutablePath = s.ActiveProfile!.ExecutablePath;
                 });
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var launchProfileProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var launchProfileProvider = new ActiveLaunchProfileCommonValueProvider(settingsProvider);
 
             await launchProfileProvider.OnSetPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.ExecutablePathPropertyName, @"C:\user\bin\delta.exe", Mock.Of<IProjectProperties>());
 
@@ -107,9 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             string activeProfileLaunchTarget = "AlphaCommand";
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "Alpha", activeProfileLaunchTarget: activeProfileLaunchTarget);
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var launchProfileProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var launchProfileProvider = new ActiveLaunchProfileCommonValueProvider(settingsProvider);
 
             var actualValue = await launchProfileProvider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.LaunchTargetPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
@@ -122,9 +114,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             string activeProfileLaunchTarget = "BetaCommand";
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "Beta", activeProfileLaunchTarget: activeProfileLaunchTarget);
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var launchProfileProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var launchProfileProvider = new ActiveLaunchProfileCommonValueProvider(settingsProvider);
 
             var actualValue = await launchProfileProvider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.LaunchTargetPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
@@ -143,9 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     activeProfileLaunchTarget = s.ActiveProfile!.CommandName;
                 });
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var launchProfileProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var launchProfileProvider = new ActiveLaunchProfileCommonValueProvider(settingsProvider);
 
             await launchProfileProvider.OnSetPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.LaunchTargetPropertyName, "NewCommand", Mock.Of<IProjectProperties>());
 
@@ -158,9 +146,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             string activeProfileCommandLineArguments = "/bird:YES /giraffe:NO";
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "ZooAnimals", activeProfileCommandLineArgs: activeProfileCommandLineArguments);
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var commandLineArgumentsProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var commandLineArgumentsProvider = new ActiveLaunchProfileCommonValueProvider(settingsProvider);
 
             var actualValue = await commandLineArgumentsProvider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.CommandLineArgumentsPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
@@ -173,9 +159,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             string activeProfileCommandLineArguments = "/alpaca:YES /llama:NO /vicuña:NONONO";
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "SortOfFarmAnimals", activeProfileCommandLineArgs: activeProfileCommandLineArguments);
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var commandLineArgumentsProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var commandLineArgumentsProvider = new ActiveLaunchProfileCommonValueProvider(settingsProvider);
 
             var actualValue = await commandLineArgumentsProvider.OnGetUnevaluatedPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.CommandLineArgumentsPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
@@ -196,7 +180,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var project = UnconfiguredProjectFactory.Create();
             var threadingService = IProjectThreadingServiceFactory.Create();
-            var commandLineArgumentsProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var commandLineArgumentsProvider = new ActiveLaunchProfileCommonValueProvider(settingsProvider);
 
             await commandLineArgumentsProvider.OnSetPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.CommandLineArgumentsPropertyName, "/seaotters:YES /seals:YES", Mock.Of<IProjectProperties>());
 
@@ -209,9 +193,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             string activeProfileWorkingDirectory = @"C:\alpha\beta\gamma";
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileWorkingDirectory: activeProfileWorkingDirectory);
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(settingsProvider);
 
             var actualValue = await workingDirectoryProvider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.WorkingDirectoryPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
@@ -224,9 +206,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             string activeProfileWorkingDirectory = @"C:\delta\epsilon\phi";
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "Two", activeProfileWorkingDirectory: activeProfileWorkingDirectory);
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(settingsProvider);
 
             var actualValue = await workingDirectoryProvider.OnGetUnevaluatedPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.WorkingDirectoryPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
@@ -247,7 +227,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var project = UnconfiguredProjectFactory.Create();
             var threadingService = IProjectThreadingServiceFactory.Create();
-            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(settingsProvider);
 
             await workingDirectoryProvider.OnSetPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.WorkingDirectoryPropertyName, @"C:\four\five\six", Mock.Of<IProjectProperties>());
 
@@ -260,9 +240,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             bool activeProfileLaunchBrowser = true;
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileLaunchBrowser: activeProfileLaunchBrowser);
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(settingsProvider);
 
             var actualValue = await workingDirectoryProvider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.LaunchBrowserPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
@@ -281,9 +259,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     activeProfileLaunchBrowser = s.ActiveProfile!.LaunchBrowser;
                 });
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(settingsProvider);
 
             await workingDirectoryProvider.OnSetPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.LaunchBrowserPropertyName, "true", Mock.Of<IProjectProperties>());
 
@@ -296,9 +272,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             string activeProfileLaunchUrl = "https://microsoft.com";
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileLaunchUrl: activeProfileLaunchUrl);
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(settingsProvider);
 
             var actualValue = await workingDirectoryProvider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.LaunchUrlPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
@@ -317,9 +291,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     activeProfileLaunchUrl = s.ActiveProfile!.LaunchUrl;
                 });
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(project, settingsProvider, threadingService);
+            var workingDirectoryProvider = new ActiveLaunchProfileCommonValueProvider(settingsProvider);
 
             await workingDirectoryProvider.OnSetPropertyValueAsync(ActiveLaunchProfileCommonValueProvider.LaunchUrlPropertyName, "https://microsoft.com", Mock.Of<IProjectProperties>());
 
@@ -336,9 +308,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileOtherSettings: activeProfileOtherSettings);
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+            var provider = new ActiveLaunchProfileExtensionValueProvider(settingsProvider);
 
             var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.AuthenticationModePropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
@@ -363,9 +333,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     activeProfileAuthenticationMode = (string)s.ActiveProfile.OtherSettings[LaunchProfileExtensions.RemoteAuthenticationModeProperty];
                 });
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+            var provider = new ActiveLaunchProfileExtensionValueProvider(settingsProvider);
 
             await provider.OnSetPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.AuthenticationModePropertyName, "NotWindows", Mock.Of<IProjectProperties>());
 
@@ -383,9 +351,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileOtherSettings: activeProfileOtherSettings);
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+            var provider = new ActiveLaunchProfileExtensionValueProvider(settingsProvider);
 
             var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.NativeDebuggingPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
@@ -410,9 +376,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     activeProfileNativeDebugging = (bool)s.ActiveProfile.OtherSettings[LaunchProfileExtensions.NativeDebuggingProperty];
                 });
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+            var provider = new ActiveLaunchProfileExtensionValueProvider(settingsProvider);
 
             await provider.OnSetPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.NativeDebuggingPropertyName, "true", Mock.Of<IProjectProperties>());
 
@@ -430,9 +394,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileOtherSettings: activeProfileOtherSettings);
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+            var provider = new ActiveLaunchProfileExtensionValueProvider(settingsProvider);
 
             var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.RemoteDebugEnabledPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
@@ -457,9 +419,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     activeProfileRemoteDebugEnabled = (bool)s.ActiveProfile.OtherSettings[LaunchProfileExtensions.RemoteDebugEnabledProperty];
                 });
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+            var provider = new ActiveLaunchProfileExtensionValueProvider(settingsProvider);
 
             await provider.OnSetPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.RemoteDebugEnabledPropertyName, "true", Mock.Of<IProjectProperties>());
 
@@ -477,9 +437,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileOtherSettings: activeProfileOtherSettings);
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+            var provider = new ActiveLaunchProfileExtensionValueProvider(settingsProvider);
 
             var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.RemoteDebugMachinePropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
@@ -504,9 +462,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     activeProfileRemoteMachineName = (string)s.ActiveProfile.OtherSettings[LaunchProfileExtensions.RemoteDebugMachineProperty];
                 });
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+            var provider = new ActiveLaunchProfileExtensionValueProvider(settingsProvider);
 
             await provider.OnSetPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.RemoteDebugMachinePropertyName, "Cheetah", Mock.Of<IProjectProperties>());
 
@@ -524,9 +480,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileOtherSettings: activeProfileOtherSettings);
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+            var provider = new ActiveLaunchProfileExtensionValueProvider(settingsProvider);
 
             var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.SqlDebuggingPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
@@ -551,9 +505,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     activeProfileSqlDebugEnabled = (bool)s.ActiveProfile.OtherSettings[LaunchProfileExtensions.SqlDebuggingProperty];
                 });
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var provider = new ActiveLaunchProfileExtensionValueProvider(project, settingsProvider, threadingService);
+            var provider = new ActiveLaunchProfileExtensionValueProvider(settingsProvider);
 
             await provider.OnSetPropertyValueAsync(ActiveLaunchProfileExtensionValueProvider.SqlDebuggingPropertyName, "true", Mock.Of<IProjectProperties>());
 
@@ -571,9 +523,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileEnvironmentVariables: activeProfileEnvironmentVariables);
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var provider = new ActiveLaunchProfileEnvironmentVariableValueProvider(project, settingsProvider, threadingService);
+            var provider = new ActiveLaunchProfileEnvironmentVariableValueProvider(settingsProvider);
 
             var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileEnvironmentVariableValueProvider.EnvironmentVariablesPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
@@ -592,9 +542,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var settingsProvider = SetupLaunchSettingsProvider(activeProfileName: "One", activeProfileEnvironmentVariables: activeProfileEnvironmentVariables);
 
-            var project = UnconfiguredProjectFactory.Create();
-            var threadingService = IProjectThreadingServiceFactory.Create();
-            var provider = new ActiveLaunchProfileEnvironmentVariableValueProvider(project, settingsProvider, threadingService);
+            var provider = new ActiveLaunchProfileEnvironmentVariableValueProvider(settingsProvider);
 
             var actualValue = await provider.OnGetEvaluatedPropertyValueAsync(ActiveLaunchProfileEnvironmentVariableValueProvider.EnvironmentVariablesPropertyName, string.Empty, Mock.Of<IProjectProperties>());
 
@@ -622,7 +570,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var project = UnconfiguredProjectFactory.Create();
             var threadingService = IProjectThreadingServiceFactory.Create();
-            var provider = new ActiveLaunchProfileEnvironmentVariableValueProvider(project, settingsProvider, threadingService);
+            var provider = new ActiveLaunchProfileEnvironmentVariableValueProvider(settingsProvider);
 
             await provider.OnSetPropertyValueAsync(ActiveLaunchProfileEnvironmentVariableValueProvider.EnvironmentVariablesPropertyName, "Alpha=Equals: /= Comma: /, Slash: //,Beta=two", Mock.Of<IProjectProperties>());
 


### PR DESCRIPTION
Fixes #6430.

`LaunchSettingsValueProviderBase.OnSetPropertyValueAsync` will often be called in a context where certain project locks have already been acquired. This was problematic because it often called `ILaunchSettingsProvider.UpdateAndSaveSettingsAsync` which tried (and failed) to acquire the locks again. To work around this `OnSetPropertyValueAsync` used `RunAndForget` to do its work in a context that held no locks; it would then simply block until it could acquire the needed locks.

This solved one problem but created another: when setting multiple properties `RunAndForget` would cause them to run in parallel rather than sequentially. This could lead to races and data loss. For example, operation "A" might retrieve the current launch settings. Then operation "B" retrieves them, makes changes, and updates the launch profile. Then A makes change and updates the launch profile. At this point the changes made by B have been lost because A started from earlier data.

PR #6343 changed `UpdateAndSaveSettingsAsync` to no longer need the lock, so the call to `RunAndForget` is no longer needed and we can enforce property sequential access to the launch settings. This also allows us to simplify the code and tests a fair bit as we no longer need the threading service.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6482)