### PR TITLE
Reverting task to deprecated as artifactDropTask  didn't seem to work

### DIFF
--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -101,12 +101,12 @@ steps:
     publishLocation: Container
   displayName: 'Publish Artifact: symbols'
 
-- task: artifactDropTask@0
+- task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
   displayName: Publish Symbols to Artifact Services (symweb)
   inputs:
-    dropServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
-    buildNumber: '$(system.teamProject)/$(Build.DefinitionName)/$(Build.BuildNumber)/$(Build.BuildId)'
-    sourcePath: '$(Build.ArtifactStagingDirectory)/symbols'
+    symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
+    requestName: '$(system.teamProject)/$(Build.DefinitionName)/$(Build.BuildNumber)/$(Build.BuildId)'
+    sourcePath: $(Build.ArtifactStagingDirectory)/symbols
     usePat: false
         
 - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1


### PR DESCRIPTION
We're getting errors that the symbols aren't correctly getting published. I've contacted the team in charge of artifactDropTask in order to understand it better since the logs seem to be doing the right thing.

This unblocks insertions.

Reopens #5905 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6561)