### PR TITLE
Always use project name in caption

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModel.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             bool isImplicit,
             IImmutableDictionary<string, string> properties)
             : base(
-                caption: System.IO.Path.GetFileNameWithoutExtension(path),
+                caption: System.IO.Path.GetFileNameWithoutExtension(originalItemSpec),
                 path,
                 originalItemSpec,
                 flags: s_flagCache.Get(isResolved, isImplicit).Add($"$ID:{System.IO.Path.GetFileNameWithoutExtension(path)}"),

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
@@ -17,16 +17,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             var properties = ImmutableStringDictionary<string>.EmptyOrdinal.Add("myProp", "myVal");
 
             var model = new ProjectDependencyModel(
-                "c:\\myPath.dll",
-                "myOriginalItemSpec",
+                "c:\\ResolvedPath\\MyProject.dll",
+                "Project\\MyProject.csproj",
                 isResolved: true,
                 isImplicit: false,
                 properties: properties);
 
             Assert.Equal(ProjectRuleHandler.ProviderTypeString, model.ProviderType);
-            Assert.Equal("c:\\myPath.dll", model.Path);
-            Assert.Equal("myOriginalItemSpec", model.OriginalItemSpec);
-            Assert.Equal("myPath", model.Caption);
+            Assert.Equal("c:\\ResolvedPath\\MyProject.dll", model.Path);
+            Assert.Equal("Project\\MyProject.csproj", model.OriginalItemSpec);
+            Assert.Equal("MyProject", model.Caption);
             Assert.Equal(ResolvedProjectReference.SchemaName, model.SchemaName);
             Assert.True(model.Resolved);
             Assert.False(model.Implicit);
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags +
-                ProjectTreeFlags.Create("$ID:myPath"),
+                ProjectTreeFlags.Create("$ID:MyProject"),
                 model.Flags);
         }
 
@@ -49,16 +49,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             var properties = ImmutableStringDictionary<string>.EmptyOrdinal.Add("myProp", "myVal");
 
             var model = new ProjectDependencyModel(
-                "c:\\myPath.dll",
-                "myOriginalItemSpec",
+                "c:\\ResolvedPath\\MyProject.dll",
+                "Project\\MyProject.csproj",
                 isResolved: false,
                 isImplicit: false,
                 properties: properties);
 
             Assert.Equal(ProjectRuleHandler.ProviderTypeString, model.ProviderType);
-            Assert.Equal("c:\\myPath.dll", model.Path);
-            Assert.Equal("myOriginalItemSpec", model.OriginalItemSpec);
-            Assert.Equal("myPath", model.Caption);
+            Assert.Equal("c:\\ResolvedPath\\MyProject.dll", model.Path);
+            Assert.Equal("Project\\MyProject.csproj", model.OriginalItemSpec);
+            Assert.Equal("MyProject", model.Caption);
             Assert.Equal(ProjectReference.SchemaName, model.SchemaName);
             Assert.False(model.Resolved);
             Assert.False(model.Implicit);
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags +
-                ProjectTreeFlags.Create("$ID:myPath"),
+                ProjectTreeFlags.Create("$ID:MyProject"),
                 model.Flags);
         }
 
@@ -81,16 +81,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             var properties = ImmutableStringDictionary<string>.EmptyOrdinal.Add("myProp", "myVal");
 
             var model = new ProjectDependencyModel(
-                "c:\\myPath.dll",
-                "myOriginalItemSpec",
+                "c:\\ResolvedPath\\MyProject.dll",
+                "Project\\MyProject.csproj",
                 isResolved: true,
                 isImplicit: true,
                 properties: properties);
 
             Assert.Equal(ProjectRuleHandler.ProviderTypeString, model.ProviderType);
-            Assert.Equal("c:\\myPath.dll", model.Path);
-            Assert.Equal("myOriginalItemSpec", model.OriginalItemSpec);
-            Assert.Equal("myPath", model.Caption);
+            Assert.Equal("c:\\ResolvedPath\\MyProject.dll", model.Path);
+            Assert.Equal("Project\\MyProject.csproj", model.OriginalItemSpec);
+            Assert.Equal("MyProject", model.Caption);
             Assert.Equal(ResolvedProjectReference.SchemaName, model.SchemaName);
             Assert.True(model.Resolved);
             Assert.True(model.Implicit);
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
                 DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove +
-                ProjectTreeFlags.Create("$ID:myPath"),
+                ProjectTreeFlags.Create("$ID:MyProject"),
                 model.Flags);
         }
     }


### PR DESCRIPTION
Fixes #3685.

Previously, if a referenced project changes its assembly name, that assembly name would be used in the caption for that top-level dependency in Solution Explorer.

With this change, the project's name is used.

Given `ClassLibrary1.csproj`:

```xml
  <PropertyGroup>
    <TargetFramework>netstandard2.1</TargetFramework>
    <AssemblyName>Renamed</AssemblyName>
  </PropertyGroup>
```

## Before

![image](https://user-images.githubusercontent.com/350947/90884005-42c4b580-e3f2-11ea-9905-51a7e7505661.png)

## After

![image](https://user-images.githubusercontent.com/350947/90884022-49532d00-e3f2-11ea-9c32-572e8741c376.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6538)