### PR TITLE
Produce telemetry on yellow triangles in the dependency tree

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
@@ -38,7 +38,14 @@ namespace Microsoft.VisualStudio.Telemetry
             var telemetryEvent = new TelemetryEvent(eventName);
             foreach ((string propertyName, object propertyValue) in properties)
             {
-                telemetryEvent.Properties.Add(propertyName, propertyValue);
+                if (propertyValue is ComplexPropertyValue complexProperty)
+                {
+                    telemetryEvent.Properties.Add(propertyName, new TelemetryComplexProperty(complexProperty.Data));
+                }
+                else
+                {
+                    telemetryEvent.Properties.Add(propertyName, propertyValue);
+                }
             }
 
             PostTelemetryEvent(telemetryEvent);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -377,10 +377,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 {
                     dependenciesNode = await viewProvider.BuildTreeAsync(dependenciesNode, snapshot, cancellationToken);
 
-                    if (_treeTelemetryService.IsActive)
-                    {
-                        await _treeTelemetryService.ObserveTreeUpdateCompletedAsync(snapshot.MaximumVisibleDiagnosticLevel != DiagnosticLevel.None);
-                    }
+                    await _treeTelemetryService.ObserveTreeUpdateCompletedAsync(snapshot.MaximumVisibleDiagnosticLevel != DiagnosticLevel.None);
                 }
 
                 return new TreeUpdateResult(dependenciesNode);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -56,8 +56,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             }
         }
 
-        public bool IsActive => _stateByFramework != null;
-
         public void InitializeTargetFrameworkRules(ImmutableArray<TargetFramework> targetFrameworks, IReadOnlyCollection<string> rules)
         {
             if (_stateByFramework == null)
@@ -103,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             }
         }
 
-        public async Task ObserveTreeUpdateCompletedAsync(bool hasUnresolvedDependency)
+        public async ValueTask ObserveTreeUpdateCompletedAsync(bool hasUnresolvedDependency)
         {
             if (_stateByFramework == null)
                 return;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -4,8 +4,10 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot;
 using Microsoft.VisualStudio.Telemetry;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
@@ -22,13 +24,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
     /// </remarks>
     [Export(typeof(IDependencyTreeTelemetryService))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
-    internal sealed class DependencyTreeTelemetryService : IDependencyTreeTelemetryService
+    internal sealed class DependencyTreeTelemetryService : IDependencyTreeTelemetryService, IDisposable
     {
         private const int MaxEventCount = 10;
 
         private readonly UnconfiguredProject _project;
         private readonly ITelemetryService? _telemetryService;
         private readonly ISafeProjectGuidService _safeProjectGuidService;
+        private readonly Stopwatch _projectLoadTime = Stopwatch.StartNew();
         private readonly object _stateUpdateLock = new object();
 
         /// <summary>
@@ -39,6 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
         private string? _projectId;
         private int _eventCount;
+        private DependenciesSnapshot? _dependenciesSnapshot;
 
         [ImportingConstructor]
         public DependencyTreeTelemetryService(
@@ -156,6 +160,78 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                     return _telemetryService.HashValue(_project.FullPath);
                 }
             }
+        }
+
+        public void ObserveSnapshot(DependenciesSnapshot dependenciesSnapshot)
+        {
+            _dependenciesSnapshot = dependenciesSnapshot;
+        }
+
+        public void Dispose()
+        {
+            if (_telemetryService != null && _dependenciesSnapshot != null && _projectId != null)
+            {
+                var data = new Dictionary<string, Dictionary<string, DependencyCount>>();
+                int totalDependencyCount = 0;
+                int unresolvedDependencyCount = 0;
+
+                // Scan the snapshot and tally dependencies
+                foreach ((TargetFramework targetFramework, TargetedDependenciesSnapshot targetedSnapshot) in _dependenciesSnapshot.DependenciesByTargetFramework)
+                {
+                    var countsByType = new Dictionary<string, DependencyCount>();
+
+                    data[targetFramework.ShortName] = countsByType;
+
+                    foreach (IDependency dependency in targetedSnapshot.Dependencies)
+                    {
+                        // Only include visible dependencies in telemetry counts
+                        if (!dependency.Visible)
+                        {
+                            continue;
+                        }
+
+                        if (!countsByType.TryGetValue(dependency.ProviderType, out DependencyCount counts))
+                        {
+                            counts = new DependencyCount();
+                        }
+
+                        countsByType[dependency.ProviderType] = counts.Add(dependency.Resolved);
+
+                        totalDependencyCount++;
+
+                        if (!dependency.Resolved)
+                        {
+                            unresolvedDependencyCount++;
+                        }
+                    }
+                }
+
+                _telemetryService.PostProperties(TelemetryEventName.ProjectUnloadDependencies, new (string, object)[]
+                {
+                    (TelemetryPropertyName.ProjectUnloadProject, _projectId),
+                    (TelemetryPropertyName.ProjectUnloadProjectAgeMillis, _projectLoadTime.ElapsedMilliseconds),
+                    (TelemetryPropertyName.ProjectUnloadTotalDependencyCount, totalDependencyCount),
+                    (TelemetryPropertyName.ProjectUnloadUnresolvedDependencyCount, unresolvedDependencyCount),
+                    (TelemetryPropertyName.ProjectUnloadTargetFrameworkCount, _dependenciesSnapshot.DependenciesByTargetFramework.Count),
+                    (TelemetryPropertyName.ProjectUnloadDependencyBreakdown, new ComplexPropertyValue(data))
+                });
+            }
+        }
+
+        private readonly struct DependencyCount
+        {
+            public int TotalCount { get; } 
+            public int UnresolvedCount { get; }
+
+            public DependencyCount(int totalCount, int unresolvedCount)
+            {
+                TotalCount = totalCount;
+                UnresolvedCount = unresolvedCount;
+            }
+
+            public DependencyCount Add(bool isResolved) => new DependencyCount(
+                TotalCount + 1,
+                isResolved ? UnresolvedCount : UnresolvedCount + 1);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -208,7 +208,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
                 _telemetryService.PostProperties(TelemetryEventName.ProjectUnloadDependencies, new (string, object)[]
                 {
-                    (TelemetryPropertyName.ProjectUnloadProject, _projectId),
+                    (TelemetryPropertyName.ProjectUnloadDependenciesProject, _projectId),
                     (TelemetryPropertyName.ProjectUnloadProjectAgeMillis, _projectLoadTime.ElapsedMilliseconds),
                     (TelemetryPropertyName.ProjectUnloadTotalDependencyCount, totalDependencyCount),
                     (TelemetryPropertyName.ProjectUnloadUnresolvedDependencyCount, unresolvedDependencyCount),

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -106,6 +106,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             if (_stateByFramework == null)
                 return;
 
+            Assumes.NotNull(_telemetryService);
+
             bool observedAllRules;
             lock (_stateUpdateLock)
             {
@@ -124,7 +126,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
             if (hasUnresolvedDependency)
             {
-                _telemetryService!.PostProperties(TelemetryEventName.TreeUpdatedUnresolved, new[]
+                _telemetryService.PostProperties(TelemetryEventName.TreeUpdatedUnresolved, new[]
                 {
                     (TelemetryPropertyName.TreeUpdatedUnresolvedProject, (object)_projectId),
                     (TelemetryPropertyName.TreeUpdatedUnresolvedObservedAllRules, observedAllRules)
@@ -132,7 +134,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             }
             else
             {
-                _telemetryService!.PostProperties(TelemetryEventName.TreeUpdatedResolved, new[]
+                _telemetryService.PostProperties(TelemetryEventName.TreeUpdatedResolved, new[]
                 {
                     (TelemetryPropertyName.TreeUpdatedResolvedProject, (object)_projectId),
                     (TelemetryPropertyName.TreeUpdatedResolvedObservedAllRules, observedAllRules)
@@ -151,7 +153,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 }
                 else
                 {
-                    return _telemetryService!.HashValue(_project.FullPath);
+                    return _telemetryService.HashValue(_project.FullPath);
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/IDependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/IDependencyTreeTelemetryService.cs
@@ -14,13 +14,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
     internal interface IDependencyTreeTelemetryService
     {
         /// <summary>
-        /// Gets a value indicating whether this telemetry service is active.
-        /// If not, then it will remain inactive and no methods need be called on it.
-        /// Note that an instance may become inactive during its lifetime.
-        /// </summary>
-        bool IsActive { get; }
-
-        /// <summary>
         /// Initialize telemetry state with the set of target frameworks and rules we expect to observe.
         /// </summary>
         void InitializeTargetFrameworkRules(ImmutableArray<TargetFramework> targetFrameworks, IReadOnlyCollection<string> rules);
@@ -36,6 +29,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
         /// Fire telemetry when dependency tree completes an update
         /// </summary>
         /// <param name="hasUnresolvedDependency">indicates if the snapshot used for the update had any unresolved dependencies</param>
-        Task ObserveTreeUpdateCompletedAsync(bool hasUnresolvedDependency);
+        ValueTask ObserveTreeUpdateCompletedAsync(bool hasUnresolvedDependency);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/IDependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/IDependencyTreeTelemetryService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 {
@@ -30,5 +31,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
         /// </summary>
         /// <param name="hasUnresolvedDependency">indicates if the snapshot used for the update had any unresolved dependencies</param>
         ValueTask ObserveTreeUpdateCompletedAsync(bool hasUnresolvedDependency);
+
+        /// <summary>
+        /// Provides an updated dependency snapshot so that telemetry may be reported about the
+        /// state of the project's dependencies.
+        /// </summary>
+        /// <param name="dependenciesSnapshot">The dependency snapshot.</param>
+        void ObserveSnapshot(DependenciesSnapshot dependenciesSnapshot);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ComplexPropertyValue.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ComplexPropertyValue.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.Telemetry
+{
+    /// <summary>
+    ///     Wrapper for complex (non-scalar) property values being reported
+    ///     via <see cref="ITelemetryService"/>.
+    /// </summary>
+    internal readonly struct ComplexPropertyValue
+    {
+        public object Data { get; }
+
+        public ComplexPropertyValue(object data)
+        {
+            Data = data;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryEventName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryEventName.cs
@@ -38,17 +38,17 @@ namespace Microsoft.VisualStudio.Telemetry
         public static readonly string DesignTimeBuildComplete = BuildEventName("DesignTimeBuildComplete");
 
         /// <summary>
-        ///     Indicates that .NET Core SDK version.
+        ///     Indicates the .NET Core SDK version.
         /// </summary>
         public static readonly string SDKVersion = BuildEventName("SDKVersion");
 
         /// <summary>
-        ///     Indicates that the TempPE compilation queue has been processed
+        ///     Indicates that the TempPE compilation queue has been processed.
         /// </summary>
         public static readonly string TempPEProcessQueue = BuildEventName("TempPE/ProcessCompileQueue");
 
         /// <summary>
-        ///     Indicates that the TempPE compilation has occurred on demand from a designer
+        ///     Indicates that the TempPE compilation has occurred on demand from a designer.
         /// </summary>
         public static readonly string TempPECompileOnDemand = BuildEventName("TempPE/CompileOnDemand");
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryEventName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryEventName.cs
@@ -52,6 +52,11 @@ namespace Microsoft.VisualStudio.Telemetry
         /// </summary>
         public static readonly string TempPECompileOnDemand = BuildEventName("TempPE/CompileOnDemand");
 
+        /// <summary>
+        ///     Indicates that the summary of a project's dependencies is being reported during project unload.
+        /// </summary>
+        public static readonly string ProjectUnloadDependencies = BuildEventName("ProjectUnload/Dependencies");
+
         private static string BuildEventName(string eventName)
         {
             return Prefix + "/" + eventName.ToLowerInvariant();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
@@ -28,6 +28,42 @@ namespace Microsoft.VisualStudio.Telemetry
         public static readonly string TreeUpdatedUnresolvedProject = BuildPropertyName(TelemetryEventName.TreeUpdatedUnresolved, "Project");
 
         /// <summary>
+        ///     Identifies the project to which data in the telemetry event applies.
+        /// </summary>
+        public static readonly string ProjectUnloadProject = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "Project");
+
+        /// <summary>
+        ///     Identifies the time between project load and unload, in milliseconds.
+        /// </summary>
+        public static readonly string ProjectUnloadProjectAgeMillis = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "ProjectAgeMillis");
+
+        /// <summary>
+        ///     Identifies the total number of visible dependencies in the project.
+        ///     If a project multi-targets (i.e. <see cref="ProjectUnloadTargetFrameworkCount"/> is greater than one) then the count of dependencies
+        ///     in each target is summed together to produce this single value. If a breakdown is required, <see cref="ProjectUnloadDependencyBreakdown"/>
+        ///     may be used.
+        /// </summary>
+        public static readonly string ProjectUnloadTotalDependencyCount = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "TotalDependencyCount");
+
+        /// <summary>
+        ///     Identifies the total number of visible unresolved dependencies in the project.
+        ///     If a project multi-targets (i.e. <see cref="ProjectUnloadTargetFrameworkCount"/> is greater than one) then the count of unresolved dependencies
+        ///     in each target is summed together to produce this single value. If a breakdown is required, <see cref="ProjectUnloadDependencyBreakdown"/>
+        ///     may be used.
+        /// </summary>
+        public static readonly string ProjectUnloadUnresolvedDependencyCount = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "UnresolvedDependencyCount");
+
+        /// <summary>
+        ///     Identifies the number of frameworks this project targets.
+        /// </summary>
+        public static readonly string ProjectUnloadTargetFrameworkCount = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "TargetFrameworkCount");
+
+        /// <summary>
+        ///     Contains structured data describing the number of total/unresolved dependencies broken down by target framework and dependency type.
+        /// </summary>
+        public static readonly string ProjectUnloadDependencyBreakdown = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "DependencyBreakdown");
+
+        /// <summary>
         ///     Indicates whether seen all rules initialized when the dependency tree is updated with all resolved dependencies.
         /// </summary>
         public static readonly string TreeUpdatedResolvedObservedAllRules = BuildPropertyName(TelemetryEventName.TreeUpdatedResolved, "ObservedAllRules");

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.Telemetry
         /// <summary>
         ///     Identifies the project to which data in the telemetry event applies.
         /// </summary>
-        public static readonly string ProjectUnloadProject = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "Project");
+        public static readonly string ProjectUnloadDependenciesProject = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "Project");
 
         /// <summary>
         ///     Identifies the time between project load and unload, in milliseconds.


### PR DESCRIPTION
Fixes #6575.

On project unload, publish a telemetry event with data about a project's dependencies.

A sample event:

| Field | Value |
|---|---|
| vs.projectsystem.managed.projectunload.dependencies.dependencybreakdown | `{"netcoreapp3.1":{"Framework":{"TotalCount":1,"UnresolvedCount":0},"Package":{"TotalCount":1,"UnresolvedCount":0}},"net48":{"Assembly":{"TotalCount":9,"UnresolvedCount":0},"Package":{"TotalCount":1,"UnresolvedCount":0}}}` |
| vs.projectsystem.managed.projectunload.dependencies.project | 0c63db02-c6b6-465e-a104-4af7bd775739 |
| vs.projectsystem.managed.projectunload.dependencies.projectagemillis | 35636 |
| vs.projectsystem.managed.projectunload.dependencies.targetframeworkcount | 2 |
| vs.projectsystem.managed.projectunload.dependencies.totaldependencycount | 12 |
| vs.projectsystem.managed.projectunload.dependencies.unresolveddependencycount | 0 |

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6593)