### PR TITLE
Bind F12 to "Navigate to Project"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
@@ -202,8 +202,14 @@
       </Button>
     </Buttons>
   </Commands>
-
+  
+  <KeyBindings>
+    <KeyBinding guid="guidManagedProjectSystemCommandSet" id="cmdidNavigateToProject" editor="guidSolutionExplorerToolWindow" key1="VK_F12"/>
+  </KeyBindings>
+  
   <Symbols>
+    <GuidSymbol name="guidSolutionExplorerToolWindow" value="{3AE79031-E1BC-11D0-8F78-00A0C9110057}" />
+    
     <!-- This is out managed package guid. -->
     <GuidSymbol name="PackageGuidString" value="{860A27C0-B665-47F3-BC12-637E16A1050A}" />
 


### PR DESCRIPTION
All the navigate commands, "Go To Test", "Go To Definition" are all bound to F12. Do the same here, but make sure its only in Solution Explorer which does not use this shortcut.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6562)