### PR TITLE
 Replace MSBuild item with MEF service 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/ProjectAssetsProjectEvaluationDependencyProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/ProjectAssetsProjectEvaluationDependencyProvider.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.Build.Execution;
+using Microsoft.VisualStudio.IO;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
+{
+    /// <summary>
+    ///     Provides the project.assets.json as an input into evaluation.
+    /// </summary>
+    /// <remarks>
+    ///     Typically inputs into evaluation are provided declaratively by the AdditionalDesignTimeBuildInput 
+    ///     item, however, we want to lightup package restore in projects where we don't have control over 
+    ///     the targets they input, so we imperatively provide this input.
+    /// </remarks>
+    [Export(typeof(IProjectEvaluationDependencyProvider))]
+    [AppliesTo(ProjectCapability.PackageReferences)]
+    internal class ProjectAssetsProjectEvaluationDependencyProvider : IProjectEvaluationDependencyProvider
+    {
+        private readonly IFileSystem _fileSystem;
+
+        [ImportingConstructor]
+        public ProjectAssetsProjectEvaluationDependencyProvider(IFileSystem fileSystem)
+        {
+            _fileSystem = fileSystem;
+        }
+
+        public IEnumerable<KeyValuePair<string, bool>> GetContentIrrelevantProjectDependentFiles(ProjectInstance projectInstance)
+        {
+            return Enumerable.Empty<KeyValuePair<string, bool>>();
+        }
+
+        public IEnumerable<KeyValuePair<string, DateTime?>> GetContentSensitiveProjectDependentFileTimes(ProjectInstance projectInstance)
+        {
+            Requires.NotNull(projectInstance, nameof(projectInstance));
+
+            string assetsFile = projectInstance.GetPropertyValue(ConfigurationGeneral.ProjectAssetsFileProperty);
+
+            if (assetsFile.Length == 0)
+                yield break;
+
+            _ = _fileSystem.TryGetLastFileWriteTimeUtc(assetsFile, out DateTime? lastWriteTime);
+
+            // Equivalent of <AdditionalDesignTimeBuildInput Include = "$(ProjectAssetsFile)" ContentSensitive = "true" />
+            yield return new KeyValuePair<string, DateTime?>(assetsFile, lastWriteTime);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -296,9 +296,6 @@
   <!-- List of external files that trigger re-evaluation & design-time builds when they are added or removed, or edited -->
   <ItemGroup>
     
-    <!-- NuGet assets file -->
-    <AdditionalDesignTimeBuildInput Include="$(ProjectAssetsFile)" ContentSensitive="true" />   
-  
     <!-- Potential Editor config locations, we only want to trigger design-time builds on removal/addition and not edits  -->
     <AdditionalDesignTimeBuildInput Include="@(PotentialEditorConfigFiles)" ContentSensitive="false" />   
   

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Build/ProjectInstanceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Build/ProjectInstanceFactory.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.Build.Construction;
+using Microsoft.Build.Definition;
+
+namespace Microsoft.Build.Execution
+{
+    internal static class ProjectInstanceFactory
+    {
+        public static ProjectInstance Create(string? xml = null)
+        {
+            var element = ProjectRootElementFactory.Create(xml);
+
+            return ProjectInstance.FromProjectRootElement(element, new ProjectOptions());
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Moq/ReturnsExtensions.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Moq/ReturnsExtensions.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft;
 using Moq.Language;
 using Moq.Language.Flow;
 
@@ -39,45 +37,6 @@ namespace Moq
         public static IReturnsResult<TMock> ReturnsAsync<TMock, T1, T2, T3, T4, T5>(this IReturns<TMock, Task> mock, Action<T1, T2, T3, T4, T5> action) where TMock : class
         {
             return mock.Returns((T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) => { action(arg1, arg2, arg3, arg4, arg5); return Task.CompletedTask; });
-        }
-
-        public static IReturnsThrows<TMock, TReturn> Returns<TMock, TReturn, TOut, TResult>(this IReturns<TMock, TReturn> valueFunction, FuncWithOut<TOut, TResult> action)
-              where TMock : class
-        {
-            return Returns(valueFunction, (object)action);
-        }
-
-        public static IReturnsThrows<TMock, TReturn> Returns<TMock, TReturn, T1, TOut, TResult>(this IReturns<TMock, TReturn> valueFunction, FuncWithOut<T1, TOut, TResult> action)
-            where TMock : class
-        {
-            return Returns(valueFunction, (object)action);
-        }
-
-        public static IReturnsThrows<TMock, TReturn> Returns<TMock, TReturn, T1, TOut1, TOut2, TResult>(this IReturns<TMock, TReturn> valueFunction, FuncWithOut<T1, TOut1, TOut2, TResult> action)
-            where TMock : class
-        {
-            return Returns(valueFunction, (object)action);
-        }
-
-        public static IReturnsThrows<TMock, TReturn> Returns<TMock, TReturn, T1, T2, TOut1, TOut2, TResult>(this IReturns<TMock, TReturn> valueFunction, FuncWithOut<T1, T2, TOut1, TOut2, TResult> action)
-            where TMock : class
-        {
-            return Returns(valueFunction, (object)action);
-        }
-
-        public static IReturnsThrows<TMock, TReturn> Returns<TMock, TReturn, TOut1, TOut2, TOut3, TResult>(this IReturns<TMock, TReturn> valueFunction, FuncWithOutThreeArgs<TOut1, TOut2, TOut3, TResult> action)
-            where TMock : class
-        {
-            return Returns(valueFunction, (object)action);
-        }
-
-        private static IReturnsThrows<TMock, TReturn> Returns<TMock, TReturn>(IReturns<TMock, TReturn> valueFunction, object action)
-            where TMock : class
-        {
-            valueFunction.GetType()
-                         .InvokeMember("SetReturnDelegate", BindingFlags.InvokeMethod | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, binder: null, valueFunction, new[] { action });
-
-            return (IReturnsThrows<TMock, TReturn>)valueFunction;
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
@@ -8,6 +8,16 @@ namespace Microsoft.VisualStudio.IO
 {
     internal static class IFileSystemFactory
     {
+        public static IFileSystem ImplementTryGetLastFileWriteTimeUtc(FuncWithOut<string, DateTime?, bool> action)
+        {
+            DateTime? result;
+            var mock = new Mock<IFileSystem>();
+            mock.Setup(f => f.TryGetLastFileWriteTimeUtc(It.IsAny<string>(), out result))
+                .Returns(action);
+
+            return mock.Object;
+        }
+
         public static IFileSystem Create()
         {
             return Mock.Of<IFileSystem>();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/ProjectAssetsProjectEvaluationDependencyProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/ProjectAssetsProjectEvaluationDependencyProviderTests.cs
@@ -1,0 +1,114 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Linq;
+using Microsoft.Build.Execution;
+using Microsoft.VisualStudio.IO;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
+{
+    public class ProjectAssetsProjectEvaluationDependencyProviderTests
+    {
+        [Fact]
+        public void GetContentIrrelevantProjectDependentFiles_ReturnsEmpty()
+        {
+            var provider = CreateInstance();
+
+            var projectInstance = ProjectInstanceFactory.Create();
+            var result = provider.GetContentIrrelevantProjectDependentFiles(projectInstance);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void GetContentSensitiveProjectDependentFileTimes_WhenProjectAssetsFileIsMissing_ReturnsEmpty()
+        {
+            string projectXml =
+@"<Project>
+</Project>";
+
+            var projectInstance = ProjectInstanceFactory.Create(projectXml);
+
+            var provider = CreateInstance();
+
+            var result = provider.GetContentSensitiveProjectDependentFileTimes(projectInstance);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void GetContentSensitiveProjectDependentFileTimes_WhenProjectAssetsFileIsEmpty_ReturnsEmpty()
+        {
+            string projectXml =
+@"<Project>
+  <PropertyGroup>
+     <ProjectAssetsFile></ProjectAssetsFile>
+  </PropertyGroup>
+</Project>";
+
+            var projectInstance = ProjectInstanceFactory.Create(projectXml);
+
+            var provider = CreateInstance();
+            
+            var result = provider.GetContentSensitiveProjectDependentFileTimes(projectInstance);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void GetContentSensitiveProjectDependentFileTimes_WhenProjectAssetsFileExists_ReturnsLastWriteTime()
+        {
+            string projectXml =
+@"<Project>
+  <PropertyGroup>
+     <ProjectAssetsFile>C:\Project\project.assets.json</ProjectAssetsFile>
+  </PropertyGroup>
+</Project>";
+
+            var lastWriteTime = DateTime.UtcNow;
+
+            var projectInstance = ProjectInstanceFactory.Create(projectXml);
+
+            var fileSystem = IFileSystemFactory.ImplementTryGetLastFileWriteTimeUtc((string path, out DateTime? result) => { result = lastWriteTime; return true; });
+
+            var provider = CreateInstance(fileSystem);
+
+            var result = provider.GetContentSensitiveProjectDependentFileTimes(projectInstance).First();
+
+            Assert.Equal(@"C:\Project\project.assets.json", result.Key);
+            Assert.Equal(lastWriteTime, result.Value);
+        }
+
+        [Fact]
+        public void GetContentSensitiveProjectDependentFileTimes_WhenProjectAssetsFileDoesNotExist_ReturnsNullForLastWriteTime()
+        {
+            string projectXml =
+@"<Project>
+  <PropertyGroup>
+     <ProjectAssetsFile>C:\Project\project.assets.json</ProjectAssetsFile>
+  </PropertyGroup>
+</Project>";
+
+            var lastWriteTime = DateTime.UtcNow;
+
+            var projectInstance = ProjectInstanceFactory.Create(projectXml);
+
+            var fileSystem = IFileSystemFactory.ImplementTryGetLastFileWriteTimeUtc((string path, out DateTime? result) => { result = null; return false; });
+
+            var provider = CreateInstance();
+
+            var result = provider.GetContentSensitiveProjectDependentFileTimes(projectInstance).First();
+
+            Assert.Equal(@"C:\Project\project.assets.json", result.Key);
+            Assert.Null(result.Value);
+        }
+
+        private static ProjectAssetsProjectEvaluationDependencyProvider CreateInstance(IFileSystem? fileSystem = null)
+        {
+            fileSystem ??= IFileSystemFactory.Create();
+
+            return new ProjectAssetsProjectEvaluationDependencyProvider(fileSystem);
+        }
+    }
+}


### PR DESCRIPTION
This replaces the MSBuild item with a MEF service, that has the added advantage of being tied to a project capability and allowing it to be loaded in project types that have not imported our Managed.DesignTime.targets.

This is a part of #2491 and enables C++ and other project types to moniter the project assets file and trigger evaluation/design-time builds when it is changed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6545)