### PR TITLE
Opt out test projects for Roslyn-based analyzers

### DIFF
--- a/build/import/HostAgnostic.props
+++ b/build/import/HostAgnostic.props
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" />
-    <PackageReference Include="Roslyn.Diagnostics.Analyzers" />
+    <PackageReference Include="Roslyn.Diagnostics.Analyzers" PrivateAssets="all" Condition="'$(IsTestProject)' != 'true'" />
 
     <!-- Framework packages -->
     <PackageReference Include="Microsoft.IO.Redist" />

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -20,12 +20,6 @@ dotnet_diagnostic.CA2009.severity = none
 # System.Runtime.Analyzers
 dotnet_diagnostic.CA1825.severity = none        # Avoid zero length allocations - suppress for non-shipping/test projects (originally RS0007)
 
-# Microsoft.Composition.Analyzers
-dotnet_diagnostic.RS0006.severity = none
-dotnet_diagnostic.RS0016.severity = none        # Symbol is not part of the declared API
-dotnet_diagnostic.RS0037.severity = none        # PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded
-dotnet_diagnostic.RS0023.severity = none
-
 # Microsoft.CodeAnalysis.CSharp.Features
 dotnet_diagnostic.IDE0001.severity = none       # Too noisy due to https://github.com/dotnet/roslyn/issues/27819
 dotnet_diagnostic.IDE1006.severity = none       # Naming styles is too noisy as it fires on all async tests
@@ -46,6 +40,3 @@ dotnet_diagnostic.VSTHRD200.severity = none     # Naming stylesNaming styles:  B
 # xunit.analyzers
 dotnet_diagnostic.xUnit1026.severity = none     # Theory methods must use all parameters
 dotnet_diagnostic.xUnit1004.severity = none     # Test methods should not be skipped
-
-dotnet_diagnostic.RS0043.severity = none        # Do not call test accessors from production code
-dotnet_diagnostic.RS0100.severity = none        # Statements must be placed on their own line


### PR DESCRIPTION
This fixes the situation called out here: https://github.com/dotnet/roslyn/issues/43371#issuecomment-676948659.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6506)