### PR TITLE
Complete workaround for WPF temp projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,6 +47,8 @@
   <Import Project="$(RepoToolsetDir)Settings.props" Condition="'$(ExcludeRestorePackageImports)' != 'true' AND Exists('$(RepoToolsetDir)Settings.props')" />
   <Import Project="build\import\OverrideRepoToolsetVersions.props"/>
 
+  <Import Project="build\import\Workarounds.props"/>
+    
   <PropertyGroup>
     <_IsVisualStudioDeveloperBuild Condition="'$(OfficialBuild)' != 'true' AND '$(CIBuild)' != 'true' AND '$(BuildingInsideVisualStudio)' == 'true'">true</_IsVisualStudioDeveloperBuild>
 
@@ -82,6 +84,4 @@
     <NoWarn>$(NoWarn);NU5125</NoWarn>
   </PropertyGroup>
 
-  <!-- Workaround https://github.com/dotnet/wpf/issues/810 -->
-  <Import Project="$(_WpfTempProjectNuGetFilePathNoExt).props" Condition="'$(_WpfTempProjectNuGetFilePathNoExt)' != '' and Exists('$(_WpfTempProjectNuGetFilePathNoExt).props')"/>
 </Project>

--- a/build/import/Workarounds.props
+++ b/build/import/Workarounds.props
@@ -1,0 +1,30 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
+<Project>
+  
+  <!-- WORKAROUND: https://github.com/dotnet/wpf/issues/810
+       WPF temp-projects do not import .props and .targets files from NuGet packages. -->
+  
+  
+  <PropertyGroup Condition="'$(IsWpfTempProject)' == ''">
+    <IsWpfTempProject>false</IsWpfTempProject>
+    <IsWpfTempProject Condition="$(MSBuildProjectName.EndsWith('_wpftmp'))">true</IsWpfTempProject>
+  </PropertyGroup>
+
+  
+  <!-- Property _TargetAssemblyProjectName is set by GenerateTemporaryTargetAssembly task.
+       Disable Source Link and Xliff in WPF temp projects to avoid generating non-deterministic file names to obj dir.
+       The project name is non-deterministic and is included in the Source Link json file name and xlf directory names.
+       It's also not necessary to generate these assets. -->
+  
+  <PropertyGroup Condition="'$(IsWpfTempProject)' == 'true'">
+    <_WpfTempProjectNuGetFilePathNoExt>$(ArtifactsObjDir)$(_TargetAssemblyProjectName)\$(_TargetAssemblyProjectName)$(MSBuildProjectExtension).nuget.g</_WpfTempProjectNuGetFilePathNoExt>
+
+    <EnableSourceLink>false</EnableSourceLink>
+    <EmbedUntrackedSources>false</EmbedUntrackedSources>
+    <DeterministicSourcePaths>false</DeterministicSourcePaths>
+    <EnableXlfLocalization>false</EnableXlfLocalization>
+  </PropertyGroup>
+
+  <Import Project="$(_WpfTempProjectNuGetFilePathNoExt).props" Condition="'$(_WpfTempProjectNuGetFilePathNoExt)' != '' and Exists('$(_WpfTempProjectNuGetFilePathNoExt).props')"/>
+
+</Project>

--- a/build/import/Workarounds.targets
+++ b/build/import/Workarounds.targets
@@ -21,30 +21,7 @@
   </Target>
 
 
-  <!-- WORKAROUND: https://github.com/dotnet/wpf/issues/810
-       WPF temp-projects do not import .props and .targets files from NuGet packages. -->
-  
-  
-  <PropertyGroup Condition="'$(IsWpfTempProject)' == ''">
-    <IsWpfTempProject>false</IsWpfTempProject>
-    <IsWpfTempProject Condition="$(MSBuildProjectName.EndsWith('_wpftmp'))">true</IsWpfTempProject>
-  </PropertyGroup>
-
-  
-  <!-- Property _TargetAssemblyProjectName is set by GenerateTemporaryTargetAssembly task.
-       Disable Source Link and Xliff in WPF temp projects to avoid generating non-deterministic file names to obj dir.
-       The project name is non-deterministic and is included in the Source Link json file name and xlf directory names.
-       It's also not necessary to generate these assets. -->
-  
-  <PropertyGroup Condition="'$(IsWpfTempProject)' == 'true'">
-    <_WpfTempProjectNuGetFilePathNoExt>$(ArtifactsObjDir)$(_TargetAssemblyProjectName)\$(_TargetAssemblyProjectName)$(MSBuildProjectExtension).nuget.g</_WpfTempProjectNuGetFilePathNoExt>
-
-    <EnableSourceLink>false</EnableSourceLink>
-    <EmbedUntrackedSources>false</EmbedUntrackedSources>
-    <DeterministicSourcePaths>false</DeterministicSourcePaths>
-    <EnableXlfLocalization>false</EnableXlfLocalization>
-  </PropertyGroup>
-
+  <!-- WORKAROUND: https://github.com/dotnet/wpf/issues/810 -->
   <Import Project="$(_WpfTempProjectNuGetFilePathNoExt).targets" Condition="'$(_WpfTempProjectNuGetFilePathNoExt)' != '' and Exists('$(_WpfTempProjectNuGetFilePathNoExt).targets')"/>
 
 </Project>


### PR DESCRIPTION
This is a complete workaround for the WPF temp projects not picking up NuGet packages.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6492)