### PR TITLE
Add support for AnalysisLevel and EnableNETAnalyzers properties

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.Designer.vb
@@ -23,6 +23,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         <System.Diagnostics.DebuggerStepThrough()> Private Sub InitializeComponent()
             Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(CodeAnalysisPropPage))
             Me.FxCopAnalyzersPanel = New System.Windows.Forms.Panel()
+            Me.NETAnalyzersLinkLabel = New System.Windows.Forms.LinkLabel()
+            Me.EnableNETAnalyzersCheckBox = New System.Windows.Forms.CheckBox()
+            Me.Label1 = New System.Windows.Forms.Label()
+            Me.Label2 = New System.Windows.Forms.Label()
+            Me.AnalysisLevelLabel = New System.Windows.Forms.Label()
+            Me.AnalysisLevelComboBox = New System.Windows.Forms.ComboBox()
             Me.RunAnalyzersDuringLiveAnalysis = New System.Windows.Forms.CheckBox()
             Me.RunAnalyzersDuringBuild = New System.Windows.Forms.CheckBox()
             Me.RoslynAnalyzersLabel = New System.Windows.Forms.Label()
@@ -33,6 +39,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             '
             'FxCopAnalyzersPanel
             '
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.NETAnalyzersLinkLabel)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.EnableNETAnalyzersCheckBox)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.Label1)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.Label2)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.AnalysisLevelLabel)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.AnalysisLevelComboBox)
             Me.FxCopAnalyzersPanel.Controls.Add(Me.RunAnalyzersDuringLiveAnalysis)
             Me.FxCopAnalyzersPanel.Controls.Add(Me.RunAnalyzersDuringBuild)
             Me.FxCopAnalyzersPanel.Controls.Add(Me.RoslynAnalyzersLabel)
@@ -40,6 +52,45 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.FxCopAnalyzersPanel.Controls.Add(Me.RoslynAnalyzersHelpLinkLabel)
             resources.ApplyResources(Me.FxCopAnalyzersPanel, "FxCopAnalyzersPanel")
             Me.FxCopAnalyzersPanel.Name = "FxCopAnalyzersPanel"
+            '
+            'NETAnalyzersLinkLabel
+            '
+            resources.ApplyResources(Me.NETAnalyzersLinkLabel, "NETAnalyzersLinkLabel")
+            Me.NETAnalyzersLinkLabel.Name = "NETAnalyzersLinkLabel"
+            Me.NETAnalyzersLinkLabel.TabStop = True
+            '
+            'EnableNETAnalyzersCheckBox
+            '
+            resources.ApplyResources(Me.EnableNETAnalyzersCheckBox, "EnableNETAnalyzersCheckBox")
+            Me.EnableNETAnalyzersCheckBox.Checked = True
+            Me.EnableNETAnalyzersCheckBox.CheckState = System.Windows.Forms.CheckState.Checked
+            Me.EnableNETAnalyzersCheckBox.Name = "EnableNETAnalyzersCheckBox"
+            Me.EnableNETAnalyzersCheckBox.UseVisualStyleBackColor = True
+            '
+            'Label1
+            '
+            resources.ApplyResources(Me.Label1, "Label1")
+            Me.Label1.Name = "Label1"
+            '
+            'Label2
+            '
+            Me.Label2.AccessibleRole = System.Windows.Forms.AccessibleRole.Separator
+            Me.Label2.BackColor = System.Drawing.SystemColors.ControlDark
+            resources.ApplyResources(Me.Label2, "Label2")
+            Me.Label2.Name = "Label2"
+            '
+            'AnalysisLevelLabel
+            '
+            resources.ApplyResources(Me.AnalysisLevelLabel, "AnalysisLevelLabel")
+            Me.AnalysisLevelLabel.Name = "AnalysisLevelLabel"
+            '
+            'AnalysisLevelComboBox
+            '
+            Me.AnalysisLevelComboBox.AutoCompleteCustomSource.AddRange(New String() {resources.GetString("AnalysisLevelComboBox.AutoCompleteCustomSource"), resources.GetString("AnalysisLevelComboBox.AutoCompleteCustomSource1"), resources.GetString("AnalysisLevelComboBox.AutoCompleteCustomSource2"), resources.GetString("AnalysisLevelComboBox.AutoCompleteCustomSource3")})
+            Me.AnalysisLevelComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
+            Me.AnalysisLevelComboBox.FormattingEnabled = True
+            resources.ApplyResources(Me.AnalysisLevelComboBox, "AnalysisLevelComboBox")
+            Me.AnalysisLevelComboBox.Name = "AnalysisLevelComboBox"
             '
             'RunAnalyzersDuringLiveAnalysis
             '
@@ -86,6 +137,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.ResumeLayout(False)
 
         End Sub
+
+        Friend WithEvents AnalysisLevelComboBox As Windows.Forms.ComboBox
+        Friend WithEvents AnalysisLevelLabel As Windows.Forms.Label
+        Friend WithEvents EnableNETAnalyzersCheckBox As Windows.Forms.CheckBox
+        Friend WithEvents Label1 As Windows.Forms.Label
+        Friend WithEvents Label2 As Windows.Forms.Label
+        Friend WithEvents NETAnalyzersLinkLabel As Windows.Forms.LinkLabel
     End Class
 
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.resx
@@ -127,7 +127,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="NETAnalyzersLinkLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>43, 154</value>
+    <value>39, 154</value>
   </data>
   <data name="NETAnalyzersLinkLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>132, 13</value>
@@ -157,7 +157,7 @@
     <value>NoControl</value>
   </data>
   <data name="EnableNETAnalyzersCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>42, 182</value>
+    <value>41, 182</value>
   </data>
   <data name="EnableNETAnalyzersCheckBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>134, 17</value>
@@ -238,7 +238,7 @@
     <value>True</value>
   </data>
   <data name="AnalysisLevelLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>43, 209</value>
+    <value>38, 208</value>
   </data>
   <data name="AnalysisLevelLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>74, 13</value>
@@ -274,7 +274,7 @@
     <value>none</value>
   </data>
   <data name="AnalysisLevelComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>123, 205</value>
+    <value>118, 205</value>
   </data>
   <data name="AnalysisLevelComboBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>121, 21</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.resx
@@ -118,14 +118,188 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="RunAnalyzersDuringLiveAnalysis.AutoSize" type="System.Boolean, mscorlib">
+  <data name="NETAnalyzersLinkLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="RunAnalyzersDuringLiveAnalysis.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="NETAnalyzersLinkLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="NETAnalyzersLinkLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>43, 154</value>
+  </data>
+  <data name="NETAnalyzersLinkLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>132, 13</value>
+  </data>
+  <data name="NETAnalyzersLinkLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
+  <data name="NETAnalyzersLinkLabel.Text" xml:space="preserve">
+    <value>What are .NET analyzers?</value>
+  </data>
+  <data name="&gt;&gt;NETAnalyzersLinkLabel.Name" xml:space="preserve">
+    <value>NETAnalyzersLinkLabel</value>
+  </data>
+  <data name="&gt;&gt;NETAnalyzersLinkLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;NETAnalyzersLinkLabel.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;NETAnalyzersLinkLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="EnableNETAnalyzersCheckBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="EnableNETAnalyzersCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="EnableNETAnalyzersCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>42, 182</value>
+  </data>
+  <data name="EnableNETAnalyzersCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>134, 17</value>
+  </data>
+  <data name="EnableNETAnalyzersCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="EnableNETAnalyzersCheckBox.Text" xml:space="preserve">
+    <value>Enable .NET analyzers</value>
+  </data>
+  <data name="&gt;&gt;EnableNETAnalyzersCheckBox.Name" xml:space="preserve">
+    <value>EnableNETAnalyzersCheckBox</value>
+  </data>
+  <data name="&gt;&gt;EnableNETAnalyzersCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;EnableNETAnalyzersCheckBox.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;EnableNETAnalyzersCheckBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="Label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>31, 124</value>
+  </data>
+  <data name="Label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>79, 13</value>
+  </data>
+  <data name="Label1.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="Label1.Text" xml:space="preserve">
+    <value>.NET analyzers</value>
+  </data>
+  <data name="&gt;&gt;Label1.Name" xml:space="preserve">
+    <value>Label1</value>
+  </data>
+  <data name="&gt;&gt;Label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label1.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;Label1.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="Label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>87, 131</value>
+  </data>
+  <data name="Label2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>350, 1</value>
+  </data>
+  <data name="Label2.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;Label2.Name" xml:space="preserve">
+    <value>Label2</value>
+  </data>
+  <data name="&gt;&gt;Label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label2.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;Label2.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="AnalysisLevelLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="AnalysisLevelLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>43, 209</value>
+  </data>
+  <data name="AnalysisLevelLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>74, 13</value>
+  </data>
+  <data name="AnalysisLevelLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="AnalysisLevelLabel.Text" xml:space="preserve">
+    <value>Analysis Level</value>
+  </data>
+  <data name="&gt;&gt;AnalysisLevelLabel.Name" xml:space="preserve">
+    <value>AnalysisLevelLabel</value>
+  </data>
+  <data name="&gt;&gt;AnalysisLevelLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;AnalysisLevelLabel.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;AnalysisLevelLabel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="AnalysisLevelComboBox.AutoCompleteCustomSource" xml:space="preserve">
+    <value>preview</value>
+  </data>
+  <data name="AnalysisLevelComboBox.AutoCompleteCustomSource1" xml:space="preserve">
+    <value>latest</value>
+  </data>
+  <data name="AnalysisLevelComboBox.AutoCompleteCustomSource2" xml:space="preserve">
+    <value>5.0</value>
+  </data>
+  <data name="AnalysisLevelComboBox.AutoCompleteCustomSource3" xml:space="preserve">
+    <value>none</value>
+  </data>
+  <data name="AnalysisLevelComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>123, 205</value>
+  </data>
+  <data name="AnalysisLevelComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 21</value>
+  </data>
+  <data name="AnalysisLevelComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;AnalysisLevelComboBox.Name" xml:space="preserve">
+    <value>AnalysisLevelComboBox</value>
+  </data>
+  <data name="&gt;&gt;AnalysisLevelComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;AnalysisLevelComboBox.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;AnalysisLevelComboBox.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="RunAnalyzersDuringLiveAnalysis.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="RunAnalyzersDuringLiveAnalysis.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="RunAnalyzersDuringLiveAnalysis.Location" type="System.Drawing.Point, System.Drawing">
     <value>41, 85</value>
   </data>
@@ -148,7 +322,7 @@
     <value>FxCopAnalyzersPanel</value>
   </data>
   <data name="&gt;&gt;RunAnalyzersDuringLiveAnalysis.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>6</value>
   </data>
   <data name="RunAnalyzersDuringBuild.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -178,7 +352,7 @@
     <value>FxCopAnalyzersPanel</value>
   </data>
   <data name="&gt;&gt;RunAnalyzersDuringBuild.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>7</value>
   </data>
   <data name="RoslynAnalyzersLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -187,13 +361,13 @@
     <value>31, 9</value>
   </data>
   <data name="RoslynAnalyzersLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 13</value>
+    <value>65, 13</value>
   </data>
   <data name="RoslynAnalyzersLabel.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
   </data>
   <data name="RoslynAnalyzersLabel.Text" xml:space="preserve">
-    <value>Analyzers</value>
+    <value>All analyzers</value>
   </data>
   <data name="&gt;&gt;RoslynAnalyzersLabel.Name" xml:space="preserve">
     <value>RoslynAnalyzersLabel</value>
@@ -205,7 +379,7 @@
     <value>FxCopAnalyzersPanel</value>
   </data>
   <data name="&gt;&gt;RoslynAnalyzersLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>8</value>
   </data>
   <data name="RoslynAnalyzersLineLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>87, 16</value>
@@ -226,7 +400,7 @@
     <value>FxCopAnalyzersPanel</value>
   </data>
   <data name="&gt;&gt;RoslynAnalyzersLineLabel.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>9</value>
   </data>
   <data name="RoslynAnalyzersHelpLinkLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -253,7 +427,7 @@
     <value>FxCopAnalyzersPanel</value>
   </data>
   <data name="&gt;&gt;RoslynAnalyzersHelpLinkLabel.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>10</value>
   </data>
   <data name="FxCopAnalyzersPanel.Location" type="System.Drawing.Point, System.Drawing">
     <value>-30, 0</value>
@@ -262,7 +436,7 @@
     <value>2, 2, 2, 2</value>
   </data>
   <data name="FxCopAnalyzersPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>448, 222</value>
+    <value>448, 257</value>
   </data>
   <data name="FxCopAnalyzersPanel.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.vb
@@ -1,5 +1,6 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+Imports System.ComponentModel
 Imports System.Windows.Forms
 
 Namespace Microsoft.VisualStudio.Editors.PropertyPages
@@ -8,6 +9,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Inherits PropPageUserControlBase
 
         Private Const RoslynAnalyzersDocumentationLink As String = "https://docs.microsoft.com/visualstudio/code-quality/roslyn-analyzers-overview"
+        Private Const NETAnalyzersDocumentationLink As String = "https://aka.ms/dotnetanalyzers"
 
         Public Sub New()
             MyBase.New()
@@ -19,6 +21,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             'Add any initialization after the InitializeComponent() call
             AddChangeHandlers()
+
+            PopulateAnalysisLevelComboBoxItems()
         End Sub
 
         Protected Overrides ReadOnly Property ControlData As PropertyControlData()
@@ -26,12 +30,35 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 If m_ControlData Is Nothing Then
                     m_ControlData = New PropertyControlData() {
                         New PropertyControlData(1, "RunAnalyzersDuringBuild", RunAnalyzersDuringBuild, ControlDataFlags.None),
-                        New PropertyControlData(2, "RunAnalyzersDuringLiveAnalysis", RunAnalyzersDuringLiveAnalysis, ControlDataFlags.PersistedInProjectUserFile)
+                        New PropertyControlData(2, "RunAnalyzersDuringLiveAnalysis", RunAnalyzersDuringLiveAnalysis, ControlDataFlags.PersistedInProjectUserFile),
+                        New PropertyControlData(3, "EnableNETAnalyzers", EnableNETAnalyzersCheckBox, ControlDataFlags.None),
+                        New PropertyControlData(4, "AnalysisLevel", AnalysisLevelComboBox, AddressOf AnalysisLevelSet, AddressOf AnalysisLevelGet, ControlDataFlags.None)
                     }
                 End If
                 Return m_ControlData
             End Get
         End Property
+
+        Private Function AnalysisLevelSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
+            Dim selectionValue As String = CType(value, String)
+
+            If selectionValue <> "" Then
+                For index = 0 To AnalysisLevelComboBox.Items.Count - 1
+                    Dim item = AnalysisLevelComboBox.Items(index)
+                    Dim itemText = AnalysisLevelComboBox.GetItemText(item)
+                    If StringComparers.SettingNames.Equals(itemText, selectionValue) Then
+                        AnalysisLevelComboBox.SelectedIndex = index
+                    End If
+                Next
+            Else
+                AnalysisLevelComboBox.SelectedIndex = 1
+            End If
+        End Function
+
+        Private Function AnalysisLevelGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
+            value = AnalysisLevelComboBox.Text
+            Return True
+        End Function
 
         Protected Overrides Function GetF1HelpKeyword() As String
             ' TODO: New help keyword
@@ -41,6 +68,20 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private Sub RoslynAnalyzersLabel_LinkClicked(sender As Object, e As LinkLabelLinkClickedEventArgs) Handles RoslynAnalyzersHelpLinkLabel.LinkClicked
             RoslynAnalyzersHelpLinkLabel.LinkVisited = True
             Process.Start(RoslynAnalyzersDocumentationLink)
+        End Sub
+
+        Private Sub NETAnalyzersLinkLabel_LinkClicked(sender As Object, e As LinkLabelLinkClickedEventArgs) Handles NETAnalyzersLinkLabel.LinkClicked
+            NETAnalyzersLinkLabel.LinkVisited = True
+            Process.Start(NETAnalyzersDocumentationLink)
+        End Sub
+
+        Private Sub PopulateAnalysisLevelComboBoxItems()
+            If AnalysisLevelComboBox.Items.Count = 0 Then
+                AnalysisLevelComboBox.Items.Add("preview")
+                AnalysisLevelComboBox.Items.Add("latest")
+                AnalysisLevelComboBox.Items.Add("5.0")
+                AnalysisLevelComboBox.Items.Add("none")
+            End If
         End Sub
 
     End Class

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.cs.xlf
@@ -2,9 +2,49 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource1">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource2">
+        <source>5.0</source>
+        <target state="new">5.0</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource3">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelLabel.Text">
+        <source>Analysis Level</source>
+        <target state="new">Analysis Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNETAnalyzersCheckBox.Text">
+        <source>Enable .NET analyzers</source>
+        <target state="new">Enable .NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label1.Text">
+        <source>.NET analyzers</source>
+        <target state="new">.NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NETAnalyzersLinkLabel.Text">
+        <source>What are .NET analyzers?</source>
+        <target state="new">What are .NET analyzers?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Analyzers</source>
-        <target state="translated">Analyzátory</target>
+        <source>All analyzers</source>
+        <target state="needs-review-translation">Analyzátory</target>
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.de.xlf
@@ -2,9 +2,49 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource1">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource2">
+        <source>5.0</source>
+        <target state="new">5.0</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource3">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelLabel.Text">
+        <source>Analysis Level</source>
+        <target state="new">Analysis Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNETAnalyzersCheckBox.Text">
+        <source>Enable .NET analyzers</source>
+        <target state="new">Enable .NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label1.Text">
+        <source>.NET analyzers</source>
+        <target state="new">.NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NETAnalyzersLinkLabel.Text">
+        <source>What are .NET analyzers?</source>
+        <target state="new">What are .NET analyzers?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Analyzers</source>
-        <target state="translated">Analysetools</target>
+        <source>All analyzers</source>
+        <target state="needs-review-translation">Analysetools</target>
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.es.xlf
@@ -2,9 +2,49 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource1">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource2">
+        <source>5.0</source>
+        <target state="new">5.0</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource3">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelLabel.Text">
+        <source>Analysis Level</source>
+        <target state="new">Analysis Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNETAnalyzersCheckBox.Text">
+        <source>Enable .NET analyzers</source>
+        <target state="new">Enable .NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label1.Text">
+        <source>.NET analyzers</source>
+        <target state="new">.NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NETAnalyzersLinkLabel.Text">
+        <source>What are .NET analyzers?</source>
+        <target state="new">What are .NET analyzers?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Analyzers</source>
-        <target state="translated">Analizadores</target>
+        <source>All analyzers</source>
+        <target state="needs-review-translation">Analizadores</target>
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.fr.xlf
@@ -2,9 +2,49 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource1">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource2">
+        <source>5.0</source>
+        <target state="new">5.0</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource3">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelLabel.Text">
+        <source>Analysis Level</source>
+        <target state="new">Analysis Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNETAnalyzersCheckBox.Text">
+        <source>Enable .NET analyzers</source>
+        <target state="new">Enable .NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label1.Text">
+        <source>.NET analyzers</source>
+        <target state="new">.NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NETAnalyzersLinkLabel.Text">
+        <source>What are .NET analyzers?</source>
+        <target state="new">What are .NET analyzers?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Analyzers</source>
-        <target state="translated">Analyseurs</target>
+        <source>All analyzers</source>
+        <target state="needs-review-translation">Analyseurs</target>
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.it.xlf
@@ -2,9 +2,49 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource1">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource2">
+        <source>5.0</source>
+        <target state="new">5.0</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource3">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelLabel.Text">
+        <source>Analysis Level</source>
+        <target state="new">Analysis Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNETAnalyzersCheckBox.Text">
+        <source>Enable .NET analyzers</source>
+        <target state="new">Enable .NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label1.Text">
+        <source>.NET analyzers</source>
+        <target state="new">.NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NETAnalyzersLinkLabel.Text">
+        <source>What are .NET analyzers?</source>
+        <target state="new">What are .NET analyzers?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Analyzers</source>
-        <target state="translated">Analizzatori</target>
+        <source>All analyzers</source>
+        <target state="needs-review-translation">Analizzatori</target>
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ja.xlf
@@ -2,9 +2,49 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource1">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource2">
+        <source>5.0</source>
+        <target state="new">5.0</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource3">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelLabel.Text">
+        <source>Analysis Level</source>
+        <target state="new">Analysis Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNETAnalyzersCheckBox.Text">
+        <source>Enable .NET analyzers</source>
+        <target state="new">Enable .NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label1.Text">
+        <source>.NET analyzers</source>
+        <target state="new">.NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NETAnalyzersLinkLabel.Text">
+        <source>What are .NET analyzers?</source>
+        <target state="new">What are .NET analyzers?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Analyzers</source>
-        <target state="translated">アナライザー</target>
+        <source>All analyzers</source>
+        <target state="needs-review-translation">アナライザー</target>
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ko.xlf
@@ -2,9 +2,49 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource1">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource2">
+        <source>5.0</source>
+        <target state="new">5.0</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource3">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelLabel.Text">
+        <source>Analysis Level</source>
+        <target state="new">Analysis Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNETAnalyzersCheckBox.Text">
+        <source>Enable .NET analyzers</source>
+        <target state="new">Enable .NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label1.Text">
+        <source>.NET analyzers</source>
+        <target state="new">.NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NETAnalyzersLinkLabel.Text">
+        <source>What are .NET analyzers?</source>
+        <target state="new">What are .NET analyzers?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Analyzers</source>
-        <target state="translated">분석기</target>
+        <source>All analyzers</source>
+        <target state="needs-review-translation">분석기</target>
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pl.xlf
@@ -2,9 +2,49 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource1">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource2">
+        <source>5.0</source>
+        <target state="new">5.0</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource3">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelLabel.Text">
+        <source>Analysis Level</source>
+        <target state="new">Analysis Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNETAnalyzersCheckBox.Text">
+        <source>Enable .NET analyzers</source>
+        <target state="new">Enable .NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label1.Text">
+        <source>.NET analyzers</source>
+        <target state="new">.NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NETAnalyzersLinkLabel.Text">
+        <source>What are .NET analyzers?</source>
+        <target state="new">What are .NET analyzers?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Analyzers</source>
-        <target state="translated">Analizatory</target>
+        <source>All analyzers</source>
+        <target state="needs-review-translation">Analizatory</target>
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pt-BR.xlf
@@ -2,9 +2,49 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource1">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource2">
+        <source>5.0</source>
+        <target state="new">5.0</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource3">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelLabel.Text">
+        <source>Analysis Level</source>
+        <target state="new">Analysis Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNETAnalyzersCheckBox.Text">
+        <source>Enable .NET analyzers</source>
+        <target state="new">Enable .NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label1.Text">
+        <source>.NET analyzers</source>
+        <target state="new">.NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NETAnalyzersLinkLabel.Text">
+        <source>What are .NET analyzers?</source>
+        <target state="new">What are .NET analyzers?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Analyzers</source>
-        <target state="translated">Analisadores</target>
+        <source>All analyzers</source>
+        <target state="needs-review-translation">Analisadores</target>
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ru.xlf
@@ -2,9 +2,49 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource1">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource2">
+        <source>5.0</source>
+        <target state="new">5.0</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource3">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelLabel.Text">
+        <source>Analysis Level</source>
+        <target state="new">Analysis Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNETAnalyzersCheckBox.Text">
+        <source>Enable .NET analyzers</source>
+        <target state="new">Enable .NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label1.Text">
+        <source>.NET analyzers</source>
+        <target state="new">.NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NETAnalyzersLinkLabel.Text">
+        <source>What are .NET analyzers?</source>
+        <target state="new">What are .NET analyzers?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Analyzers</source>
-        <target state="translated">Анализаторы</target>
+        <source>All analyzers</source>
+        <target state="needs-review-translation">Анализаторы</target>
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.tr.xlf
@@ -2,9 +2,49 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource1">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource2">
+        <source>5.0</source>
+        <target state="new">5.0</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource3">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelLabel.Text">
+        <source>Analysis Level</source>
+        <target state="new">Analysis Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNETAnalyzersCheckBox.Text">
+        <source>Enable .NET analyzers</source>
+        <target state="new">Enable .NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label1.Text">
+        <source>.NET analyzers</source>
+        <target state="new">.NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NETAnalyzersLinkLabel.Text">
+        <source>What are .NET analyzers?</source>
+        <target state="new">What are .NET analyzers?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Analyzers</source>
-        <target state="translated">Çözümleyiciler</target>
+        <source>All analyzers</source>
+        <target state="needs-review-translation">Çözümleyiciler</target>
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hans.xlf
@@ -2,9 +2,49 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource1">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource2">
+        <source>5.0</source>
+        <target state="new">5.0</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource3">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelLabel.Text">
+        <source>Analysis Level</source>
+        <target state="new">Analysis Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNETAnalyzersCheckBox.Text">
+        <source>Enable .NET analyzers</source>
+        <target state="new">Enable .NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label1.Text">
+        <source>.NET analyzers</source>
+        <target state="new">.NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NETAnalyzersLinkLabel.Text">
+        <source>What are .NET analyzers?</source>
+        <target state="new">What are .NET analyzers?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Analyzers</source>
-        <target state="translated">分析器</target>
+        <source>All analyzers</source>
+        <target state="needs-review-translation">分析器</target>
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hant.xlf
@@ -2,9 +2,49 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource1">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource2">
+        <source>5.0</source>
+        <target state="new">5.0</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource3">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnalysisLevelLabel.Text">
+        <source>Analysis Level</source>
+        <target state="new">Analysis Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNETAnalyzersCheckBox.Text">
+        <source>Enable .NET analyzers</source>
+        <target state="new">Enable .NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label1.Text">
+        <source>.NET analyzers</source>
+        <target state="new">.NET analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NETAnalyzersLinkLabel.Text">
+        <source>What are .NET analyzers?</source>
+        <target state="new">What are .NET analyzers?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Analyzers</source>
-        <target state="translated">分析器</target>
+        <source>All analyzers</source>
+        <target state="needs-review-translation">分析器</target>
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -428,4 +428,24 @@
                   SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>
   </BoolProperty>
+
+  <BoolProperty Name="EnableNETAnalyzers"
+                Visible="False">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="EnableNETAnalyzers"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
+
+  <StringProperty Name="AnalysisLevel"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="AnalysisLevel"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 </Rule>


### PR DESCRIPTION
fixes https://github.com/dotnet/project-system/issues/6528

This is what the code analysis page looks like with this change:

![image](https://user-images.githubusercontent.com/9797472/90837991-77f4d900-e308-11ea-96ba-d6aeb7420fa2.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6529)