### PR TITLE
Increase official builds timeout

### DIFF
--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -12,6 +12,7 @@ resources:
 queue:
   name: VSEng-MicroBuildVS2019
   demands: Cmd
+  timeoutInMinutes: 90
 variables:
   BuildConfiguration: Release
   TeamName: DotNet-Project-System


### PR DESCRIPTION
Signing can take anywhere from 30 minutes to over 1 hour depending on load, increase the timeout to 90 minutes to reduce number of aborts.

Examples tonight:
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3995747&view=results
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3995577&view=results
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3995428&view=results


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6527)