### PR TITLE
Add TaskCompletionSource

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -17,6 +17,7 @@ using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.VS.Debug;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading.Tasks;
 using DialogResult = System.Windows.Forms.DialogResult;
 using Task = System.Threading.Tasks.Task;
 
@@ -39,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         private List<LaunchType> _providerLaunchTypes;
         private LaunchType _selectedLaunchType;
         private OrderPrecedenceImportCollection<ILaunchSettingsUIProvider> _uiProviders;
-        private readonly TaskCompletionSource<bool> _firstSnapshotCompleteSource;
+        private readonly TaskCompletionSource _firstSnapshotCompleteSource;
         private ICommand _addEnvironmentVariableRowCommand;
         private ICommand _removeEnvironmentVariableRowCommand;
         private ICommand _browseDirectoryCommand;
@@ -56,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         }
 
         // for unit testing
-        internal DebugPageViewModel(TaskCompletionSource<bool> snapshotComplete, UnconfiguredProject project)
+        internal DebugPageViewModel(TaskCompletionSource snapshotComplete, UnconfiguredProject project)
         {
             _firstSnapshotCompleteSource = snapshotComplete;
             Project = project;
@@ -918,7 +919,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             finally
             {
                 PopIgnoreEvents();
-                _firstSnapshotCompleteSource?.TrySetResult(true);
+                _firstSnapshotCompleteSource?.TrySetResult();
                 _debugTargetsCoreInitialized = true;
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/ImplicitlyActiveConfiguredProjectReadyToBuild.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/ImplicitlyActiveConfiguredProjectReadyToBuild.cs
@@ -3,6 +3,7 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Build
 {
@@ -14,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
         private readonly ConfiguredProject _configuredProject;
         private readonly IActiveConfiguredProjectProvider _activeConfiguredProjectProvider;
 
-        private TaskCompletionSource<object?> _activationTask;
+        private TaskCompletionSource _activationTask;
 
         [ImportingConstructor]
         public ImplicitlyActiveConfiguredProjectReadyToBuild(
@@ -23,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
         {
             _configuredProject = configuredProject;
             _activeConfiguredProjectProvider = activeConfiguredProjectProvider;
-            _activationTask = new TaskCompletionSource<object?>();
+            _activationTask = new TaskCompletionSource();
 
             _activeConfiguredProjectProvider.Changed += ActiveConfiguredProject_Changed;
         }
@@ -44,12 +45,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
                 {
                     if (!nowActive)
                     {
-                        _activationTask = new TaskCompletionSource<object?>();
+                        _activationTask = new TaskCompletionSource();
                     }
                 }
                 else if (nowActive)
                 {
-                    _activationTask.TrySetResult(null);
+                    _activationTask.TrySetResult();
                 }
 
                 return _activationTask.Task;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ConfiguredProjectImplicitActivationTracking.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ConfiguredProjectImplicitActivationTracking.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private readonly IProjectAsynchronousTasksService _tasksService;
         private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
         private readonly ITargetBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> _targetBlock;
-        private TaskCompletionSource<object?> _isImplicitlyActiveSource = new TaskCompletionSource<object?>();
+        private TaskCompletionSource _isImplicitlyActiveSource = new TaskCompletionSource();
         private IDisposable? _subscription;
 
         [ImportingConstructor]
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         private Task OnImplicitlyActivated()
         {
-            _isImplicitlyActiveSource.TrySetResult(null);
+            _isImplicitlyActiveSource.TrySetResult();
 
             IEnumerable<Task> tasks = ImplicitlyActiveServices.Select(c => c.Value.ActivateAsync());
 
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         private Task OnImplicitlyDeactivated()
         {
-            var source = new TaskCompletionSource<object?>();
+            var source = new TaskCompletionSource();
 
             // Make sure the writes in constructor don't 
             // move to after we publish the value

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         private readonly IUnconfiguredProjectCommonServices _commonProjectServices;
         private readonly IActiveConfiguredProjectSubscriptionService? _projectSubscriptionService;
         private readonly IFileSystem _fileSystem;
-        private readonly TaskCompletionSource<bool> _firstSnapshotCompletionSource = new TaskCompletionSource<bool>();
+        private readonly TaskCompletionSource _firstSnapshotCompletionSource = new TaskCompletionSource();
         private readonly SequentialTaskExecutor _sequentialTaskQueue = new SequentialTaskExecutor();
         private IReceivableSourceBlock<ILaunchSettings>? _changedSourceBlock;
         private IBroadcastBlock<ILaunchSettings>? _broadcastBlock;
@@ -146,7 +146,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 // If this is the first snapshot, complete the taskCompletionSource
                 if (_currentSnapshot == null)
                 {
-                    _firstSnapshotCompletionSource.TrySetResult(true);
+                    _firstSnapshotCompletionSource.TrySetResult();
                 }
                 _currentSnapshot = value;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
@@ -16,8 +17,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private readonly IProjectAsynchronousTasksService _tasksService;
         private readonly IProjectThreadingService _threadingService;
         private readonly ILoadedInHostListener? _loadedInHostListener;
-        private readonly TaskCompletionSource<object?> _projectLoadedInHost = new TaskCompletionSource<object?>();
-        private readonly TaskCompletionSource<object?> _prioritizedProjectLoadedInHost = new TaskCompletionSource<object?>();
+        private readonly TaskCompletionSource _projectLoadedInHost = new TaskCompletionSource();
+        private readonly TaskCompletionSource _prioritizedProjectLoadedInHost = new TaskCompletionSource();
         private readonly JoinableTaskCollection _prioritizedTasks;
 
         [ImportingConstructor]
@@ -43,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             }
             else
             {
-                _projectLoadedInHost.TrySetResult(null);
+                _projectLoadedInHost.TrySetResult();
                 return Task.CompletedTask;
             }
         }
@@ -108,12 +109,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public void OnProjectLoadedInHost()
         {
-            _projectLoadedInHost.SetResult(null);
+            _projectLoadedInHost.SetResult();
         }
 
         public void OnPrioritizedProjectLoadedInHost()
         {
-            _prioritizedProjectLoadedInHost.SetResult(null);
+            _prioritizedProjectLoadedInHost.SetResult();
 
             _threadingService.ExecuteSynchronously(() => _prioritizedTasks.JoinTillEmptyAsync());
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskCompletionSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskCompletionSource.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Threading.Tasks
+{
+    /// <inheritdoc cref="TaskCompletionSource{TResult}"/>
+    /// <remarks>
+    ///     This provides the non-generic version of a <see cref="TaskCompletionSource{TResult}"/>
+    /// </remarks>
+    internal class TaskCompletionSource : TaskCompletionSource<object?>
+    {
+        /// <inheritdoc cref="TaskCompletionSource{TResult}.Task"/>
+        public new Task Task
+        {
+            get { return base.Task; }
+        }
+
+        /// <inheritdoc cref="TaskCompletionSource{TResult}.SetResult(TResult)"/>
+        public void SetResult()
+        {
+            base.SetResult(null);
+        }
+
+        /// <inheritdoc cref="TaskCompletionSource{TResult}.TrySetResult(TResult)"/>
+        public bool TrySetResult()
+        {
+            return base.TrySetResult(null);
+        }
+
+        /// <inheritdoc cref="TaskCompletionSource{TResult}.SetResult(TResult)"/>
+        [Obsolete("Use TaskCompletionSource.SetResult()")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new void SetResult(object? result)
+        {
+            base.SetResult(result);
+        }
+
+        /// <inheritdoc cref="TaskCompletionSource{TResult}.TrySetResult(TResult)"/>
+        [Obsolete("Use TaskCompletionSource.TrySetResult()")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new bool TrySetResult(object? result)
+        {
+            return base.TrySetResult(result);
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/DebugPageViewModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/DebugPageViewModelTests.cs
@@ -9,6 +9,7 @@ using System.Windows.Controls;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
+using Microsoft.VisualStudio.Threading.Tasks;
 using Moq;
 using Moq.Protected;
 using Xunit;
@@ -23,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             public ILaunchSettingsProvider? ProfileProvider { get; set; }
             public ILaunchSettings? LaunchProfiles { get; set; }
             public IList<Lazy<ILaunchSettingsUIProvider, IOrderPrecedenceMetadataView>> UIProviders { get; set; } = new List<Lazy<ILaunchSettingsUIProvider, IOrderPrecedenceMetadataView>>();
-            public TaskCompletionSource<bool>? FirstSnapshotComplete { get; set; }
+            public TaskCompletionSource? FirstSnapshotComplete { get; set; }
         }
 
         private static Mock<DebugPageViewModel> CreateViewModel(ViewModelData data)
@@ -33,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             var mockProfiles = new Mock<ILaunchSettings>();
             var project = UnconfiguredProjectFactory.Create(fullPath: @"C:\Foo\foo.proj");
 
-            data.FirstSnapshotComplete = new TaskCompletionSource<bool>();
+            data.FirstSnapshotComplete = new TaskCompletionSource();
             var viewModel = new Mock<DebugPageViewModel>(data.FirstSnapshotComplete, project);
 
             mockSourceBlock.Setup(m => m.LinkTo(It.IsAny<ITargetBlock<ILaunchSettings>>(), It.IsAny<DataflowLinkOptions>())).Callback

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTrackerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTrackerTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading.Tasks;
 using Moq;
 using Xunit;
 using Xunit.Sdk;
@@ -22,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         private readonly DesignTimeInputsChangeTracker _changeTracker;
 
         private readonly List<DesignTimeInputSnapshot> _outputProduced = new List<DesignTimeInputSnapshot>();
-        private readonly TaskCompletionSource<bool> _outputProducedSource = new TaskCompletionSource<bool>();
+        private readonly TaskCompletionSource _outputProducedSource = new TaskCompletionSource();
         private int _expectedOutput;
 
         [Fact]
@@ -253,7 +254,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             if (_outputProduced.Count == _expectedOutput)
             {
-                _outputProducedSource?.SetResult(true);
+                _outputProducedSource?.SetResult();
             }
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompilerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompilerTests.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 using Microsoft.VisualStudio.Telemetry;
+using Microsoft.VisualStudio.Threading.Tasks;
 using Moq;
 using Xunit;
 using Xunit.Sdk;
@@ -29,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
         // For tracking compilation events that occur, to verify
         private readonly List<(string OutputFileName, string[] SourceFiles)> _compilationResults = new List<(string, string[])>();
-        private TaskCompletionSource<bool>? _compilationOccurredCompletionSource;
+        private TaskCompletionSource? _compilationOccurredCompletionSource;
         private int _expectedCompilations;
         private Func<string, ISet<string>, bool> _compilationCallback;
 
@@ -294,7 +295,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             _compilationResults.Add((output, files.Select(f => Path.GetFileName(f)).ToArray()));
             if (_compilationResults.Count == _expectedCompilations)
             {
-                _compilationOccurredCompletionSource?.SetResult(true);
+                _compilationOccurredCompletionSource?.SetResult();
             }
 
             return true;
@@ -326,7 +327,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         {
             int initialCompilations = _compilationResults.Count;
             _expectedCompilations = initialCompilations + numberOfDLLsExpected;
-            _compilationOccurredCompletionSource = new TaskCompletionSource<bool>();
+            _compilationOccurredCompletionSource = new TaskCompletionSource();
 
             actionThatCausesCompilation();
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
@@ -2,9 +2,9 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading.Tasks;
 using Moq;
 using Xunit;
 using Xunit.Sdk;
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             await source.SendAsync(new DesignTimeInputs(designTimeInputs.Select(f => f), sharedDesignTimeInputs.Select(f => f)));
 
             // The TaskCompletionSource is the thing we use to wait for the test to finish
-            var finished = new TaskCompletionSource<bool>();
+            var finished = new TaskCompletionSource();
 
             int notificationCount = 0;
             // Create a block to receive the output
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                 // if we've seen every file, we're done
                 if (notificationCount == fileChangeNotificationsExpected.Length)
                 {
-                    finished.SetResult(true);
+                    finished.SetResult();
                 }
             });
             watcher.SourceBlock.LinkTo(receiver, DataflowOption.PropagateCompletion);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Utilities/TestUtil.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Utilities/TestUtil.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
 {
@@ -13,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
         /// </summary>
         public static Task RunStaTestAsync(Action action)
         {
-            var tcs = new TaskCompletionSource<object?>();
+            var tcs = new TaskCompletionSource();
 
             var thread = new Thread(ThreadMethod);
             thread.SetApartmentState(ApartmentState.STA);
@@ -27,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
                 {
                     action();
 
-                    tcs.SetResult(null);
+                    tcs.SetResult();
                 }
                 catch (Exception e)
                 {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsSafeProjectGuidServiceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsSafeProjectGuidServiceTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
@@ -23,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         [Fact]
         public async Task GetProjectGuidAsync_WhenProjectUnloads_CancelsTask()
         {
-            var projectUnloaded = new TaskCompletionSource<object>();
+            var projectUnloaded = new TaskCompletionSource();
             var tasksService = IUnconfiguredProjectTasksServiceFactory.ImplementPrioritizedProjectLoadedInHost(() => projectUnloaded.Task);
 
             var accessor = CreateInstance(tasksService);


### PR DESCRIPTION
We were almost entirely using TaskCompletionSource<TResult> without actually using the result. Replace with TaskCompletionSource that hides away the result.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6488)