### PR TITLE
Organize rule exporter + tests

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/RuleExporter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/RuleExporter.cs
@@ -14,6 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
         /// </summary>
         [ExportRule(nameof(AppDesigner), PropertyPageContexts.ProjectSubscriptionService)]
         [AppliesTo(ProjectCapability.AppDesigner)]
+        [Order(Order.Default)]
         public static int AppDesignerRule;
 
         /// <summary>
@@ -21,6 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
         /// </summary>
         [ExportRule(nameof(CompilerCommandLineArgs), PropertyPageContexts.ProjectSubscriptionService)]
         [AppliesTo(ProjectCapability.DotNetLanguageService)]
+        [Order(Order.Default)]
         public static int CompilerCommandLineArgsRule;
 
         /// <summary>
@@ -28,6 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
         /// </summary>
         [ExportRule(nameof(LanguageService), PropertyPageContexts.ProjectSubscriptionService)]
         [AppliesTo(ProjectCapability.DotNetLanguageService)]
+        [Order(Order.Default)]
         public static int LanguageServiceRule;
 
         /// <summary>
@@ -35,6 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
         /// </summary>
         [ExportRule(nameof(ResolvedCompilationReference), PropertyPageContexts.ProjectSubscriptionService)]
         [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
+        [Order(Order.Default)]
         public static int ResolvedCompilationReferencedRule;        
 
         /// <summary>
@@ -42,6 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
         /// </summary>
         [ExportRule(nameof(NuGetRestore), PropertyPageContexts.ProjectSubscriptionService)]
         [AppliesTo(ProjectCapability.PackageReferences)]
+        [Order(Order.Default)]
         public static int NuGetRestoreRule;
 
         /// <summary>
@@ -49,6 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
         /// </summary>
         [ExportRule(nameof(CopyUpToDateMarker), PropertyPageContexts.ProjectSubscriptionService)]
         [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
+        [Order(Order.Default)]
         public static int CopyUpToDateMarkerRule;
 
         /// <summary>
@@ -56,6 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
         /// </summary>
         [ExportRule(nameof(UpToDateCheckInput), PropertyPageContexts.ProjectSubscriptionService)]
         [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
+        [Order(Order.Default)]
         public static int UpToDateCheckInputRule;
 
         /// <summary>
@@ -63,6 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
         /// </summary>
         [ExportRule(nameof(UpToDateCheckOutput), PropertyPageContexts.ProjectSubscriptionService)]
         [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
+        [Order(Order.Default)]
         public static int UpToDateCheckOutputRule;
 
         /// <summary>
@@ -70,6 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
         /// </summary>
         [ExportRule(nameof(UpToDateCheckBuilt), PropertyPageContexts.ProjectSubscriptionService)]
         [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
+        [Order(Order.Default)]
         public static int UpToDateCheckBuiltRule;
 
         /// <summary>
@@ -78,6 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
         /// </summary>
         [ExportRule(nameof(SourceControl), PropertyPageContexts.Invisible)]
         [AppliesTo(ProjectCapability.DotNet)]
+        [Order(Order.Default)]
         public static int SourceControlRule;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/RuleExporter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/RuleExporter.cs
@@ -1,6 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.UpToDate;
+
+#pragma warning disable 0649
 
 namespace Microsoft.VisualStudio.ProjectSystem.Rules
 {
@@ -9,85 +13,109 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
     /// </summary>
     internal static class RuleExporter
     {
-        /// <summary>
-        ///     Represents the evaluation properties that is used for AppDesigner folder services.
-        /// </summary>
-        [ExportRule(nameof(AppDesigner), PropertyPageContexts.ProjectSubscriptionService)]
-        [AppliesTo(ProjectCapability.AppDesigner)]
-        [Order(Order.Default)]
-        public static int AppDesignerRule;
+        private static class ProjectRules
+        {
+            /// <summary>
+            ///     Represents the evaluation properties representings source control bindings, 
+            ///     typically used in projects connected to Team Foundation Source Control.
+            /// </summary>
+            [ExportRule(nameof(SourceControl), PropertyPageContexts.Invisible)]
+            [AppliesTo(ProjectCapability.DotNet)]
+            [Order(Order.Default)]
+            public static int SourceControlRule;
+        }
+
+        private static class AppDesignerRules
+        {
+            /// <summary>
+            ///     Represents the evaluation properties that is used for AppDesigner folder services.
+            /// </summary>
+            [ExportRule(nameof(AppDesigner), PropertyPageContexts.ProjectSubscriptionService)]
+            [AppliesTo(ProjectCapability.AppDesigner)]
+            [Order(Order.Default)]
+            public static int AppDesignerRule;
+        }
 
         /// <summary>
-        ///     Represents the design-time build items containing the compiler command-line that is passed to Roslyn.
+        ///     Contains rules for the PackageRestoreDataSource.
         /// </summary>
-        [ExportRule(nameof(CompilerCommandLineArgs), PropertyPageContexts.ProjectSubscriptionService)]
-        [AppliesTo(ProjectCapability.DotNetLanguageService)]
-        [Order(Order.Default)]
-        public static int CompilerCommandLineArgsRule;
+        private static class PackageRestoreRules
+        {
+            /// <summary>
+            ///     Represents the evaluation properties that are passed to NuGet.
+            /// </summary>
+            [ExportRule(nameof(NuGetRestore), PropertyPageContexts.ProjectSubscriptionService)]
+            [AppliesTo(ProjectCapability.PackageReferences)]
+            [Order(Order.Default)]
+            public static int NuGetRestoreRule;
+        }
 
         /// <summary>
-        ///     Represents the evaluation properties that are passed to Roslyn.
+        ///     Contains rules for the <see cref="ApplyChangesToWorkspaceContext"/> component.
         /// </summary>
-        [ExportRule(nameof(LanguageService), PropertyPageContexts.ProjectSubscriptionService)]
-        [AppliesTo(ProjectCapability.DotNetLanguageService)]
-        [Order(Order.Default)]
-        public static int LanguageServiceRule;
+        private static class LanguageServiceRules
+        {
+            /// <summary>
+            ///     Represents the design-time build items containing the compiler command-line that is passed to Roslyn.
+            /// </summary>
+            [ExportRule(nameof(CompilerCommandLineArgs), PropertyPageContexts.ProjectSubscriptionService)]
+            [AppliesTo(ProjectCapability.DotNetLanguageService)]
+            [Order(Order.Default)]
+            public static int CompilerCommandLineArgsRule;
+
+            /// <summary>
+            ///     Represents the evaluation properties that are passed to Roslyn.
+            /// </summary>
+            [ExportRule(nameof(LanguageService), PropertyPageContexts.ProjectSubscriptionService)]
+            [AppliesTo(ProjectCapability.DotNetLanguageService)]
+            [Order(Order.Default)]
+            public static int LanguageServiceRule;
+        }
 
         /// <summary>
-        ///     Represents the design-time build items containing resolved references path.
+        ///     Contains rules for the <see cref="BuildUpToDateCheck"/> component.
         /// </summary>
-        [ExportRule(nameof(ResolvedCompilationReference), PropertyPageContexts.ProjectSubscriptionService)]
-        [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
-        [Order(Order.Default)]
-        public static int ResolvedCompilationReferencedRule;        
+        private static class BuildUpToDateCheckRules
+        {
+            /// <summary>
+            ///     Represents evaluation items containing marker files indicating that reference projects have out of date references.
+            /// </summary>
+            [ExportRule(nameof(CopyUpToDateMarker), PropertyPageContexts.ProjectSubscriptionService)]
+            [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
+            [Order(Order.Default)]
+            public static int CopyUpToDateMarkerRule;
 
-        /// <summary>
-        ///     Represents the evaluation properties that are passed to NuGet.
-        /// </summary>
-        [ExportRule(nameof(NuGetRestore), PropertyPageContexts.ProjectSubscriptionService)]
-        [AppliesTo(ProjectCapability.PackageReferences)]
-        [Order(Order.Default)]
-        public static int NuGetRestoreRule;
+            /// <summary>
+            ///     Represents the design-time build items containing resolved references path.
+            /// </summary>
+            [ExportRule(nameof(ResolvedCompilationReference), PropertyPageContexts.ProjectSubscriptionService)]
+            [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
+            [Order(Order.Default)]
+            public static int ResolvedCompilationReferencedRule;
 
-        /// <summary>
-        ///     Represents evaluation items containing marker files indicating that reference projects have out of date references.
-        /// </summary>
-        [ExportRule(nameof(CopyUpToDateMarker), PropertyPageContexts.ProjectSubscriptionService)]
-        [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
-        [Order(Order.Default)]
-        public static int CopyUpToDateMarkerRule;
+            /// <summary>
+            ///     Represents design-time build items containing the input files into the build.
+            /// </summary>
+            [ExportRule(nameof(UpToDateCheckInput), PropertyPageContexts.ProjectSubscriptionService)]
+            [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
+            [Order(Order.Default)]
+            public static int UpToDateCheckInputRule;
 
-        /// <summary>
-        ///     Represents design-time build items containing the input files into the build.
-        /// </summary>
-        [ExportRule(nameof(UpToDateCheckInput), PropertyPageContexts.ProjectSubscriptionService)]
-        [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
-        [Order(Order.Default)]
-        public static int UpToDateCheckInputRule;
+            /// <summary>
+            ///     Represents design-time build items containing the output files of the build.
+            /// </summary>
+            [ExportRule(nameof(UpToDateCheckOutput), PropertyPageContexts.ProjectSubscriptionService)]
+            [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
+            [Order(Order.Default)]
+            public static int UpToDateCheckOutputRule;
 
-        /// <summary>
-        ///     Represents design-time build items containing the output files of the build.
-        /// </summary>
-        [ExportRule(nameof(UpToDateCheckOutput), PropertyPageContexts.ProjectSubscriptionService)]
-        [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
-        [Order(Order.Default)]
-        public static int UpToDateCheckOutputRule;
-
-        /// <summary>
-        ///     Represents design-time build items containing a mapping between input and the output files of the build.
-        /// </summary>
-        [ExportRule(nameof(UpToDateCheckBuilt), PropertyPageContexts.ProjectSubscriptionService)]
-        [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
-        [Order(Order.Default)]
-        public static int UpToDateCheckBuiltRule;
-
-        /// <summary>
-        ///     Represents the evaluation properties representings source control bindings, 
-        ///     typically used in projects connected to Team Foundation Source Control.
-        /// </summary>
-        [ExportRule(nameof(SourceControl), PropertyPageContexts.Invisible)]
-        [AppliesTo(ProjectCapability.DotNet)]
-        [Order(Order.Default)]
-        public static int SourceControlRule;
+            /// <summary>
+            ///     Represents design-time build items containing a mapping between input and the output files of the build.
+            /// </summary>
+            [ExportRule(nameof(UpToDateCheckBuilt), PropertyPageContexts.ProjectSubscriptionService)]
+            [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
+            [Order(Order.Default)]
+            public static int UpToDateCheckBuiltRule;
+        }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/ExportedRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/ExportedRuleTests.cs
@@ -1,15 +1,28 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Rules
 {
-    public sealed class RuleExporterTests
+    public sealed class RuleExporterTests : XamlRuleTestBase
     {
+        [Theory(Skip="Waiting on all rules to be embedded")]
+        [MemberData(nameof(GetAllRules))]
+        public void AllRulesMustBeExported(string name, string fullPath)
+        {
+            name = name.Replace(".", "");
+
+            MemberInfo member = typeof(RuleExporter).GetField(name);
+
+            Assert.True(member != null, $"Rule '{fullPath}' has not been exported by {nameof(RuleExporter)}. Export this rule from a member called {name}.");
+        }
+
         [Theory]
         [MemberData(nameof(GetAllExportedMembers))]
         public void ExportedRulesMustBeStaticFields(MemberInfo member)
@@ -19,19 +32,50 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
 
         [Theory]
         [MemberData(nameof(GetAllExportedMembers))]
-        public void ExportedRulesMustHaveAppliesTo(MemberInfo member)
+        public void ExportedRulesMustBeMarkedWithAppliesTo(MemberInfo member)
         {
             var attribute = member.GetCustomAttribute<AppliesToAttribute>();
 
-            Assert.True(attribute != null, $"'{GetTypeQualifiedName(member)}' must be marked with AppliesTo");
+            Assert.True(attribute != null, $"'{GetTypeQualifiedName(member)}' must be marked with [AppliesTo]");
+        }
+
+
+        [Theory]
+        [MemberData(nameof(GetAllExportedMembers))]
+        public void ExportedRulesMustBeMarkedWithOrder(MemberInfo member)
+        {   
+            var attribute = member.GetCustomAttribute<OrderAttribute>();
+
+            Assert.True(attribute != null && attribute.OrderPrecedence == Order.Default, $"'{GetTypeQualifiedName(member)}' must be marked with [Order(Order.Default)]");
         }
 
         [Theory]
         [MemberData(nameof(GetAllExportedMembers))]
-        public void ExportedRulesMustExist(MemberInfo member)
+        public void ExportedFieldsMustEndInRule(MemberInfo member)
         {
-            var attribute = member.GetCustomAttribute<ExportPropertyXamlRuleDefinitionAttribute>();
+            Assert.True(member.Name.EndsWith("Rule"), $"'{GetTypeQualifiedName(member)}' must be end in 'Rule' so that the '[ExportRule(nameof(RuleName))]' expression refers to the rule itself");
+        }
 
+        [Theory]
+        [MemberData(nameof(GetAllExportedMembersWithAttribute))]
+        public void BrowseObjectsMustBeInBrowseObjectContext(MemberInfo member, ExportPropertyXamlRuleDefinitionAttribute attribute)
+        {
+            if (!member.Name.Contains("BrowseObject"))
+                return;
+            
+            foreach (string context in attribute.Context.Split(';'))
+            {
+                if (context == PropertyPageContexts.BrowseObject)
+                    return;
+            }
+
+            Assert.True(false, $"'{GetTypeQualifiedName(member)}' must live in the PropertyPageContexts.BrowseObject context.");
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAllExportedMembersWithAttribute))]
+        public void ExportedRulesMustExist(MemberInfo member, ExportPropertyXamlRuleDefinitionAttribute attribute)
+        {
             Assert.NotNull(attribute);
 
             var assembly = Assembly.Load(attribute.XamlResourceAssemblyName);
@@ -48,10 +92,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
 
         public static IEnumerable<object[]> GetAllExportedMembers()
         {
+            return GetAllExportedMembersCore().Select(member => new[] { member });
+        }
+
+        public static IEnumerable<object[]> GetAllExportedMembersWithAttribute()
+        {
+            foreach (MemberInfo member in GetAllExportedMembersCore())
+            {
+                Attribute attribute = member.GetCustomAttribute<ExportPropertyXamlRuleDefinitionAttribute>();
+
+                yield return new object[] { member, attribute };
+
+            }
+        }
+
+        private static IEnumerable<object[]> GetAllRules()
+        {
+            return Project(GetRules(suffix: string.Empty, recursive: true));
+        }
+
+        private static IEnumerable<MemberInfo> GetAllExportedMembersCore()
+        {
+            foreach (var type in typeof(RuleExporter).GetNestedTypes(BindingFlags.NonPublic | BindingFlags.Public))
+            {
+                foreach (var member in type.GetMembers())
+                {
+                    if (member.DeclaringType == type)
+                        yield return member;
+                }
+            }
+
             foreach (var member in typeof(RuleExporter).GetMembers())
             {
                 if (member.DeclaringType == typeof(RuleExporter))
-                    yield return new[] { member };
+                    yield return member;
             }
         }
     }


### PR DESCRIPTION
- Apply [Order]
- Split into separate classes per component (this makes it easier to validate AppliesTo)
- Add a bunch of new tests


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6500)