### PR TITLE
Remove workaround

### DIFF
--- a/build/import/HostAgnostic.props
+++ b/build/import/HostAgnostic.props
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" />
-    <PackageReference Include="Roslyn.Diagnostics.Analyzers" />
+    <PackageReference Include="Roslyn.Diagnostics.Analyzers" PrivateAssets="all" Condition="'$(IsTestProject)' != 'true'" />
 
     <!-- Framework packages -->
     <PackageReference Include="Microsoft.IO.Redist" />

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -20,12 +20,6 @@ dotnet_diagnostic.CA2009.severity = none
 # System.Runtime.Analyzers
 dotnet_diagnostic.CA1825.severity = none        # Avoid zero length allocations - suppress for non-shipping/test projects (originally RS0007)
 
-# Microsoft.Composition.Analyzers
-dotnet_diagnostic.RS0006.severity = none
-dotnet_diagnostic.RS0016.severity = none        # Symbol is not part of the declared API
-dotnet_diagnostic.RS0037.severity = none        # PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded
-dotnet_diagnostic.RS0023.severity = none
-
 # Microsoft.CodeAnalysis.CSharp.Features
 dotnet_diagnostic.IDE0001.severity = none       # Too noisy due to https://github.com/dotnet/roslyn/issues/27819
 dotnet_diagnostic.IDE1006.severity = none       # Naming styles is too noisy as it fires on all async tests
@@ -46,6 +40,3 @@ dotnet_diagnostic.VSTHRD200.severity = none     # Naming stylesNaming styles:  B
 # xunit.analyzers
 dotnet_diagnostic.xUnit1026.severity = none     # Theory methods must use all parameters
 dotnet_diagnostic.xUnit1004.severity = none     # Test methods should not be skipped
-
-dotnet_diagnostic.RS0043.severity = none        # Do not call test accessors from production code
-dotnet_diagnostic.RS0100.severity = none        # Statements must be placed on their own line

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -21,7 +21,6 @@ dotnet_diagnostic.CA2009.severity = none
 dotnet_diagnostic.CA1825.severity = none        # Avoid zero length allocations - suppress for non-shipping/test projects (originally RS0007)
 
 # Microsoft.CodeAnalysis.CSharp.Features
-dotnet_diagnostic.IDE0001.severity = none       # Too noisy due to https://github.com/dotnet/roslyn/issues/27819
 dotnet_diagnostic.IDE1006.severity = none       # Naming styles is too noisy as it fires on all async tests
 dotnet_diagnostic.IDE1006WithoutSuggestion.severity = none
 dotnet_diagnostic.IDE0060.severity = none       # Unused parameter rule fires on [MemberData] usage

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentComposition.ScopeComponents.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentComposition.ScopeComponents.cs
@@ -28,16 +28,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             private ExportFactory<UnconfiguredProject>? UnconfiguredProjectFactory { get; set; }
         }
 
-        [Export(typeof(ProjectSystem.UnconfiguredProject))]
+        [Export(typeof(UnconfiguredProject))]
         [Shared(ExportContractNames.Scopes.UnconfiguredProject)]
         private class UnconfiguredProjectScope
         {
             [Import]
             [SharingBoundary(ExportContractNames.Scopes.ConfiguredProject)]
-            private ExportFactory<ProjectSystem.ConfiguredProject>? ConfiguredProjectFactory { get; set; }
+            private ExportFactory<ConfiguredProject>? ConfiguredProjectFactory { get; set; }
         }
 
-        [Export(typeof(ProjectSystem.ConfiguredProject))]
+        [Export(typeof(ConfiguredProject))]
         [Shared(ExportContractNames.Scopes.ConfiguredProject)]
         private class ConfiguredProjectScope
         {


### PR DESCRIPTION
This includes https://github.com/dotnet/project-system/pull/6506, so just review: https://github.com/dotnet/project-system/commit/f50ab95aba6a6948c442b492487d0b369b7cbdd4.

This removes an analyzer workaround for a bug that has since been fixed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6507)