### PR TITLE
Pass TPI & TPV

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -146,6 +146,14 @@
                   ReadOnly="True"
                   Visible="False" />
 
+  <StringProperty Name="TargetPlatformIdentifier"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="TargetPlatformVersion"
+                  ReadOnly="True"
+                  Visible="False" />                  
+
   <StringProperty Name="TreatWarningsAsErrors"
                   ReadOnly="True"
                   Visible="False" />


### PR DESCRIPTION
In 16.8 P2, .NET 5.0 SDK P8 NuGet will be reading the TargetPlatform* from the inner build. 
In 16.8 P2, NuGet is reading TargetPlatformIdentifier/TargetPlatformVersion. 
In 16.8 P3, as we discussed in a previous e-mail, NuGet will rely on TargetPlatformMoniker instead. 

Adding TPI & TPV so that P2 works consistently across commandline and VS. 

@davkean Is this the right branch for P2?

I will create a revert issue for P3 once/if we merge this.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6495)