### PR TITLE
RCS1033: Remove redundant boolean literal

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -487,7 +487,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 if (_environmentVariablesValid != value)
                 {
                     _environmentVariablesValid = value;
-                    if (value == true)
+                    if (value)
                     {
                         ClearEnvironmentVariablesGridError?.Invoke(this, EventArgs.Empty);
                     }


### PR DESCRIPTION
Removed `== true` where it wasn't required using Roslynator.
https://github.com/JosefPihrt/Roslynator/blob/master/docs/analyzers/RCS1033.md

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6512)