### PR TITLE
Fix potential ProjectInstance leak

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -109,6 +109,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
             IProjectSubscriptionUpdate projectUpdate = e.Item1;
             IProjectCatalogSnapshot catalogSnapshot = e.Item2;
 
+            // Broken design-time builds can produce updates containing no rule data.
+            // Later code assumes that the requested rules are available.
+            // If we see no rule data, return now.
+            if (projectUpdate.ProjectChanges.Count == 0)
+            {
+                return;
+            }
+
             // Create an object to track dependency changes.
             var changesBuilder = new DependenciesChangesBuilder();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -109,19 +109,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
             IProjectSubscriptionUpdate projectUpdate = e.Item1;
             IProjectCatalogSnapshot catalogSnapshot = e.Item2;
 
-            // Broken design time builds sometimes cause updates with no project changes and sometimes
-            // cause updates with a project change that has no difference.
-            // We handle the former case here, and the latter case is handled in the CommandLineItemHandler.
-            if (projectUpdate.ProjectChanges.Count == 0)
-            {
-                return;
-            }
-
-            if (!projectUpdate.ProjectChanges.Any(x => x.Value.Difference.AnyChanges))
-            {
-                return;
-            }
-
             // Create an object to track dependency changes.
             var changesBuilder = new DependenciesChangesBuilder();
 


### PR DESCRIPTION
Fixes #5836.

Removes a guard that attempts to return early from processing on data changes. The condition here only considered one kind of change, which may result it downstream code retaining objects from earlier updates, such as a `ProjectInstance` via `IProjectCatalogSnapshot`.

Downstream code will handle the no-op case correctly anyway, so removing this guard here does not introduce considerably more work for the tree.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6606)