### PR TITLE
Unify code style analyzer versions

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -110,7 +110,7 @@
     <!-- Analyzers -->
     <PackageReference Update="Microsoft.CodeAnalysis.Analyzers"                                       Version="3.3.0" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle"                                Version="3.8.0-1.20330.4" />
-    <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"                           Version="3.8.0-1.20313.1" />
+    <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"                           Version="3.8.0-1.20330.4" />
     <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers"                                  Version="3.3.0" />
     <PackageReference Update="Roslyn.Diagnostics.Analyzers"                                           Version="3.3.0" />
 


### PR DESCRIPTION
We were running into this: https://github.com/dotnet/roslyn-analyzers/issues/4044.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6504)