### PR TITLE
Embed translated rules into satellite assemblies

### DIFF
--- a/build/import/VisualStudio.XamlRules.targets
+++ b/build/import/VisualStudio.XamlRules.targets
@@ -6,12 +6,18 @@
       <Namespace>Microsoft.VisualStudio.ProjectSystem</Namespace>
       <RuleInjectionClassName>$(XamlPropertyRuleInjectionClassName)</RuleInjectionClassName>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <XlfOutputItem>EmbeddedResource</XlfOutputItem>
+      <LogicalName>XamlRuleToCode:%(Filename)%(Extension)</LogicalName>
     </XamlPropertyRule>
     <XamlPropertyRuleNoCodeBehind>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <XlfOutputItem>EmbeddedResource</XlfOutputItem>
+      <LogicalName>XamlRuleToCode:%(Filename)%(Extension)</LogicalName>
     </XamlPropertyRuleNoCodeBehind>
     <XamlPropertyProjectItemsSchema>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <XlfOutputItem>EmbeddedResource</XlfOutputItem>
+      <LogicalName>XamlRuleToCode:%(Filename)%(Extension)</LogicalName>
     </XamlPropertyProjectItemsSchema>
     <DesignTimeTargetsFile>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -43,8 +49,13 @@
   <!-- Copy translated XAML rule files for testing and setup authoring purposes -->
   <Target Name="CopyTranslatedXamlRulesToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory" DependsOnTargets="TranslateSourceFromXlf">
 
-    <Copy SourceFiles="@(XamlPropertyRuleTranslated)"  
-          DestinationFiles="@(XamlPropertyRuleTranslated->'$(VisualStudioXamlRulesDir)%(XlfLanguage)\$([System.IO.Path]::GetFileName('%(XlfSource)'))')"
+    <ItemGroup>
+        <_TranslatedItemsToCopy Include="@(EmbeddedResource)"
+                                Condition="'%(EmbeddedResource.XlfSourceFormat)' == 'XamlRule'" />
+    </ItemGroup>    
+
+    <Copy SourceFiles="@(_TranslatedItemsToCopy)"
+          DestinationFiles="@(_TranslatedItemsToCopy->'$(VisualStudioXamlRulesDir)%(XlfLanguage)\$([System.IO.Path]::GetFileName('%(XlfSource)'))')"
           SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"
@@ -54,4 +65,5 @@
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
     </Copy>
   </Target>
+
 </Project>


### PR DESCRIPTION
This embeds translated rules into satellite assemblies, ready for CPS to automatically load them from our assembly.

This doesn't change how we load these rules, that will becoming in the next PR.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6496)