### PR TITLE
Fix exception for empty TargetFrameworkVersion string

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.VisualBasic.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.VisualBasic.DesignTime.targets
@@ -40,7 +40,9 @@
                           ClassDesigner;
                           SharedProjectReferences;" />
 
-      <ProjectCapability Include="EnableMyApplication" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)','5.0')) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(UseWindowsForms)' == 'true'" />
+      <ProjectCapability Include="EnableMyApplication" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"/>
+
+      <ProjectCapability Include="EnableMyApplication" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(UseWindowsForms)' == 'true' And '$(TargetFrameworkVersion)' != '' And $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)','5.0'))"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(DefineCommonManagedItemSchemas)' == 'true'">


### PR DESCRIPTION
Separated the conditionality for .NET Framework and .NET Core, and for the latter added the case for an empty TargetFrameworkVersion string.

Fix for bug introduced in #6486. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6548)