### PR TITLE
RCS1015: Use nameof operator

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/ServiceProviderToOleServiceProviderAdapter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/ServiceProviderToOleServiceProviderAdapter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.Shell
 
         public ServiceProviderToOleServiceProviderAdapter(IServiceProvider serviceProvider)
         {
-            Requires.NotNull(serviceProvider, "serviceProvider");
+            Requires.NotNull(serviceProvider, nameof(serviceProvider));
 
             _serviceProvider = serviceProvider;
         }
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.Shell
 
         private static HResult GetComInterfaceForObject(object instance, Guid iid, out IntPtr ppvObject)
         {
-            Requires.NotNull(instance, "instance");
+            Requires.NotNull(instance, nameof(instance));
 
             IntPtr unknown = Marshal.GetIUnknownForObject(instance);
             if (iid.Equals(VSConstants.IID_IUnknown))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.Build
         /// <returns>Requested project property. Null if the property is not present.</returns>
         public static ProjectPropertyElement? GetProperty(ProjectRootElement project, string propertyName)
         {
-            Requires.NotNull(project, "project");
+            Requires.NotNull(project, nameof(project));
 
             return project.Properties
                 .FirstOrDefault(p => string.Equals(p.Name, propertyName, StringComparisons.PropertyNames));
@@ -219,7 +219,7 @@ namespace Microsoft.VisualStudio.Build
         /// <param name="propertyName">Property name.</param>
         public static ProjectPropertyElement GetOrAddProperty(ProjectRootElement project, string propertyName)
         {
-            Requires.NotNull(project, "project");
+            Requires.NotNull(project, nameof(project));
             ProjectPropertyElement? property = GetProperty(project, propertyName);
 
             if (property != null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/DictionaryEqualityComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/DictionaryEqualityComparer.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.Collections
         /// </summary>
         private static bool AreEquivalent(IReadOnlyDictionary<TKey, TValue>? dictionary1, IReadOnlyDictionary<TKey, TValue>? dictionary2, IEqualityComparer<TValue> valueComparer)
         {
-            Requires.NotNull(valueComparer, "valueComparer");
+            Requires.NotNull(valueComparer, nameof(valueComparer));
 
             if (ReferenceEquals(dictionary1, dictionary2))
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VsLangProjectPropertiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VsLangProjectPropertiesTests.cs
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             Assert.Equal(prjOutputTypeEx.prjOutputTypeEx_AppContainerExe, vsLangProjectProperties.OutputTypeEx);
 
             vsLangProjectProperties.OutputTypeEx = prjOutputTypeEx.prjOutputTypeEx_WinExe;
-            Assert.Equal(setValues.Single().ToString(), prjOutputTypeEx.prjOutputTypeEx_WinExe.ToString());
+            Assert.Equal(setValues.Single().ToString(), nameof(prjOutputTypeEx.prjOutputTypeEx_WinExe));
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VsLangProjectPropertiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VsLangProjectPropertiesTests.cs
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             Assert.Equal(prjOutputTypeEx.prjOutputTypeEx_AppContainerExe, vsLangProjectProperties.OutputTypeEx);
 
             vsLangProjectProperties.OutputTypeEx = prjOutputTypeEx.prjOutputTypeEx_WinExe;
-            Assert.Equal(setValues.Single().ToString(), nameof(prjOutputTypeEx.prjOutputTypeEx_WinExe));
+            Assert.Equal(nameof(prjOutputTypeEx.prjOutputTypeEx_WinExe), setValues.Single().ToString());
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractAddItemCommandHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractAddItemCommandHandlerTests.cs
@@ -137,8 +137,8 @@ Root (flags: {ProjectRoot})
             await command.TryHandleCommandAsync(nodes, TestAddItemCommand.CommandId, true, 0, IntPtr.Zero, IntPtr.Zero);
 
             Assert.Equal(1, callCount);
-            Assert.Equal(TestAddItemCommand.ResourceIds.DirName.ToString(), localizedDirectoryNameResult);
-            Assert.Equal(TestAddItemCommand.ResourceIds.TemplateName.ToString(), localizedTemplateNameResult);
+            Assert.Equal(nameof(TestAddItemCommand.ResourceIds.DirName), localizedDirectoryNameResult);
+            Assert.Equal(nameof(TestAddItemCommand.ResourceIds.TemplateName), localizedTemplateNameResult);
             Assert.Same(tree.Children[0], nodeResult);
         }
 


### PR DESCRIPTION
Converts strings to `nameof` operator. I used Roslynator.
https://github.com/JosefPihrt/Roslynator/blob/master/docs/analyzers/RCS1015.md

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6509)