### PR TITLE
RCS1246: Use element access instead of Linq First()

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/ProjectImports/ImportTreeCommandGroupHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/ProjectImports/ImportTreeCommandGroupHandler.cs
@@ -163,7 +163,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.ProjectImports
             {
                 if (exceptions.Count == 1)
                 {
-                    ExceptionDispatchInfo.Capture(exceptions.First()).Throw();
+                    ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
                 }
                 else
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             {
                 // First value is the default one.
                 var defaultValues = PooledArray<KeyValuePair<string, string>>.GetInstance();
-                defaultValues.Add(new KeyValuePair<string, string>(DimensionName, values.First()));
+                defaultValues.Add(new KeyValuePair<string, string>(DimensionName, values[0]));
                 return defaultValues.ToImmutableAndFree();
             }
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridgeTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridgeTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.VS.Automation;
 using Moq;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridgeTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridgeTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             // One file should have been added
             Assert.Single(_buildManager.DirtyItems);
-            Assert.Equal("Resources1.Designer.cs", _buildManager.DirtyItems.First());
+            Assert.Equal("Resources1.Designer.cs", _buildManager.DirtyItems[0]);
             Assert.Empty(_buildManager.DeletedItems);
         }
 
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             // One file should have been added
             Assert.Empty(_buildManager.DirtyItems);
             Assert.Single(_buildManager.DeletedItems);
-            Assert.Equal("Resources1.Designer.cs", _buildManager.DeletedItems.First());
+            Assert.Equal("Resources1.Designer.cs", _buildManager.DeletedItems[0]);
         }
 
         [Fact]


### PR DESCRIPTION
https://github.com/JosefPihrt/Roslynator/blob/master/docs/analyzers/RCS1246.md

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6530)