### PR TITLE
Track project references having ReferenceOutputAssembly="false"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -337,6 +337,27 @@
   <Target Name="ResolveFrameworkReferences" />
 
   <Target
+    Name="ResolveProjectReferencesDesignTime2"
+    Returns="@(_ProjectReferencesFromRAR2);@(_ProjectReferencesWithoutOutputAssembly)"
+    DependsOnTargets="ResolveProjectReferences;ResolveAssemblyReferences">
+    <!-- This is similar to ResolveProjectReferencesDesignTime, except it also returns projects that do not get
+         resolved (hence do not appear in ReferencePath) because ReferenceOutputAssembly is set to false. -->
+    <ItemGroup>
+      <!-- We need to do this here because we only want project references which have passed through RAR and have
+           not been unresolved due to violating some multi-targeting rule which means we need to pull the project
+           references out of the referencepath item because they will only exist there if they were correctly
+           resolved. -->
+      <_ProjectReferencesFromRAR2 Include="@(ReferencePath->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))">
+        <OriginalItemSpec>%(ReferencePath.ProjectReferenceOriginalItemSpec)</OriginalItemSpec>
+      </_ProjectReferencesFromRAR2>
+
+      <_ProjectReferencesWithoutOutputAssembly Include="@(ProjectReference->WithMetadataValue('ReferenceOutputAssembly', 'false'))">
+        <OriginalItemSpec>%(ProjectReference.Identity)</OriginalItemSpec>
+      </_ProjectReferencesWithoutOutputAssembly>
+    </ItemGroup>
+  </Target>
+
+  <Target
     Name="ResolveFrameworkReferencesDesignTime"
     Returns="@(ResolvedFrameworkReference)"
     DependsOnTargets="ResolveFrameworkReferences" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedProjectReference.xaml
@@ -8,7 +8,7 @@
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="ProjectReference"
-                MSBuildTarget="ResolveProjectReferencesDesignTime"
+                MSBuildTarget="ResolveProjectReferencesDesignTime2"
                 Persistence="ResolvedReference"
                 SourceOfDefaultValue="AfterContext"
                 SourceType="TargetResults" />


### PR DESCRIPTION
Fixes #2928.

Project resolution has historically been determined by the presence of an item in the `ReferencePath` group, for which the source was a `ProjectReference`.

When a `ProjectReference` specifies `ReferenceOutputAssembly="false"`, it is explicitly stating that the referenced project's output assembly should not be included in `ReferencePath`. However, for the purposes of populating the Dependencies tree, we still wish to know that this item was present. Its absence from the `ResolvedProjectReference` item group results in a yellow triangle appearing on the reference in the tree.

To fix this, we override the target used by the `ResolvedProjectReference` rule to also return `ProjectReference` items having `ReferenceOutputAssembly="false"`.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6536)