### PR TITLE
Fix assert when active config doesn't match known configs

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -144,7 +144,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 }
             }
 
-            Assumes.True(builder.Count > 0, "We have an active configuration that isn't one of the known configurations");
+            if (builder.Count == 0)
+            {   
+                // Active config is different to the known configs, 
+                // however we should still return it
+                builder.Add(activeSolutionConfiguration);
+            }
+
             return new ActiveConfiguredObjects<ProjectConfiguration>(builder.ToImmutableAndFree(), dimensionNames);
         }
 


### PR DESCRIPTION
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1155124
Fixes: https://github.com/dotnet/project-system/issues/6122
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1155302

Active config can be set to values that aren't one of the known configs, this can happen when the project is opened without configurations and we have an active config based on the default.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6547)