### PR TITLE
Minor property page cleanup

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -5,6 +5,7 @@
       DisplayName="General"
       OverrideMode="Replace"
       PageTemplate="generic"
+      PropertyPagesHidden="True"
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="General"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -4,6 +4,7 @@
       Description="General"
       DisplayName="Application"
       PageTemplate="generic"
+      Order="100"
       xmlns="http://schemas.microsoft.com/build/2009/properties">
 
   <Rule.Categories>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -4,6 +4,7 @@
       Description="General"
       DisplayName="Build"
       PageTemplate="generic"
+      Order="200"
       xmlns="http://schemas.microsoft.com/build/2009/properties" >
 
   <Rule.Categories>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
@@ -4,6 +4,7 @@
       Description="Properties related to producing NuGet packages."
       DisplayName="Package"
       PageTemplate="generic"
+      Order="400"
       xmlns="http://schemas.microsoft.com/build/2009/properties" >
 
   <Rule.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ParentDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ParentDebugPropertyPage.xaml
@@ -4,6 +4,7 @@
       Description="Debug"
       DisplayName="Debug"
       PageTemplate="debuggerParent"
+      Order="500"
       xmlns:sys="clr-namespace:System;assembly=mscorlib"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns="http://schemas.microsoft.com/build/2009/properties">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/SigningPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/SigningPropertyPage.xaml
@@ -4,6 +4,7 @@
       Description="Properties related to producing signing assemblies."
       DisplayName="Signing"
       PageTemplate="generic"
+      Order="700"
       xmlns="http://schemas.microsoft.com/build/2009/properties" >
 
   <Rule.DataSource>


### PR DESCRIPTION
Clean up the property pages used for Codespaces.

1. Hide the ConfigurationGeneral page. We don't want this page to be turned into a user-visible property page, so we need to tag it with `PropertyPagesHidden="True"`.
2. Explicitly set the order for our pages. None of our pages make use of the `Order` attribute so we're getting some arbitrary order that is probably just a result of the implementation details rather than a conscious choice. Here we explicitly state the ordering based on the order of the original property pages. The `Order` values are all multiple of 100 to allow for the possibility of inserting new pages later without needing to re-number everything. Also, some gaps have been left for pages that we have not yet implemented.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6499)