### PR TITLE
Avoid SubType fighting in multi-target projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataflowOption.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataflowOption.cs
@@ -3,6 +3,7 @@
 #pragma warning disable RS0030 // Do not used banned APIs (we are wrapping them)
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
@@ -27,6 +28,21 @@ namespace Microsoft.VisualStudio.ProjectSystem
                     PropagateCompletion = true  // Make sure source block completion and faults flow onto the target block to avoid hangs.
                 };
             }
+        }
+
+        /// <summary>
+        ///     Returns a new instance of <see cref="StandardRuleDataflowLinkOptions"/> with
+        ///     <see cref="StandardRuleDataflowLinkOptions.RuleNames"/> set to <paramref name="ruleNames"/>
+        ///     and <see cref="DataflowLinkOptions.PropagateCompletion"/> set to <see langword="true"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="ruleNames"/> is <see langword="null"/>.
+        /// </exception>
+        public static StandardRuleDataflowLinkOptions WithRuleNames(IEnumerable<string> ruleNames)
+        {
+            Requires.NotNull(ruleNames, nameof(ruleNames));
+
+            return WithRuleNames(ImmutableHashSet.CreateRange(ruleNames));
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ActiveMode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ActiveMode.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    internal readonly struct ContextState
+    {
+        public ContextState(bool isActiveEditorContext, bool isActiveConfiguration)
+        {
+            IsActiveEditorContext = isActiveEditorContext;
+            IsActiveConfiguration = isActiveConfiguration;
+        }
+
+        /// <summary>
+        ///     Gets a value indicating whether the <see cref="IWorkspaceProjectContext"/> is the active one for 
+        ///     the editor.
+        /// </summary>
+        /// <remarks>
+        ///     The "active" context for the editor is the one that Roslyn uses to drive IntelliSense, refactorings
+        ///     and code fixes. This is typically controlled by the user via the project drop down in the top-left
+        ///     of the editor, but can be changed in reaction to other factors.
+        /// </remarks>
+        public bool IsActiveEditorContext { get; }
+
+        /// <summary>
+        ///     Gets a value indicating whether the <see cref="IWorkspaceProjectContext"/> is context in the active 
+        ///     configuration for a project.
+        /// </summary>
+        /// <remarks>
+        ///     The context in the active configuration for the project is the one that Roslyn uses to analyze types 
+        ///     to push "SubType"  metadata of source files to the project system. This avoids having conflicting 
+        ///     metadata between contexts of the same source file in multi-targeted projects. 
+        /// </remarks>
+        public bool IsActiveConfiguration { get; }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _project = project;
         }
 
-        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger)
+        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(added, nameof(added));
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             {
                 string fullPath = _project.MakeRooted(additionalFile.Path);
 
-                AddToContextIfNotPresent(fullPath, isActiveContext, logger);
+                AddToContextIfNotPresent(fullPath, state.IsActiveEditorContext, logger);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerConfigItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerConfigItemHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _project = project;
         }
 
-        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger)
+        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(added, nameof(added));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _project = project;
         }
 
-        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger)
+        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(added, nameof(added));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineNotificationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineNotificationHandler.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [ImportMany]
         public OrderPrecedenceImportCollection<Action<string, BuildOptions, BuildOptions>> CommandLineNotifications { get; }
 
-        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger)
+        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(added, nameof(added));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CompileItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CompileItemHandler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             get { return Compile.SchemaName; }
         }
 
-        public void Handle(IComparable version, IProjectChangeDescription projectChange, bool isActiveContext, IProjectLogger logger)
+        public void Handle(IComparable version, IProjectChangeDescription projectChange, ContextState state, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(projectChange, nameof(projectChange));
@@ -43,10 +43,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             VerifyInitialized();
 
-            ApplyProjectEvaluation(version, projectChange.Difference, projectChange.Before.Items, projectChange.After.Items, isActiveContext, logger);
+            ApplyProjectEvaluation(version, projectChange.Difference, projectChange.Before.Items, projectChange.After.Items, state.IsActiveEditorContext, logger);
         }
 
-        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger)
+        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(added, nameof(added));
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             IProjectChangeDiff difference = ConvertToProjectDiff(added, removed);
 
-            ApplyProjectBuild(version, difference, isActiveContext, logger);
+            ApplyProjectBuild(version, difference, state.IsActiveEditorContext, logger);
         }
 
         public void HandleProjectUpdate(IComparable version, IProjectChangeDescription projectChange, IProjectLogger logger)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/DynamicItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/DynamicItemHandler.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             get { return Content.SchemaName; }
         }
 
-        public void Handle(IComparable version, IProjectChangeDescription projectChange, bool isActiveContext, IProjectLogger logger)
+        public void Handle(IComparable version, IProjectChangeDescription projectChange, ContextState state, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(projectChange, nameof(projectChange));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _project = project;
         }
 
-        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger)
+        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(added, nameof(added));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandler.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             get { return ConfigurationGeneral.SchemaName; }
         }
 
-        public void Handle(IComparable version, IProjectChangeDescription projectChange, bool isActiveContext, IProjectLogger logger)
+        public void Handle(IComparable version, IProjectChangeDescription projectChange, ContextState state, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(projectChange, nameof(projectChange));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             get { return LanguageService.SchemaName; }
         }
 
-        public void Handle(IComparable version, IProjectChangeDescription projectChange, bool isActiveContext, IProjectLogger logger)
+        public void Handle(IComparable version, IProjectChangeDescription projectChange, ContextState state, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(projectChange, nameof(projectChange));
@@ -42,6 +42,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                 logger.WriteLine("{0}: {1}", name, value);
                 Context.SetProperty(name, value);
             }
+
+            // NOTE: Roslyn treats "unset" as true, so always set it.
+            Context.IsPrimary = state.IsActiveConfiguration;
         }
 
         private bool TryHandleSpecificProperties(string name, string value, IProjectLogger logger)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
@@ -17,13 +17,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     {
         /// <summary>
         ///     Returns an enumerable of project evaluation rules that should passed to
-        ///     <see cref="ApplyProjectEvaluationAsync(IProjectVersionedValue{IProjectSubscriptionUpdate}, bool, CancellationToken)"/>.
+        ///     <see cref="ApplyProjectEvaluationAsync(IProjectVersionedValue{IProjectSubscriptionUpdate}, ContextState, CancellationToken)"/>.
         /// </summary>
         IEnumerable<string> GetProjectEvaluationRules();
 
         /// <summary>
         ///     Returns an enumerable of project build rules that should passed to
-        ///     <see cref="ApplyProjectBuildAsync(IProjectVersionedValue{IProjectSubscriptionUpdate}, bool, CancellationToken)"/>.
+        ///     <see cref="ApplyProjectBuildAsync(IProjectVersionedValue{IProjectSubscriptionUpdate}, ContextState, CancellationToken)"/>.
         /// </summary>
         IEnumerable<string> GetProjectBuildRules();
 
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     to the project snapshot state. The cancellation token should only be cancelled with the
         ///     intention that the <see cref="IWorkspaceProjectContext"/> will be immediately disposed.
         /// </remarks>
-        Task ApplyProjectEvaluationAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext, CancellationToken cancellationToken);
+        Task ApplyProjectEvaluationAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, ContextState state, CancellationToken cancellationToken);
 
         /// <summary>
         ///     Applies project build changes to the underlying <see cref="IWorkspaceProjectContext"/>.
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     to the project snapshot state. The cancellation token should only be cancelled with the
         ///     intention that the <see cref="IWorkspaceProjectContext"/> will be immediately disposed.
         /// </remarks>
-        Task ApplyProjectBuildAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext, CancellationToken cancellationToken);
+        Task ApplyProjectBuildAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, ContextState state, CancellationToken cancellationToken);
 
         /// <summary>
         ///     Applies project changes to the underlying <see cref="IWorkspaceProjectContext"/>.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ICommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ICommandLineHandler.cs
@@ -26,9 +26,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         /// <param name="removed">
         ///     A <see cref="BuildOptions"/> representing the removed arguments.
         /// </param>
-        /// <param name="isActiveContext">
-        ///     <see langword="true"/> if the underlying <see cref="IWorkspaceProjectContext"/>
-        ///     is the active context; otherwise, <see langword="false"/>.
+        /// <param name="state">
+        ///     A <see cref="ContextState"/> describing the state of the <see cref="IWorkspaceProjectContext"/>.
         /// </param>
         /// <param name="logger">
         ///     The <see cref="IProjectLogger"/> for logging to the log.
@@ -48,6 +47,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     </para>
         ///     <paramref name="logger"/> is <see langword="null"/>.
         /// </exception>
-        void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger);
+        void Handle(IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IProjectLogger logger);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IProjectEvaluationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IProjectEvaluationHandler.cs
@@ -29,9 +29,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     A <see cref="IProjectChangeDescription"/> representing the set of
         ///     changes made to the project.
         /// </param>
-        /// <param name="isActiveContext">
-        ///     <see langword="true"/> if the underlying <see cref="IWorkspaceProjectContext"/>
-        ///     is the active context; otherwise, <see langword="false"/>.
+        /// <param name="state">
+        ///     A <see cref="ContextState"/> describing the state of the <see cref="IWorkspaceProjectContext"/>.
         /// </param>
         /// <param name="logger">
         ///     The <see cref="IProjectLogger"/> for logging to the log.
@@ -47,6 +46,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     </para>
         ///     <paramref name="logger"/> is <see langword="null"/>.
         /// </exception>
-        void Handle(IComparable version, IProjectChangeDescription projectChange, bool isActiveContext, IProjectLogger logger);
+        void Handle(IComparable version, IProjectChangeDescription projectChange, ContextState state, IProjectLogger logger);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.OperationProgress;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
@@ -24,6 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             private readonly IUnconfiguredProjectTasksService _tasksService;
             private readonly IWorkspaceProjectContextProvider _workspaceProjectContextProvider;
             private readonly IActiveEditorContextTracker _activeWorkspaceProjectContextTracker;
+            private readonly IActiveConfiguredProjectProvider _activeConfiguredProjectProvider;
             private readonly ExportFactory<IApplyChangesToWorkspaceContext> _applyChangesToWorkspaceContextFactory;
             private readonly IDataProgressTrackerService _dataProgressTrackerService;
 
@@ -39,6 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                                        IProjectSubscriptionService projectSubscriptionService,
                                                        IWorkspaceProjectContextProvider workspaceProjectContextProvider,
                                                        IActiveEditorContextTracker activeWorkspaceProjectContextTracker,
+                                                       IActiveConfiguredProjectProvider activeConfiguredProjectProvider,
                                                        ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory,
                                                        IDataProgressTrackerService dataProgressTrackerService)
                 : base(threadingService.JoinableTaskContext)
@@ -48,6 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 _tasksService = tasksService;
                 _workspaceProjectContextProvider = workspaceProjectContextProvider;
                 _activeWorkspaceProjectContextTracker = activeWorkspaceProjectContextTracker;
+                _activeConfiguredProjectProvider = activeConfiguredProjectProvider;
                 _applyChangesToWorkspaceContextFactory = applyChangesToWorkspaceContextFactory;
                 _dataProgressTrackerService = dataProgressTrackerService;
             }
@@ -78,22 +82,37 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     _evaluationProgressRegistration,
                     _projectBuildProgressRegistration,
 
-                    // We avoid suppressing version updates, so that progress tracker doesn't
-                    // think we're still "in progress" in the case of an empty change
-                    _projectSubscriptionService.ProjectRuleSource.SourceBlock.LinkToAsyncAction(
-                        target: e => OnProjectChangedAsync(e, evaluation: true),
-                        _project.UnconfiguredProject,
-                        ProjectFaultSeverity.LimitedFunctionality,
-                        suppressVersionOnlyUpdates: false,
-                        ruleNames: _applyChangesToWorkspaceContext.Value.GetProjectEvaluationRules()),
+                    ProjectDataSources.SyncLinkTo(
+                        _activeConfiguredProjectProvider.ActiveConfiguredProjectBlock.SyncLinkOptions(),
+                        _projectSubscriptionService.ProjectRuleSource.SourceBlock.SyncLinkOptions(GetProjectEvaluationOptions()),
+                            target: DataflowBlockFactory.CreateActionBlock<IProjectVersionedValue<ValueTuple<ConfiguredProject, IProjectSubscriptionUpdate>>>(e =>
+                                OnProjectChangedAsync(e, evaluation: true),
+                                _project.UnconfiguredProject,
+                                ProjectFaultSeverity.LimitedFunctionality),
+                            linkOptions: DataflowOption.PropagateCompletion,
+                            cancellationToken: cancellationToken),
 
-                    _projectSubscriptionService.ProjectBuildRuleSource.SourceBlock.LinkToAsyncAction(
-                        target: e => OnProjectChangedAsync(e, evaluation: false),
-                        _project.UnconfiguredProject,
-                        ProjectFaultSeverity.LimitedFunctionality,
-                        suppressVersionOnlyUpdates: false,
-                        ruleNames: _applyChangesToWorkspaceContext.Value.GetProjectBuildRules())
+                    ProjectDataSources.SyncLinkTo(
+                        _activeConfiguredProjectProvider.ActiveConfiguredProjectBlock.SyncLinkOptions(),
+                        _projectSubscriptionService.ProjectBuildRuleSource.SourceBlock.SyncLinkOptions(GetProjectBuildOptions()),
+                            target: DataflowBlockFactory.CreateActionBlock<IProjectVersionedValue<ValueTuple<ConfiguredProject, IProjectSubscriptionUpdate>>>(e =>
+                                OnProjectChangedAsync(e, evaluation: false),
+                                _project.UnconfiguredProject,
+                                ProjectFaultSeverity.LimitedFunctionality),
+                            linkOptions: DataflowOption.PropagateCompletion,
+                            cancellationToken: cancellationToken),
+
                 };
+            }
+
+            private StandardRuleDataflowLinkOptions GetProjectEvaluationOptions()
+            {
+                return DataflowOption.WithRuleNames(_applyChangesToWorkspaceContext!.Value.GetProjectEvaluationRules());
+            }
+
+            private StandardRuleDataflowLinkOptions GetProjectBuildOptions()
+            {
+                return DataflowOption.WithRuleNames(_applyChangesToWorkspaceContext!.Value.GetProjectBuildRules());
             }
 
             protected override async Task DisposeCoreUnderLockAsync(bool initialized)
@@ -142,28 +161,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 }
             }
 
-            internal Task OnProjectChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool evaluation)
+            internal Task OnProjectChangedAsync(IProjectVersionedValue<(ConfiguredProject project, IProjectSubscriptionUpdate subscription)> update, bool evaluation)
             {
                 return ExecuteUnderLockAsync(ct => ApplyProjectChangesUnderLockAsync(update, evaluation, ct), _tasksService.UnloadCancellationToken);
             }
 
-            private async Task ApplyProjectChangesUnderLockAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool evaluation, CancellationToken cancellationToken)
+            private async Task ApplyProjectChangesUnderLockAsync(IProjectVersionedValue<(ConfiguredProject project, IProjectSubscriptionUpdate subscription)> update, bool evaluation, CancellationToken cancellationToken)
             {
                 IWorkspaceProjectContext context = _contextAccessor!.Context;
+                IProjectVersionedValue<IProjectSubscriptionUpdate> subscription = update.Derive(u => u.subscription);
+                bool isActiveEditorContext = _activeWorkspaceProjectContextTracker.IsActiveEditorContext(_contextAccessor.ContextId);
+                bool isActiveConfiguration = update.Value.project == _project;
+
+                var state = new ContextState(isActiveEditorContext, isActiveConfiguration);
 
                 context.StartBatch();
 
                 try
                 {
-                    bool isActiveContext = _activeWorkspaceProjectContextTracker.IsActiveEditorContext(_contextAccessor.ContextId);
-
                     if (evaluation)
                     {
-                        await _applyChangesToWorkspaceContext!.Value.ApplyProjectEvaluationAsync(update, isActiveContext, cancellationToken);
+                        await _applyChangesToWorkspaceContext!.Value.ApplyProjectEvaluationAsync(subscription, state, cancellationToken);
                     }
                     else
                     {
-                        await _applyChangesToWorkspaceContext!.Value.ApplyProjectBuildAsync(update, isActiveContext, cancellationToken);
+                        await _applyChangesToWorkspaceContext!.Value.ApplyProjectBuildAsync(subscription, state, cancellationToken);
                     }
                 }
                 finally
@@ -173,7 +195,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     NotifyOutputDataCalculated(update.DataSourceVersions, evaluation);
                 }
 
-                await _applyChangesToWorkspaceContext.Value.ApplyProjectEndBatchAsync(update, cancellationToken);
+                await _applyChangesToWorkspaceContext.Value.ApplyProjectEndBatchAsync(subscription, cancellationToken);
             }
 
             private void NotifyOutputDataCalculated(IImmutableDictionary<NamedIdentity, IComparable> dataSourceVersions, bool evaluation)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.cs
@@ -23,6 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         private readonly IProjectSubscriptionService _projectSubscriptionService;
         private readonly IWorkspaceProjectContextProvider _workspaceProjectContextProvider;
         private readonly IActiveEditorContextTracker _activeWorkspaceProjectContextTracker;
+        private readonly IActiveConfiguredProjectProvider _activeConfiguredProjectProvider;
         private readonly ExportFactory<IApplyChangesToWorkspaceContext> _applyChangesToWorkspaceContextFactory;
         private readonly IDataProgressTrackerService _dataProgressTrackerService;
 
@@ -33,6 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                            IProjectSubscriptionService projectSubscriptionService,
                                            IWorkspaceProjectContextProvider workspaceProjectContextProvider,
                                            IActiveEditorContextTracker activeWorkspaceProjectContextTracker,
+                                           IActiveConfiguredProjectProvider activeConfiguredProjectProvider,
                                            ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory,
                                            IDataProgressTrackerService dataProgressTrackerService)
             : base(threadingService.JoinableTaskContext)
@@ -43,6 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             _projectSubscriptionService = projectSubscriptionService;
             _workspaceProjectContextProvider = workspaceProjectContextProvider;
             _activeWorkspaceProjectContextTracker = activeWorkspaceProjectContextTracker;
+            _activeConfiguredProjectProvider = activeConfiguredProjectProvider;
             _applyChangesToWorkspaceContextFactory = applyChangesToWorkspaceContextFactory;
             _dataProgressTrackerService = dataProgressTrackerService;
         }
@@ -84,7 +87,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         protected override WorkspaceProjectContextHostInstance CreateInstance()
         {
-            return new WorkspaceProjectContextHostInstance(_project, _threadingService, _tasksService, _projectSubscriptionService, _workspaceProjectContextProvider, _activeWorkspaceProjectContextTracker, _applyChangesToWorkspaceContextFactory, _dataProgressTrackerService);
+            return new WorkspaceProjectContextHostInstance(
+                _project,
+                _threadingService,
+                _tasksService,
+                _projectSubscriptionService,
+                _workspaceProjectContextProvider,
+                _activeWorkspaceProjectContextTracker,
+                _activeConfiguredProjectProvider,
+                _applyChangesToWorkspaceContextFactory,
+                _dataProgressTrackerService);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectProviderFactory.cs
@@ -16,6 +16,15 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return mock.Object;
         }
 
+        public static IActiveConfiguredProjectProvider Create()
+        {
+            var mock = new Mock<IActiveConfiguredProjectProvider>();
+            mock.SetupGet(p => p.ActiveConfiguredProjectBlock)
+                .Returns(DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<ConfiguredProject>>());
+
+            return mock.Object;
+        }
+
         public static IActiveConfiguredProjectProvider Create(
             Func<ProjectConfiguration?>? getActiveProjectConfiguration = null,
             Func<ConfiguredProject?>? getActiveConfiguredProject = null)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IApplyChangesToWorkspaceContextFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IApplyChangesToWorkspaceContextFactory.cs
@@ -14,20 +14,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return Mock.Of<IApplyChangesToWorkspaceContext>();
         }
 
-        public static IApplyChangesToWorkspaceContext ImplementApplyProjectBuildAsync(Action<IProjectVersionedValue<IProjectSubscriptionUpdate>, bool, CancellationToken> action)
+        public static IApplyChangesToWorkspaceContext ImplementApplyProjectBuildAsync(Action<IProjectVersionedValue<IProjectSubscriptionUpdate>, ContextState, CancellationToken> action)
         {
             var mock = new Mock<IApplyChangesToWorkspaceContext>();
-            mock.Setup(c => c.ApplyProjectBuildAsync(It.IsAny<IProjectVersionedValue<IProjectSubscriptionUpdate>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            mock.Setup(c => c.ApplyProjectBuildAsync(It.IsAny<IProjectVersionedValue<IProjectSubscriptionUpdate>>(), It.IsAny<ContextState>(), It.IsAny<CancellationToken>()))
                 .Callback(action)
                 .Returns(Task.CompletedTask);
 
             return mock.Object;
         }
 
-        public static IApplyChangesToWorkspaceContext ImplementApplyProjectEvaluationAsync(Action<IProjectVersionedValue<IProjectSubscriptionUpdate>, bool, CancellationToken> action)
+        public static IApplyChangesToWorkspaceContext ImplementApplyProjectEvaluationAsync(Action<IProjectVersionedValue<IProjectSubscriptionUpdate>, ContextState, CancellationToken> action)
         {
             var mock = new Mock<IApplyChangesToWorkspaceContext>();
-            mock.Setup(c => c.ApplyProjectEvaluationAsync(It.IsAny<IProjectVersionedValue<IProjectSubscriptionUpdate>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            mock.Setup(c => c.ApplyProjectEvaluationAsync(It.IsAny<IProjectVersionedValue<IProjectSubscriptionUpdate>>(), It.IsAny<ContextState>(), It.IsAny<CancellationToken>()))
                 .Callback(action)
                 .Returns(Task.CompletedTask);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ICommandLineHandlerFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ICommandLineHandlerFactory.cs
@@ -8,11 +8,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
     internal static class ICommandLineHandlerFactory
     {
-        public static ICommandLineHandler ImplementHandle(Action<IComparable, BuildOptions, BuildOptions, bool, IProjectLogger> action)
+        public static ICommandLineHandler ImplementHandle(Action<IComparable, BuildOptions, BuildOptions, ContextState, IProjectLogger> action)
         {
             var mock = new Mock<ICommandLineHandler>();
 
-            mock.Setup(h => h.Handle(It.IsAny<IComparable>(), It.IsAny<BuildOptions>(), It.IsAny<BuildOptions>(), It.IsAny<bool>(), It.IsAny<IProjectLogger>()))
+            mock.Setup(h => h.Handle(It.IsAny<IComparable>(), It.IsAny<BuildOptions>(), It.IsAny<BuildOptions>(), It.IsAny<ContextState>(), It.IsAny<IProjectLogger>()))
                 .Callback(action);
 
             return mock.Object;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IEvaluationHandlerFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IEvaluationHandlerFactory.cs
@@ -18,14 +18,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return mock.Object;
         }
 
-        public static IProjectEvaluationHandler ImplementHandle(string evaluationRule, Action<IComparable, IProjectChangeDescription, bool, IProjectLogger> action)
+        public static IProjectEvaluationHandler ImplementHandle(string evaluationRule, Action<IComparable, IProjectChangeDescription, ContextState, IProjectLogger> action)
         {
             var mock = new Mock<IProjectEvaluationHandler>();
 
             mock.SetupGet(h => h.ProjectEvaluationRule)
                 .Returns(evaluationRule);
 
-            mock.Setup(h => h.Handle(It.IsAny<IComparable>(), It.IsAny<IProjectChangeDescription>(), It.IsAny<bool>(), It.IsAny<IProjectLogger>()))
+            mock.Setup(h => h.Handle(It.IsAny<IComparable>(), It.IsAny<IProjectChangeDescription>(), It.IsAny<ContextState>(), It.IsAny<IProjectLogger>()))
                 .Callback(action);
 
             return mock.Object;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContextTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContextTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             await Assert.ThrowsAsync<InvalidOperationException>(() =>
             {
-                return applyChangesToWorkspace.ApplyProjectEvaluationAsync(update, false, CancellationToken.None);
+                return applyChangesToWorkspace.ApplyProjectEvaluationAsync(update, new ContextState(), CancellationToken.None);
             });
         }
 
@@ -135,7 +135,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             await Assert.ThrowsAsync<InvalidOperationException>(() =>
             {
-                return applyChangesToWorkspace.ApplyProjectBuildAsync(update, false, CancellationToken.None);
+                return applyChangesToWorkspace.ApplyProjectBuildAsync(update, new ContextState(), CancellationToken.None);
             });
         }
 
@@ -190,7 +190,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             await Assert.ThrowsAsync<ObjectDisposedException>(() =>
             {
-                return applyChangesToWorkspace.ApplyProjectEvaluationAsync(update, true, CancellationToken.None);
+                return applyChangesToWorkspace.ApplyProjectEvaluationAsync(update, new ContextState(), CancellationToken.None);
             });
         }
 
@@ -205,7 +205,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             await Assert.ThrowsAsync<ObjectDisposedException>(() =>
             {
-                return applyChangesToWorkspace.ApplyProjectBuildAsync(update, true, CancellationToken.None);
+                return applyChangesToWorkspace.ApplyProjectBuildAsync(update, new ContextState(), CancellationToken.None);
             });
         }
 
@@ -236,7 +236,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         public async Task ApplyProjectEvaluationAsync_WhenNoRuleChanges_DoesNotCallHandler()
         {
             int callCount = 0;
-            var handler = IEvaluationHandlerFactory.ImplementHandle("RuleName", (version, description, isActiveContext, logger) => { callCount++; });
+            var handler = IEvaluationHandlerFactory.ImplementHandle("RuleName", (version, description, state, logger) => { callCount++; });
 
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler });
 
@@ -251,7 +251,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     }
 }");
 
-            await applyChangesToWorkspace.ApplyProjectEvaluationAsync(update, isActiveContext: false, CancellationToken.None);
+            await applyChangesToWorkspace.ApplyProjectEvaluationAsync(update, new ContextState(true, false), CancellationToken.None);
 
             Assert.Equal(0, callCount);
         }
@@ -260,7 +260,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         public async Task ApplyProjectBuildAsync_WhenNoCompilerCommandLineArgsRuleChanges_DoesNotCallHandler()
         {
             int callCount = 0;
-            var handler = ICommandLineHandlerFactory.ImplementHandle((version, added, removed, isActiveContext, logger) => { callCount++; });
+            var handler = ICommandLineHandlerFactory.ImplementHandle((version, added, removed, state, logger) => { callCount++; });
 
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler });
 
@@ -275,7 +275,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     }
 }");
 
-            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, isActiveContext: false, CancellationToken.None);
+            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, new ContextState(), CancellationToken.None);
 
             Assert.Equal(0, callCount);
         }
@@ -283,11 +283,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         [Fact]
         public async Task ApplyProjectEvaluationAsync_CallsHandler()
         {
-            (IComparable version, IProjectChangeDescription description, bool isActiveContext, IProjectLogger logger) result = default;
+            (IComparable version, IProjectChangeDescription description, ContextState state, IProjectLogger logger) result = default;
 
-            var handler = IEvaluationHandlerFactory.ImplementHandle("RuleName", (version, description, isActiveContext, logger) =>
+            var handler = IEvaluationHandlerFactory.ImplementHandle("RuleName", (version, description, state, logger) =>
             {
-                result = (version, description, isActiveContext, logger);
+                result = (version, description, state, logger);
             });
 
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler });
@@ -302,22 +302,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
     }
 }");
-            await applyChangesToWorkspace.ApplyProjectEvaluationAsync(update, isActiveContext: true, CancellationToken.None);
+            await applyChangesToWorkspace.ApplyProjectEvaluationAsync(update, new ContextState(isActiveEditorContext: true, isActiveConfiguration: true), CancellationToken.None);
 
             Assert.Equal(2, result.version);
             Assert.NotNull(result.description);
-            Assert.True(result.isActiveContext);
+            Assert.True(result.state.IsActiveEditorContext);
+            Assert.True(result.state.IsActiveConfiguration);
             Assert.NotNull(result.logger);
         }
 
         [Fact]
         public async Task ApplyProjectBuildAsync_ParseCommandLineAndCallsHandler()
         {
-            (IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger) result = default;
+            (IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IProjectLogger logger) result = default;
 
-            var handler = ICommandLineHandlerFactory.ImplementHandle((version, added, removed, isActiveContext, logger) =>
+            var handler = ICommandLineHandlerFactory.ImplementHandle((version, added, removed, state, logger) =>
             {
-                result = (version, added, removed, isActiveContext, logger);
+                result = (version, added, removed, state, logger);
             });
 
             var parser = ICommandLineParserServiceFactory.CreateCSharp();
@@ -336,10 +337,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
     }
 }");
-            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, isActiveContext: true, CancellationToken.None);
+            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), CancellationToken.None);
 
             Assert.Equal(2, result.version);
-            Assert.True(result.isActiveContext);
+            Assert.True(result.state.IsActiveEditorContext);
             Assert.NotNull(result.logger);
 
             Assert.Single(result.added!.MetadataReferences.Select(r => r.Reference), "Added.dll");
@@ -351,13 +352,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             var cancellationTokenSource = new CancellationTokenSource();
 
-            var handler1 = IEvaluationHandlerFactory.ImplementHandle("RuleName1", (version, description, isActiveContext, logger) =>
+            var handler1 = IEvaluationHandlerFactory.ImplementHandle("RuleName1", (version, description, state, logger) =>
             {
                 cancellationTokenSource.Cancel();
             });
 
             int callCount = 0;
-            var handler2 = IEvaluationHandlerFactory.ImplementHandle("RuleName2", (version, description, isActiveContext, logger) =>
+            var handler2 = IEvaluationHandlerFactory.ImplementHandle("RuleName2", (version, description, state, logger) =>
             {
                 callCount++;
             });
@@ -381,7 +382,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 }");
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
             {
-                return applyChangesToWorkspace.ApplyProjectEvaluationAsync(update, isActiveContext: true, cancellationTokenSource.Token);
+                return applyChangesToWorkspace.ApplyProjectEvaluationAsync(update, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), cancellationTokenSource.Token);
             });
 
             Assert.True(cancellationTokenSource.IsCancellationRequested);
@@ -393,13 +394,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             var cancellationTokenSource = new CancellationTokenSource();
 
-            var handler1 = ICommandLineHandlerFactory.ImplementHandle((version, added, removed, isActiveContext, logger) =>
+            var handler1 = ICommandLineHandlerFactory.ImplementHandle((version, added, removed, state, logger) =>
             {
                 cancellationTokenSource.Cancel();
             });
 
             int callCount = 0;
-            var handler2 = ICommandLineHandlerFactory.ImplementHandle((version, added, removed, isActiveContext, logger) =>
+            var handler2 = ICommandLineHandlerFactory.ImplementHandle((version, added, removed, state, logger) =>
             {
                 callCount++;
             });
@@ -418,7 +419,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 }");
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
             {
-                return applyChangesToWorkspace.ApplyProjectBuildAsync(update, isActiveContext: true, cancellationTokenSource.Token);
+                return applyChangesToWorkspace.ApplyProjectBuildAsync(update, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), cancellationTokenSource.Token);
             });
 
             Assert.True(cancellationTokenSource.IsCancellationRequested);
@@ -429,7 +430,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         public async Task ApplyProjectEvaluationAsync_IgnoresCommandLineHandlers()
         {
             int callCount = 0;
-            var handler = ICommandLineHandlerFactory.ImplementHandle((version, added, removed, isActiveContext, logger) => { callCount++; });
+            var handler = ICommandLineHandlerFactory.ImplementHandle((version, added, removed, state, logger) => { callCount++; });
 
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler });
 
@@ -448,7 +449,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
     }
 }");
-            await applyChangesToWorkspace.ApplyProjectEvaluationAsync(update, isActiveContext: true, CancellationToken.None);
+            await applyChangesToWorkspace.ApplyProjectEvaluationAsync(update, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), CancellationToken.None);
 
             Assert.Equal(0, callCount);
         }
@@ -457,7 +458,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         public async Task ApplyProjectBuildAsync_IgnoresEvaluationHandlers()
         {
             int callCount = 0;
-            var handler = IEvaluationHandlerFactory.ImplementHandle("RuleName", (version, description, isActiveContext, logger) => { callCount++; });
+            var handler = IEvaluationHandlerFactory.ImplementHandle("RuleName", (version, description, state, logger) => { callCount++; });
 
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler });
 
@@ -476,7 +477,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
     }
 }");
-            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, isActiveContext: true, CancellationToken.None);
+            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), CancellationToken.None);
 
             Assert.Equal(0, callCount);
         }
@@ -501,7 +502,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     }
 }");
 
-            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, isActiveContext: false, CancellationToken.None);
+            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, new ContextState(), CancellationToken.None);
 
             Assert.False(context.LastDesignTimeBuildSucceeded);
         }
@@ -525,7 +526,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     }
 }");
 
-            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, isActiveContext: false, CancellationToken.None);
+            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, new ContextState(true, false), CancellationToken.None);
 
             Assert.True(context.LastDesignTimeBuildSucceeded);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/CommandLineHandlerTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/CommandLineHandlerTestBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>("version", () =>
             {
-                handler.Handle(null!, added, removed, true, logger);
+                handler.Handle(null!, added, removed, new ContextState(), logger);
             });
         }
 
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>("added", () =>
             {
-                handler.Handle(10, null!, removed, true, logger);
+                handler.Handle(10, null!, removed, new ContextState(), logger);
             });
         }
 
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>("removed", () =>
             {
-                handler.Handle(10, added, null!, true, logger);
+                handler.Handle(10, added, null!, new ContextState(), logger);
             });
         }
 
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>("logger", () =>
             {
-                handler.Handle(10, added, removed, true, null!);
+                handler.Handle(10, added, removed, new ContextState(), null!);
             });
         }
 
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                handler.Handle(10, added, removed, true, logger);
+                handler.Handle(10, added, removed, new ContextState(), logger);
             });
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/CompileItemHandler_CommandLineTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/CompileItemHandler_CommandLineTests.cs
@@ -38,14 +38,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"C:\file1.cs", @"C:\file2.cs", @"C:\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
             var empty = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
 
-            handler.Handle(10, added: added, removed: empty, isActiveContext: true, logger: logger);
+            handler.Handle(10, added: added, removed: empty, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), logger: logger);
 
             AssertEx.CollectionLength(sourceFilesPushedToWorkspace, 2);
             Assert.Contains(@"C:\file1.cs", sourceFilesPushedToWorkspace);
             Assert.Contains(@"C:\file2.cs", sourceFilesPushedToWorkspace);
 
             var removed = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"C:\file1.cs", @"C:\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
-            handler.Handle(10, added: empty, removed: removed, isActiveContext: true, logger: logger);
+            handler.Handle(10, added: empty, removed: removed, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), logger: logger);
 
             Assert.Single(sourceFilesPushedToWorkspace);
             Assert.Contains(@"C:\file2.cs", sourceFilesPushedToWorkspace);
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"file1.cs", @"..\ProjectFolder\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
             var removed = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
 
-            handler.Handle(10, added: added, removed: removed, isActiveContext: true, logger: logger);
+            handler.Handle(10, added: added, removed: removed, new ContextState(true, false), logger: logger);
 
             Assert.Single(sourceFilesPushedToWorkspace);
             Assert.Contains(@"C:\ProjectFolder\file1.cs", sourceFilesPushedToWorkspace);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/EvaluationHandlerTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/EvaluationHandlerTestBase.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>("version", () =>
             {
-                handler.Handle(null!, projectChange, true, logger);
+                handler.Handle(null!, projectChange, new ContextState(), logger);
             });
         }
 
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>("projectChange", () =>
             {
-                handler.Handle(10, null!, true, logger);
+                handler.Handle(10, null!, new ContextState(), logger);
             });
         }
 
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>("logger", () =>
             {
-                handler.Handle(10, projectChange, true, null!);
+                handler.Handle(10, projectChange, new ContextState(), null!);
             });
         }
 
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                handler.Handle(10, projectChange, true, logger);
+                handler.Handle(10, projectChange, new ContextState(), logger);
             });
         }
 
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         internal static void Handle(IProjectEvaluationHandler handler, IProjectChangeDescription projectChange)
         {
-            handler.Handle(1, projectChange, false, IProjectLoggerFactory.Create());
+            handler.Handle(1, projectChange, new ContextState(), IProjectLoggerFactory.Create());
         }
 
         internal abstract IProjectEvaluationHandler CreateInstance();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
@@ -28,14 +28,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:C:\Assembly1.dll", @"/reference:C:\Assembly2.dll", @"/reference:C:\Assembly1.dll" }, baseDirectory: projectDir, sdkDirectory: null));
             var empty = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
 
-            handler.Handle(10, added: added, removed: empty, isActiveContext: true, logger: logger);
+            handler.Handle(10, added: added, removed: empty, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), logger: logger);
 
             AssertEx.CollectionLength(referencesPushedToWorkspace, 2);
             Assert.Contains(@"C:\Assembly1.dll", referencesPushedToWorkspace);
             Assert.Contains(@"C:\Assembly2.dll", referencesPushedToWorkspace);
 
             var removed = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:C:\Assembly1.dll", @"/reference:C:\Assembly1.dll" }, baseDirectory: projectDir, sdkDirectory: null));
-            handler.Handle(10, added: empty, removed: removed, isActiveContext: true, logger: logger);
+            handler.Handle(10, added: empty, removed: removed, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), logger: logger);
 
             Assert.Single(referencesPushedToWorkspace);
             Assert.Contains(@"C:\Assembly2.dll", referencesPushedToWorkspace);
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:Assembly1.dll", @"/reference:C:\ProjectFolder\Assembly2.dll", @"/reference:..\ProjectFolder\Assembly3.dll" }, baseDirectory: projectDir, sdkDirectory: null));
             var removed = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
 
-            handler.Handle(10, added: added, removed: removed, isActiveContext: true, logger: logger);
+            handler.Handle(10, added: added, removed: removed, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), logger: logger);
 
             AssertEx.CollectionLength(referencesPushedToWorkspace, 3);
             Assert.Contains(@"C:\ProjectFolder\Assembly1.dll", referencesPushedToWorkspace);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostTests.cs
@@ -131,6 +131,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             workspaceProjectContextProvider ??= IWorkspaceProjectContextProviderFactory.ImplementCreateProjectContextAsync(IWorkspaceProjectContextAccessorFactory.Create());
             applyChangesToWorkspaceContext ??= IApplyChangesToWorkspaceContextFactory.Create();
             IDataProgressTrackerService dataProgressTrackerService = IDataProgressTrackerServiceFactory.Create();
+            IActiveConfiguredProjectProvider activeConfiguredProjectProvider = IActiveConfiguredProjectProviderFactory.Create();
 
             return new WorkspaceProjectContextHost(project,
                                                    threadingService,
@@ -138,6 +139,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                                    projectSubscriptionService,
                                                    workspaceProjectContextProvider,
                                                    activeWorkspaceProjectContextTracker,
+                                                   activeConfiguredProjectProvider,
                                                    ExportFactoryFactory.ImplementCreateValueWithAutoDispose(() => applyChangesToWorkspaceContext),
                                                    dataProgressTrackerService);
         }


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/961596

Roslyn is responsible for applying SubType to Forms, Components and other types. In multi-targeted projects, the same file can have conflicting "sub types":

```
#if NET45
    class MyComponent : Form
#else
    class MyComponent : Component
#endif
```

This results Roslyn pushing "Form" when it encounters scans the first definition and "Component" when it encounters the second definition.
There is no guaranteed order to which one of these get scanned first, so this can result in the same source file having a different sub type every time Roslyn does analysis. Sub Type affects the designer and icon that a type gets, so this results in tree flickering between two different icons.

This was worse before https://github.com/dotnet/project-system/pull/5880 as we'd see the sub type change and go back to Roslyn to add/remove the file, resulting in a constant churn. This longer occurs, but we still have the fighting sub type dance whenver the file content changes.

To fix this, Roslyn will now only scan the the primary context: https://github.com/dotnet/roslyn/pull/44270.

This change plumbs through this property by finding the context that lives in the "active configuration" and passing this through to Roslyn.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6567)