### PR TITLE
Review use of ProjectTreeFlags in the dependencies tree

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/BrowseToDependencyInExplorerCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/BrowseToDependencyInExplorerCommand.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
         protected override bool CanOpen(IProjectTree node)
         {
-            return node.Flags.Contains(DependencyTreeFlags.GenericDependency | DependencyTreeFlags.SupportsBrowse);
+            return node.Flags.Contains(DependencyTreeFlags.Dependency | DependencyTreeFlags.SupportsBrowse);
         }
 
         protected override void Open(string path)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/ExploreDependencyFolderInWindowsCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/ExploreDependencyFolderInWindowsCommand.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
         protected override bool CanOpen(IProjectTree node)
         {
-            return node.Flags.Contains(DependencyTreeFlags.GenericDependency | DependencyTreeFlags.SupportsFolderBrowse);
+            return node.Flags.Contains(DependencyTreeFlags.Dependency | DependencyTreeFlags.SupportsFolderBrowse);
         }
 
         protected override void Open(string path)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/CopyPaste/DependencyTextPackager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/CopyPaste/DependencyTextPackager.cs
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.CopyPaste
         {
             Requires.NotNull(treeNodes, nameof(treeNodes));
 
-            return treeNodes.All(node => node.Flags.Contains(DependencyTreeFlags.GenericDependency | DependencyTreeFlags.SupportsBrowse));
+            return treeNodes.All(node => node.Flags.Contains(DependencyTreeFlags.Dependency | DependencyTreeFlags.SupportsBrowse));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyServices.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
         private static async Task<string?> GetMaybeRelativeBrowsePath(UnconfiguredProject project, IProjectTree node)
         {
-            Assumes.True(node.Flags.Contains(DependencyTreeFlags.GenericDependency));
+            Assumes.True(node.Flags.Contains(DependencyTreeFlags.Dependency));
 
             // Shared Projects are special, the file path points directly to the import
             if (node.Flags.Contains(DependencyTreeFlags.SharedProjectDependency))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeFlags.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeFlags.cs
@@ -60,8 +60,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         public static readonly ProjectTreeFlags DependencyFlags
                 = Dependency
-                + ProjectTreeFlags.VirtualFolder
-                + ProjectTreeFlags.BubbleUp
                 + SupportsRuleProperties
                 + SupportsRemove;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeFlags.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeFlags.cs
@@ -19,7 +19,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         internal static readonly ProjectTreeFlags DependenciesRootNode = ProjectTreeFlags.Create("DependenciesRootNode");
 
-        internal static readonly ProjectTreeFlags GenericDependency = ProjectTreeFlags.Create("GenericDependency");
+        /// <summary>
+        /// Applied to all top-level dependency items under the dependencies tree.
+        /// </summary>
+        internal static readonly ProjectTreeFlags Dependency = ProjectTreeFlags.Create("Dependency");
 
         /// <summary>
         /// Added to dependency tree items which can be removed from the project.
@@ -56,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// implementations. This is to have a way to distinguish dependency nodes in general.
         /// </summary>
         public static readonly ProjectTreeFlags DependencyFlags
-                = ProjectTreeFlags.Create("Dependency")
+                = Dependency
                 + ProjectTreeFlags.VirtualFolder
                 + ProjectTreeFlags.BubbleUp
                 + SupportsRuleProperties
@@ -74,8 +77,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         internal static readonly ProjectTreeFlags GenericUnresolvedDependencyFlags
                 = ProjectTreeFlags.Reference
                 + ProjectTreeFlags.BrokenReference
-                + UnresolvedDependencyFlags
-                + GenericDependency;
+                + UnresolvedDependencyFlags;
 
         /// <summary>
         /// The set of flags to assign to resolved Reference nodes.
@@ -83,8 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         internal static readonly ProjectTreeFlags GenericResolvedDependencyFlags
                 = ProjectTreeFlags.Reference
                 + ProjectTreeFlags.ResolvedReference
-                + ResolvedDependencyFlags
-                + GenericDependency;
+                + ResolvedDependencyFlags;
 
         /// <summary>
         /// Identifies nodes used to group dependencies specific to a given implicit configuration,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeFlags.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeFlags.cs
@@ -60,30 +60,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         public static readonly ProjectTreeFlags DependencyFlags
                 = Dependency
+                + ProjectTreeFlags.Reference
                 + SupportsRuleProperties
                 + SupportsRemove;
-
-        internal static readonly ProjectTreeFlags Unresolved = ProjectTreeFlags.Create("Unresolved");
-        internal static readonly ProjectTreeFlags Resolved = ProjectTreeFlags.Create("Resolved");
-
-        public static readonly ProjectTreeFlags UnresolvedDependencyFlags = Unresolved + DependencyFlags;
-        public static readonly ProjectTreeFlags ResolvedDependencyFlags = Resolved + DependencyFlags;
 
         /// <summary>
         /// The set of flags to assign to unresolved Reference nodes.
         /// </summary>
-        internal static readonly ProjectTreeFlags GenericUnresolvedDependencyFlags
-                = ProjectTreeFlags.Reference
-                + ProjectTreeFlags.BrokenReference
-                + UnresolvedDependencyFlags;
-
+        public static readonly ProjectTreeFlags UnresolvedDependencyFlags = ProjectTreeFlags.BrokenReference + DependencyFlags;
+        
         /// <summary>
         /// The set of flags to assign to resolved Reference nodes.
         /// </summary>
-        internal static readonly ProjectTreeFlags GenericResolvedDependencyFlags
-                = ProjectTreeFlags.Reference
-                + ProjectTreeFlags.ResolvedReference
-                + ResolvedDependencyFlags;
+        public static readonly ProjectTreeFlags ResolvedDependencyFlags = ProjectTreeFlags.ResolvedReference + DependencyFlags;
 
         /// <summary>
         /// Identifies nodes used to group dependencies specific to a given implicit configuration,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependencyModel.DependencyFlagCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependencyModel.DependencyFlagCache.cs
@@ -24,8 +24,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
                 // The 'isResolved' dimension determines whether we start with generic resolved or unresolved dependency flags.
                 // We then add (union) and remove (except) any other flags as instructed.
 
-                ProjectTreeFlags combinedResolved = DependencyTreeFlags.GenericResolvedDependencyFlags.Union(resolved).Except(remove);
-                ProjectTreeFlags combinedUnresolved = DependencyTreeFlags.GenericUnresolvedDependencyFlags.Union(unresolved).Except(remove);
+                ProjectTreeFlags combinedResolved = DependencyTreeFlags.ResolvedDependencyFlags.Union(resolved).Except(remove);
+                ProjectTreeFlags combinedUnresolved = DependencyTreeFlags.UnresolvedDependencyFlags.Union(unresolved).Except(remove);
 
                 // The 'isImplicit' dimension only enforces, when true, that the dependency cannot be removed.
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/TargetDependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/TargetDependencyViewModel.cs
@@ -26,7 +26,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
                 return ImmutableInterlocked.GetOrAdd(
                     ref s_configurationFlags,
                     targetFramework.FullName,
-                    fullName => DependencyTreeFlags.TargetNode.Add($"$TFM:{fullName}"));
+                    fullName => DependencyTreeFlags.TargetNode
+                        .Add($"$TFM:{fullName}")
+                        .Add(ProjectTreeFlags.Common.VirtualFolder));
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
@@ -35,16 +35,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             // in the tree to avoid flicks).
             if (Resolved)
             {
-                if (!Flags.Contains(DependencyTreeFlags.Resolved))
+                if (!Flags.Contains(ProjectTreeFlags.ResolvedReference))
                 {
-                    Flags += DependencyTreeFlags.Resolved;
+                    Flags += ProjectTreeFlags.ResolvedReference;
                 }
             }
             else
             {
-                if (!Flags.Contains(DependencyTreeFlags.Unresolved))
+                if (!Flags.Contains(ProjectTreeFlags.BrokenReference))
                 {
-                    Flags += DependencyTreeFlags.Unresolved;
+                    Flags += ProjectTreeFlags.BrokenReference;
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             OriginalItemSpec = dependencyModel.OriginalItemSpec;
             FilePath = dependencyModel.Path;
             SchemaName = dependencyModel.SchemaName ?? Folder.SchemaName;
-            _schemaItemType = dependencyModel.SchemaItemType ?? Folder.PrimaryDataSourceItemType;
+            SchemaItemType = dependencyModel.SchemaItemType ?? Folder.PrimaryDataSourceItemType;
             Resolved = dependencyModel.Resolved;
             Implicit = dependencyModel.Implicit;
             Visible = dependencyModel.Visible;
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             ProviderType = dependency.ProviderType;
             OriginalItemSpec = dependency.OriginalItemSpec;
             FilePath = dependency.FilePath;
-            _schemaItemType = dependency._schemaItemType;
+            SchemaItemType = dependency.SchemaItemType;
             Visible = dependency.Visible;
             BrowseObjectProperties = dependency.BrowseObjectProperties; // NOTE we explicitly do not update Identity in these properties if caption changes
             Caption = caption ?? dependency.Caption; // TODO if Properties contains "Folder.IdentityProperty" should we update it? (see public ctor)
@@ -110,22 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         public string? OriginalItemSpec { get; }
 
         public string SchemaName { get; }
-
-        private readonly string _schemaItemType;
-
-        public string SchemaItemType
-        {
-            get
-            {
-                // For generic node types we do set correct, known item types, however for custom nodes
-                // provided by third party extensions we can not guarantee that item type will be known.
-                // Thus always set predefined itemType for all custom nodes.
-                // TODO: generate specific xaml rule for generic Dependency nodes
-                // tracking issue: https://github.com/dotnet/project-system/issues/1102
-                bool isGenericNodeType = Flags.Contains(DependencyTreeFlags.GenericDependency);
-                return isGenericNodeType ? _schemaItemType : Folder.PrimaryDataSourceItemType;
-            }
-        }
+        public string SchemaItemType { get; }
 
         public string Caption { get; }
         public bool Resolved { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/ImplicitDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Filters/ImplicitDependenciesSnapshotFilter.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot.Filter
                 && !Strings.IsNullOrEmpty(dependency.OriginalItemSpec)
                 && !dependency.Implicit                                               // explicit
                 && dependency.Resolved                                                // resolved
-                && dependency.Flags.Contains(DependencyTreeFlags.GenericDependency)   // generic dependency
+                && dependency.Flags.Contains(DependencyTreeFlags.Dependency)          // dependency
                 && !dependency.Flags.Contains(DependencyTreeFlags.SharedProjectDependency) // except for shared projects
                 && !projectItemSpecs.Contains(dependency.OriginalItemSpec)            // is not a known item spec
                 && subTreeProviderByProviderType.TryGetValue(dependency.ProviderType, out IProjectDependenciesSubTreeProvider provider)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 {
@@ -39,15 +38,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         private static ProjectTreeFlags GetResolvedFlags(this IDependency dependency)
         {
             return dependency.Flags
-                .Union(DependencyTreeFlags.Resolved)
-                .Except(DependencyTreeFlags.Unresolved);
+                .Union(ProjectTreeFlags.ResolvedReference)
+                .Except(ProjectTreeFlags.BrokenReference);
         }
 
         private static ProjectTreeFlags GetUnresolvedFlags(this IDependency dependency)
         {
             return dependency.Flags
-                .Union(DependencyTreeFlags.Unresolved)
-                .Except(DependencyTreeFlags.Resolved);
+                .Union(ProjectTreeFlags.BrokenReference)
+                .Except(ProjectTreeFlags.ResolvedReference);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/TestDependencyModel.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/TestDependencyModel.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                    && (OriginalItemSpec == null || OriginalItemSpec == dependency.OriginalItemSpec)
                    && (Path == null || Path == dependency.FilePath)
                    && (SchemaName == null || SchemaName == dependency.SchemaName)
-                   && (SchemaItemType == null || !Flags.Contains(DependencyTreeFlags.GenericDependency) || SchemaItemType == dependency.SchemaItemType)
+                   && (SchemaItemType == null || !Flags.Contains(DependencyTreeFlags.Dependency) || SchemaItemType == dependency.SchemaItemType)
                    && Resolved == dependency.Resolved
                    && Implicit == dependency.Implicit
                    && Visible == dependency.Visible

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
@@ -176,7 +176,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                             {
                                 Caption = "DependencyExisting",
                                 CustomTag = "Untouched",
-                                Flags = DependencyTreeFlags.Unresolved
+                                Flags = ProjectTreeFlags.BrokenReference
                             }
                         }
                     }
@@ -234,7 +234,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                             {
                                 Caption = "DependencyExisting",
                                 CustomTag = "Untouched",
-                                Flags = DependencyTreeFlags.Resolved
+                                Flags = ProjectTreeFlags.ResolvedReference
                             }
                         }
                     }
@@ -292,7 +292,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                             new TestProjectTree
                             {
                                 Caption = "DependencyExisting",
-                                Flags = DependencyTreeFlags.Resolved
+                                Flags = ProjectTreeFlags.ResolvedReference
                             }
                         }
                     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/AnalyzerDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/AnalyzerDependencyModelTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.AnalyzerDependency +
                 DependencyTreeFlags.SupportsBrowse +
-                DependencyTreeFlags.GenericResolvedDependencyFlags,
+                DependencyTreeFlags.ResolvedDependencyFlags,
                 model.Flags);
         }
 
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.AnalyzerDependency +
                 DependencyTreeFlags.SupportsBrowse +
-                DependencyTreeFlags.GenericUnresolvedDependencyFlags,
+                DependencyTreeFlags.UnresolvedDependencyFlags,
                 model.Flags);
         }
 
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.AnalyzerDependency +
                 DependencyTreeFlags.SupportsBrowse + 
-                DependencyTreeFlags.GenericResolvedDependencyFlags -
+                DependencyTreeFlags.ResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove,
                 model.Flags);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/AssemblyDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/AssemblyDependencyModelTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.AssemblyDependency +
                 DependencyTreeFlags.SupportsBrowse +
-                DependencyTreeFlags.GenericResolvedDependencyFlags,
+                DependencyTreeFlags.ResolvedDependencyFlags,
                 model.Flags);
         }
 
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.AssemblyDependency +
                 DependencyTreeFlags.SupportsBrowse +
-                DependencyTreeFlags.GenericResolvedDependencyFlags,
+                DependencyTreeFlags.ResolvedDependencyFlags,
                 model.Flags);
         }
 
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.AssemblyDependency +
-                DependencyTreeFlags.GenericUnresolvedDependencyFlags,
+                DependencyTreeFlags.UnresolvedDependencyFlags,
                 model.Flags);
         }
 
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.AssemblyDependency +
                 DependencyTreeFlags.SupportsBrowse +
-                DependencyTreeFlags.GenericResolvedDependencyFlags -
+                DependencyTreeFlags.ResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove,
                 model.Flags);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/ComDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/ComDependencyModelTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.ComDependency +
                 DependencyTreeFlags.SupportsBrowse +
-                DependencyTreeFlags.GenericResolvedDependencyFlags,
+                DependencyTreeFlags.ResolvedDependencyFlags,
                 model.Flags);
         }
 
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.ComponentWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.ComDependency +
-                DependencyTreeFlags.GenericUnresolvedDependencyFlags,
+                DependencyTreeFlags.UnresolvedDependencyFlags,
                 model.Flags);
         }
 
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.ComDependency +
                 DependencyTreeFlags.SupportsBrowse +
-                DependencyTreeFlags.GenericResolvedDependencyFlags -
+                DependencyTreeFlags.ResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove,
                 model.Flags);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/PackageDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/PackageDependencyModelTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.PackageDependency +
                 DependencyTreeFlags.SupportsFolderBrowse +
-                DependencyTreeFlags.GenericResolvedDependencyFlags +
+                DependencyTreeFlags.ResolvedDependencyFlags +
                 ProjectTreeFlags.Create("$ID:myOriginalItemSpec"),
                 model.Flags);
         }
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.PackageDependency +
-                DependencyTreeFlags.GenericUnresolvedDependencyFlags +
+                DependencyTreeFlags.UnresolvedDependencyFlags +
                 ProjectTreeFlags.Create("$ID:myOriginalItemSpec"),
                 model.Flags);
         }
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.PackageDependency +
                 DependencyTreeFlags.SupportsFolderBrowse +
-                DependencyTreeFlags.GenericResolvedDependencyFlags +
+                DependencyTreeFlags.ResolvedDependencyFlags +
                 ProjectTreeFlags.Create("$ID:myOriginalItemSpec") -
                 DependencyTreeFlags.SupportsRemove,
                 model.Flags);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.SupportsBrowse +
-                DependencyTreeFlags.GenericResolvedDependencyFlags +
+                DependencyTreeFlags.ResolvedDependencyFlags +
                 ProjectTreeFlags.Create("$ID:MyProject"),
                 model.Flags);
         }
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.SupportsBrowse +
-                DependencyTreeFlags.GenericUnresolvedDependencyFlags +
+                DependencyTreeFlags.UnresolvedDependencyFlags +
                 ProjectTreeFlags.Create("$ID:MyProject"),
                 model.Flags);
         }
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.SupportsBrowse +
-                DependencyTreeFlags.GenericResolvedDependencyFlags -
+                DependencyTreeFlags.ResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove +
                 ProjectTreeFlags.Create("$ID:MyProject"),
                 model.Flags);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/SdkDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/SdkDependencyModelTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.SdkDependency +
                 DependencyTreeFlags.SupportsFolderBrowse +
-                DependencyTreeFlags.GenericResolvedDependencyFlags,
+                DependencyTreeFlags.ResolvedDependencyFlags,
                 model.Flags);
         }
 
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.SdkWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.SdkDependency +
-                DependencyTreeFlags.GenericUnresolvedDependencyFlags,
+                DependencyTreeFlags.UnresolvedDependencyFlags,
                 model.Flags);
         }
 
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.SdkDependency +
                 DependencyTreeFlags.SupportsFolderBrowse +
-                DependencyTreeFlags.GenericResolvedDependencyFlags -
+                DependencyTreeFlags.ResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove,
                 model.Flags);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/SharedProjectDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/SharedProjectDependencyModelTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
                 DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.SharedProjectDependency +
                 DependencyTreeFlags.SupportsBrowse +
-                DependencyTreeFlags.GenericResolvedDependencyFlags -
+                DependencyTreeFlags.ResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRuleProperties,
                 model.Flags);
         }
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
                 DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.SharedProjectDependency +
                 DependencyTreeFlags.SupportsBrowse +
-                DependencyTreeFlags.GenericUnresolvedDependencyFlags -
+                DependencyTreeFlags.UnresolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRuleProperties,
                 model.Flags);
         }
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
                 DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.SharedProjectDependency +
                 DependencyTreeFlags.SupportsBrowse +
-                DependencyTreeFlags.GenericResolvedDependencyFlags -
+                DependencyTreeFlags.ResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRuleProperties -
                 DependencyTreeFlags.SupportsRemove,
                 model.Flags);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             Assert.Equal(mockModel.Visible, dependency.Visible);
             Assert.Single(dependency.BrowseObjectProperties);
             Assert.True(dependency.BrowseObjectProperties.ContainsKey("prop1"));
-            Assert.Equal(DependencyTreeFlags.Resolved + DependencyTreeFlags.Dependency, dependency.Flags);
+            Assert.Equal(ProjectTreeFlags.ResolvedReference + DependencyTreeFlags.Dependency, dependency.Flags);
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 Resolved = true,
                 Implicit = true,
                 Visible = true,
-                Flags = DependencyTreeFlags.GenericDependency,
+                Flags = DependencyTreeFlags.Dependency,
                 Icon = KnownMonikers.Path,
                 ExpandedIcon = KnownMonikers.PathIcon,
                 UnresolvedIcon = KnownMonikers.PathListBox,
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             Assert.Equal(mockModel.Visible, dependency.Visible);
             Assert.Single(dependency.BrowseObjectProperties);
             Assert.True(dependency.BrowseObjectProperties.ContainsKey("prop1"));
-            Assert.Equal(DependencyTreeFlags.Resolved + DependencyTreeFlags.GenericDependency, dependency.Flags);
+            Assert.Equal(DependencyTreeFlags.Resolved + DependencyTreeFlags.Dependency, dependency.Flags);
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/ImplicitDependenciesSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/ImplicitDependenciesSnapshotFilterTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 ProviderType = providerType,
                 Implicit = false,
                 Resolved = true,
-                Flags = DependencyTreeFlags.GenericResolvedDependencyFlags,
+                Flags = DependencyTreeFlags.ResolvedDependencyFlags,
                 OriginalItemSpec = projectItemSpec,
                 IconSet = new DependencyIconSet(KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference)
             };
@@ -145,7 +145,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                         implicitIcon,
                         KnownMonikers.Reference,
                         KnownMonikers.Reference),
-                    Flags = DependencyTreeFlags.GenericResolvedDependencyFlags.Except(DependencyTreeFlags.SupportsRemove)
+                    Flags = DependencyTreeFlags.ResolvedDependencyFlags.Except(DependencyTreeFlags.SupportsRemove)
                 }, acceptedDependency!);
 
             // No other changes made

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/ImplicitDependenciesSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/ImplicitDependenciesSnapshotFilterTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             Id = "dependency1",
             Implicit = false,
             Resolved = true,
-            Flags = DependencyTreeFlags.GenericDependency,
+            Flags = DependencyTreeFlags.Dependency,
             OriginalItemSpec = ProjectItemSpec
         };
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 Id = packageName,
                 ProviderType = SdkRuleHandler.ProviderTypeString,
                 Resolved = true,
-                Flags = DependencyTreeFlags.PackageDependency.Union(DependencyTreeFlags.Unresolved) // to see if unresolved is fixed
+                Flags = DependencyTreeFlags.PackageDependency.Union(ProjectTreeFlags.BrokenReference) // to see if unresolved is fixed
             };
 
             var packageDependency = new TestDependency
@@ -155,7 +155,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 Id = packageName,
                 ProviderType = SdkRuleHandler.ProviderTypeString,
                 Resolved = true,
-                Flags = DependencyTreeFlags.SdkDependency.Union(DependencyTreeFlags.Resolved)
+                Flags = DependencyTreeFlags.SdkDependency.Union(ProjectTreeFlags.ResolvedReference)
             };
 
             var packageDependency = new TestDependency

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 OriginalItemSpec = "Dependency1",
                 Caption = "Dependency1",
                 Resolved = true,
-                Flags = DependencyTreeFlags.Resolved,
+                Flags = ProjectTreeFlags.ResolvedReference,
                 Icon = KnownMonikers.Uninstall,
                 ExpandedIcon = KnownMonikers.Uninstall
             };
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 OriginalItemSpec = "Dependency2",
                 Caption = "Dependency2",
                 Resolved = false,
-                Flags = DependencyTreeFlags.Unresolved,
+                Flags = ProjectTreeFlags.BrokenReference,
                 Icon = KnownMonikers.Uninstall,
                 ExpandedIcon = KnownMonikers.Uninstall
             };


### PR DESCRIPTION
Tidies up a bunch of the tree flags used by the dependencies tree.
Fixes: https://github.com/dotnet/project-system/issues/402

Review commit by commit.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6552)