### PR TITLE
Adds explorer-related commands for references 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Input/VisualStudioStandard97CommandId.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Input/VisualStudioStandard97CommandId.cs
@@ -9,6 +9,5 @@ namespace Microsoft.VisualStudio.Input
     {
         public const long Open = (long)VSConstants.VSStd97CmdID.Open;
         public const long AddClass = (long)VSConstants.VSStd97CmdID.AddClass;
-        public const long SaveProjectItem = (long)VSConstants.VSStd97CmdID.SaveProjectItem;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/AbstractDependencyExplorerCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/AbstractDependencyExplorerCommand.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies;
@@ -42,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             {
                 foreach (IProjectTree node in nodes)
                 {
-                    string? path = await DependencyServices.GetBrowsePath(_project, node);
+                    string? path = await DependencyServices.GetBrowsePathAsync(_project, node);
                     if (path == null)
                         continue;
 
@@ -58,20 +57,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         protected abstract bool CanOpen(IProjectTree node);
 
         protected abstract void Open(string path);
-
-        protected static void ShellExecute(string operation, string filePath, string? parameters = null)
-        {
-            // Workaround of CLR bug 1134711; System.Diagnostics.Process.Start() does not support GB18030
-            _ = ShellExecute(IntPtr.Zero, operation, filePath, parameters, lpDirectory: null, 1);
-        }
-
-        [DllImport("shell32.dll", EntryPoint = "ShellExecuteW")]
-        internal static extern IntPtr ShellExecute(
-            IntPtr hwnd,
-            [MarshalAs(UnmanagedType.LPWStr)] string lpOperation,
-            [MarshalAs(UnmanagedType.LPWStr)] string lpFile,
-            [MarshalAs(UnmanagedType.LPWStr)] string? lpParameters,
-            [MarshalAs(UnmanagedType.LPWStr)] string? lpDirectory,
-            int nShowCmd);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/AbstractDependencyExplorerCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/AbstractDependencyExplorerCommand.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Input;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+{
+    /// <summary>
+    ///     Provides the <see langword="abstract"/> base class for commands
+    ///     that handle Explorer-like commands for dependency <see cref="IProjectTree"/>
+    ///     nodes.
+    /// </summary>
+    internal abstract class AbstractDependencyExplorerCommand : AbstractProjectCommand
+    {
+        private readonly UnconfiguredProject _project;
+
+        protected AbstractDependencyExplorerCommand(UnconfiguredProject project)
+        {
+            _project = project;
+        }
+
+        protected override Task<CommandStatusResult> GetCommandStatusAsync(IImmutableSet<IProjectTree> nodes, bool focused, string? commandText, CommandStatus progressiveStatus)
+        {
+            // Only handle when Solution Explorer has focus so that we don't take over Tab Well handling
+            if (focused && nodes.All(CanOpen))
+            {
+                return GetCommandStatusResult.Handled(commandText, progressiveStatus | CommandStatus.Enabled);
+            }
+
+            return GetCommandStatusResult.Unhandled;
+        }
+
+        protected override async Task<bool> TryHandleCommandAsync(IImmutableSet<IProjectTree> nodes, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
+        {
+            // Only handle when Solution Explorer has focus so that we don't take over Tab Well handling
+            if (focused && nodes.All(CanOpen))
+            {
+                foreach (IProjectTree node in nodes)
+                {
+                    string? path = await DependencyServices.GetBrowsePath(_project, node);
+                    if (path == null)
+                        continue;
+
+                    Open(path);
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        protected abstract bool CanOpen(IProjectTree node);
+
+        protected abstract void Open(string path);
+
+        protected static void ShellExecute(string operation, string filePath, string? parameters = null)
+        {
+            // Workaround of CLR bug 1134711; System.Diagnostics.Process.Start() does not support GB18030
+            _ = ShellExecute(IntPtr.Zero, operation, filePath, parameters, lpDirectory: null, 1);
+        }
+
+        [DllImport("shell32.dll", EntryPoint = "ShellExecuteW")]
+        internal static extern IntPtr ShellExecute(
+            IntPtr hwnd,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpOperation,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFile,
+            [MarshalAs(UnmanagedType.LPWStr)] string? lpParameters,
+            [MarshalAs(UnmanagedType.LPWStr)] string? lpDirectory,
+            int nShowCmd);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/BrowseToDependencyInExplorerCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/BrowseToDependencyInExplorerCommand.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 
@@ -20,10 +21,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
     [Order(Order.Default)]
     internal class BrowseToDependencyInExplorerCommand : AbstractDependencyExplorerCommand
     {
+        private readonly IFileExplorer _fileExplorer;
+
         [ImportingConstructor]
-        public BrowseToDependencyInExplorerCommand(UnconfiguredProject project)
+        public BrowseToDependencyInExplorerCommand(UnconfiguredProject project, IFileExplorer fileExplorer)
             : base(project)
         {
+            _fileExplorer = fileExplorer;
         }
 
         protected override bool CanOpen(IProjectTree node)
@@ -33,8 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
         protected override void Open(string path)
         {
-            // Tell Explorer to open the parent folder of the item, selecting the item
-            ShellExecute(string.Empty, "explorer.exe", parameters: $"/select,\"{path}\"");            
+            _fileExplorer.OpenContainingFolder(path);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/BrowseToDependencyInExplorerCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/BrowseToDependencyInExplorerCommand.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Input;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+{
+    /// <summary>
+    ///     Opens the containing folder for references.
+    /// </summary>
+    /// <remarks>
+    ///     NOTE: Similar to folders and the project node, this command is supported 
+    ///     for container-like references, such as Package References, however, is not 
+    ///     placed on the context menu by default, in lieu of 
+    ///     VSConstants.VSStd2KCmdID.ExploreFolderInWindows.
+    /// </remarks>
+    [ProjectCommand(VSConstants.CMDSETID.StandardCommandSet2K_string, (long)VSConstants.VSStd2KCmdID.BrowseToFileInExplorer)]
+    [AppliesTo(ProjectCapability.DependenciesTree)]
+    [Order(Order.Default)]
+    internal class BrowseToDependencyInExplorerCommand : AbstractDependencyExplorerCommand
+    {
+        [ImportingConstructor]
+        public BrowseToDependencyInExplorerCommand(UnconfiguredProject project)
+            : base(project)
+        {
+        }
+
+        protected override bool CanOpen(IProjectTree node)
+        {
+            return node.Flags.Contains(DependencyTreeFlags.GenericDependency | DependencyTreeFlags.SupportsBrowse);
+        }
+
+        protected override void Open(string path)
+        {
+            // Tell Explorer to open the parent folder of the item, selecting the item
+            ShellExecute(string.Empty, "explorer.exe", parameters: $"/select,\"{path}\"");            
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/ExploreDependencyFolderInWindowsCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/ExploreDependencyFolderInWindowsCommand.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Input;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+{
+    /// <summary>
+    ///     Opens the folder for references that are backed by folders on disk, including
+    ///     package references, framework references and SDK references.
+    /// </summary>
+    [ProjectCommand(VSConstants.CMDSETID.StandardCommandSet2K_string, (long)VSConstants.VSStd2KCmdID.ExploreFolderInWindows)]
+    [AppliesTo(ProjectCapability.DependenciesTree)]
+    [Order(Order.Default)]
+    internal class ExploreDependencyFolderInWindowsCommand : AbstractDependencyExplorerCommand
+    {
+        [ImportingConstructor]
+        public ExploreDependencyFolderInWindowsCommand(UnconfiguredProject project)
+            : base(project)
+        {
+        }
+
+        protected override bool CanOpen(IProjectTree node)
+        {
+            return node.Flags.Contains(DependencyTreeFlags.GenericDependency | DependencyTreeFlags.SupportsFolderBrowse);
+        }
+
+        protected override void Open(string path)
+        {
+            // Tell Explorer just open the contents of the folder, selecting nothing
+            ShellExecute("explore", path);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/ExploreDependencyFolderInWindowsCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/ExploreDependencyFolderInWindowsCommand.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 
@@ -15,10 +16,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
     [Order(Order.Default)]
     internal class ExploreDependencyFolderInWindowsCommand : AbstractDependencyExplorerCommand
     {
+        private readonly IFileExplorer _fileExplorer;
+
         [ImportingConstructor]
-        public ExploreDependencyFolderInWindowsCommand(UnconfiguredProject project)
+        public ExploreDependencyFolderInWindowsCommand(UnconfiguredProject project, IFileExplorer fileExplorer)
             : base(project)
         {
+            _fileExplorer = fileExplorer;
         }
 
         protected override bool CanOpen(IProjectTree node)
@@ -28,8 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
         protected override void Open(string path)
         {
-            // Tell Explorer just open the contents of the folder, selecting nothing
-            ShellExecute("explore", path);
+            _fileExplorer.OpenFolder(path);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileExplorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileExplorer.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Composition;
+using Microsoft.VisualStudio.ProjectSystem;
+
+namespace Microsoft.VisualStudio.IO
+{
+    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    internal interface IFileExplorer
+    {
+        /// <summary>
+        ///     Opens the containing folder of the specified path in File Explorer, selecting the file if it exists.
+        /// </summary>
+        void OpenContainingFolder(string path);
+
+        /// <summary>
+        ///     Opens the contents of the specified folder in File Explorer.
+        /// </summary>
+        void OpenFolder(string path);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -18,6 +18,8 @@ namespace Microsoft.VisualStudio.IO
     {
         Stream Create(string path);
 
+        bool PathExists(string path);
+
         bool FileExists(string path);
         void RemoveFile(string path);
         void CopyFile(string source, string destination, bool overwrite);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
@@ -28,6 +28,11 @@ namespace Microsoft.VisualStudio.IO
             return File.Exists(path);
         }
 
+        public bool PathExists(string path)
+        {
+            return File.Exists(path) || Directory.Exists(path);
+        }
+
         public void RemoveFile(string path)
         {
             if (FileExists(path))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/WindowsFileExplorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/WindowsFileExplorer.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Runtime.InteropServices;
+using Microsoft.IO;
+
+namespace Microsoft.VisualStudio.IO
+{
+    [Export(typeof(IFileExplorer))]
+    internal class WindowsFileExplorer : IFileExplorer
+    {
+        private readonly IFileSystem _fileSystem;
+
+        [ImportingConstructor]
+        public WindowsFileExplorer(IFileSystem fileSystem)
+        {
+            _fileSystem = fileSystem;
+        }
+
+        public void OpenContainingFolder(string path)
+        {
+            Requires.NotNullOrEmpty(path, nameof(path));
+
+            // When 'path' doesn't exist, Explorer just opens the default
+            // "Quick Access" page, so try to something better than that.
+            if (_fileSystem.PathExists(path))
+            {
+                // Tell Explorer to open the parent folder of the item, selecting the item
+                ShellExecute(string.Empty, "explorer.exe", parameters: $"/select,\"{path}\"");
+            }
+            else
+            {
+                string? parentPath = GetParentPath(path);
+                if (parentPath != null && _fileSystem.DirectoryExists(parentPath))
+                {
+                    OpenFolder(parentPath);
+                }
+            }
+        }
+
+        public void OpenFolder(string path)
+        {
+            Requires.NotNullOrEmpty(path, nameof(path));
+
+            // Tell Explorer just open the contents of the folder, selecting nothing
+            ShellExecute("explore", path);
+        }
+
+        protected static void ShellExecute(string operation, string filePath, string? parameters = null)
+        {
+            // Workaround of CLR bug 1134711; System.Diagnostics.Process.Start() does not support GB18030
+            _ = ShellExecute(IntPtr.Zero, operation, filePath, parameters, lpDirectory: null, 1);
+        }
+
+        private static string? GetParentPath(string path)
+        {
+            // Remove trailing slashes, so that GetDirectoryName returns 
+            // "Foo" in C:\Foo\Project\" instead of "C:\Foo\Project".
+            if (Path.EndsInDirectorySeparator(path))
+            {
+                path = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+
+            return Path.GetDirectoryName(path);
+        }
+
+        [DllImport("shell32.dll", EntryPoint = "ShellExecuteW")]
+        internal static extern IntPtr ShellExecute(
+            IntPtr hwnd,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpOperation,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFile,
+            [MarshalAs(UnmanagedType.LPWStr)] string? lpParameters,
+            [MarshalAs(UnmanagedType.LPWStr)] string? lpDirectory,
+            int nShowCmd);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/CopyPaste/ClipboardFormat.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/CopyPaste/ClipboardFormat.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.CopyPaste
+{
+    internal class ClipboardFormat
+    {
+        /// <summary>
+        /// A ushort used by data objects to get and set the text format. Constant defined in WinUser.h.
+        /// </summary>
+        internal const ushort CF_TEXT = 1;
+
+        /// <summary>
+        /// A ushort used by data objects to get and set the unicode text format. Constant defined in WinUser.h.
+        /// </summary>
+        internal const ushort CF_UNICODETEXT = 13;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/CopyPaste/ClipboardFormat.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/CopyPaste/ClipboardFormat.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.VisualStudio.ProjectSystem.CopyPaste
 {
-    internal class ClipboardFormat
+    internal static class ClipboardFormat
     {
         /// <summary>
         /// A ushort used by data objects to get and set the text format. Constant defined in WinUser.h.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/CopyPaste/DependencyTextPackager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/CopyPaste/DependencyTextPackager.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
+
+namespace Microsoft.VisualStudio.ProjectSystem.CopyPaste
+{
+    /// <summary>
+    ///     Packages dependency <see cref="IProjectTree"/> nodes as text for the "Copy Full Path" command.
+    /// </summary>
+    [Export(typeof(ICopyPackager))]
+    [AppliesTo(ProjectCapability.DependenciesTree)]
+    [Order(Order.Default)]
+    internal class DependencyTextPackager : ICopyPackager
+    {
+        private static readonly ImmutableHashSet<int> s_formats = ImmutableHashSet.Create<int>(ClipboardFormat.CF_TEXT, ClipboardFormat.CF_UNICODETEXT);
+        private readonly UnconfiguredProject _project;
+
+        [ImportingConstructor]
+        public DependencyTextPackager(UnconfiguredProject project)
+        {
+            _project = project;
+        }
+
+        public IImmutableSet<int> ClipboardDataFormats
+        {
+            get { return s_formats; }
+        }
+
+        public CopyPasteOperations GetAllowedOperations(IEnumerable<IProjectTree> selectedNodes, IProjectTreeProvider currentProvider)
+        {
+            return IsValidSetOfNodes(selectedNodes) ? CopyPasteOperations.Copy : CopyPasteOperations.None;
+        }
+
+        public async Task<IEnumerable<Tuple<int, IntPtr>>> GetPointerToDataAsync(IReadOnlyCollection<int> types, IEnumerable<IProjectTree> selectedNodes, IProjectTreeProvider currentProvider)
+        {
+            var paths = new StringBuilder();
+            var data = new List<Tuple<int, IntPtr>>();
+
+            foreach (IProjectTree node in selectedNodes)
+            {
+                string? path = await DependencyServices.GetBrowsePath(_project, node);
+                if (path == null)
+                    continue;
+
+                // Note we leave trailing slashes to mimic what happens with normal folders
+                if (node.Flags.Contains(DependencyTreeFlags.SupportsFolderBrowse))
+                    path = PathHelper.EnsureTrailingSlash(path);
+
+                if (paths.Length > 0)
+                {
+                    paths.AppendLine();
+                }
+
+                paths.Append(path); 
+            }
+
+            if (types.Contains(ClipboardFormat.CF_TEXT))
+            {
+                data.Add(new Tuple<int, IntPtr>(ClipboardFormat.CF_TEXT, Marshal.StringToHGlobalAnsi(paths.ToString())));
+            }
+
+            if (types.Contains(ClipboardFormat.CF_UNICODETEXT))
+            {
+                data.Add(new Tuple<int, IntPtr>(ClipboardFormat.CF_UNICODETEXT, Marshal.StringToHGlobalUni(paths.ToString())));
+            }
+
+            return data;
+        }
+
+        private static bool IsValidSetOfNodes(IEnumerable<IProjectTree> treeNodes)
+        {
+            Requires.NotNull(treeNodes, nameof(treeNodes));
+
+            return treeNodes.All(node => node.Flags.Contains(DependencyTreeFlags.GenericDependency | DependencyTreeFlags.SupportsBrowse));
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/CopyPaste/DependencyTextPackager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/CopyPaste/DependencyTextPackager.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.CopyPaste
 
             foreach (IProjectTree node in selectedNodes)
             {
-                string? path = await DependencyServices.GetBrowsePath(_project, node);
+                string? path = await DependencyServices.GetBrowsePathAsync(_project, node);
                 if (path == null)
                     continue;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/AnalyzerReference.xaml
@@ -13,10 +13,22 @@
                 SourceOfDefaultValue="AfterContext"
                 SourceType="TargetResults" />
   </Rule.DataSource>
+  
+  <StringProperty Name="BrowsePath"
+                  ReadOnly="True"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Reference"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <StringProperty Name="IsImplicitlyDefined"
                   ReadOnly="True"
                   Visible="False" />
+  
 
   <!-- NOTE this property will never be populated for unresolved items, but is included to make the UI consistent -->
   <StringProperty Name="ResolvedPath"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ProjectReference.xaml
@@ -23,6 +23,17 @@
                   SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
+  
+  <StringProperty Name="BrowsePath"
+                  ReadOnly="True"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource ItemType="ProjectReference"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <BoolProperty Name="CopyLocal"
                 Description="Indicates whether the reference will be copied to the output directory."
@@ -103,7 +114,7 @@
                   SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-
+  
   <StringProperty Name="ReferencedProjectIdentifier"
                   Visible="False" />
 
@@ -120,7 +131,7 @@
                   SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-
+  
   <BoolProperty Name="UseLibraryDependencyInputs"
                 Visible="False" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedAnalyzerReference.xaml
@@ -14,6 +14,15 @@
                 SourceType="TargetResults" />
   </Rule.DataSource>
 
+  <StringProperty Name="BrowsePath"
+                  ReadOnly="True"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="Identity"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
   <StringProperty Name="IsImplicitlyDefined"
                   ReadOnly="True"
                   Visible="False" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedAssemblyReference.xaml
@@ -25,6 +25,15 @@
                   SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
+  
+  <StringProperty Name="BrowsePath"
+                  ReadOnly="True"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="Identity"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <BoolProperty Name="CopyLocal"
                 Description="Indicates whether the reference will be copied to the output directory."

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedCOMReference.xaml
@@ -26,6 +26,17 @@
     </StringListProperty.DataSource>
   </StringListProperty>
 
+  <StringProperty Name="BrowsePath"
+                  ReadOnly="True"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource ItemType="COMReference"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+                  
   <BoolProperty Name="CopyLocal"
                 Description="Indicates whether the reference will be copied to the output directory."
                 DisplayName="Copy Local">
@@ -139,6 +150,15 @@
                   Description="Location of the file being referenced."
                   DisplayName="Path"
                   ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="Identity"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Path"
+                  ReadOnly="True"
+                  Visible="False">
     <StringProperty.DataSource>
       <DataSource PersistedName="Identity"
                   SourceOfDefaultValue="AfterContext" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedFrameworkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedFrameworkReference.xaml
@@ -14,6 +14,15 @@
                 SourceOfDefaultValue="AfterContext"
                 SourceType="TargetResults" />
   </Rule.DataSource>
+  
+  <StringProperty Name="BrowsePath"
+                  ReadOnly="True"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="TargetingPackPath"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <StringProperty Name="OriginalItemSpec"
                   ReadOnly="True"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedPackageReference.xaml
@@ -26,6 +26,15 @@
     </StringListProperty.DataSource>
   </StringListProperty>
 
+   <StringProperty Name="BrowsePath"
+                  ReadOnly="True"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="Path"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+    
   <StringProperty Name="ExcludeAssets"
                   Description="Assets to exclude from this reference."
                   DisplayName="Excluded Assets">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedProjectReference.xaml
@@ -25,6 +25,17 @@
                   SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
+  
+  <StringProperty Name="BrowsePath"
+                  ReadOnly="True"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource ItemType="ProjectReference"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <BoolProperty Name="CopyLocal"
                 Description="Indicates whether the reference will be copied to the output directory."

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedSdkReference.xaml
@@ -17,6 +17,17 @@
   <StringProperty Name="AppXLocation"
                   DisplayName="App Package Location"
                   ReadOnly="True" />
+  
+  <StringProperty Name="BrowsePath"
+                  ReadOnly="True"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource ItemType="SDKReference"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies"
                 DisplayName="Copy Local Expanded Reference Assemblies"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyServices.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
         ///     to the file on disk, or in the case of framework, package and SDK references
         ///     the containing folder.
         /// </summary>
-        public static async Task<string?> GetBrowsePath(UnconfiguredProject project, IProjectTree node)
+        public static async Task<string?> GetBrowsePathAsync(UnconfiguredProject project, IProjectTree node)
         {
             Requires.NotNull(project, nameof(project));
             Requires.NotNull(node, nameof(node));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyServices.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
+{
+    internal static class DependencyServices
+    {
+        /// <summary>
+        ///     Returns the "BrowsePath" property from the browse object, which represents the path
+        ///     to the file on disk, or in the case of framework, package and SDK references
+        ///     the containing folder.
+        /// </summary>
+        public static async Task<string?> GetBrowsePath(UnconfiguredProject project, IProjectTree node)
+        {
+            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(node, nameof(node));
+
+            string? path = await GetMaybeRelativeBrowsePath(node);
+            if (path == null)
+                return null;
+
+            return project.MakeRooted(path);
+        }
+
+        private static async Task<string?> GetMaybeRelativeBrowsePath(IProjectTree node)
+        {
+            Assumes.True(node.Flags.Contains(DependencyTreeFlags.GenericDependency));
+
+            // Shared Projects are special, the file path points directly to the import
+            if (node.Flags.Contains(DependencyTreeFlags.SharedProjectDependency))
+                return node.FilePath;
+
+            if (node.BrowseObjectProperties == null)
+                return null;
+
+            // This property typically only exists for "Resolved" dependencies with exception 
+            // to analyzers/projects which can provide these paths at evaluation time.
+            string path = await node.BrowseObjectProperties.GetPropertyValueAsync(ResolvedAssemblyReference.BrowsePathProperty);
+
+            return path.Length == 0 ? null : path;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeFlags.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeFlags.cs
@@ -30,6 +30,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public static readonly ProjectTreeFlags SupportsRemove = ProjectTreeFlags.Create("SupportsRemove");
 
         /// <summary>
+        /// Indicates that the dependency supports "Open Containing Folder" and "Copy Full Path" commands.
+        /// </summary>
+        internal static readonly ProjectTreeFlags SupportsBrowse = ProjectTreeFlags.Create(nameof(SupportsBrowse));
+
+        /// <summary>
+        /// Indicates that the dependency supports "Open Folder in File Explorer", "Open Containing Folder" and "Copy Full Path" commands.
+        /// </summary>
+        internal static readonly ProjectTreeFlags SupportsFolderBrowse = ProjectTreeFlags.Create(nameof(SupportsFolderBrowse)) + SupportsBrowse;
+
+        /// <summary>
         /// Dependencies having this flag support displaying a browse object, where the corresponding <see cref="IRule" />
         /// is obtained by <see cref="IDependenciesTreeServices.GetBrowseObjectRuleAsync(IDependency, TargetFramework, IProjectCatalogSnapshot)" />.
         /// </summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/AnalyzerDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/AnalyzerDependencyModel.cs
@@ -10,7 +10,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
     internal class AnalyzerDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.AnalyzerDependency);
+        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
+            resolved: DependencyTreeFlags.AnalyzerDependency + DependencyTreeFlags.SupportsBrowse,
+            unresolved: DependencyTreeFlags.AnalyzerDependency + DependencyTreeFlags.SupportsBrowse);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
             icon: KnownMonikers.CodeInformation,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/AssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/AssemblyDependencyModel.cs
@@ -12,7 +12,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
     internal class AssemblyDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.AssemblyDependency);
+        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
+            resolved: DependencyTreeFlags.AssemblyDependency + DependencyTreeFlags.SupportsBrowse,
+            unresolved: DependencyTreeFlags.AssemblyDependency);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
             icon: KnownMonikers.Reference,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/ComDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/ComDependencyModel.cs
@@ -9,7 +9,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
     internal class ComDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.ComDependency);
+        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
+            resolved: DependencyTreeFlags.ComDependency + DependencyTreeFlags.SupportsBrowse,
+            unresolved: DependencyTreeFlags.ComDependency);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
             icon: ManagedImageMonikers.Component,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependencyModel.DependencyFlagCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependencyModel.DependencyFlagCache.cs
@@ -19,21 +19,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
         {
             private readonly ProjectTreeFlags[] _lookup;
 
-            public DependencyFlagCache(ProjectTreeFlags add = default, ProjectTreeFlags remove = default)
+            public DependencyFlagCache(ProjectTreeFlags resolved, ProjectTreeFlags unresolved, ProjectTreeFlags remove = default)
             {
                 // The 'isResolved' dimension determines whether we start with generic resolved or unresolved dependency flags.
                 // We then add (union) and remove (except) any other flags as instructed.
 
-                ProjectTreeFlags resolved = DependencyTreeFlags.GenericResolvedDependencyFlags.Union(add).Except(remove);
-                ProjectTreeFlags unresolved = DependencyTreeFlags.GenericUnresolvedDependencyFlags.Union(add).Except(remove);
+                ProjectTreeFlags combinedResolved = DependencyTreeFlags.GenericResolvedDependencyFlags.Union(resolved).Except(remove);
+                ProjectTreeFlags combinedUnresolved = DependencyTreeFlags.GenericUnresolvedDependencyFlags.Union(unresolved).Except(remove);
 
                 // The 'isImplicit' dimension only enforces, when true, that the dependency cannot be removed.
 
                 _lookup = new ProjectTreeFlags[4];
-                _lookup[Index(isResolved: true, isImplicit: false)] = resolved;
-                _lookup[Index(isResolved: true, isImplicit: true)] = resolved.Except(DependencyTreeFlags.SupportsRemove);
-                _lookup[Index(isResolved: false, isImplicit: false)] = unresolved;
-                _lookup[Index(isResolved: false, isImplicit: true)] = unresolved.Except(DependencyTreeFlags.SupportsRemove);
+                _lookup[Index(isResolved: true, isImplicit: false)] = combinedResolved;
+                _lookup[Index(isResolved: true, isImplicit: true)] = combinedResolved.Except(DependencyTreeFlags.SupportsRemove);
+                _lookup[Index(isResolved: false, isImplicit: false)] = combinedUnresolved;
+                _lookup[Index(isResolved: false, isImplicit: true)] = combinedUnresolved.Except(DependencyTreeFlags.SupportsRemove);
             }
 
             /// <summary>Retrieves the cached <see cref="ProjectTreeFlags"/> given the arguments.</summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/FrameworkDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/FrameworkDependencyModel.cs
@@ -9,7 +9,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
     internal sealed class FrameworkDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.FrameworkDependency);
+        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
+            resolved: DependencyTreeFlags.FrameworkDependency + DependencyTreeFlags.SupportsFolderBrowse,
+            unresolved: DependencyTreeFlags.FrameworkDependency);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
             icon: ManagedImageMonikers.Framework,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/PackageDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/PackageDependencyModel.cs
@@ -10,7 +10,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
     internal class PackageDependencyModel : DependencyModel
     {
         private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
-            add: DependencyTreeFlags.PackageDependency);
+            resolved: DependencyTreeFlags.PackageDependency + DependencyTreeFlags.SupportsFolderBrowse,
+            unresolved: DependencyTreeFlags.PackageDependency);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
             icon: ManagedImageMonikers.NuGetGrey,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModel.cs
@@ -11,7 +11,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
     internal class ProjectDependencyModel : DependencyModel
     {
         private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
-            add: DependencyTreeFlags.ProjectDependency);
+            resolved: DependencyTreeFlags.ProjectDependency + DependencyTreeFlags.SupportsBrowse,
+            unresolved: DependencyTreeFlags.ProjectDependency + DependencyTreeFlags.SupportsBrowse);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
             icon: KnownMonikers.Application,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/SdkDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/SdkDependencyModel.cs
@@ -13,7 +13,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
     internal class SdkDependencyModel : DependencyModel
     {
         private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
-            add: DependencyTreeFlags.SdkDependency);
+            resolved: DependencyTreeFlags.SdkDependency + DependencyTreeFlags.SupportsFolderBrowse,
+            unresolved: DependencyTreeFlags.SdkDependency);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
             icon: ManagedImageMonikers.Sdk,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
@@ -11,8 +11,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
     internal class SharedProjectDependencyModel : DependencyModel
     {
         private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
-            resolved: DependencyTreeFlags.ProjectDependency + DependencyTreeFlags.SharedProjectDependency | DependencyTreeFlags.SupportsBrowse,
-            unresolved: DependencyTreeFlags.ProjectDependency + DependencyTreeFlags.SharedProjectDependency | DependencyTreeFlags.SupportsBrowse,
+            resolved: DependencyTreeFlags.ProjectDependency + DependencyTreeFlags.SharedProjectDependency + DependencyTreeFlags.SupportsBrowse,
+            unresolved: DependencyTreeFlags.ProjectDependency + DependencyTreeFlags.SharedProjectDependency + DependencyTreeFlags.SupportsBrowse,
             remove: DependencyTreeFlags.SupportsRuleProperties);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
@@ -11,8 +11,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
     internal class SharedProjectDependencyModel : DependencyModel
     {
         private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
-            add: DependencyTreeFlags.ProjectDependency +
-                 DependencyTreeFlags.SharedProjectDependency,
+            resolved: DependencyTreeFlags.ProjectDependency + DependencyTreeFlags.SharedProjectDependency | DependencyTreeFlags.SupportsBrowse,
+            unresolved: DependencyTreeFlags.ProjectDependency + DependencyTreeFlags.SharedProjectDependency | DependencyTreeFlags.SupportsBrowse,
             remove: DependencyTreeFlags.SupportsRuleProperties);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -279,5 +279,10 @@ namespace Microsoft.VisualStudio.IO
         {
             return ReadAllText(filename).Length;
         }
+
+        public bool PathExists(string path)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/AnalyzerDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/AnalyzerDependencyModelTests.cs
@@ -38,6 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.AnalyzerDependency +
+                DependencyTreeFlags.SupportsBrowse +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
         }
@@ -69,6 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.AnalyzerDependency +
+                DependencyTreeFlags.SupportsBrowse +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
         }
@@ -100,6 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.AnalyzerDependency +
+                DependencyTreeFlags.SupportsBrowse + 
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove,
                 model.Flags);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/AssemblyDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/AssemblyDependencyModelTests.cs
@@ -38,6 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.AssemblyDependency +
+                DependencyTreeFlags.SupportsBrowse +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
         }
@@ -69,6 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.AssemblyDependency +
+                DependencyTreeFlags.SupportsBrowse +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
         }
@@ -131,6 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.AssemblyDependency +
+                DependencyTreeFlags.SupportsBrowse +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove,
                 model.Flags);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/ComDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/ComDependencyModelTests.cs
@@ -37,6 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.ComponentWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.ComDependency +
+                DependencyTreeFlags.SupportsBrowse +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
         }
@@ -99,6 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.ComponentWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.ComDependency +
+                DependencyTreeFlags.SupportsBrowse +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove,
                 model.Flags);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/PackageDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/PackageDependencyModelTests.cs
@@ -39,6 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.PackageDependency +
+                DependencyTreeFlags.SupportsFolderBrowse +
                 DependencyTreeFlags.GenericResolvedDependencyFlags +
                 ProjectTreeFlags.Create("$ID:myOriginalItemSpec"),
                 model.Flags);
@@ -107,6 +108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.PackageDependency +
+                DependencyTreeFlags.SupportsFolderBrowse +
                 DependencyTreeFlags.GenericResolvedDependencyFlags +
                 ProjectTreeFlags.Create("$ID:myOriginalItemSpec") -
                 DependencyTreeFlags.SupportsRemove,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
@@ -38,6 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.ApplicationWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
+                DependencyTreeFlags.SupportsBrowse +
                 DependencyTreeFlags.GenericResolvedDependencyFlags +
                 ProjectTreeFlags.Create("$ID:MyProject"),
                 model.Flags);
@@ -70,6 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.ApplicationWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
+                DependencyTreeFlags.SupportsBrowse +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags +
                 ProjectTreeFlags.Create("$ID:MyProject"),
                 model.Flags);
@@ -102,6 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.ApplicationWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
+                DependencyTreeFlags.SupportsBrowse +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove +
                 ProjectTreeFlags.Create("$ID:MyProject"),

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/SdkDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/SdkDependencyModelTests.cs
@@ -37,6 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.SdkWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.SdkDependency +
+                DependencyTreeFlags.SupportsFolderBrowse +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
         }
@@ -99,6 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(ManagedImageMonikers.SdkWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
                 DependencyTreeFlags.SdkDependency +
+                DependencyTreeFlags.SupportsFolderBrowse +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove,
                 model.Flags);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/SharedProjectDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/SharedProjectDependencyModelTests.cs
@@ -41,6 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.SharedProjectDependency +
+                DependencyTreeFlags.SupportsBrowse +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRuleProperties,
                 model.Flags);
@@ -74,6 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.SharedProjectDependency +
+                DependencyTreeFlags.SupportsBrowse +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRuleProperties,
                 model.Flags);
@@ -107,6 +109,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.SharedProjectDependency +
+                DependencyTreeFlags.SupportsBrowse +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRuleProperties -
                 DependencyTreeFlags.SupportsRemove,


### PR DESCRIPTION
This adds explorer-related commands for top-level references:

Adds support for "Open Containing Folder" and "Copy Full Path" to:

- Projects (Unresolved/Resolved)
- Shared Projects (Unresolved/Resolved)
- Analyzers (Unresolved/Resolved)
- COM (Resolved)
- Assembly (Resolved)
- Package Reference (Resolved)
- Framework Reference (Resolved)
- SDK Reference (Resolved)

And adds support for "Open Folder in File Explorer" to:

- Package Reference (Resolved)
- Framework Reference (Resolved)
- SDK Reference (Resolved)

This behavior is similar to built-in folders, which support all 3 commands, but only actually exposes "Open Folder in FIle Explorer" and "Copy Full Path" on the context menu. 

This PR actuallys exposes the commands on the context menus: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/270313.

Here's an example:
![image](https://user-images.githubusercontent.com/1103906/91372114-1e376600-e856-11ea-8205-c07338bc2c48.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6554)