### PR TITLE
Simplify IWaitIndicator 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FSharp/FSharpProjectSelector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FSharp/FSharpProjectSelector.cs
@@ -34,7 +34,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.FSharp
         public async Task InitializeAsync(IAsyncServiceProvider asyncServiceProvider)
         {
             Assumes.Null(_projectSelector);
-            Assumes.True(_context.IsOnMainThread, "Must be on UI thread");
+
+            _context.VerifyIsOnMainThread();
 
             _projectSelector = await asyncServiceProvider.GetServiceAsync<SVsRegisterProjectTypes, IVsRegisterProjectSelector>();
 
@@ -69,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.FSharp
 
         public void Dispose()
         {
-            Assumes.True(_context.IsOnMainThread, "Must be on UI thread");
+            _context.VerifyIsOnMainThread();
 
             if (_cookie != VSConstants.VSCOOKIE_NIL)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/PackageCommandRegistrationService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/PackageCommandRegistrationService.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
         public async Task InitializeAsync(IAsyncServiceProvider asyncServiceProvider)
         {
-            Assumes.True(_context.IsOnMainThread, "Must be on UI thread");
+            _context.VerifyIsOnMainThread();
 
             IMenuCommandService menuCommandService = await asyncServiceProvider.GetServiceAsync<IMenuCommandService, IMenuCommandService>();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.LanguageServices;
 using Microsoft.VisualStudio.OperationProgress;
 using Microsoft.VisualStudio.ProjectSystem.Waiting;
 using Microsoft.VisualStudio.Shell.Interop;
+using Solution = Microsoft.CodeAnalysis.Solution;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
 {
@@ -116,26 +117,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                 await stageStatus.WaitForCompletionAsync();
 
                 // Apply actions and notify other VS features
-                CodeAnalysis.Solution? currentSolution = GetCurrentProject()?.Solution;
+                Solution? currentSolution = GetCurrentProject()?.Solution;
                 if (currentSolution == null)
                 {
                     return;
                 }
                 string renameOperationName = string.Format(CultureInfo.CurrentCulture, VSResources.Renaming_Type_from_0_to_1, oldName, value);
-                (WaitIndicatorResult result, CodeAnalysis.Solution renamedSolution) = _waitService.WaitForAsyncFunctionWithResult(
+                WaitIndicatorResult<Solution> result = _waitService.Run(
                                 title: VSResources.Renaming_Type,
                                 message: renameOperationName,
                                 allowCancel: true,
                                 token => documentRenameResult.UpdateSolutionAsync(currentSolution, token));
 
                 // Do not warn the user if the rename was cancelled by the user	
-                if (result.WasCanceled())
+                if (result.IsCancelled)
                 {
                     return;
                 }
 
                 await _projectVsServices.ThreadingService.SwitchToUIThread();
-                if (!_roslynServices.ApplyChangesToSolution(currentSolution.Workspace, renamedSolution))
+                if (!_roslynServices.ApplyChangesToSolution(currentSolution.Workspace, result.Result))
                 {
                     string failureMessage = string.Format(CultureInfo.CurrentCulture, VSResources.RenameSymbolFailed, oldName);
                     _userNotificationServices.ShowWarning(failureMessage);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsUIService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsUIService`1.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.ComponentModel.Composition;
-using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 
@@ -34,15 +33,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
+
                 // We always verify that we're on the UI thread regardless 
                 // of whether we've already retrieved the service to always
                 // enforce this.
-                if (_joinableTaskContext.IsOnMainThread)
-                {
-                    return _value.Value;
-                }
+                _joinableTaskContext.VerifyIsOnMainThread();
 
-                throw new COMException("This method must be called on the UI thread.", HResult.WrongThread);
+                return _value.Value;
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitIndicator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitIndicator.cs
@@ -25,86 +25,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
             _waitDialogFactoryService = waitDialogFactoryService;
         }
 
-        public void Wait(string title, string message, bool allowCancel, Action<CancellationToken> action)
+        public WaitIndicatorResult<T> Run<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncMethod) where T : class?
         {
-            _ = WaitWithResult(title, message, allowCancel, action);
-        }
-
-        public T Wait<T>(string title, string message, bool allowCancel, Func<CancellationToken, T> action)
-        {
-            if (typeof(T) == typeof(Task))
-                throw new ArgumentException("Type argument must not be Task", nameof(T));
-
-            (_, T result) = WaitWithResult(title, message, allowCancel, action);
-            return result;
-        }
-
-        public void WaitForAsyncFunction(string title, string message, bool allowCancel, Func<CancellationToken, Task> asyncFunction)
-        {
-            _ = WaitForAsyncFunctionWithResult(title, message, allowCancel, asyncFunction);
-        }
-
-        public T WaitForAsyncFunction<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncFunction)
-        {
-            (_, T result) = WaitForAsyncFunctionWithResult(title, message, allowCancel, asyncFunction);
-            return result;
-        }
-
-        public WaitIndicatorResult WaitForAsyncFunctionWithResult(string title, string message, bool allowCancel, Func<CancellationToken, Task> asyncFunction)
-        {
-            (WaitIndicatorResult waitResult, _) = WaitForOperationImpl(title, message, allowCancel, token =>
-            {
-                _joinableTaskContext.Factory.Run(() => asyncFunction(token));
-                return true;
-            });
-
-            return waitResult;
-        }
-
-        public WaitIndicatorResult WaitWithResult(string title, string message, bool allowCancel, Action<CancellationToken> action)
-        {
-            (WaitIndicatorResult waitResult, _) = WaitForOperationImpl(title, message, allowCancel, token =>
-            {
-                action(token);
-                return true;
-            });
-
-            return waitResult;
-        }
-
-        public (WaitIndicatorResult, T) WaitForAsyncFunctionWithResult<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncFunction)
-        {
-            return WaitForOperationImpl(title, message, allowCancel, token => _joinableTaskContext.Factory.Run(() => asyncFunction(token)));
-        }
-
-        public (WaitIndicatorResult, T) WaitWithResult<T>(string title, string message, bool allowCancel, Func<CancellationToken, T> function)
-        {
-            return WaitForOperationImpl(title, message, allowCancel, function);
-        }
-
-        private (WaitIndicatorResult, T) WaitForOperationImpl<T>(string title, string message, bool allowCancel, Func<CancellationToken, T> function)
-        {
-            Assumes.True(_joinableTaskContext.IsOnMainThread);
+            _joinableTaskContext.VerifyIsOnMainThread();
 
             using IWaitContext waitContext = StartWait(title, message, allowCancel);
 
             try
             {
-                T result = function(waitContext.CancellationToken);
+#pragma warning disable VSTHRD102 // Deliberate usage  
+                T result = _joinableTaskContext.Factory.Run(() => asyncMethod(waitContext.CancellationToken));
+#pragma warning restore VSTHRD102
 
-                return (WaitIndicatorResult.Completed, result);
+                return WaitIndicatorResult<T>.FromResult(result);
             }
             catch (OperationCanceledException)
             {
-#pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type.
-                return (WaitIndicatorResult.Canceled, default);
-#pragma warning restore CS8619 // Nullability of reference types in value doesn't match target type.
+                return WaitIndicatorResult<T>.Cancelled;
             }
             catch (AggregateException aggregate) when (aggregate.InnerExceptions.All(e => e is OperationCanceledException))
             {
-#pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type.
-                return (WaitIndicatorResult.Canceled, default);
-#pragma warning restore CS8619 // Nullability of reference types in value doesn't match target type.
+                return WaitIndicatorResult<T>.Cancelled;
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Xproj/XprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Xproj/XprojProjectFactory.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         public async Task InitializeAsync(IAsyncServiceProvider asyncServiceProvider)
         {
             Assumes.Null(_registerProjectTypes);
-            Assumes.True(_context.IsOnMainThread, "Must be on UI thread");
+            _context.VerifyIsOnMainThread();
 
             _registerProjectTypes = await asyncServiceProvider.GetServiceAsync<SVsRegisterProjectTypes, IVsRegisterProjectTypes>();
 
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 
         public void Dispose()
         {
-            Assumes.True(_context.IsOnMainThread, "Must be on UI thread");
+            _context.VerifyIsOnMainThread();
 
             if (_cookie != VSConstants.VSCOOKIE_NIL && _registerProjectTypes != null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Threading/JoinableTaskContextExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Threading/JoinableTaskContextExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.ProjectSystem.VS;
+
+namespace Microsoft.VisualStudio.Threading
+{
+    internal static class JoinableTaskContextExtensions
+    {
+        /// <summary>
+        ///     Verifies that this method is called on the main ("UI") thread,
+        ///     and throws an exception if not.
+        /// </summary>
+        public static void VerifyIsOnMainThread(this JoinableTaskContext joinableTaskContext)
+        {
+            Requires.NotNull(joinableTaskContext, nameof(joinableTaskContext));
+
+            if (!joinableTaskContext.IsOnMainThread)
+            {
+                throw new COMException("This method must be called on the UI thread.", HResult.WrongThread);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/IWaitIndicator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/IWaitIndicator.cs
@@ -10,13 +10,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Waiting
     [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IWaitIndicator
     {
-        void Wait(string title, string message, bool allowCancel, Action<CancellationToken> action);
-        T Wait<T>(string title, string message, bool allowCancel, Func<CancellationToken, T> action);
-        void WaitForAsyncFunction(string title, string message, bool allowCancel, Func<CancellationToken, Task> asyncFunction);
-        T WaitForAsyncFunction<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncFunction);
-        WaitIndicatorResult WaitWithResult(string title, string message, bool allowCancel, Action<CancellationToken> action);
-        (WaitIndicatorResult, T) WaitWithResult<T>(string title, string message, bool allowCancel, Func<CancellationToken, T> function);
-        WaitIndicatorResult WaitForAsyncFunctionWithResult(string title, string message, bool allowCancel, Func<CancellationToken, Task> asyncFunction);
-        (WaitIndicatorResult, T) WaitForAsyncFunctionWithResult<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncFunction);
+        WaitIndicatorResult<T> Run<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncMethod) where T : class?;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/WaitIndicatorResult.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/WaitIndicatorResult.cs
@@ -1,15 +1,50 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
+
 namespace Microsoft.VisualStudio.ProjectSystem.Waiting
 {
-    internal enum WaitIndicatorResult
+    /// <summary>
+    ///     Represents the result of <see cref="IWaitIndicator.Run{T}(string, string, bool, Func{System.Threading.CancellationToken, System.Threading.Tasks.Task{T}})"/>.
+    /// </summary>
+    internal readonly struct WaitIndicatorResult<T>
+        where T : class?
     {
-        Completed,
-        Canceled,
-    }
+#pragma warning disable RS0038 // Prefer null literal
+        public static readonly WaitIndicatorResult<T> Cancelled = new WaitIndicatorResult<T>(isCancelled: true, result: default!);
+#pragma warning restore RS0038 
 
-    internal static class WaitIndicatorResultExtensions
-    {
-        public static bool WasCanceled(this WaitIndicatorResult result) => result == WaitIndicatorResult.Canceled;
+        private readonly bool _isCancelled;
+        private readonly T _result;
+
+        private WaitIndicatorResult(bool isCancelled, T result)
+        {
+            _isCancelled = isCancelled;
+            _result = result;
+        }
+
+        /// <summary>
+        ///     Gets a value indicating whether the operation was cancelled, either 
+        ///     by the user or the operation itself.
+        /// </summary>
+        public bool IsCancelled => _isCancelled;
+
+        /// <summary>
+        ///     Gets the result of the operation.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        ///     <see cref="IsCancelled"/> is <see langword="true"/>.
+        /// </exception>
+        public T Result
+        {
+            get
+            {
+                Verify.Operation(!_isCancelled, "Cannot get the result of a cancelled operation.");
+
+                return _result!;
+            }
+        }
+
+        public static WaitIndicatorResult<T> FromResult(T result) => new WaitIndicatorResult<T>(isCancelled: false, result: result);
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitIndicatorTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitIndicatorTests.cs
@@ -3,8 +3,8 @@
 #pragma warning disable VSSDK005 // Avoid instantiating JoinableTaskContext
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.ProjectSystem.Waiting;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using Xunit;
@@ -14,362 +14,84 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
     public class VisualStudioWaitIndicatorTests
     {
         [Fact]
-        public static void Wait_Exception_Test()
+        public static void Run_WhenAsyncMethodThrows_Throws()
         {
             var (instance, _) = CreateInstance();
             Assert.Throws<Exception>(() =>
             {
-                instance.Wait("", "", false, _
+                instance.Run<string>("", "", false, _
                     => throw new Exception());
             });
         }
 
         [Fact]
-        public static void WaitForAsyncFunction_Wrapped_Exception_Test()
+        public static void Run_WhenAsyncMethodThrowsWrapped_Throws()
         {
             var (instance, _) = CreateInstance();
             Assert.Throws<Exception>(() =>
             {
-                instance.WaitForAsyncFunction("", "", false, async _
-                    => await Task.FromException(new Exception()));
+                instance.Run("", "", false, async _
+                    => await Task.FromException<string>(new Exception()));
             });
         }
 
         [Fact]
-        public static void WaitForAsyncFunction_Wrapped_Canceled_Test()
+        public static void Run_WhenAsyncMethodThrowsOperationCanceled_SetsIsCancelledToTrue()
         {
             var (instance, _) = CreateInstance();
-            instance.WaitForAsyncFunction("", "", false, async _
-                => await Task.FromException(new OperationCanceledException()));
+
+            var result = instance.Run("", "", false, async _
+                    => await Task.FromException<string>(new OperationCanceledException()));
+
+            Assert.True(result.IsCancelled);
         }
 
         [Fact]
-        public static void Wait_DoNotReturnTask_Test()
+        public static void Run_WhenAsyncMethodThrowsAggregrateContainedOperationCanceled_SetsIsCancelledToTrue()
         {
             var (instance, _) = CreateInstance();
-            Assert.Throws<ArgumentException>(() =>
-            {
-                instance.Wait("", "", false, async _ =>
-                {
-                    await Task.FromException(new OperationCanceledException());
-                });
-            });
-        }
 
-        [Fact]
-        public static void WaitForAsyncFunction_Wrapped_Canceled_Test2()
-        {
-            var (instance, _) = CreateInstance();
-            instance.WaitForAsyncFunction("", "", false, async _ =>
+            var result = instance.Run("", "", false, async _ =>
             {
                 await Task.WhenAll(
                     Task.Run(() => throw new OperationCanceledException()),
                     Task.Run(() => throw new OperationCanceledException()));
+
+                return "";
             });
+
+            Assert.True(result.IsCancelled);
         }
 
         [Fact]
-        public static void WaitForAsyncFunction_Wrapped_Canceled_Test3()
+        public static void Run_WhenUserCancels_CancellationTokenIsCancelled()
+        {
+            var (instance, userCancel) = CreateInstance(isCancelable: true);
+
+            CancellationToken? result = default;
+            instance.Run("", "", true, token =>
+            {
+                userCancel();
+
+                result = token;
+
+                return Task.FromResult("");
+            });
+
+            Assert.True(result!.Value.IsCancellationRequested);
+        }
+
+        [Fact]
+        public static void Run_ReturnsResultOfAsyncMethod()
         {
             var (instance, _) = CreateInstance();
-            instance.WaitForAsyncFunction("", "", false, _ =>
-            {
-                throw new AggregateException(new[] { new OperationCanceledException(), new OperationCanceledException() });
-            });
-        }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public static void WaitForAsyncFunction_Test(bool isCancelable)
-        {
-            bool wasCalled = false;
-            string title = "Test01";
-            string message = "Testing01";
-            var (instance, _) = CreateInstance(title, message, isCancelable);
-            instance.WaitForAsyncFunction(title, message, isCancelable, _ =>
+            var result = instance.Run("", "", false, token =>
             {
-                wasCalled = true;
-                return Task.CompletedTask;
-            });
-            Assert.True(wasCalled);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public static void Wait_Test(bool isCancelable)
-        {
-            bool wasCalled = false;
-            string title = "Test01";
-            string message = "Testing01";
-            var (instance, _) = CreateInstance(title, message, isCancelable);
-            instance.Wait(title, message, isCancelable, _ =>
-            {
-                wasCalled = true;
-                throw new OperationCanceledException();
+                return Task.FromResult("Hello");
             });
 
-            Assert.True(wasCalled);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public static void WaitWithResult_Test(bool isCancelable)
-        {
-            bool wasCalled = false;
-            string title = "Test02";
-            string message = "Testing02";
-            var (instance, _) = CreateInstance(title, message, isCancelable);
-            instance.WaitWithResult(title, message, isCancelable, _ =>
-            {
-                wasCalled = true;
-            });
-            Assert.True(wasCalled);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public static void WaitWithResult_Canceled_Test(bool isCancelable)
-        {
-            bool wasCalled = false;
-            string title = "Test02";
-            string message = "Testing02";
-            var (instance, _) = CreateInstance(title, message, isCancelable);
-            instance.WaitWithResult(title, message, isCancelable, _ =>
-            {
-                wasCalled = true;
-                throw new OperationCanceledException();
-            });
-            Assert.True(wasCalled);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public static void WaitForAsyncFunction_Test2(bool isCancelable)
-        {
-            bool wasCalled = false;
-            string title = "Test03";
-            string message = "Testing03";
-            var (instance, _) = CreateInstance(title, message, isCancelable);
-            instance.WaitForAsyncFunction(title, message, isCancelable, _ =>
-            {
-                wasCalled = true;
-                return Task.CompletedTask;
-            });
-            Assert.True(wasCalled);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public static void WaitForAsyncFunction_Canceled_Test(bool isCancelable)
-        {
-            bool wasCalled = false;
-            string title = "Test03";
-            string message = "Testing03";
-            var (instance, _) = CreateInstance(title, message, isCancelable);
-            instance.WaitForAsyncFunction(title, message, isCancelable, _ =>
-            {
-                wasCalled = true;
-                throw new OperationCanceledException();
-            });
-            Assert.True(wasCalled);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public static void WaitForAsyncFunctionWithResult_Test(bool isCancelable)
-        {
-            bool wasCalled = false;
-            string title = "Test04";
-            string message = "Testing04";
-            var (instance, _) = CreateInstance(title, message, isCancelable);
-            var result = instance.WaitForAsyncFunctionWithResult(title, message, isCancelable, _ =>
-            {
-                wasCalled = true;
-                return Task.CompletedTask;
-            });
-            Assert.True(wasCalled);
-            Assert.Equal(WaitIndicatorResult.Completed, result);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public static void WaitForAsyncFunctionWithResult_Canceled_Test(bool isCancelable)
-        {
-            bool wasCalled = false;
-            string title = "Test04";
-            string message = "Testing04";
-            var (instance, _) = CreateInstance(title, message, isCancelable);
-            var result = instance.WaitForAsyncFunctionWithResult(title, message, isCancelable, _ =>
-            {
-                wasCalled = true;
-                throw new OperationCanceledException();
-            });
-            Assert.True(wasCalled);
-            Assert.Equal(WaitIndicatorResult.Canceled, result);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public static void Wait_Returns_Test(bool isCancelable)
-        {
-            string title = "Test05";
-            string message = "Testing05";
-            var (instance, _) = CreateInstance(title, message, isCancelable);
-            var result = instance.Wait(title, message, isCancelable, _ =>
-            {
-                return 42;
-            });
-            Assert.Equal(42, result);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        public static void WaitReturns_Canceled_Test(bool isCancelable)
-        {
-            string title = "Test05";
-            string message = "Testing05";
-            var (instance, _) = CreateInstance(title, message, isCancelable);
-            var result = instance.Wait(title, message, isCancelable, _ =>
-            {
-                if (isCancelable)
-                {
-                    throw new OperationCanceledException();
-                }
-
-                return 42;
-            });
-            Assert.Equal(0, result);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public static void WaitWithResult_Returns_Test(bool isCancelable)
-        {
-            string title = "Test06";
-            string message = "Testing06";
-            var (instance, _) = CreateInstance(title, message, isCancelable);
-            var (cancelled, result) = instance.WaitWithResult(title, message, isCancelable, _ =>
-            {
-                return 42;
-            });
-            Assert.Equal(42, result);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        public static void WaitWithResult_Canceled_Test2(bool isCancelable)
-        {
-            string title = "Test06";
-            string message = "Testing06";
-            var (instance, _) = CreateInstance(title, message, isCancelable);
-            var (cancelled, result) = instance.WaitWithResult(title, message, isCancelable, _ =>
-            {
-                if (isCancelable)
-                {
-                    throw new OperationCanceledException();
-                }
-
-                return 42;
-            });
-            Assert.Equal(0, result);
-            Assert.Equal(WaitIndicatorResult.Canceled, cancelled);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public static void WaitForAsyncOperation_Returns_Test(bool isCancelable)
-        {
-            string title = "Test07";
-            string message = "Testing07";
-            var (instance, _) = CreateInstance(title, message, isCancelable);
-            var result = instance.WaitForAsyncFunction(title, message, isCancelable, _ =>
-            {
-                return Task.FromResult(42);
-            });
-            Assert.Equal(42, result);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        public static void WaitForAsyncFunctionReturns_Canceled_Test(bool isCancelable)
-        {
-            string title = "Test07";
-            string message = "Testing07";
-            var (instance, _) = CreateInstance(title, message, isCancelable);
-            object? result = instance.WaitForAsyncFunction(title, message, isCancelable, _ =>
-            {
-                if (isCancelable)
-                {
-                    throw new OperationCanceledException();
-                }
-
-                return Task.FromResult((object?)null);
-            });
-            Assert.Null(result);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public static void WaitForAsyncFunctionWithResult_Returns_Test(bool isCancelable)
-        {
-            string title = "Test08";
-            string message = "Testing08";
-            var (instance, _) = CreateInstance(title, message, isCancelable);
-            var (_, result) = instance.WaitForAsyncFunctionWithResult(title, message, isCancelable, _ =>
-            {
-                return Task.FromResult(42);
-            });
-            Assert.Equal(42, result);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        public static void WaitForAsyncFunctionWithResult_Returns_Canceled_Test(bool isCancelable)
-        {
-            string title = "Test08";
-            string message = "Testing08";
-            var (instance, _) = CreateInstance(title, message, isCancelable);
-            var (canceled, result) = instance.WaitForAsyncFunctionWithResult(title, message, isCancelable, _ =>
-            {
-                if (isCancelable)
-                {
-                    throw new OperationCanceledException();
-                }
-
-                return Task.FromResult(42);
-            });
-            Assert.Equal(0, result);
-            Assert.Equal(WaitIndicatorResult.Canceled, canceled);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public static void Wait_Cancellation_Test(bool isCancelable)
-        {
-            bool wasCalled = false;
-            string title = "Test01";
-            string message = "Testing01";
-            var (instance, cancel) = CreateInstance(title, message, isCancelable);
-            instance.Wait(title, message, isCancelable, token =>
-            {
-                cancel();
-                Assert.Equal(isCancelable, token.IsCancellationRequested);
-                wasCalled = true;
-            });
-            Assert.True(wasCalled);
+            Assert.Equal("Hello", result.Result);
         }
 
         private static (VisualStudioWaitIndicator, Action cancel) CreateInstance(string title = "", string message = "", bool isCancelable = false)


### PR DESCRIPTION
IWaitIndicator had a significant amount of code handling situations that were never hit, just simplify into a single method that returns a result.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6549)