### PR TITLE
RCS1214: Unnecessary interpolated string

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/Tokenizer.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/Tokenizer.cs
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             Token? token = ReadToken();    // Consume token, so "position" is correct
             if (token == null)
             {
-                throw FormatException(ProjectTreeFormatError.IdExpected_EncounteredEndOfString, $"Expected identifier, but encountered end-of-string.");
+                throw FormatException(ProjectTreeFormatError.IdExpected_EncounteredEndOfString, "Expected identifier, but encountered end-of-string.");
             }
 
             // Otherwise, we must have hit a delimiter as whitespace will have been consumed as part of the identifier


### PR DESCRIPTION
Removed unnecessary interpolated string using Roslynator.
https://github.com/JosefPihrt/Roslynator/blob/master/docs/analyzers/RCS1214.md

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6515)