### PR TITLE
Fix assert in ProjectSubscriptionService

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/AnalyzerReference.xaml
@@ -18,7 +18,7 @@
                   ReadOnly="True"
                   Visible="False">
     <StringProperty.DataSource>
-      <DataSource ItemType="Reference"
+      <DataSource ItemType="Analyzer"
                   PersistedName="Identity"
                   Persistence="Intrinsic"
                   SourceOfDefaultValue="AfterContext" />

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/MiscellaneousRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/MiscellaneousRuleTests.cs
@@ -131,6 +131,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
             }
         }
 
+        [Theory]
+        [MemberData(nameof(GetAllRules))]
+        public void PropertiesDataSourcesMustMatchItemDataSources(string ruleName, string fullPath)
+        {
+            var root = LoadXamlRule(fullPath, out var namespaceManager);
+
+            var dataSource = root.XPathSelectElement(@"/msb:Rule/msb:Rule.DataSource/msb:DataSource", namespaceManager);
+
+            var itemType = dataSource?.Attribute("ItemType");
+            if (itemType != null)
+            {
+                foreach (var property in GetProperties(root))
+                {
+                    var element = GetDataSource(property);
+
+                    var propertyItemType = element?.Attribute("ItemType");
+                    if (propertyItemType != null)
+                    {
+                        Assert.Equal(itemType?.Value, propertyItemType.Value);
+                    }
+                }
+            }
+        }
+
         public static IEnumerable<object[]> GetMiscellaneousRules()
         {
             return Project(GetRules(""));

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/XamlRuleTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/XamlRuleTestBase.cs
@@ -79,6 +79,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
             }
         }
 
+        protected static XElement? GetDataSource(XElement property)
+        {
+            foreach (var child in property.Elements())
+            {
+                if (child.Name.LocalName.EndsWith("DataSource", StringComparison.Ordinal))
+                    return child.Elements().First();
+            }
+
+            return null;
+        }
+
         protected static IEnumerable<XElement> GetVisibleProperties(XElement rule)
         {
             foreach (var property in GetProperties(rule))


### PR DESCRIPTION
This was firing an assert because we had the wrong item data source, and it was confusing Analyzers with References.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6566)