### PR TITLE
Publish only files within artifacts directory

### DIFF
--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -130,7 +130,7 @@ steps:
 
 - task: PublishBuildArtifacts@1
   inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)/drop'
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/drop/artifacts/$(BuildConfiguration)'
     ArtifactName: '$(Build.BuildNumber)'
     publishLocation: Container
   displayName: 'Publish Artifact: drop'


### PR DESCRIPTION
Our packages now go into something like `20200826.5/artifacts/Release/packages/`  instead of `20200826.5/packages` which is what the insertion tool looks for [here](https://github.com/dotnet/roslyn-tools/blob/master/src/RoslynInsertionTool/RoslynInsertionTool/LegacyInsertionArtifacts.cs#L42)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6555)