### PR TITLE
Delay StartupProjectRegistrar until after solution load 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
@@ -5,27 +5,37 @@ using System.ComponentModel.Composition;
 using System.Threading;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Threading.Tasks;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     /// <summary>
-    ///     Responsible for listening to project loaded events and firing <see cref="IUnconfiguredProjectTasksService.PrioritizedProjectLoadedInHost"/> and 
-    ///     <see cref="IUnconfiguredProjectTasksService.ProjectLoadedInHost"/>.
+    ///     Responsible for listening to project and solution loaded events and firing 
+    ///     <see cref="IUnconfiguredProjectTasksService.PrioritizedProjectLoadedInHost"/>, 
+    ///     <see cref="IUnconfiguredProjectTasksService.ProjectLoadedInHost"/> and
+    ///     <see cref="LoadedInHost"/>.
     /// </summary>
     [Export(typeof(ILoadedInHostListener))]
-    internal class VsSolutionEventListener : OnceInitializedOnceDisposedAsync, IVsSolutionEvents, IVsPrioritizedSolutionEvents, ILoadedInHostListener
+    [Export(typeof(ISolutionService))]
+    internal class VsSolutionEventListener : OnceInitializedOnceDisposedAsync, IVsSolutionEvents, IVsSolutionLoadEvents, IVsPrioritizedSolutionEvents, ILoadedInHostListener, ISolutionService
     {
         private readonly IVsUIService<IVsSolution> _solution;
-        private readonly IProjectThreadingService _threadingService;
+
+        private TaskCompletionSource _loadedInHost = new TaskCompletionSource();
         private uint _cookie = VSConstants.VSCOOKIE_NIL;
 
         [ImportingConstructor]
-        public VsSolutionEventListener(IVsUIService<SVsSolution, IVsSolution> solution, IProjectThreadingService threadingService)
-            : base(threadingService.JoinableTaskContext)
+        public VsSolutionEventListener(IVsUIService<SVsSolution, IVsSolution> solution, JoinableTaskContext joinableTaskContext)
+            : base(new JoinableTaskContextNode(joinableTaskContext))
         {
             _solution = solution;
-            _threadingService = threadingService;
+        }
+
+        public Task LoadedInHost
+        {
+            get { return _loadedInHost.Task; }
         }
 
         public Task StartListeningAsync()
@@ -35,9 +45,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
         {
-            await _threadingService.SwitchToUIThread(cancellationToken);
+            await JoinableFactory.SwitchToMainThreadAsync(cancellationToken);
 
             Verify.HResult(_solution.Value.AdviseSolutionEvents(this, out _cookie));
+
+            // In the situation where the solution has already been loaded by the time we're 
+            // initialized, we need to make sure we set LoadedInHost as we will have missed the 
+            // event. This can occur when the first CPS project is loaded due to reload of 
+            // an unloaded project or the first CPS project is loaded in the Add New/Existing Project 
+            // case.
+            Verify.HResult(_solution.Value.GetProperty((int)__VSPROPID4.VSPROPID_IsSolutionFullyLoaded, out object isFullyLoaded));
+            
+            if ((bool)isFullyLoaded)
+            {
+                _loadedInHost.SetResult();
+            }
         }
 
         protected override async Task DisposeCoreAsync(bool initialized)
@@ -46,10 +68,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             {
                 if (_cookie != VSConstants.VSCOOKIE_NIL)
                 {
-                    await _threadingService.SwitchToUIThread();
+                    await JoinableFactory.SwitchToMainThreadAsync();
 
                     Verify.HResult(_solution.Value.UnadviseSolutionEvents(_cookie));
 
+                    _loadedInHost.TrySetCanceled();
                     _cookie = VSConstants.VSCOOKIE_NIL;
                 }
             }
@@ -58,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         public int OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)
         {
             UnconfiguredProjectTasksService? tasksService = GetUnconfiguredProjectTasksServiceIfApplicable(pHierarchy);
-            tasksService?.OnProjectLoadedInHost();
+            tasksService?.OnProjectLoadedInHost();        
 
             return HResult.OK;
         }
@@ -68,6 +91,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             UnconfiguredProjectTasksService? tasksService = GetUnconfiguredProjectTasksServiceIfApplicable(pHierarchy);
             tasksService?.OnPrioritizedProjectLoadedInHost();
 
+            return HResult.OK;
+        }
+
+        public int OnAfterBackgroundSolutionLoadComplete()
+        {
+            _loadedInHost.SetResult();
+            return HResult.OK;
+        }
+
+        public int OnAfterCloseSolution(object pUnkReserved)
+        {
+            _loadedInHost = new TaskCompletionSource();
             return HResult.OK;
         }
 
@@ -122,11 +157,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         }
 
         public int OnBeforeCloseSolution(object pUnkReserved)
-        {
-            return HResult.NotImplemented;
-        }
-
-        public int OnAfterCloseSolution(object pUnkReserved)
         {
             return HResult.NotImplemented;
         }
@@ -197,6 +227,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         }
 
         public int PrioritizedOnAfterAsynchOpenProject(IVsHierarchy pHierarchy, int fAdded)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int OnBeforeOpenSolution(string pszSolutionFilename)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int OnBeforeBackgroundSolutionLoadBegins()
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int OnQueryBackgroundLoadProjectBatch(out bool pfShouldDelayLoadToNextIdle)
+        {
+            pfShouldDelayLoadToNextIdle = false;
+            return HResult.NotImplemented;
+        }
+
+        public int OnBeforeLoadProjectBatch(bool fIsBackgroundIdleBatch)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int OnAfterLoadProjectBatch(bool fIsBackgroundIdleBatch)
         {
             return HResult.NotImplemented;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ILoadedInHostListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ILoadedInHostListener.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     /// <summary>
     ///     Represents a service that listen for project loaded events in a host.
     /// </summary>
-    [ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.Private)]
+    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private)]
     internal interface ILoadedInHostListener
     {
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ISolutionService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ISolutionService.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     Provides a single property; <see cref="LoadedInHost"/>, which completes when the host 
+    ///     recognizes that the solution is loaded.
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private)]
+    internal interface ISolutionService
+    {
+        /// <summary>
+        ///     Gets a task that completes when the host recognizes that the solution is loaded.
+        /// </summary>
+        /// <remarks>
+        ///     Use <see cref="IUnconfiguredProjectTasksService.SolutionLoadedInHost"/> if 
+        ///     within project context.
+        /// </remarks>
+        /// <exception cref="OperationCanceledException">
+        ///     Thrown when host is closed without a solution being loaded.
+        /// </exception>
+        Task LoadedInHost
+        {
+            get;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IUnconfiguredProjectTasksService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IUnconfiguredProjectTasksService.cs
@@ -24,6 +24,15 @@ namespace Microsoft.VisualStudio.ProjectSystem
         CancellationToken UnloadCancellationToken { get; }
 
         /// <summary>
+        ///     Gets a task that completes when the host recognizes that the solution is loaded, 
+        ///     or is cancelled if the project is unloaded before that occurs.
+        /// </summary>
+        /// <exception cref="OperationCanceledException">
+        ///     Thrown if the project was unloaded before the solution finished loading.
+        /// </exception>
+        Task SolutionLoadedInHost { get; }
+
+        /// <summary>
         ///     Gets a task that completes when the host recognizes that the project is loaded, 
         ///     or is cancelled if the project is unloaded before that occurs.
         /// </summary>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ISolutionServiceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ISolutionServiceFactory.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class ISolutionServiceFactory
+    {
+        public static ISolutionService Create()
+        {
+            return ImplementSolutionLoadedInHost(() => new Task(() => { }));
+        }
+
+        public static ISolutionService ImplementSolutionLoadedInHost(Func<Task> action)
+        {
+            var mock = new Mock<ISolutionService>();
+            mock.Setup(m => m.LoadedInHost)
+                .Returns(action);
+
+            return mock.Object;
+        }
+    }
+}


### PR DESCRIPTION
In #6443, StartupProjectRegistrar started initializing LaunchProfilesDebugLaunchProvider much earlier than previous, causing it to overlap with solution load. This delays initialiation until after solution load.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6489)