### PR TITLE
Implement property page support for Project Query API

### DIFF
--- a/build/import/HostAgnostic.props
+++ b/build/import/HostAgnostic.props
@@ -26,6 +26,7 @@
     
     <!-- CPS -->
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Query" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Analyzers" />

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -97,9 +97,9 @@
     <PackageReference Include="VSSDK.TemplateWizardInterface"                                         Version="12.0.4"                          ExcludeAssets="All" />
 
     <!-- CPS -->
-    <!-- Analyzers have a different version due to https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/266100 -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.8.145-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.7.232-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.8.338-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.8.338-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="16.8.338-pre" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="3.8.0-2.20402.1" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryByIdDataProducer.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles retrieving an <see cref="ProjectSystem.Query.ProjectModel.ICategory"/> based on an ID.
+    /// </summary>
+    internal class CategoryByIdDataProducer : CategoryDataProducer, IQueryDataProducer<IReadOnlyCollection<EntityIdentity>, IEntityValue>
+    {
+        private readonly IProjectService2 _projectService;
+
+        public CategoryByIdDataProducer(ICategoryPropertiesAvailableStatus properties, IProjectService2 projectService)
+            : base(properties)
+        {
+            Requires.NotNull(projectService, nameof(projectService));
+            _projectService = projectService;
+        }
+
+        public async Task SendRequestAsync(QueryProcessRequest<IReadOnlyCollection<EntityIdentity>> request)
+        {
+            Requires.NotNull(request, nameof(request));
+
+            foreach (var requestId in request.RequestData)
+            {
+                if (requestId.KeysCount == 3
+                    && requestId.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string path)
+                    && requestId.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName)
+                    && requestId.TryGetValue(ProjectModelIdentityKeys.CategoryName, out string categoryName))
+                {
+                    try
+                    {
+                        if (_projectService.GetLoadedProject(path) is UnconfiguredProject project
+                            && await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
+                            && projectCatalog.GetSchema(propertyPageName) is Rule rule)
+                        {
+                            // We need the category's index in order to populate the "Order" field of the query model.
+                            // This requires that we do a linear traversal of the categories, even though we only care
+                            // about one.
+                            //
+                            // TODO: if the "Order" property hasn't been requested, we can skip the linear traversal in
+                            // favor of just looking it up by name.
+                            foreach ((var index, var category) in rule.EvaluatedCategories.WithIndices())
+                            {
+                                if (StringComparers.CategoryNames.Equals(category.Name, categoryName))
+                                {
+                                    IEntityValue categoryValue = CreateCategoryValue(request.QueryExecutionContext.EntityRuntime, requestId, category, index);
+                                    await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(categoryValue, request, ProjectModelZones.Cps));
+                                }
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        request.QueryExecutionContext.ReportError(ex);
+                    }
+                }
+            }
+
+            await ResultReceiver.OnRequestProcessFinishedAsync(request);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducer.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles the creation of <see cref="ICategory"/> instances and populating the requested members.
+    /// </summary>
+    internal abstract class CategoryDataProducer : QueryDataProducerBase<IEntityValue>
+    {
+        public CategoryDataProducer(ICategoryPropertiesAvailableStatus properties)
+        {
+            Requires.NotNull(properties, nameof(properties));
+            Properties = properties;
+        }
+
+        protected ICategoryPropertiesAvailableStatus Properties { get; }
+
+        protected IEntityValue CreateCategoryValue(IEntityValue entity, Category category, int order)
+        {
+            Requires.NotNull(entity, nameof(entity));
+            Requires.NotNull(category, nameof(category));
+
+            var identity = new EntityIdentity(
+                ((IEntityWithId)entity).Id,
+                new KeyValuePair<string, string>[]
+                {
+                    new(ProjectModelIdentityKeys.CategoryName, category.Name)
+                });
+
+            return CreateCategoryValue(entity.EntityRuntime, identity, category, order);
+        }
+
+        protected IEntityValue CreateCategoryValue(IEntityRuntimeModel runtimeModel, EntityIdentity id, Category category, int order)
+        {
+            Requires.NotNull(category, nameof(category));
+            var newCategory = new CategoryValue(runtimeModel, id, new CategoryPropertiesAvailableStatus());
+
+            if (Properties.DisplayName)
+            {
+                newCategory.DisplayName = category.DisplayName;
+            }
+
+            if (Properties.Name)
+            {
+                newCategory.Name = category.Name;
+            }
+
+            if (Properties.Order)
+            {
+                newCategory.Order = order;
+            }
+
+            ((IEntityValueFromProvider)newCategory).ProviderState = category;
+
+            return newCategory;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducer.cs
@@ -1,59 +1,53 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
-using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {
     /// <summary>
-    /// Handles the creation of <see cref="ICategory"/> instances and populating the requested members.
+    /// Handles the creation of <see cref="ProjectSystem.Query.ProjectModel.ICategory"/> instances and populating the requested members.
     /// </summary>
-    internal abstract class CategoryDataProducer : QueryDataProducerBase<IEntityValue>
+    internal static class CategoryDataProducer
     {
-        protected CategoryDataProducer(ICategoryPropertiesAvailableStatus properties)
+        public static IEntityValue CreateCategoryValue(IEntityValue parent, Category category, int order, ICategoryPropertiesAvailableStatus requestedProperties)
         {
-            Requires.NotNull(properties, nameof(properties));
-            Properties = properties;
-        }
-
-        protected ICategoryPropertiesAvailableStatus Properties { get; }
-
-        protected IEntityValue CreateCategoryValue(IEntityValue entity, Category category, int order)
-        {
-            Requires.NotNull(entity, nameof(entity));
+            Requires.NotNull(parent, nameof(parent));
             Requires.NotNull(category, nameof(category));
 
             var identity = new EntityIdentity(
-                ((IEntityWithId)entity).Id,
+                ((IEntityWithId)parent).Id,
                 new KeyValuePair<string, string>[]
                 {
                     new(ProjectModelIdentityKeys.CategoryName, category.Name)
                 });
 
-            return CreateCategoryValue(entity.EntityRuntime, identity, category, order);
+            return CreateCategoryValue(parent.EntityRuntime, identity, category, order, requestedProperties);
         }
 
-        protected IEntityValue CreateCategoryValue(IEntityRuntimeModel runtimeModel, EntityIdentity id, Category category, int order)
+        public static IEntityValue CreateCategoryValue(IEntityRuntimeModel runtimeModel, EntityIdentity id, Category category, int order, ICategoryPropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(category, nameof(category));
             var newCategory = new CategoryValue(runtimeModel, id, new CategoryPropertiesAvailableStatus());
 
-            if (Properties.DisplayName)
+            if (requestedProperties.DisplayName)
             {
                 newCategory.DisplayName = category.DisplayName;
             }
 
-            if (Properties.Name)
+            if (requestedProperties.Name)
             {
                 newCategory.Name = category.Name;
             }
 
-            if (Properties.Order)
+            if (requestedProperties.Order)
             {
                 newCategory.Order = order;
             }
@@ -61,6 +55,47 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             ((IEntityValueFromProvider)newCategory).ProviderState = category;
 
             return newCategory;
+        }
+
+        public static IEnumerable<IEntityValue> CreateCategoryValues(IEntityValue parent, Rule rule, ICategoryPropertiesAvailableStatus requestedProperties)
+        {
+            foreach ((int index, Category category) in rule.EvaluatedCategories.WithIndices())
+            {
+                IEntityValue categoryValue = CreateCategoryValue(parent, category, index, requestedProperties);
+                yield return categoryValue;
+            }
+        }
+
+        public static async Task<IEntityValue?> CreateCategoryValueAsync(
+            IEntityRuntimeModel runtimeModel,
+            EntityIdentity id,
+            IProjectService2 projectService,
+            string projectPath,
+            string propertyPageName,
+            string categoryName,
+            ICategoryPropertiesAvailableStatus requestedProperties)
+        {
+            if (projectService.GetLoadedProject(projectPath) is UnconfiguredProject project
+                && await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
+                && projectCatalog.GetSchema(propertyPageName) is Rule rule)
+            {
+                // We need the category's index in order to populate the "Order" field of the query model.
+                // This requires that we do a linear traversal of the categories, even though we only care
+                // about one.
+                //
+                // TODO: if the "Order" property hasn't been requested, we can skip the linear traversal in
+                // favor of just looking it up by name.
+                foreach ((int index, Category category) in rule.EvaluatedCategories.WithIndices())
+                {
+                    if (StringComparers.CategoryNames.Equals(category.Name, categoryName))
+                    {
+                        IEntityValue categoryValue = CreateCategoryValue(runtimeModel, id, category, index, requestedProperties);
+                        return categoryValue;
+                    }
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducer.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal abstract class CategoryDataProducer : QueryDataProducerBase<IEntityValue>
     {
-        public CategoryDataProducer(ICategoryPropertiesAvailableStatus properties)
+        protected CategoryDataProducer(ICategoryPropertiesAvailableStatus properties)
         {
             Requires.NotNull(properties, nameof(properties));
             Properties = properties;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     [QueryDataProviderZone(ProjectModelZones.Cps)]
     [Export(typeof(IQueryByIdDataProvider))]
     [Export(typeof(IQueryByRelationshipDataProvider))]
-    internal partial class CategoryDataProvider : QueryDataProviderBase, IQueryByIdDataProvider, IQueryByRelationshipDataProvider
+    internal class CategoryDataProvider : QueryDataProviderBase, IQueryByIdDataProvider, IQueryByRelationshipDataProvider
     {
         [ImportingConstructor]
         public CategoryDataProvider(IProjectServiceAccessor projectServiceAccessor)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProvider.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Metadata;
+using Microsoft.VisualStudio.ProjectSystem.Query.Providers;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Creates <see cref="IQueryDataProducer{TRequest, TResult}"/> instances that retrieve category information (<see
+    /// cref="ICategory"/>).
+    /// </summary>
+    /// <remarks>
+    /// Responsible for populating <see cref="IPropertyPage.Categories"/>. Can also retrieve a <see cref="ICategory"/>
+    /// based on its ID.
+    /// </remarks>
+    [QueryDataProvider(CategoryType.TypeName, ProjectModel.ModelName)]
+    [RelationshipQueryDataProvider(PropertyPageType.TypeName, PropertyPageType.CategoriesPropertyName)]
+    [QueryDataProviderZone(ProjectModelZones.Cps)]
+    [Export(typeof(IQueryByIdDataProvider))]
+    [Export(typeof(IQueryByRelationshipDataProvider))]
+    internal partial class CategoryDataProvider : QueryDataProviderBase, IQueryByIdDataProvider, IQueryByRelationshipDataProvider
+    {
+        [ImportingConstructor]
+        public CategoryDataProvider(IProjectServiceAccessor projectServiceAccessor)
+            : base(projectServiceAccessor)
+        {
+        }
+
+        public IQueryDataProducer<IReadOnlyCollection<EntityIdentity>, IEntityValue> CreateQueryDataSource(IPropertiesAvailableStatus properties)
+        {
+            return new CategoryByIdDataProducer((ICategoryPropertiesAvailableStatus)properties, ProjectService);
+        }
+
+        IQueryDataProducer<IEntityValue, IEntityValue> IQueryByRelationshipDataProvider.CreateQueryDataSource(IPropertiesAvailableStatus properties)
+        {
+            return new CategoryFromPropertyPageDataProducer((ICategoryPropertiesAvailableStatus)properties);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryFromPropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryFromPropertyPageDataProducer.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles retrieving a set of <see cref="ICategory"/>s from an <see cref="IPropertyPage"/>.
+    /// </summary>
+    internal class CategoryFromPropertyPageDataProducer : CategoryDataProducer, IQueryDataProducer<IEntityValue, IEntityValue>
+    {
+        public CategoryFromPropertyPageDataProducer(ICategoryPropertiesAvailableStatus properties)
+            : base(properties)
+        {
+        }
+
+        public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
+        {
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (PropertyPageQueryCache context, Rule rule))
+            {
+                try
+                {
+                    foreach ((var index, var category) in rule.EvaluatedCategories.WithIndices())
+                    {
+                        IEntityValue categoryValue = CreateCategoryValue(request.RequestData, category, index);
+                        await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(categoryValue, request, ProjectModelZones.Cps));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    request.QueryExecutionContext.ReportError(ex);
+                }
+            }
+
+            await ResultReceiver.OnRequestProcessFinishedAsync(request);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryFromPropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryFromPropertyPageDataProducer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
         {
-            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (PropertyPageQueryCache context, Rule rule))
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (IPropertyPageQueryCache context, Rule rule))
             {
                 try
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducer.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal abstract class ConfigurationDimensionDataProducer : QueryDataProducerBase<IEntityValue>
     {
-        public ConfigurationDimensionDataProducer(IConfigurationDimensionPropertiesAvailableStatus properties)
+        protected ConfigurationDimensionDataProducer(IConfigurationDimensionPropertiesAvailableStatus properties)
         {
             Requires.NotNull(properties, nameof(properties));
             Properties = properties;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducer.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
-using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {
@@ -12,31 +11,35 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// Handles the creation of <see cref="IConfigurationDimension"/> instances and populating the requested
     /// members.
     /// </summary>
-    internal abstract class ConfigurationDimensionDataProducer : QueryDataProducerBase<IEntityValue>
+    internal static class ConfigurationDimensionDataProducer
     {
-        protected ConfigurationDimensionDataProducer(IConfigurationDimensionPropertiesAvailableStatus properties)
-        {
-            Requires.NotNull(properties, nameof(properties));
-            Properties = properties;
-        }
-
-        protected IConfigurationDimensionPropertiesAvailableStatus Properties { get; }
-
-        protected IEntityValue CreateProjectConfigurationDimension(IEntityRuntimeModel runtimeModel, KeyValuePair<string, string> projectConfigurationDimension)
+        public static IEntityValue CreateProjectConfigurationDimension(
+            IEntityRuntimeModel runtimeModel,
+            KeyValuePair<string, string> projectConfigurationDimension,
+            IConfigurationDimensionPropertiesAvailableStatus requestedProperties)
         {
             var newProjectConfigurationDimension = new ConfigurationDimensionValue(runtimeModel, new ConfigurationDimensionPropertiesAvailableStatus());
 
-            if (Properties.Name)
+            if (requestedProperties.Name)
             {
                 newProjectConfigurationDimension.Name = projectConfigurationDimension.Key;
             }
 
-            if (Properties.Value)
+            if (requestedProperties.Value)
             {
                 newProjectConfigurationDimension.Value = projectConfigurationDimension.Value;
             }
 
             return newProjectConfigurationDimension;
+        }
+
+        public static IEnumerable<IEntityValue> CreateProjectConfigurationDimensions(IEntityRuntimeModel runtimeModel, ProjectConfiguration configuration, IConfigurationDimensionPropertiesAvailableStatus requestedProperties)
+        {
+            foreach (KeyValuePair<string, string> dimension in configuration.Dimensions)
+            {
+                IEntityValue projectConfigurationDimension = CreateProjectConfigurationDimension(runtimeModel, dimension, requestedProperties);
+                yield return projectConfigurationDimension;
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducer.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles the creation of <see cref="IConfigurationDimension"/> instances and populating the requested
+    /// members.
+    /// </summary>
+    internal abstract class ConfigurationDimensionDataProducer : QueryDataProducerBase<IEntityValue>
+    {
+        public ConfigurationDimensionDataProducer(IConfigurationDimensionPropertiesAvailableStatus properties)
+        {
+            Requires.NotNull(properties, nameof(properties));
+            Properties = properties;
+        }
+
+        protected IConfigurationDimensionPropertiesAvailableStatus Properties { get; }
+
+        protected IEntityValue CreateProjectConfigurationDimension(IEntityRuntimeModel runtimeModel, KeyValuePair<string, string> projectConfigurationDimension)
+        {
+            var newProjectConfigurationDimension = new ConfigurationDimensionValue(runtimeModel, new ConfigurationDimensionPropertiesAvailableStatus());
+
+            if (Properties.Name)
+            {
+                newProjectConfigurationDimension.Name = projectConfigurationDimension.Key;
+            }
+
+            if (Properties.Value)
+            {
+                newProjectConfigurationDimension.Value = projectConfigurationDimension.Value;
+            }
+
+            return newProjectConfigurationDimension;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProvider.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     [RelationshipQueryDataProvider(UIPropertyValueType.TypeName, UIPropertyValueType.ConfigurationDimensionsPropertyName)]
     [QueryDataProviderZone(ProjectModelZones.Cps)]
     [Export(typeof(IQueryByRelationshipDataProvider))]
-    internal partial class ConfigurationDimensionDataProvider : IQueryByRelationshipDataProvider
+    internal class ConfigurationDimensionDataProvider : IQueryByRelationshipDataProvider
     {
         IQueryDataProducer<IEntityValue, IEntityValue> IQueryByRelationshipDataProvider.CreateQueryDataSource(IPropertiesAvailableStatus properties)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProvider.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Metadata;
+using Microsoft.VisualStudio.ProjectSystem.Query.Providers;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Creates <see cref="IQueryDataProducer{TRequest, TResult}"/> instances that retrieve configuration dimension
+    /// information (<see cref="IConfigurationDimension"/>).
+    /// </summary>
+    /// <remarks>
+    /// Responsible for populating <see cref="IUIPropertyValue.ConfigurationDimensions"/>. See <see
+    /// cref="ConfigurationDimensionDataProducer"/> and <see cref="ConfigurationDimensionFromPropertyDataProducer"/> for
+    /// the important logic.
+    /// </remarks>
+    [QueryDataProvider(ConfigurationDimensionType.TypeName, ProjectModel.ModelName)]
+    [RelationshipQueryDataProvider(UIPropertyValueType.TypeName, UIPropertyValueType.ConfigurationDimensionsPropertyName)]
+    [QueryDataProviderZone(ProjectModelZones.Cps)]
+    [Export(typeof(IQueryByRelationshipDataProvider))]
+    internal partial class ConfigurationDimensionDataProvider : IQueryByRelationshipDataProvider
+    {
+        IQueryDataProducer<IEntityValue, IEntityValue> IQueryByRelationshipDataProvider.CreateQueryDataSource(IPropertiesAvailableStatus properties)
+        {
+            return new ConfigurationDimensionFromPropertyDataProducer((IConfigurationDimensionPropertiesAvailableStatus)properties);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionFromPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionFromPropertyDataProducer.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles retrieving a set of <see cref="IConfigurationDimension"/>s from an <see cref="ProjectSystem.Properties.IProperty"/>.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="ProjectSystem.Properties.IProperty"/> comes from the parent <see cref="IUIPropertyValue"/>
+    /// </remarks>
+    internal class ConfigurationDimensionFromPropertyDataProducer : ConfigurationDimensionDataProducer, IQueryDataProducer<IEntityValue, IEntityValue>
+    {
+        public ConfigurationDimensionFromPropertyDataProducer(IConfigurationDimensionPropertiesAvailableStatus properties)
+            : base(properties)
+        {
+        }
+
+        public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
+        {
+            Requires.NotNull(request, nameof(request));
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property))
+            {
+                try
+                {
+                    foreach (KeyValuePair<string, string> dimension in configuration.Dimensions)
+                    {
+                        IEntityValue ProjectConfigurationDimension = CreateProjectConfigurationDimension(request.RequestData.EntityRuntime, dimension);
+                        await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(ProjectConfigurationDimension, request, ProjectModelZones.Cps));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    request.QueryExecutionContext.ReportError(ex);
+                }
+            }
+
+            await ResultReceiver.OnRequestProcessFinishedAsync(request);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionFromPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionFromPropertyDataProducer.cs
@@ -17,11 +17,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// <remarks>
     /// The <see cref="ProjectSystem.Properties.IProperty"/> comes from the parent <see cref="IUIPropertyValue"/>
     /// </remarks>
-    internal class ConfigurationDimensionFromPropertyDataProducer : ConfigurationDimensionDataProducer, IQueryDataProducer<IEntityValue, IEntityValue>
+    internal class ConfigurationDimensionFromPropertyDataProducer : QueryDataProducerBase<IEntityValue>, IQueryDataProducer<IEntityValue, IEntityValue>
     {
+        private readonly IConfigurationDimensionPropertiesAvailableStatus _properties;
+
         public ConfigurationDimensionFromPropertyDataProducer(IConfigurationDimensionPropertiesAvailableStatus properties)
-            : base(properties)
         {
+            _properties = properties;
         }
 
         public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
@@ -31,10 +33,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             {
                 try
                 {
-                    foreach (KeyValuePair<string, string> dimension in configuration.Dimensions)
+                    foreach (IEntityValue dimension in ConfigurationDimensionDataProducer.CreateProjectConfigurationDimensions(request.QueryExecutionContext.EntityRuntime, configuration, _properties))
                     {
-                        IEntityValue ProjectConfigurationDimension = CreateProjectConfigurationDimension(request.RequestData.EntityRuntime, dimension);
-                        await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(ProjectConfigurationDimension, request, ProjectModelZones.Cps));
+                        await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(dimension, request, ProjectModelZones.Cps));
                     }
                 }
                 catch (Exception ex)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/IPropertyPageQueryCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/IPropertyPageQueryCache.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Caches data that we expect to access frequently while processing queries for property page information.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This interface exists in order to simplify unit tests of the data produers.
+    /// </para>
+    /// <para>
+    /// The expectation is that at most one instance of this type will be created per query, and that instance will be
+    /// passed from one provider to the next as part of <see cref="IEntityValueFromProvider.ProviderState"/>. This
+    /// allows us to maximize the use of the cache within a query, but we are also guaranteed that the cache will not be
+    /// held past the end of the query.
+    /// </para>
+    /// <para>
+    /// As an example, consider what needs to occur when we want to retrieve the set of <see cref="IUIPropertyValue"/>s
+    /// for a <see cref="IUIProperty"/>:
+    /// <list type="bullet">
+    /// <item>Retrieve the set of known configurations from the <see cref="UnconfiguredProject"/>.</item>
+    /// <item>For each configuration, get the property page catalog.</item>
+    /// <item>Retrieve the <see cref="IRule"/> for the property page from the catalog.</item>
+    /// <item>Find the property within the <see cref="IRule"/>.</item>
+    /// <item>Retrieve the property value.</item>
+    /// </list>
+    /// The <see cref="UIPropertyValueDataProvider"/> produces <see cref="IUIPropertyValue"/>s one at a time, and needs
+    /// to do these steps for each one. Given that a query will likely retrieve values for multiple properties on
+    /// multiple pages across multiple configurations, introducing caching at key levels in the process can
+    /// significantly reduce the amount of work we need to do.
+    /// </para>
+    /// </remarks>
+    internal interface IPropertyPageQueryCache
+    {
+        Task<IRule?> BindToRule(ProjectConfiguration projectConfiguration, string schemaName);
+        Task<IImmutableSet<ProjectConfiguration>?> GetKnownConfigurationsAsync();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageByIdDataProducer.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles retrieving an <see cref="IPropertyPage"/> based on an ID.
+    /// </summary>
+    internal class PropertyPageByIdDataProducer : PropertyPageDataProducer, IQueryDataProducer<IReadOnlyCollection<EntityIdentity>, IEntityValue>
+    {
+        private readonly IProjectService2 _projectService;
+
+        public PropertyPageByIdDataProducer(IPropertyPagePropertiesAvailableStatus properties, IProjectService2 projectService)
+            : base(properties)
+        {
+            Requires.NotNull(projectService, nameof(projectService));
+            _projectService = projectService;
+        }
+
+        public async Task SendRequestAsync(QueryProcessRequest<IReadOnlyCollection<EntityIdentity>> request)
+        {
+            Requires.NotNull(request, nameof(request));
+
+            foreach (var requestId in request.RequestData)
+            {
+                if (requestId.KeysCount == 2
+                    && requestId.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string path)
+                    && requestId.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName))
+                {
+                    try
+                    {
+                        if (_projectService.GetLoadedProject(path) is UnconfiguredProject project
+                            && await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
+                            && projectCatalog.GetSchema(propertyPageName) is Rule rule
+                            && !rule.PropertyPagesHidden)
+                        {
+                            var propertyPageQueryContext = new PropertyPageQueryCache(project);
+                            IEntityValue propertyPageValue = await CreatePropertyPageValueAsync(request.QueryExecutionContext.EntityRuntime, requestId, propertyPageQueryContext, rule);
+                            await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(propertyPageValue, request, ProjectModelZones.Cps));
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        request.QueryExecutionContext.ReportError(ex);
+                    }
+                }
+            }
+
+            await ResultReceiver.OnRequestProcessFinishedAsync(request);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
@@ -17,22 +17,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal static class PropertyPageDataProducer
     {
-        public static IEntityValue CreatePropertyPageValue(IEntityValue entity, IPropertyPageQueryCache context, Rule rule, IPropertyPagePropertiesAvailableStatus requestedProperties)
+        public static IEntityValue CreatePropertyPageValue(IEntityValue parent, IPropertyPageQueryCache cache, Rule rule, IPropertyPagePropertiesAvailableStatus requestedProperties)
         {
-            Requires.NotNull(entity, nameof(entity));
+            Requires.NotNull(parent, nameof(parent));
             Requires.NotNull(rule, nameof(rule));
 
             var identity = new EntityIdentity(
-                ((IEntityWithId)entity).Id,
+                ((IEntityWithId)parent).Id,
                 new KeyValuePair<string, string>[]
                 {
                     new(ProjectModelIdentityKeys.PropertyPageName, rule.Name)
                 });
 
-            return CreatePropertyPageValue(entity.EntityRuntime, identity, context, rule, requestedProperties);
+            return CreatePropertyPageValue(parent.EntityRuntime, identity, cache, rule, requestedProperties);
         }
 
-        public static IEntityValue CreatePropertyPageValue(IEntityRuntimeModel runtimeModel, EntityIdentity id, IPropertyPageQueryCache context, Rule rule, IPropertyPagePropertiesAvailableStatus requestedProperties)
+        public static IEntityValue CreatePropertyPageValue(IEntityRuntimeModel runtimeModel, EntityIdentity id, IPropertyPageQueryCache cache, Rule rule, IPropertyPagePropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(rule, nameof(rule));
             var newPropertyPage = new PropertyPageValue(runtimeModel, id, new PropertyPagePropertiesAvailableStatus());
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 newPropertyPage.Kind = rule.PageTemplate;
             }
 
-            ((IEntityValueFromProvider)newPropertyPage).ProviderState = (context, rule);
+            ((IEntityValueFromProvider)newPropertyPage).ProviderState = (cache, rule);
 
             return newPropertyPage;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal abstract class PropertyPageDataProducer : QueryDataProducerBase<IEntityValue>
     {
-        public PropertyPageDataProducer(IPropertyPagePropertiesAvailableStatus properties)
+        protected PropertyPageDataProducer(IPropertyPagePropertiesAvailableStatus properties)
         {
             Requires.NotNull(properties, nameof(properties));
             Properties = properties;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         protected IPropertyPagePropertiesAvailableStatus Properties { get; }
 
-        protected Task<IEntityValue> CreatePropertyPageValueAsync(IEntityValue entity, PropertyPageQueryCache context, Rule rule)
+        protected Task<IEntityValue> CreatePropertyPageValueAsync(IEntityValue entity, IPropertyPageQueryCache context, Rule rule)
         {
             Requires.NotNull(entity, nameof(entity));
             Requires.NotNull(rule, nameof(rule));
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             return CreatePropertyPageValueAsync(entity.EntityRuntime, identity, context, rule);
         }
 
-        protected Task<IEntityValue> CreatePropertyPageValueAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, PropertyPageQueryCache context, Rule rule)
+        protected Task<IEntityValue> CreatePropertyPageValueAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, IPropertyPageQueryCache context, Rule rule)
         {
             Requires.NotNull(rule, nameof(rule));
             var newPropertyPage = new PropertyPageValue(runtimeModel, id, new PropertyPagePropertiesAvailableStatus());

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles the creation of <see cref="IPropertyPage"/> instances and populating the requested members.
+    /// </summary>
+    internal abstract class PropertyPageDataProducer : QueryDataProducerBase<IEntityValue>
+    {
+        public PropertyPageDataProducer(IPropertyPagePropertiesAvailableStatus properties)
+        {
+            Requires.NotNull(properties, nameof(properties));
+            Properties = properties;
+        }
+
+        protected IPropertyPagePropertiesAvailableStatus Properties { get; }
+
+        protected Task<IEntityValue> CreatePropertyPageValueAsync(IEntityValue entity, PropertyPageQueryCache context, Rule rule)
+        {
+            Requires.NotNull(entity, nameof(entity));
+            Requires.NotNull(rule, nameof(rule));
+
+            var identity = new EntityIdentity(
+                ((IEntityWithId)entity).Id,
+                new KeyValuePair<string, string>[]
+                {
+                        new KeyValuePair<string, string>(ProjectModelIdentityKeys.PropertyPageName, rule.Name)
+                });
+
+            return CreatePropertyPageValueAsync(entity.EntityRuntime, identity, context, rule);
+        }
+
+        protected Task<IEntityValue> CreatePropertyPageValueAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, PropertyPageQueryCache context, Rule rule)
+        {
+            Requires.NotNull(rule, nameof(rule));
+            var newPropertyPage = new PropertyPageValue(runtimeModel, id, new PropertyPagePropertiesAvailableStatus());
+
+            if (Properties.Name)
+            {
+                newPropertyPage.Name = rule.Name;
+            }
+
+            if (Properties.DisplayName)
+            {
+                newPropertyPage.DisplayName = rule.DisplayName;
+            }
+
+            if (Properties.Order)
+            {
+                newPropertyPage.Order = rule.Order;
+            }
+
+            if (Properties.Kind)
+            {
+                newPropertyPage.Kind = rule.PageTemplate;
+            }
+
+            ((IEntityValueFromProvider)newPropertyPage).ProviderState = (context, rule);
+
+            return Task.FromResult<IEntityValue>(newPropertyPage);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
@@ -1,30 +1,23 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
-using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {
     /// <summary>
     /// Handles the creation of <see cref="IPropertyPage"/> instances and populating the requested members.
     /// </summary>
-    internal abstract class PropertyPageDataProducer : QueryDataProducerBase<IEntityValue>
+    internal static class PropertyPageDataProducer
     {
-        protected PropertyPageDataProducer(IPropertyPagePropertiesAvailableStatus properties)
-        {
-            Requires.NotNull(properties, nameof(properties));
-            Properties = properties;
-        }
-
-        protected IPropertyPagePropertiesAvailableStatus Properties { get; }
-
-        protected Task<IEntityValue> CreatePropertyPageValueAsync(IEntityValue entity, IPropertyPageQueryCache context, Rule rule)
+        public static IEntityValue CreatePropertyPageValue(IEntityValue entity, IPropertyPageQueryCache context, Rule rule, IPropertyPagePropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(entity, nameof(entity));
             Requires.NotNull(rule, nameof(rule));
@@ -33,40 +26,88 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 ((IEntityWithId)entity).Id,
                 new KeyValuePair<string, string>[]
                 {
-                        new KeyValuePair<string, string>(ProjectModelIdentityKeys.PropertyPageName, rule.Name)
+                    new(ProjectModelIdentityKeys.PropertyPageName, rule.Name)
                 });
 
-            return CreatePropertyPageValueAsync(entity.EntityRuntime, identity, context, rule);
+            return CreatePropertyPageValue(entity.EntityRuntime, identity, context, rule, requestedProperties);
         }
 
-        protected Task<IEntityValue> CreatePropertyPageValueAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, IPropertyPageQueryCache context, Rule rule)
+        public static IEntityValue CreatePropertyPageValue(IEntityRuntimeModel runtimeModel, EntityIdentity id, IPropertyPageQueryCache context, Rule rule, IPropertyPagePropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(rule, nameof(rule));
             var newPropertyPage = new PropertyPageValue(runtimeModel, id, new PropertyPagePropertiesAvailableStatus());
 
-            if (Properties.Name)
+            if (requestedProperties.Name)
             {
                 newPropertyPage.Name = rule.Name;
             }
 
-            if (Properties.DisplayName)
+            if (requestedProperties.DisplayName)
             {
                 newPropertyPage.DisplayName = rule.DisplayName;
             }
 
-            if (Properties.Order)
+            if (requestedProperties.Order)
             {
                 newPropertyPage.Order = rule.Order;
             }
 
-            if (Properties.Kind)
+            if (requestedProperties.Kind)
             {
                 newPropertyPage.Kind = rule.PageTemplate;
             }
 
             ((IEntityValueFromProvider)newPropertyPage).ProviderState = (context, rule);
 
-            return Task.FromResult<IEntityValue>(newPropertyPage);
+            return newPropertyPage;
+        }
+
+        public static async Task<IEntityValue?> CreatePropertyPageValueAsync(
+            IEntityRuntimeModel runtimeModel,
+            EntityIdentity id,
+            IProjectService2 projectService,
+            string projectPath,
+            string propertyPageName,
+            IPropertyPagePropertiesAvailableStatus requestedProperties)
+        {
+            if (projectService.GetLoadedProject(projectPath) is UnconfiguredProject project
+                && await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
+                && projectCatalog.GetSchema(propertyPageName) is Rule rule
+                && !rule.PropertyPagesHidden)
+            {
+                var propertyPageQueryCache = new PropertyPageQueryCache(project);
+                IEntityValue propertyPageValue = CreatePropertyPageValue(runtimeModel, id, propertyPageQueryCache, rule, requestedProperties);
+                return propertyPageValue;
+            }
+
+            return null;
+        }
+
+        public static async Task<IEnumerable<IEntityValue>> CreatePropertyPageValuesAsync(
+            IEntityValue parent,
+            UnconfiguredProject project,
+            IPropertyPagePropertiesAvailableStatus requestedProperties)
+        {
+            if (await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog)
+            {
+                return createPropertyPageValuesAsync();
+            }
+
+            return Enumerable.Empty<IEntityValue>();
+
+            IEnumerable<IEntityValue> createPropertyPageValuesAsync()
+            {
+                var propertyPageQueryContext = new PropertyPageQueryCache(project);
+                foreach (string schemaName in projectCatalog.GetProjectLevelPropertyPagesSchemas())
+                {
+                    if (projectCatalog.GetSchema(schemaName) is Rule rule
+                        && !rule.PropertyPagesHidden)
+                    {
+                        IEntityValue propertyPageValue = CreatePropertyPageValue(parent, propertyPageQueryContext, rule, requestedProperties);
+                        yield return propertyPageValue;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProvider.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Metadata;
+using Microsoft.VisualStudio.ProjectSystem.Query.Providers;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Creates <see cref="IQueryDataProducer{TRequest, TResult}"/> instances that retrieve property page information
+    /// (<see cref="IPropertyPage"/>) for a project.
+    /// </summary>
+    /// <remarks>
+    /// Responsible for populating <see cref="IProject.PropertyPages"/>. Can also retrieve a <see cref="IPropertyPage"/>
+    /// based on its ID.
+    /// </remarks>
+    [QueryDataProvider(PropertyPageType.TypeName, ProjectModel.ModelName)]
+    [RelationshipQueryDataProvider(ProjectSystem.Query.ProjectModel.Metadata.ProjectType.TypeName, ProjectSystem.Query.ProjectModel.Metadata.ProjectType.PropertyPagesPropertyName)]
+    [QueryDataProviderZone(ProjectModelZones.Cps)]
+    [Export(typeof(IQueryByIdDataProvider))]
+    [Export(typeof(IQueryByRelationshipDataProvider))]
+    internal partial class PropertyPageDataProvider : QueryDataProviderBase, IQueryByIdDataProvider, IQueryByRelationshipDataProvider
+    {
+        [ImportingConstructor]
+        public PropertyPageDataProvider(IProjectServiceAccessor projectServiceAccessor)
+            : base(projectServiceAccessor)
+        {
+        }
+
+        public IQueryDataProducer<IReadOnlyCollection<EntityIdentity>, IEntityValue> CreateQueryDataSource(IPropertiesAvailableStatus properties)
+        {
+            return new PropertyPageByIdDataProducer((IPropertyPagePropertiesAvailableStatus)properties, ProjectService);
+        }
+
+        IQueryDataProducer<IEntityValue, IEntityValue> IQueryByRelationshipDataProvider.CreateQueryDataSource(IPropertiesAvailableStatus properties)
+        {
+            return new PropertyPageFromProjectDataProducer((IPropertyPagePropertiesAvailableStatus)properties);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     [QueryDataProviderZone(ProjectModelZones.Cps)]
     [Export(typeof(IQueryByIdDataProvider))]
     [Export(typeof(IQueryByRelationshipDataProvider))]
-    internal partial class PropertyPageDataProvider : QueryDataProviderBase, IQueryByIdDataProvider, IQueryByRelationshipDataProvider
+    internal class PropertyPageDataProvider : QueryDataProviderBase, IQueryByIdDataProvider, IQueryByRelationshipDataProvider
     {
         [ImportingConstructor]
         public PropertyPageDataProvider(IProjectServiceAccessor projectServiceAccessor)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageFromProjectDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageFromProjectDataProducer.cs
@@ -1,9 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Build.Framework.XamlTypes;
-using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
@@ -15,11 +14,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// <summary>
     /// Handles retrieving a set of <see cref="IPropertyPage"/>s from an <see cref="IProject"/>.
     /// </summary>
-    internal class PropertyPageFromProjectDataProducer : PropertyPageDataProducer, IQueryDataProducer<IEntityValue, IEntityValue>
+    internal class PropertyPageFromProjectDataProducer : QueryDataProducerBase<IEntityValue>, IQueryDataProducer<IEntityValue, IEntityValue>
     {
+        private readonly IPropertyPagePropertiesAvailableStatus _properties;
+
         public PropertyPageFromProjectDataProducer(IPropertyPagePropertiesAvailableStatus properties)
-            : base(properties)
         {
+            _properties = properties;
         }
 
         public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
@@ -30,18 +31,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             {
                 try
                 {
-                    if (await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog)
+                    IEnumerable<IEntityValue> propertyPageValues = await PropertyPageDataProducer.CreatePropertyPageValuesAsync(request.RequestData, project, _properties);
+                    foreach (IEntityValue propertyPageValue in propertyPageValues)
                     {
-                        var propertyPageQueryContext = new PropertyPageQueryCache(project);
-                        foreach (var schemaName in projectCatalog.GetProjectLevelPropertyPagesSchemas())
-                        {
-                            if (projectCatalog.GetSchema(schemaName) is Rule rule
-                                && !rule.PropertyPagesHidden)
-                            {
-                                IEntityValue propertyPageValue = await CreatePropertyPageValueAsync(request.RequestData, propertyPageQueryContext, rule);
-                                await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(propertyPageValue, request, ProjectModelZones.Cps));
-                            }
-                        }
+                        await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(propertyPageValue, request, ProjectModelZones.Cps));
                     }
                 }
                 catch (Exception ex)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageFromProjectDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageFromProjectDataProducer.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles retrieving a set of <see cref="IPropertyPage"/>s from an <see cref="IProject"/>.
+    /// </summary>
+    internal class PropertyPageFromProjectDataProducer : PropertyPageDataProducer, IQueryDataProducer<IEntityValue, IEntityValue>
+    {
+        public PropertyPageFromProjectDataProducer(IPropertyPagePropertiesAvailableStatus properties)
+            : base(properties)
+        {
+        }
+
+        public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
+        {
+            Requires.NotNull(request, nameof(request));
+
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is UnconfiguredProject project)
+            {
+                try
+                {
+                    if (await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog)
+                    {
+                        var propertyPageQueryContext = new PropertyPageQueryCache(project);
+                        foreach (var schemaName in projectCatalog.GetProjectLevelPropertyPagesSchemas())
+                        {
+                            if (projectCatalog.GetSchema(schemaName) is Rule rule
+                                && !rule.PropertyPagesHidden)
+                            {
+                                IEntityValue propertyPageValue = await CreatePropertyPageValueAsync(request.RequestData, propertyPageQueryContext, rule);
+                                await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(propertyPageValue, request, ProjectModelZones.Cps));
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    request.QueryExecutionContext.ReportError(ex);
+                }
+            }
+
+            await ResultReceiver.OnRequestProcessFinishedAsync(request);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryCache.cs
@@ -1,0 +1,111 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Caches data that we expect to access frequently while processing queries for property page information.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The expectation is that at most one instance of this type will be created per query, and that instance will be
+    /// passed from one provider to the next as part of <see cref="IEntityValueFromProvider.ProviderState"/>. This
+    /// allows us to maximize the use of the cache within a query, but we are also guaranteed that the cache will not be
+    /// held past the end of the query.
+    /// </para>
+    /// <para>
+    /// As an example, consider what needs to occur when we want to retrieve the set of <see cref="IUIPropertyValue"/>s
+    /// for a <see cref="IUIProperty"/>:
+    /// <list type="bullet">
+    /// <item>Retrieve the set of known configurations from the <see cref="UnconfiguredProject"/>.</item>
+    /// <item>For each configuration, get the property page catalog.</item>
+    /// <item>Retrieve the <see cref="IRule"/> for the property page from the catalog.</item>
+    /// <item>Find the property within the <see cref="IRule"/>.</item>
+    /// <item>Retrieve the property value.</item>
+    /// </list>
+    /// The <see cref="UIPropertyValueDataProvider"/> produces <see cref="IUIPropertyValue"/>s one at a time, and needs
+    /// to do these steps for each one. Given that a query will likely retrieve values for multiple properties on
+    /// multiple pages across multiple configurations, introducing caching at key levels in the process can
+    /// significantly reduce the amount of work we need to do.
+    /// </para>
+    /// </remarks>
+    internal class PropertyPageQueryCache
+    {
+        private readonly UnconfiguredProject _unconfiguredProject;
+        private readonly Dictionary<ProjectConfiguration, IPropertyPagesCatalog?> _catalogCache;
+        private readonly Dictionary<(ProjectConfiguration, string), IRule?> _ruleCache;
+
+        private readonly AsyncLazy<IImmutableSet<ProjectConfiguration>?> _knownProjectConfigurations;
+
+        public PropertyPageQueryCache(UnconfiguredProject project)
+        {
+            _unconfiguredProject = project;
+            var joinableTaskFactory = project.Services.ThreadingPolicy.JoinableTaskFactory;
+
+            _knownProjectConfigurations = new AsyncLazy<IImmutableSet<ProjectConfiguration>?>(CreateKnownConfigurationsAsync, joinableTaskFactory);
+            _catalogCache = new Dictionary<ProjectConfiguration, IPropertyPagesCatalog?>();
+            _ruleCache = new Dictionary<(ProjectConfiguration, string), IRule?>();
+        }
+
+        /// <summary>
+        /// Retrieves the set of <see cref="ProjectConfiguration"/>s for the project.
+        /// </summary>
+        public Task<IImmutableSet<ProjectConfiguration>?> GetKnownConfigurationsAsync() => _knownProjectConfigurations.GetValueAsync();
+
+        private async Task<IImmutableSet<ProjectConfiguration>?> CreateKnownConfigurationsAsync()
+        {
+            if (_unconfiguredProject.Services.ProjectConfigurationsService is IProjectConfigurationsService configurationsService)
+            {
+                return await configurationsService.GetKnownProjectConfigurationsAsync();
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Retrieves the set of property pages that apply to the project level for the given <paramref
+        /// name="projectConfiguration"/>.
+        /// </summary>
+        public async Task<IPropertyPagesCatalog?> GetProjectLevelPropertyPagesCatalogAsync(ProjectConfiguration projectConfiguration)
+        {
+            if (_catalogCache.TryGetValue(projectConfiguration, out var cachedCatalog))
+            {
+                return cachedCatalog;
+            }
+
+            var configuredProject = await _unconfiguredProject.LoadConfiguredProjectAsync(projectConfiguration);
+            var catalog = await configuredProject.GetProjectLevelPropertyPagesCatalogAsync();
+
+            _catalogCache.Add(projectConfiguration, catalog);
+            return catalog;
+        }
+
+        /// <summary>
+        /// Retrieves the <see cref="IRule"/> with name "<paramref name="schemaName"/>" within the given <paramref
+        /// name="projectConfiguration"/>.
+        /// </summary>
+        public async Task<IRule?> BindToRule(ProjectConfiguration projectConfiguration, string schemaName)
+        {
+            if (_ruleCache.TryGetValue((projectConfiguration, schemaName), out var cachedRule))
+            {
+                return cachedRule;
+            }
+
+            IRule? rule = null;
+            if (await GetProjectLevelPropertyPagesCatalogAsync(projectConfiguration) is IPropertyPagesCatalog catalog)
+            {
+                rule = catalog.BindToContext(schemaName, file: null, itemType: null, itemName: null);
+            }
+
+            _ruleCache.Add((projectConfiguration, schemaName), rule);
+            return rule;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryCache.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         /// Retrieves the set of property pages that apply to the project level for the given <paramref
         /// name="projectConfiguration"/>.
         /// </summary>
-        public async Task<IPropertyPagesCatalog?> GetProjectLevelPropertyPagesCatalogAsync(ProjectConfiguration projectConfiguration)
+        private async Task<IPropertyPagesCatalog?> GetProjectLevelPropertyPagesCatalogAsync(ProjectConfiguration projectConfiguration)
         {
             if (_catalogCache.TryGetValue(projectConfiguration, out var cachedCatalog))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryCache.cs
@@ -4,39 +4,11 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
-using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {
-    /// <summary>
-    /// Caches data that we expect to access frequently while processing queries for property page information.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// The expectation is that at most one instance of this type will be created per query, and that instance will be
-    /// passed from one provider to the next as part of <see cref="IEntityValueFromProvider.ProviderState"/>. This
-    /// allows us to maximize the use of the cache within a query, but we are also guaranteed that the cache will not be
-    /// held past the end of the query.
-    /// </para>
-    /// <para>
-    /// As an example, consider what needs to occur when we want to retrieve the set of <see cref="IUIPropertyValue"/>s
-    /// for a <see cref="IUIProperty"/>:
-    /// <list type="bullet">
-    /// <item>Retrieve the set of known configurations from the <see cref="UnconfiguredProject"/>.</item>
-    /// <item>For each configuration, get the property page catalog.</item>
-    /// <item>Retrieve the <see cref="IRule"/> for the property page from the catalog.</item>
-    /// <item>Find the property within the <see cref="IRule"/>.</item>
-    /// <item>Retrieve the property value.</item>
-    /// </list>
-    /// The <see cref="UIPropertyValueDataProvider"/> produces <see cref="IUIPropertyValue"/>s one at a time, and needs
-    /// to do these steps for each one. Given that a query will likely retrieve values for multiple properties on
-    /// multiple pages across multiple configurations, introducing caching at key levels in the process can
-    /// significantly reduce the amount of work we need to do.
-    /// </para>
-    /// </remarks>
-    internal class PropertyPageQueryCache
+    internal class PropertyPageQueryCache : IPropertyPageQueryCache
     {
         private readonly UnconfiguredProject _unconfiguredProject;
         private readonly Dictionary<ProjectConfiguration, IPropertyPagesCatalog?> _catalogCache;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryCache.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         public PropertyPageQueryCache(UnconfiguredProject project)
         {
             _unconfiguredProject = project;
-            var joinableTaskFactory = project.Services.ThreadingPolicy.JoinableTaskFactory;
+            JoinableTaskFactory joinableTaskFactory = project.Services.ThreadingPolicy.JoinableTaskFactory;
 
             _knownProjectConfigurations = new AsyncLazy<IImmutableSet<ProjectConfiguration>?>(CreateKnownConfigurationsAsync, joinableTaskFactory);
             _catalogCache = new Dictionary<ProjectConfiguration, IPropertyPagesCatalog?>();
@@ -47,13 +47,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         /// </summary>
         private async Task<IPropertyPagesCatalog?> GetProjectLevelPropertyPagesCatalogAsync(ProjectConfiguration projectConfiguration)
         {
-            if (_catalogCache.TryGetValue(projectConfiguration, out var cachedCatalog))
+            if (_catalogCache.TryGetValue(projectConfiguration, out IPropertyPagesCatalog? cachedCatalog))
             {
                 return cachedCatalog;
             }
 
-            var configuredProject = await _unconfiguredProject.LoadConfiguredProjectAsync(projectConfiguration);
-            var catalog = await configuredProject.GetProjectLevelPropertyPagesCatalogAsync();
+            ConfiguredProject configuredProject = await _unconfiguredProject.LoadConfiguredProjectAsync(projectConfiguration);
+            IPropertyPagesCatalog? catalog = await configuredProject.GetProjectLevelPropertyPagesCatalogAsync();
 
             _catalogCache.Add(projectConfiguration, catalog);
             return catalog;
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         /// </summary>
         public async Task<IRule?> BindToRule(ProjectConfiguration projectConfiguration, string schemaName)
         {
-            if (_ruleCache.TryGetValue((projectConfiguration, schemaName), out var cachedRule))
+            if (_ruleCache.TryGetValue((projectConfiguration, schemaName), out IRule? cachedRule))
             {
                 return cachedRule;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryExtensions.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Simplifies some operations that are common across the property page query data providers.
+    /// </summary>
+    internal static class PropertyPageQueryExtensions
+    {
+        /// <summary>
+        /// Retrieves the project-level <see cref="IPropertyPagesCatalog"/> for an <see cref="UnconfiguredProject"/>.
+        /// </summary>
+        public static async Task<IPropertyPagesCatalog?> GetProjectLevelPropertyPagesCatalogAsync(this UnconfiguredProject project)
+        {
+            if (await project.GetSuggestedConfiguredProjectAsync() is ConfiguredProject configuredProject)
+            {
+                return await configuredProject.GetProjectLevelPropertyPagesCatalogAsync();
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Retrieves the project-level <see cref="IPropertyPagesCatalog"/> for a <see cref="ConfiguredProject"/>.
+        /// </summary>
+        public static async Task<IPropertyPagesCatalog?> GetProjectLevelPropertyPagesCatalogAsync(this ConfiguredProject project)
+        {
+            if (project.Services.PropertyPagesCatalog is IPropertyPagesCatalogProvider catalogProvider)
+            {
+                return await catalogProvider.GetCatalogAsync(PropertyPageContexts.Project);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Retrieves the <see cref="BaseProperty"/> of the given <paramref name="propertyName"/>, as well as the index
+        /// of the property within its <see cref="Rule"/>.
+        /// </summary>
+        public static bool TryGetPropertyAndIndex(this Rule rule, string propertyName, [NotNullWhen(true)] out BaseProperty? property, out int index)
+        {
+            foreach ((var i, var prop) in rule.Properties.WithIndices())
+            {
+                if (StringComparers.PropertyNames.Equals(prop.Name, propertyName))
+                {
+                    property = prop;
+                    index = i;
+                    return true;
+                }
+            }
+
+            property = null;
+            index = default;
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryExtensions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         /// </summary>
         public static bool TryGetPropertyAndIndex(this Rule rule, string propertyName, [NotNullWhen(true)] out BaseProperty? property, out int index)
         {
-            foreach ((var i, var prop) in rule.Properties.WithIndices())
+            foreach ((int i, BaseProperty prop) in rule.Properties.WithIndices())
             {
                 if (StringComparers.PropertyNames.Equals(prop.Name, propertyName))
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducer.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles the creation of <see cref="ISupportedValue"/> instances and populating the requested members.
+    /// </summary>
+    internal abstract class SupportedValueDataProducer : QueryDataProducerBase<IEntityValue>
+    {
+        public SupportedValueDataProducer(ISupportedValuePropertiesAvailableStatus properties)
+        {
+            Requires.NotNull(properties, nameof(properties));
+            Properties = properties;
+        }
+
+        protected ISupportedValuePropertiesAvailableStatus Properties { get; }
+
+        protected IEntityValue CreateSupportedValue(IEntityRuntimeModel runtimeModel, ProjectSystem.Properties.IEnumValue enumValue)
+        {
+            var newSupportedValue = new SupportedValueValue(runtimeModel, new SupportedValuePropertiesAvailableStatus());
+
+            if (Properties.Value)
+            {
+                newSupportedValue.DisplayName = enumValue.DisplayName;
+            }
+
+            if (Properties.DisplayName)
+            {
+                newSupportedValue.Value = enumValue.Name;
+            }
+
+            return newSupportedValue;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducer.cs
@@ -18,12 +18,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         {
             var newSupportedValue = new SupportedValueValue(runtimeModel, new SupportedValuePropertiesAvailableStatus());
 
-            if (requestedProperties.Value)
+            if (requestedProperties.DisplayName)
             {
                 newSupportedValue.DisplayName = enumValue.DisplayName;
             }
 
-            if (requestedProperties.DisplayName)
+            if (requestedProperties.Value)
             {
                 newSupportedValue.Value = enumValue.Name;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducer.cs
@@ -1,40 +1,50 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
-using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {
     /// <summary>
     /// Handles the creation of <see cref="ISupportedValue"/> instances and populating the requested members.
     /// </summary>
-    internal abstract class SupportedValueDataProducer : QueryDataProducerBase<IEntityValue>
+    internal static class SupportedValueDataProducer
     {
-        protected SupportedValueDataProducer(ISupportedValuePropertiesAvailableStatus properties)
-        {
-            Requires.NotNull(properties, nameof(properties));
-            Properties = properties;
-        }
-
-        protected ISupportedValuePropertiesAvailableStatus Properties { get; }
-
-        protected IEntityValue CreateSupportedValue(IEntityRuntimeModel runtimeModel, ProjectSystem.Properties.IEnumValue enumValue)
+        public static IEntityValue CreateSupportedValue(IEntityRuntimeModel runtimeModel, ProjectSystem.Properties.IEnumValue enumValue, ISupportedValuePropertiesAvailableStatus requestedProperties)
         {
             var newSupportedValue = new SupportedValueValue(runtimeModel, new SupportedValuePropertiesAvailableStatus());
 
-            if (Properties.Value)
+            if (requestedProperties.Value)
             {
                 newSupportedValue.DisplayName = enumValue.DisplayName;
             }
 
-            if (Properties.DisplayName)
+            if (requestedProperties.DisplayName)
             {
                 newSupportedValue.Value = enumValue.Name;
             }
 
             return newSupportedValue;
+        }
+
+        public static async Task<IEnumerable<IEntityValue>> CreateSupportedValuesAsync(IEntityRuntimeModel runtimeModel, ProjectSystem.Properties.IEnumProperty enumProperty, ISupportedValuePropertiesAvailableStatus requestedProperties)
+        {
+            ReadOnlyCollection<ProjectSystem.Properties.IEnumValue> enumValues = await enumProperty.GetAdmissibleValuesAsync();
+
+            return createSupportedValues();
+
+            IEnumerable<IEntityValue> createSupportedValues()
+            {
+                foreach (ProjectSystem.Properties.IEnumValue value in enumValues)
+                {
+                    IEntityValue supportedValue = CreateSupportedValue(runtimeModel, value, requestedProperties);
+                    yield return supportedValue;
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal abstract class SupportedValueDataProducer : QueryDataProducerBase<IEntityValue>
     {
-        public SupportedValueDataProducer(ISupportedValuePropertiesAvailableStatus properties)
+        protected SupportedValueDataProducer(ISupportedValuePropertiesAvailableStatus properties)
         {
             Requires.NotNull(properties, nameof(properties));
             Properties = properties;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProvider.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Metadata;
+using Microsoft.VisualStudio.ProjectSystem.Query.Providers;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Creates <see cref="IQueryDataProducer{TRequest, TResult}"/> instances that retrieve a property's supported
+    /// values (<see cref="ISupportedValue"/>).
+    /// </summary>'
+    /// <remarks>
+    /// Responsible for populating <see cref="IUIPropertyValue.SupportedValues"/>.
+    /// </remarks>
+    [QueryDataProvider(SupportedValueType.TypeName, ProjectModel.ModelName)]
+    [RelationshipQueryDataProvider(UIPropertyValueType.TypeName, UIPropertyValueType.SupportedValuesPropertyName)]
+    [QueryDataProviderZone(ProjectModelZones.Cps)]
+    [Export(typeof(IQueryByRelationshipDataProvider))]
+    internal partial class SupportedValueDataProvider : IQueryByRelationshipDataProvider
+    {
+        IQueryDataProducer<IEntityValue, IEntityValue> IQueryByRelationshipDataProvider.CreateQueryDataSource(IPropertiesAvailableStatus properties)
+        {
+            return new SupportedValueFromPropertyDataProducer((ISupportedValuePropertiesAvailableStatus)properties);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     [RelationshipQueryDataProvider(UIPropertyValueType.TypeName, UIPropertyValueType.SupportedValuesPropertyName)]
     [QueryDataProviderZone(ProjectModelZones.Cps)]
     [Export(typeof(IQueryByRelationshipDataProvider))]
-    internal partial class SupportedValueDataProvider : IQueryByRelationshipDataProvider
+    internal class SupportedValueDataProvider : IQueryByRelationshipDataProvider
     {
         IQueryDataProducer<IEntityValue, IEntityValue> IQueryByRelationshipDataProvider.CreateQueryDataSource(IPropertiesAvailableStatus properties)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueFromPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueFromPropertyDataProducer.cs
@@ -23,8 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
         {
             Requires.NotNull(request, nameof(request));
-            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property)
-                && property is ProjectSystem.Properties.IEnumProperty enumProperty)
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (ProjectConfiguration _, ProjectSystem.Properties.IEnumProperty enumProperty))
             {
                 foreach (var value in await enumProperty.GetAdmissibleValuesAsync())
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueFromPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueFromPropertyDataProducer.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles retrieving a set of <see cref="ISupportedValue"/>s from an <see cref="IUIPropertyValue"/>.
+    /// </summary>
+    internal class SupportedValueFromPropertyDataProducer : SupportedValueDataProducer, IQueryDataProducer<IEntityValue, IEntityValue>
+    {
+        public SupportedValueFromPropertyDataProducer(ISupportedValuePropertiesAvailableStatus properties)
+            : base(properties)
+        {
+        }
+
+        public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
+        {
+            Requires.NotNull(request, nameof(request));
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property)
+                && property is ProjectSystem.Properties.IEnumProperty enumProperty)
+            {
+                foreach (var value in await enumProperty.GetAdmissibleValuesAsync())
+                {
+                    IEntityValue ProjectConfigurationDimension = CreateSupportedValue(request.RequestData.EntityRuntime, value);
+                    await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(ProjectConfigurationDimension, request, ProjectModelZones.Cps));
+                }
+            }
+
+            await ResultReceiver.OnRequestProcessFinishedAsync(request);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueFromPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueFromPropertyDataProducer.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Query;
@@ -13,22 +14,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// <summary>
     /// Handles retrieving a set of <see cref="ISupportedValue"/>s from an <see cref="IUIPropertyValue"/>.
     /// </summary>
-    internal class SupportedValueFromPropertyDataProducer : SupportedValueDataProducer, IQueryDataProducer<IEntityValue, IEntityValue>
+    internal class SupportedValueFromPropertyDataProducer : QueryDataProducerBase<IEntityValue>, IQueryDataProducer<IEntityValue, IEntityValue>
     {
+        private readonly ISupportedValuePropertiesAvailableStatus _properties;
+
         public SupportedValueFromPropertyDataProducer(ISupportedValuePropertiesAvailableStatus properties)
-            : base(properties)
         {
+            _properties = properties;
         }
 
         public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
         {
             Requires.NotNull(request, nameof(request));
+
             if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (ProjectConfiguration _, ProjectSystem.Properties.IEnumProperty enumProperty))
             {
-                foreach (var value in await enumProperty.GetAdmissibleValuesAsync())
+                try
                 {
-                    IEntityValue projectConfigurationDimension = CreateSupportedValue(request.RequestData.EntityRuntime, value);
-                    await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(projectConfigurationDimension, request, ProjectModelZones.Cps));
+                    IEnumerable<IEntityValue> supportedValues = await SupportedValueDataProducer.CreateSupportedValuesAsync(request.RequestData.EntityRuntime, enumProperty, _properties);
+                    foreach (IEntityValue supportedValue in supportedValues)
+                    {
+                        await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(supportedValue, request, ProjectModelZones.Cps));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    request.QueryExecutionContext.ReportError(ex);
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueFromPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueFromPropertyDataProducer.cs
@@ -28,8 +28,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             {
                 foreach (var value in await enumProperty.GetAdmissibleValuesAsync())
                 {
-                    IEntityValue ProjectConfigurationDimension = CreateSupportedValue(request.RequestData.EntityRuntime, value);
-                    await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(ProjectConfigurationDimension, request, ProjectModelZones.Cps));
+                    IEntityValue projectConfigurationDimension = CreateSupportedValue(request.RequestData.EntityRuntime, value);
+                    await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(projectConfigurationDimension, request, ProjectModelZones.Cps));
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataDataProvider.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Metadata;
+using Microsoft.VisualStudio.ProjectSystem.Query.Providers;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// MEF entry point that creates <see cref="IQueryDataProducer{TRequest, TResult}"/> instances to retrieve property
+    /// value editor metadata (see <see cref="IUIEditorMetadata"/>).
+    /// </summary>
+    /// <remarks>
+    /// Responsible for populating <see cref="IUIPropertyEditor.Metadata"/>. See <see
+    /// cref="UIEditorMetadataFromValueEditorProducer"/> and <see cref="UIEditorMetadataProducer"/> for the important
+    /// logic.
+    /// </remarks>
+    [QueryDataProvider(UIEditorMetadataType.TypeName, ProjectModel.ModelName)]
+    [RelationshipQueryDataProvider(UIPropertyEditorType.TypeName, UIPropertyEditorType.MetadataPropertyName)]
+    [QueryDataProviderZone(ProjectModelZones.Cps)]
+    [Export(typeof(IQueryByRelationshipDataProvider))]
+    internal partial class UIEditorMetadataDataProvider : IQueryByRelationshipDataProvider
+    {
+        IQueryDataProducer<IEntityValue, IEntityValue> IQueryByRelationshipDataProvider.CreateQueryDataSource(IPropertiesAvailableStatus properties)
+        {
+            return new UIEditorMetadataFromValueEditorProducer((IUIEditorMetadataPropertiesAvailableStatus)properties);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataDataProvider.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     [RelationshipQueryDataProvider(UIPropertyEditorType.TypeName, UIPropertyEditorType.MetadataPropertyName)]
     [QueryDataProviderZone(ProjectModelZones.Cps)]
     [Export(typeof(IQueryByRelationshipDataProvider))]
-    internal partial class UIEditorMetadataDataProvider : IQueryByRelationshipDataProvider
+    internal class UIEditorMetadataDataProvider : IQueryByRelationshipDataProvider
     {
         IQueryDataProducer<IEntityValue, IEntityValue> IQueryByRelationshipDataProvider.CreateQueryDataSource(IPropertiesAvailableStatus properties)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataFromValueEditorProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataFromValueEditorProducer.cs
@@ -18,11 +18,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// <remarks>
     /// The <see cref="ValueEditor"/> comes from the parent <see cref="IUIPropertyEditor"/>
     /// </remarks>
-    internal class UIEditorMetadataFromValueEditorProducer : UIEditorMetadataProducer, IQueryDataProducer<IEntityValue, IEntityValue>
+    internal class UIEditorMetadataFromValueEditorProducer : QueryDataProducerBase<IEntityValue>, IQueryDataProducer<IEntityValue, IEntityValue>
     {
+        private readonly IUIEditorMetadataPropertiesAvailableStatus _properties;
+
         public UIEditorMetadataFromValueEditorProducer(IUIEditorMetadataPropertiesAvailableStatus properties)
-            : base(properties)
         {
+            _properties = properties;
         }
 
         public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
@@ -33,9 +35,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             {
                 try
                 {
-                    foreach (var metadataPair in editor.Metadata)
+                    foreach (IEntityValue metadataValue in UIEditorMetadataProducer.CreateMetadataValues(request.RequestData.EntityRuntime, editor, _properties))
                     {
-                        IEntityValue metadataValue = CreateMetadataValue(request.RequestData.EntityRuntime, metadataPair);
                         await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(metadataValue, request, ProjectModelZones.Cps));
                     }
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataFromValueEditorProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataFromValueEditorProducer.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles retrieving a set of <see cref="IUIEditorMetadata"/> from a <see cref="ValueEditor"/> and reporting the
+    /// results.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="ValueEditor"/> comes from the parent <see cref="IUIPropertyEditor"/>
+    /// </remarks>
+    internal class UIEditorMetadataFromValueEditorProducer : UIEditorMetadataProducer, IQueryDataProducer<IEntityValue, IEntityValue>
+    {
+        public UIEditorMetadataFromValueEditorProducer(IUIEditorMetadataPropertiesAvailableStatus properties)
+            : base(properties)
+        {
+        }
+
+        public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
+        {
+            Requires.NotNull(request, nameof(request));
+
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is ValueEditor editor)
+            {
+                try
+                {
+                    foreach (var metadataPair in editor.Metadata)
+                    {
+                        IEntityValue metadataValue = CreateMetadataValue(request.RequestData.EntityRuntime, metadataPair);
+                        await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(metadataValue, request, ProjectModelZones.Cps));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    request.QueryExecutionContext.ReportError(ex);
+                }
+            }
+
+            await ResultReceiver.OnRequestProcessFinishedAsync(request);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataProducer.cs
@@ -13,9 +13,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal static class UIEditorMetadataProducer
     {
-        public static IEntityValue CreateMetadataValue(IEntityRuntimeModel entityRuntime, NameValuePair metadata, IUIEditorMetadataPropertiesAvailableStatus requestedProperties)
+        public static IEntityValue CreateMetadataValue(IEntityRuntimeModel runtimeModel, NameValuePair metadata, IUIEditorMetadataPropertiesAvailableStatus requestedProperties)
         {
-            var newMetadata = new UIEditorMetadataValue(entityRuntime, new UIEditorMetadataPropertiesAvailableStatus());
+            var newMetadata = new UIEditorMetadataValue(runtimeModel, new UIEditorMetadataPropertiesAvailableStatus());
 
             if (requestedProperties.Name)
             {
@@ -30,11 +30,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             return newMetadata;
         }
 
-        public static IEnumerable<IEntityValue> CreateMetadataValues(IEntityRuntimeModel entityRuntime, ValueEditor editor, IUIEditorMetadataPropertiesAvailableStatus requestedProperties)
+        public static IEnumerable<IEntityValue> CreateMetadataValues(IEntityRuntimeModel runtimeModel, ValueEditor editor, IUIEditorMetadataPropertiesAvailableStatus requestedProperties)
         {
             foreach (NameValuePair metadataPair in editor.Metadata)
             {
-                IEntityValue metadataValue = CreateMetadataValue(entityRuntime, metadataPair, requestedProperties);
+                IEntityValue metadataValue = CreateMetadataValue(runtimeModel, metadataPair, requestedProperties);
                 yield return metadataValue;
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataProducer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal abstract class UIEditorMetadataProducer : QueryDataProducerBase<IEntityValue>
     {
-        public UIEditorMetadataProducer(IUIEditorMetadataPropertiesAvailableStatus properties)
+        protected UIEditorMetadataProducer(IUIEditorMetadataPropertiesAvailableStatus properties)
         {
             Requires.NotNull(properties, nameof(properties));
             Properties = properties;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataProducer.cs
@@ -1,41 +1,42 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Collections.Generic;
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
-using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {
     /// <summary>
     /// Handles the creation of <see cref="IUIEditorMetadata"/> instances and populating the requested members.
     /// </summary>
-    internal abstract class UIEditorMetadataProducer : QueryDataProducerBase<IEntityValue>
+    internal static class UIEditorMetadataProducer
     {
-        protected UIEditorMetadataProducer(IUIEditorMetadataPropertiesAvailableStatus properties)
-        {
-            Requires.NotNull(properties, nameof(properties));
-            Properties = properties;
-        }
-
-        protected IUIEditorMetadataPropertiesAvailableStatus Properties { get; }
-
-        protected IEntityValue CreateMetadataValue(IEntityRuntimeModel entityRuntime, NameValuePair metadata)
+        public static IEntityValue CreateMetadataValue(IEntityRuntimeModel entityRuntime, NameValuePair metadata, IUIEditorMetadataPropertiesAvailableStatus requestedProperties)
         {
             var newMetadata = new UIEditorMetadataValue(entityRuntime, new UIEditorMetadataPropertiesAvailableStatus());
 
-            if (Properties.Name)
+            if (requestedProperties.Name)
             {
                 newMetadata.Name = metadata.Name;
             }
 
-            if (Properties.Value)
+            if (requestedProperties.Value)
             {
                 newMetadata.Value = metadata.Value;
             }
 
             return newMetadata;
+        }
+
+        public static IEnumerable<IEntityValue> CreateMetadataValues(IEntityRuntimeModel entityRuntime, ValueEditor editor, IUIEditorMetadataPropertiesAvailableStatus requestedProperties)
+        {
+            foreach (NameValuePair metadataPair in editor.Metadata)
+            {
+                IEntityValue metadataValue = CreateMetadataValue(entityRuntime, metadataPair, requestedProperties);
+                yield return metadataValue;
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataProducer.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles the creation of <see cref="IUIEditorMetadata"/> instances and populating the requested members.
+    /// </summary>
+    internal abstract class UIEditorMetadataProducer : QueryDataProducerBase<IEntityValue>
+    {
+        public UIEditorMetadataProducer(IUIEditorMetadataPropertiesAvailableStatus properties)
+        {
+            Requires.NotNull(properties, nameof(properties));
+            Properties = properties;
+        }
+
+        protected IUIEditorMetadataPropertiesAvailableStatus Properties { get; }
+
+        protected IEntityValue CreateMetadataValue(IEntityRuntimeModel entityRuntime, NameValuePair metadata)
+        {
+            var newMetadata = new UIEditorMetadataValue(entityRuntime, new UIEditorMetadataPropertiesAvailableStatus());
+
+            if (Properties.Name)
+            {
+                newMetadata.Name = metadata.Name;
+            }
+
+            if (Properties.Value)
+            {
+                newMetadata.Value = metadata.Value;
+            }
+
+            return newMetadata;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyByIdProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyByIdProducer.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles retrieving an <see cref="IUIProperty"/> based on an ID.
+    /// </summary>
+    internal class UIPropertyByIdProducer : UIPropertyDataProducer, IQueryDataProducer<IReadOnlyCollection<EntityIdentity>, IEntityValue>
+    {
+        private readonly IProjectService2 _projectService;
+
+        public UIPropertyByIdProducer(IUIPropertyPropertiesAvailableStatus properties, IProjectService2 projectService)
+            : base(properties)
+        {
+            Requires.NotNull(projectService, nameof(projectService));
+            _projectService = projectService;
+        }
+
+        public async Task SendRequestAsync(QueryProcessRequest<IReadOnlyCollection<EntityIdentity>> request)
+        {
+            Requires.NotNull(request, nameof(request));
+
+            foreach (var requestId in request.RequestData)
+            {
+                if (requestId.KeysCount == 3
+                    && requestId.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string path)
+                    && requestId.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName)
+                    && requestId.TryGetValue(ProjectModelIdentityKeys.UIPropertyName, out string propertyName))
+                {
+                    try
+                    {
+                        if (_projectService.GetLoadedProject(path) is UnconfiguredProject project
+                            && await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
+                            && projectCatalog.GetSchema(propertyPageName) is Rule rule
+                            && rule.TryGetPropertyAndIndex(propertyName, out var property, out var index)
+                            && property.Visible)
+                        {
+                            var context = new PropertyPageQueryCache(project);
+                            IEntityValue propertyValue = await CreateUIPropertyValueAsync(request.QueryExecutionContext.EntityRuntime, requestId, context, property, index);
+                            await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(propertyValue, request, ProjectModelZones.Cps));
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        request.QueryExecutionContext.ReportError(ex);
+                    }
+                }
+            }
+
+            await ResultReceiver.OnRequestProcessFinishedAsync(request);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal abstract class UIPropertyDataProducer : QueryDataProducerBase<IEntityValue>
     {
-        public UIPropertyDataProducer(IUIPropertyPropertiesAvailableStatus properties)
+        protected UIPropertyDataProducer(IUIPropertyPropertiesAvailableStatus properties)
         {
             Requires.NotNull(properties, nameof(properties));
             Properties = properties;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
@@ -1,0 +1,106 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles the creation of <see cref="IPropertyPage"/> instances and populating the requested members.
+    /// </summary>
+    internal abstract class UIPropertyDataProducer : QueryDataProducerBase<IEntityValue>
+    {
+        public UIPropertyDataProducer(IUIPropertyPropertiesAvailableStatus properties)
+        {
+            Requires.NotNull(properties, nameof(properties));
+            Properties = properties;
+        }
+
+        protected IUIPropertyPropertiesAvailableStatus Properties { get; }
+
+        protected async Task<IEntityValue> CreateUIPropertyValueAsync(IEntityValue entity, PropertyPageQueryCache context, BaseProperty property, int order)
+        {
+            Requires.NotNull(entity, nameof(entity));
+            Requires.NotNull(property, nameof(property));
+
+            var identity = new EntityIdentity(
+                ((IEntityWithId)entity).Id,
+                new KeyValuePair<string, string>[]
+                {
+                        new(ProjectModelIdentityKeys.UIPropertyName, property.Name)
+                });
+
+            return await CreateUIPropertyValueAsync(entity.EntityRuntime, identity, context, property, order);
+        }
+
+        protected Task<IEntityValue> CreateUIPropertyValueAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, PropertyPageQueryCache context, BaseProperty property, int order)
+        {
+            Requires.NotNull(property, nameof(property));
+            var newUIProperty = new UIPropertyValue(runtimeModel, id, new UIPropertyPropertiesAvailableStatus());
+
+            if (Properties.Name)
+            {
+                newUIProperty.Name = property.Name;
+            }
+
+            if (Properties.DisplayName)
+            {
+                newUIProperty.DisplayName = property.DisplayName;
+            }
+
+            if (Properties.Description)
+            {
+                newUIProperty.Description = property.Description;
+            }
+
+            if (Properties.ConfigurationIndependent)
+            {
+                bool hasConfigurationCondition = property.DataSource?.HasConfigurationCondition ?? property.ContainingRule.DataSource?.HasConfigurationCondition ?? false;
+                newUIProperty.ConfigurationIndependent = !hasConfigurationCondition;
+            }
+
+            if (Properties.HelpUrl)
+            {
+                newUIProperty.HelpUrl = property.HelpUrl;
+            }
+
+            if (Properties.CategoryName)
+            {
+                newUIProperty.CategoryName = property.Category;
+            }
+
+            if (Properties.Order)
+            {
+                newUIProperty.Order = order;
+            }
+
+            if (Properties.Type)
+            {
+                newUIProperty.Type = property switch
+                {
+                    IntProperty => "int",
+                    BoolProperty => "bool",
+                    EnumProperty => "enum",
+                    DynamicEnumProperty => "enum",
+                    StringListProperty => "list",
+                    _ => "string"
+                };
+            }
+
+            if (Properties.SearchTerms)
+            {
+                // TODO: extract search terms from property metadata.
+            }
+
+            ((IEntityValueFromProvider)newUIProperty).ProviderState = (context, property.ContainingRule, property.Name);
+
+            return Task.FromResult<IEntityValue>(newUIProperty);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         protected IUIPropertyPropertiesAvailableStatus Properties { get; }
 
-        protected async Task<IEntityValue> CreateUIPropertyValueAsync(IEntityValue entity, PropertyPageQueryCache context, BaseProperty property, int order)
+        protected async Task<IEntityValue> CreateUIPropertyValueAsync(IEntityValue entity, IPropertyPageQueryCache context, BaseProperty property, int order)
         {
             Requires.NotNull(entity, nameof(entity));
             Requires.NotNull(property, nameof(property));
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             return await CreateUIPropertyValueAsync(entity.EntityRuntime, identity, context, property, order);
         }
 
-        protected Task<IEntityValue> CreateUIPropertyValueAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, PropertyPageQueryCache context, BaseProperty property, int order)
+        protected Task<IEntityValue> CreateUIPropertyValueAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, IPropertyPageQueryCache context, BaseProperty property, int order)
         {
             Requires.NotNull(property, nameof(property));
             var newUIProperty = new UIPropertyValue(runtimeModel, id, new UIPropertyPropertiesAvailableStatus());

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     [QueryDataProviderZone(ProjectModelZones.Cps)]
     [Export(typeof(IQueryByIdDataProvider))]
     [Export(typeof(IQueryByRelationshipDataProvider))]
-    internal partial class UIPropertyDataProvider : QueryDataProviderBase, IQueryByIdDataProvider, IQueryByRelationshipDataProvider
+    internal class UIPropertyDataProvider : QueryDataProviderBase, IQueryByIdDataProvider, IQueryByRelationshipDataProvider
     {
         [ImportingConstructor]
         public UIPropertyDataProvider(IProjectServiceAccessor projectServiceAccessor)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProvider.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Metadata;
+using Microsoft.VisualStudio.ProjectSystem.Query.Providers;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Creates <see cref="IQueryDataProducer{TRequest, TResult}"/> instances that retrieve property information (see
+    /// <see cref="IUIProperty"/>).
+    /// </summary>
+    /// <remarks>
+    /// Responsible for populating <see cref="IPropertyPage.Properties"/>. Can also retrieve a <see cref="IUIProperty"/>
+    /// based on its ID.
+    /// </remarks>
+    [QueryDataProvider(UIPropertyType.TypeName, ProjectModel.ModelName)]
+    [RelationshipQueryDataProvider(PropertyPageType.TypeName, PropertyPageType.PropertiesPropertyName)]
+    [QueryDataProviderZone(ProjectModelZones.Cps)]
+    [Export(typeof(IQueryByIdDataProvider))]
+    [Export(typeof(IQueryByRelationshipDataProvider))]
+    internal partial class UIPropertyDataProvider : QueryDataProviderBase, IQueryByIdDataProvider, IQueryByRelationshipDataProvider
+    {
+        [ImportingConstructor]
+        public UIPropertyDataProvider(IProjectServiceAccessor projectServiceAccessor)
+            : base(projectServiceAccessor)
+        {
+        }
+
+        public IQueryDataProducer<IReadOnlyCollection<EntityIdentity>, IEntityValue> CreateQueryDataSource(IPropertiesAvailableStatus properties)
+        {
+            return new UIPropertyByIdProducer((IUIPropertyPropertiesAvailableStatus)properties, ProjectService);
+        }
+
+        IQueryDataProducer<IEntityValue, IEntityValue> IQueryByRelationshipDataProvider.CreateQueryDataSource(IPropertiesAvailableStatus properties)
+        {
+            return new UIPropertyFromPropertyPageDataProducer((IUIPropertyPropertiesAvailableStatus)properties);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorByIdDataProducer.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles retrieving an <see cref="IUIPropertyEditor"/> base on an ID.
+    /// </summary>
+    internal class UIPropertyEditorByIdDataProducer : UIPropertyEditorDataProducer, IQueryDataProducer<IReadOnlyCollection<EntityIdentity>, IEntityValue>
+    {
+        private readonly IProjectService2 _projectService;
+
+        public UIPropertyEditorByIdDataProducer(IUIPropertyEditorPropertiesAvailableStatus properties, IProjectService2 projectService)
+            : base(properties)
+        {
+            Requires.NotNull(projectService, nameof(projectService));
+            _projectService = projectService;
+        }
+
+        public async Task SendRequestAsync(QueryProcessRequest<IReadOnlyCollection<EntityIdentity>> request)
+        {
+            Requires.NotNull(request, nameof(request));
+
+            foreach (var requestId in request.RequestData)
+            {
+                if (requestId.KeysCount == 4
+                    && requestId.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string path)
+                    && requestId.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName)
+                    && requestId.TryGetValue(ProjectModelIdentityKeys.UIPropertyName, out string propertyName)
+                    && requestId.TryGetValue(ProjectModelIdentityKeys.EditorName, out string editorName))
+                {
+                    try
+                    {
+                        if (_projectService.GetLoadedProject(path) is UnconfiguredProject project
+                            && await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
+                            && projectCatalog.GetSchema(propertyPageName) is Rule rule
+                            && rule.TryGetPropertyAndIndex(propertyName, out var property, out var index)
+                            && property.ValueEditors.FirstOrDefault(ed => string.Equals(ed.EditorType, editorName)) is ValueEditor editor)
+                        {
+                            IEntityValue editorValue = await CreateEditorValueAsync(request.QueryExecutionContext.EntityRuntime, requestId, editor);
+                            await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(editorValue, request, ProjectModelZones.Cps));
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        request.QueryExecutionContext.ReportError(ex);
+                    }
+                }
+            }
+
+            await ResultReceiver.OnRequestProcessFinishedAsync(request);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorByIdDataProducer.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                         if (_projectService.GetLoadedProject(path) is UnconfiguredProject project
                             && await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
                             && projectCatalog.GetSchema(propertyPageName) is Rule rule
-                            && rule.TryGetPropertyAndIndex(propertyName, out var property, out var index)
+                            && rule.GetProperty(propertyName) is BaseProperty property
                             && property.ValueEditors.FirstOrDefault(ed => string.Equals(ed.EditorType, editorName)) is ValueEditor editor)
                         {
                             IEntityValue editorValue = await CreateEditorValueAsync(request.QueryExecutionContext.EntityRuntime, requestId, editor);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles the creation of <see cref="IUIPropertyEditor"/> instances and populating the requested members.
+    /// </summary>
+    internal abstract class UIPropertyEditorDataProducer : QueryDataProducerBase<IEntityValue>
+    {
+        public UIPropertyEditorDataProducer(IUIPropertyEditorPropertiesAvailableStatus properties)
+        {
+            Requires.NotNull(properties, nameof(properties));
+            Properties = properties;
+        }
+
+        protected IUIPropertyEditorPropertiesAvailableStatus Properties { get; }
+
+        protected async Task<IEntityValue> CreateEditorValueAsync(IEntityValue entity, ValueEditor editor)
+        {
+            Requires.NotNull(entity, nameof(entity));
+            Requires.NotNull(editor, nameof(editor));
+
+            var identity = new EntityIdentity(
+                ((IEntityWithId)entity).Id,
+                new KeyValuePair<string, string>[]
+                {
+                        new(ProjectModelIdentityKeys.EditorName, editor.EditorType)
+                });
+
+            return await CreateEditorValueAsync(entity.EntityRuntime, identity, editor);
+        }
+
+        protected Task<IEntityValue> CreateEditorValueAsync(IEntityRuntimeModel entityRuntime, EntityIdentity identity, ValueEditor editor)
+        {
+            Requires.NotNull(editor, nameof(editor));
+            var newEditorValue = new UIPropertyEditorValue(entityRuntime, identity, new UIPropertyEditorPropertiesAvailableStatus());
+
+            if (Properties.Name)
+            {
+                newEditorValue.Name = editor.EditorType;
+            }
+
+            ((IEntityValueFromProvider)newEditorValue).ProviderState = editor;
+
+            return Task.FromResult<IEntityValue>(newEditorValue);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal abstract class UIPropertyEditorDataProducer : QueryDataProducerBase<IEntityValue>
     {
-        public UIPropertyEditorDataProducer(IUIPropertyEditorPropertiesAvailableStatus properties)
+        protected UIPropertyEditorDataProducer(IUIPropertyEditorPropertiesAvailableStatus properties)
         {
             Requires.NotNull(properties, nameof(properties));
             Properties = properties;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     [QueryDataProviderZone(ProjectModelZones.Cps)]
     [Export(typeof(IQueryByIdDataProvider))]
     [Export(typeof(IQueryByRelationshipDataProvider))]
-    internal partial class UIPropertyEditorDataProvider : QueryDataProviderBase, IQueryByIdDataProvider, IQueryByRelationshipDataProvider
+    internal class UIPropertyEditorDataProvider : QueryDataProviderBase, IQueryByIdDataProvider, IQueryByRelationshipDataProvider
     {
         [ImportingConstructor]
         public UIPropertyEditorDataProvider(IProjectServiceAccessor projectServiceAccessor)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProvider.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Metadata;
+using Microsoft.VisualStudio.ProjectSystem.Query.Providers;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Creates <see cref="IQueryDataProducer{TRequest, TResult}"/> instances that retrieve UI property value editors
+    /// (<see cref="IUIPropertyEditor"/>).
+    /// </summary>
+    /// <remarks>
+    /// Responsible for populating <see cref="IUIProperty.Editors"/>. Can also retrieve a <see
+    /// cref="IUIPropertyEditor"/> based on its ID.
+    /// </remarks>
+    [QueryDataProvider(UIPropertyEditorType.TypeName, ProjectModel.ModelName)]
+    [RelationshipQueryDataProvider(UIPropertyType.TypeName, UIPropertyType.EditorsPropertyName)]
+    [QueryDataProviderZone(ProjectModelZones.Cps)]
+    [Export(typeof(IQueryByIdDataProvider))]
+    [Export(typeof(IQueryByRelationshipDataProvider))]
+    internal partial class UIPropertyEditorDataProvider : QueryDataProviderBase, IQueryByIdDataProvider, IQueryByRelationshipDataProvider
+    {
+        [ImportingConstructor]
+        public UIPropertyEditorDataProvider(IProjectServiceAccessor projectServiceAccessor)
+            : base(projectServiceAccessor)
+        {
+        }
+
+        public IQueryDataProducer<IReadOnlyCollection<EntityIdentity>, IEntityValue> CreateQueryDataSource(IPropertiesAvailableStatus properties)
+        {
+            return new UIPropertyEditorByIdDataProducer((IUIPropertyEditorPropertiesAvailableStatus)properties, ProjectService);
+        }
+
+        IQueryDataProducer<IEntityValue, IEntityValue> IQueryByRelationshipDataProvider.CreateQueryDataSource(IPropertiesAvailableStatus properties)
+        {
+            return new UIPropertyEditorFromUIPropertyDataProducer((IUIPropertyEditorPropertiesAvailableStatus)properties);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorFromUIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorFromUIPropertyDataProducer.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles retrieving a set of <see cref="IUIPropertyEditor"/>s from an <see cref="IUIProperty"/>.
+    /// </summary>
+    internal class UIPropertyEditorFromUIPropertyDataProducer : UIPropertyEditorDataProducer, IQueryDataProducer<IEntityValue, IEntityValue>
+    {
+        public UIPropertyEditorFromUIPropertyDataProducer(IUIPropertyEditorPropertiesAvailableStatus properties)
+            : base(properties)
+        {
+        }
+
+        public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
+        {
+            Requires.NotNull(request, nameof(request));
+
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (PropertyPageQueryCache context, Rule schema, string propertyName))
+            {
+                try
+                {
+                    var property = schema.GetProperty(propertyName);
+                    foreach (var editor in property.ValueEditors)
+                    {
+                        IEntityValue editorValue = await CreateEditorValueAsync(request.RequestData, editor);
+                        await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(editorValue, request, ProjectModelZones.Cps));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    request.QueryExecutionContext.ReportError(ex);
+                }
+            }
+
+            await ResultReceiver.OnRequestProcessFinishedAsync(request);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorFromUIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorFromUIPropertyDataProducer.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         {
             Requires.NotNull(request, nameof(request));
 
-            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (PropertyPageQueryCache context, Rule schema, string propertyName))
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (IPropertyPageQueryCache context, Rule schema, string propertyName))
             {
                 try
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromPropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromPropertyPageDataProducer.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles retrieving a set of <see cref="IUIProperty"/>s from an <see cref="IPropertyPage"/>.
+    /// </summary>
+    internal class UIPropertyFromPropertyPageDataProducer : UIPropertyDataProducer, IQueryDataProducer<IEntityValue, IEntityValue>
+    {
+        public UIPropertyFromPropertyPageDataProducer(IUIPropertyPropertiesAvailableStatus properties)
+            : base(properties)
+        {
+        }
+
+        public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
+        {
+            Requires.NotNull(request, nameof(request));
+
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (PropertyPageQueryCache context, Rule rule))
+            {
+                try
+                {
+                    foreach ((var index, var property) in rule.Properties.WithIndices())
+                    {
+                        if (property.Visible)
+                        {
+                            IEntityValue propertyValue = await CreateUIPropertyValueAsync(request.RequestData, context, property, index);
+                            await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(propertyValue, request, ProjectModelZones.Cps));
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    request.QueryExecutionContext.ReportError(ex);
+                }
+            }
+
+            await ResultReceiver.OnRequestProcessFinishedAsync(request);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromPropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromPropertyPageDataProducer.cs
@@ -28,11 +28,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         {
             Requires.NotNull(request, nameof(request));
 
-            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (IPropertyPageQueryCache context, Rule rule))
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (IPropertyPageQueryCache cache, Rule rule))
             {
                 try
                 {
-                    foreach (IEntityValue propertyValue in UIPropertyDataProducer.CreateUIPropertyValues(request.RequestData, context, rule, _properties))
+                    foreach (IEntityValue propertyValue in UIPropertyDataProducer.CreateUIPropertyValues(request.RequestData, cache, rule, _properties))
                     {
                         await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(propertyValue, request, ProjectModelZones.Cps));
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromPropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromPropertyPageDataProducer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         {
             Requires.NotNull(request, nameof(request));
 
-            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (PropertyPageQueryCache context, Rule rule))
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (IPropertyPageQueryCache context, Rule rule))
             {
                 try
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -1,4 +1,4 @@
-﻿ // Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+﻿ // Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -1,31 +1,24 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
-using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {
     /// <summary>
     /// Handles the creation of <see cref="IUIPropertyValue"/> instances and populating the requested members.
     /// </summary>
-    internal abstract class UIPropertyValueDataProducer : QueryDataProducerBase<IEntityValue>
+    internal static class UIPropertyValueDataProducer
     {
-        protected UIPropertyValueDataProducer(IUIPropertyValuePropertiesAvailableStatus properties)
-        {
-            Requires.NotNull(properties, nameof(properties));
-            Properties = properties;
-        }
-
-        protected IUIPropertyValuePropertiesAvailableStatus Properties { get; }
-
-        protected async Task<IEntityValue> CreateUIPropertyValueValueAsync(IEntityValue entity, ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property)
+        public static async Task<IEntityValue> CreateUIPropertyValueValueAsync(IEntityValue entity, ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property, IUIPropertyValuePropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(entity, nameof(entity));
             Requires.NotNull(configuration, nameof(configuration));
@@ -35,16 +28,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 ((IEntityWithId)entity).Id,
                 Enumerable.Empty<KeyValuePair<string, string>>());
 
-            return await CreateUIPropertyValueValueAsync(entity.EntityRuntime, identity, configuration, property);
+            return await CreateUIPropertyValueValueAsync(entity.EntityRuntime, identity, configuration, property, requestedProperties);
         }
 
-        private async Task<IEntityValue> CreateUIPropertyValueValueAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property)
+        public static async Task<IEntityValue> CreateUIPropertyValueValueAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property, IUIPropertyValuePropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(property, nameof(property));
 
             var newUIPropertyValue = new UIPropertyValueValue(runtimeModel, id, new UIPropertyValuePropertiesAvailableStatus());
 
-            if (Properties.UnevaluatedValue)
+            if (requestedProperties.UnevaluatedValue)
             {
                 if (property is IEvaluatedProperty evaluatedProperty)
                 {
@@ -56,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 }
             }
 
-            if (Properties.EvaluatedValue)
+            if (requestedProperties.EvaluatedValue)
             {
                 newUIPropertyValue.EvaluatedValue = property switch
                 {
@@ -72,6 +65,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             ((IEntityValueFromProvider)newUIPropertyValue).ProviderState = (configuration, property);
 
             return newUIPropertyValue;
+        }
+
+        public static async Task<IEnumerable<IEntityValue>> CreateUIPropertyValueValuesAsync(
+            IEntityValue requestData,
+            IPropertyPageQueryCache context,
+            Rule schema,
+            string propertyName,
+            IUIPropertyValuePropertiesAvailableStatus requestedProperties)
+        {
+            ImmutableList<IEntityValue>.Builder builder = ImmutableList.CreateBuilder<IEntityValue>();
+
+            if (await context.GetKnownConfigurationsAsync() is IImmutableSet<ProjectConfiguration> knownConfigurations)
+            {
+                foreach (ProjectConfiguration knownConfiguration in knownConfigurations)
+                {
+                    if (await context.BindToRule(knownConfiguration, schema.Name) is IRule rule
+                        && rule.GetProperty(propertyName) is ProjectSystem.Properties.IProperty property)
+                    {
+                        IEntityValue propertyValue = await CreateUIPropertyValueValueAsync(requestData, knownConfiguration, property, requestedProperties);
+                        builder.Add(propertyValue);
+                    }
+                }
+            }
+
+            return builder.ToImmutable();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles the creation of <see cref="IUIPropertyValue"/> instances and populating the requested members.
+    /// </summary>
+    internal abstract class UIPropertyValueDataProducer : QueryDataProducerBase<IEntityValue>
+    {
+        public UIPropertyValueDataProducer(IUIPropertyValuePropertiesAvailableStatus properties)
+        {
+            Requires.NotNull(properties, nameof(properties));
+            Properties = properties;
+        }
+
+        protected IUIPropertyValuePropertiesAvailableStatus Properties { get; }
+
+        protected async Task<IEntityValue> CreateUIPropertyValueValueAsync(IEntityValue entity, ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property)
+        {
+            Requires.NotNull(entity, nameof(entity));
+            Requires.NotNull(configuration, nameof(configuration));
+            Requires.NotNull(property, nameof(property));
+
+            var identity = new EntityIdentity(
+                ((IEntityWithId)entity).Id,
+                Enumerable.Empty<KeyValuePair<string, string>>());
+
+            return await CreateUIPropertyValueValueAsync(entity.EntityRuntime, identity, configuration, property);
+        }
+
+        protected async Task<IEntityValue> CreateUIPropertyValueValueAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property)
+        {
+            Requires.NotNull(property, nameof(property));
+
+            var newUIPropertyValue = new UIPropertyValueValue(runtimeModel, id, new UIPropertyValuePropertiesAvailableStatus());
+
+            if (Properties.UnevaluatedValue)
+            {
+                if (property is IEvaluatedProperty evaluatedProperty)
+                {
+                    newUIPropertyValue.UnevaluatedValue = await evaluatedProperty.GetUnevaluatedValueAsync();
+                }
+                else
+                {
+                    newUIPropertyValue.UnevaluatedValue = await property.GetValueAsync() as string;
+                }
+            }
+
+            if (Properties.EvaluatedValue)
+            {
+                newUIPropertyValue.EvaluatedValue = property switch
+                {
+                    IBoolProperty boolProperty => await boolProperty.GetValueAsBoolAsync(),
+                    IStringProperty stringProperty => await stringProperty.GetValueAsStringAsync(),
+                    IIntProperty intProperty => await intProperty.GetValueAsIntAsync(),
+                    IEnumProperty enumProperty => (await enumProperty.GetValueAsIEnumValueAsync())?.Name,
+                    IStringListProperty stringListProperty => await stringListProperty.GetValueAsStringCollectionAsync(),
+                    _ => await property.GetValueAsync()
+                };
+            }
+
+            ((IEntityValueFromProvider)newUIPropertyValue).ProviderState = (configuration, property);
+
+            return newUIPropertyValue;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             return await CreateUIPropertyValueValueAsync(entity.EntityRuntime, identity, configuration, property);
         }
 
-        protected async Task<IEntityValue> CreateUIPropertyValueValueAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property)
+        private async Task<IEntityValue> CreateUIPropertyValueValueAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property)
         {
             Requires.NotNull(property, nameof(property));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal abstract class UIPropertyValueDataProducer : QueryDataProducerBase<IEntityValue>
     {
-        public UIPropertyValueDataProducer(IUIPropertyValuePropertiesAvailableStatus properties)
+        protected UIPropertyValueDataProducer(IUIPropertyValuePropertiesAvailableStatus properties)
         {
             Requires.NotNull(properties, nameof(properties));
             Properties = properties;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -18,17 +18,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal static class UIPropertyValueDataProducer
     {
-        public static async Task<IEntityValue> CreateUIPropertyValueValueAsync(IEntityValue entity, ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property, IUIPropertyValuePropertiesAvailableStatus requestedProperties)
+        public static async Task<IEntityValue> CreateUIPropertyValueValueAsync(IEntityValue parent, ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property, IUIPropertyValuePropertiesAvailableStatus requestedProperties)
         {
-            Requires.NotNull(entity, nameof(entity));
+            Requires.NotNull(parent, nameof(parent));
             Requires.NotNull(configuration, nameof(configuration));
             Requires.NotNull(property, nameof(property));
 
             var identity = new EntityIdentity(
-                ((IEntityWithId)entity).Id,
+                ((IEntityWithId)parent).Id,
                 Enumerable.Empty<KeyValuePair<string, string>>());
 
-            return await CreateUIPropertyValueValueAsync(entity.EntityRuntime, identity, configuration, property, requestedProperties);
+            return await CreateUIPropertyValueValueAsync(parent.EntityRuntime, identity, configuration, property, requestedProperties);
         }
 
         public static async Task<IEntityValue> CreateUIPropertyValueValueAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property, IUIPropertyValuePropertiesAvailableStatus requestedProperties)
@@ -68,22 +68,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         }
 
         public static async Task<IEnumerable<IEntityValue>> CreateUIPropertyValueValuesAsync(
-            IEntityValue requestData,
-            IPropertyPageQueryCache context,
+            IEntityValue parent,
+            IPropertyPageQueryCache cache,
             Rule schema,
             string propertyName,
             IUIPropertyValuePropertiesAvailableStatus requestedProperties)
         {
             ImmutableList<IEntityValue>.Builder builder = ImmutableList.CreateBuilder<IEntityValue>();
 
-            if (await context.GetKnownConfigurationsAsync() is IImmutableSet<ProjectConfiguration> knownConfigurations)
+            if (await cache.GetKnownConfigurationsAsync() is IImmutableSet<ProjectConfiguration> knownConfigurations)
             {
                 foreach (ProjectConfiguration knownConfiguration in knownConfigurations)
                 {
-                    if (await context.BindToRule(knownConfiguration, schema.Name) is IRule rule
+                    if (await cache.BindToRule(knownConfiguration, schema.Name) is IRule rule
                         && rule.GetProperty(propertyName) is ProjectSystem.Properties.IProperty property)
                     {
-                        IEntityValue propertyValue = await CreateUIPropertyValueValueAsync(requestData, knownConfiguration, property, requestedProperties);
+                        IEntityValue propertyValue = await CreateUIPropertyValueValueAsync(parent, knownConfiguration, property, requestedProperties);
                         builder.Add(propertyValue);
                     }
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     [RelationshipQueryDataProvider(UIPropertyType.TypeName, UIPropertyType.ValuesPropertyName)]
     [QueryDataProviderZone(ProjectModelZones.Cps)]
     [Export(typeof(IQueryByRelationshipDataProvider))]
-    internal partial class UIPropertyValueDataProvider : IQueryByRelationshipDataProvider
+    internal class UIPropertyValueDataProvider : IQueryByRelationshipDataProvider
     {
         public IQueryDataProducer<IEntityValue, IEntityValue> CreateQueryDataSource(IPropertiesAvailableStatus properties)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProvider.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Metadata;
+using Microsoft.VisualStudio.ProjectSystem.Query.Providers;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Creates <see cref="IQueryDataProducer{TRequest, TResult}"/> instances that retrieve property value information
+    /// (<see cref="IUIPropertyValue"/>).
+    /// </summary>
+    /// <remarks>
+    /// Responsible for populating <see cref="IUIProperty.Values"/>.
+    /// </remarks>
+    [QueryDataProvider(UIPropertyValueType.TypeName, ProjectModel.ModelName)]
+    [RelationshipQueryDataProvider(UIPropertyType.TypeName, UIPropertyType.ValuesPropertyName)]
+    [QueryDataProviderZone(ProjectModelZones.Cps)]
+    [Export(typeof(IQueryByRelationshipDataProvider))]
+    internal partial class UIPropertyValueDataProvider : IQueryByRelationshipDataProvider
+    {
+        public IQueryDataProducer<IEntityValue, IEntityValue> CreateQueryDataSource(IPropertiesAvailableStatus properties)
+        {
+            return new UIPropertyValueFromUIPropertyDataProducer((IUIPropertyValuePropertiesAvailableStatus)properties);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueFromUIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueFromUIPropertyDataProducer.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
         {
-            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (PropertyPageQueryCache context, Rule schema, string propertyName))
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (IPropertyPageQueryCache context, Rule schema, string propertyName))
             {
                 try
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueFromUIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueFromUIPropertyDataProducer.cs
@@ -26,13 +26,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
         {
-            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (IPropertyPageQueryCache context, Rule schema, string propertyName))
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (IPropertyPageQueryCache cache, Rule schema, string propertyName))
             {
                 try
                 {
                     IEnumerable<IEntityValue> propertyValues = await UIPropertyValueDataProducer.CreateUIPropertyValueValuesAsync(
                         request.RequestData,
-                        context,
+                        cache,
                         schema,
                         propertyName,
                         _properties);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueFromUIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueFromUIPropertyDataProducer.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles retrieving a set of <see cref="IUIPropertyValue"/>s from an <see cref="IUIProperty"/>.
+    /// </summary>
+    internal class UIPropertyValueFromUIPropertyDataProducer : UIPropertyValueDataProducer, IQueryDataProducer<IEntityValue, IEntityValue>
+    {
+        public UIPropertyValueFromUIPropertyDataProducer(IUIPropertyValuePropertiesAvailableStatus properties)
+            : base(properties)
+        {
+        }
+
+        public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
+        {
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (PropertyPageQueryCache context, Rule schema, string propertyName))
+            {
+                try
+                {
+                    if (await context.GetKnownConfigurationsAsync() is IImmutableSet<ProjectConfiguration> knownConfigurations)
+                    {
+                        foreach (var knownConfiguration in knownConfigurations)
+                        {
+                            if (await context.BindToRule(knownConfiguration, schema.Name) is IRule rule
+                                && rule.GetProperty(propertyName) is ProjectSystem.Properties.IProperty property)
+                            {
+                                IEntityValue propertyValue = await CreateUIPropertyValueValueAsync(request.RequestData, knownConfiguration, property);
+                                await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(propertyValue, request, ProjectModelZones.Cps));
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    request.QueryExecutionContext.ReportError(ex);
+                }
+            }
+
+            await ResultReceiver.OnRequestProcessFinishedAsync(request);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/QueryDataProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/QueryDataProviderBase.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal abstract class QueryDataProviderBase
+    {
+        private readonly Lazy<IProjectService2> _projectService;
+
+        protected QueryDataProviderBase(IProjectServiceAccessor projectServiceAccessor)
+        {
+            _projectService = new Lazy<IProjectService2>(
+                () => (IProjectService2)projectServiceAccessor.GetProjectService(),
+                System.Threading.LazyThreadSafetyMode.PublicationOnly);
+        }
+
+        protected IProjectService2 ProjectService => _projectService.Value;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/EnumerableExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/EnumerableExtensions.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
+{
+    internal static class EnumerableExtensions
+    {
+        /// <summary>
+        /// Given an <see cref="IEnumerable{T}"/>, returns a new <see cref="IEnumerable{T}"/> that yields tuples with
+        /// the items of the original plus their index.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="enumerable"></param>
+        /// <returns></returns>
+        public static IEnumerable<(int index, T item)> WithIndices<T>(this IEnumerable<T> enumerable)
+        {
+            int index = 0;
+            foreach (var item in enumerable)
+            {
+                yield return (index++, item);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
@@ -19,6 +19,7 @@ namespace Microsoft.VisualStudio
         public static StringComparer PropertyLiteralValues => StringComparer.OrdinalIgnoreCase;
         public static StringComparer PropertyValues => StringComparer.Ordinal;
         public static StringComparer RuleNames => StringComparer.OrdinalIgnoreCase;
+        public static StringComparer CategoryNames => StringComparer.OrdinalIgnoreCase;
         public static StringComparer ConfigurationDimensionNames => StringComparer.Ordinal;
         public static StringComparer DependencyProviderTypes => StringComparer.OrdinalIgnoreCase;
         public static StringComparer DependencyTreeIds => StringComparer.OrdinalIgnoreCase;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IEntityRuntimeModelFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IEntityRuntimeModelFactory.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IEntityRuntimeModelFactory
+    {
+        public static IEntityRuntimeModel Create()
+        {
+            var mock = new Mock<IEntityRuntimeModel>();
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IEntityWithIdFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IEntityWithIdFactory.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IEntityWithIdFactory
+    {
+        public static IEntityValue Create(string key, string value)
+        {
+            var mock = new Mock<IEntityWithId>();
+
+            mock.SetupGet(m => m.Id).Returns(new EntityIdentity(key, value));
+
+            var mockWithValue = mock.As<IEntityValue>();
+            mockWithValue.SetupGet(m => m.EntityRuntime).Returns(IEntityRuntimeModelFactory.Create());
+
+            return mockWithValue.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IEnumValueFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IEnumValueFactory.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IEnumValueFactory
+    {
+        public static IEnumValue Create(string? displayName = null, string? name = null)
+        {
+            var mock = new Mock<IEnumValue>();
+
+            if (displayName is not null)
+            {
+                mock.SetupGet(m => m.DisplayName).Returns(displayName);
+            }
+
+            if (name is not null)
+            {
+                mock.SetupGet(m => m.Name).Returns(name);
+            }
+
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPropertyFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPropertyFactory.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.ObjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IPropertyFactory
+    {
+        public static IEnumProperty CreateEnum(IEnumValue[]? admissibleValues = null)
+        {
+            var mock = new Mock<IEnumProperty>();
+
+            if (admissibleValues is not null)
+            {
+                mock.Setup(m => m.GetAdmissibleValuesAsync()).ReturnsAsync(new ReadOnlyCollection<IEnumValue>(admissibleValues));
+            }
+
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/PropertiesAvailableStatusFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/PropertiesAvailableStatusFactory.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class PropertiesAvailableStatusFactory
+    {
+        public static IUIEditorMetadataPropertiesAvailableStatus CreateUIEditorMetadataAvailableStatus(
+            bool includeName,
+            bool includeValue)
+        {
+            var mock = new Mock<IUIEditorMetadataPropertiesAvailableStatus>();
+
+            mock.SetupGet(m => m.Name).Returns(includeName);
+            mock.SetupGet(m => m.Value).Returns(includeValue);
+
+            return mock.Object;
+        }
+
+        public static ICategoryPropertiesAvailableStatus CreateCategoryPropertiesAvailableStatus(
+            bool includeDisplayName, 
+            bool includeName, 
+            bool includeOrder)
+        {
+            var mock = new Mock<ICategoryPropertiesAvailableStatus>();
+
+            mock.SetupGet(m => m.DisplayName).Returns(includeDisplayName);
+            mock.SetupGet(m => m.Name).Returns(includeName);
+            mock.SetupGet(m => m.Order).Returns(includeOrder);
+
+            return mock.Object;
+        }
+
+        public static IConfigurationDimensionPropertiesAvailableStatus CreateConfigurationDimensionAvailableStatus(
+            bool includeName,
+            bool includeValue)
+        {
+            var mock = new Mock<IConfigurationDimensionPropertiesAvailableStatus>();
+
+            mock.SetupGet(m => m.Name).Returns(includeName);
+            mock.SetupGet(m => m.Value).Returns(includeValue);
+
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/PropertiesAvailableStatusFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/PropertiesAvailableStatusFactory.cs
@@ -44,5 +44,21 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             return mock.Object;
         }
+
+        public static IPropertyPagePropertiesAvailableStatus CreatePropertyPagePropertiesAvailableStatus(
+            bool includeName = true,
+            bool includeDisplayName = true,
+            bool includeOrder = true,
+            bool includeKind = true)
+        {
+            var mock = new Mock<IPropertyPagePropertiesAvailableStatus>();
+
+            mock.SetupGet(m => m.Name).Returns(includeName);
+            mock.SetupGet(m => m.DisplayName).Returns(includeDisplayName);
+            mock.SetupGet(m => m.Order).Returns(includeOrder);
+            mock.SetupGet(m => m.Kind).Returns(includeKind);
+
+            return mock.Object;
+        }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/PropertiesAvailableStatusFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/PropertiesAvailableStatusFactory.cs
@@ -8,8 +8,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
     internal static class PropertiesAvailableStatusFactory
     {
         public static IUIEditorMetadataPropertiesAvailableStatus CreateUIEditorMetadataAvailableStatus(
-            bool includeName,
-            bool includeValue)
+            bool includeName = true,
+            bool includeValue = true)
         {
             var mock = new Mock<IUIEditorMetadataPropertiesAvailableStatus>();
 
@@ -19,10 +19,79 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return mock.Object;
         }
 
+        public static IUIEditorMetadataPropertiesAvailableStatus CreateUIEditorMetadataAvailableStatus(
+            bool includeProperties)
+        {
+            return CreateUIEditorMetadataAvailableStatus(
+                includeName: includeProperties,
+                includeValue: includeProperties);
+        }
+
+        public static IUIPropertyPropertiesAvailableStatus CreateUIPropertyPropertiesAvailableStatus(
+            bool includeName = true,
+            bool includeDisplayName = true,
+            bool includeDescription = true,
+            bool includeConfigurationIndependent = true,
+            bool includeHelpUrl = true,
+            bool includeCategoryName = true,
+            bool includeOrder = true,
+            bool includeType = true,
+            bool includeSearchTerms = true)
+        {
+            var mock = new Mock<IUIPropertyPropertiesAvailableStatus>();
+
+            mock.SetupGet(m => m.Name).Returns(includeName);
+            mock.SetupGet(m => m.DisplayName).Returns(includeDisplayName);
+            mock.SetupGet(m => m.Description).Returns(includeDescription);
+            mock.SetupGet(m => m.ConfigurationIndependent).Returns(includeConfigurationIndependent);
+            mock.SetupGet(m => m.HelpUrl).Returns(includeHelpUrl);
+            mock.SetupGet(m => m.CategoryName).Returns(includeCategoryName);
+            mock.SetupGet(m => m.Order).Returns(includeOrder);
+            mock.SetupGet(m => m.Type).Returns(includeType);
+            mock.SetupGet(m => m.SearchTerms).Returns(includeSearchTerms);
+
+            return mock.Object;
+        }
+
+        public static IUIPropertyPropertiesAvailableStatus CreateUIPropertyPropertiesAvailableStatus(
+            bool includeProperties)
+        {
+            return CreateUIPropertyPropertiesAvailableStatus(
+                includeName: includeProperties,
+                includeDisplayName: includeProperties,
+                includeDescription: includeProperties,
+                includeConfigurationIndependent: includeProperties,
+                includeHelpUrl: includeProperties,
+                includeCategoryName: includeProperties,
+                includeOrder: includeProperties,
+                includeType: includeProperties,
+                includeSearchTerms: includeProperties);
+        }
+
+        public static ISupportedValuePropertiesAvailableStatus CreateSupportedValuesPropertiesAvailableStatus(
+            bool includeDisplayName = true,
+            bool includeValue = true)
+        {
+            var mock = new Mock<ISupportedValuePropertiesAvailableStatus>();
+
+            mock.SetupGet(m => m.DisplayName).Returns(includeDisplayName);
+            mock.SetupGet(m => m.Value).Returns(includeValue);
+
+            return mock.Object;
+        }
+
+        public static ISupportedValuePropertiesAvailableStatus CreateSupportedValuesPropertiesAvailableStatus(
+            bool includeProperties)
+        {
+            return CreateSupportedValuesPropertiesAvailableStatus(
+                includeDisplayName: includeProperties,
+                includeValue: includeProperties);
+        }
+
         public static ICategoryPropertiesAvailableStatus CreateCategoryPropertiesAvailableStatus(
-            bool includeDisplayName, 
-            bool includeName, 
-            bool includeOrder)
+            bool includeDisplayName = true, 
+            bool includeName = true, 
+            bool includeOrder = true)
         {
             var mock = new Mock<ICategoryPropertiesAvailableStatus>();
 
@@ -33,9 +102,18 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return mock.Object;
         }
 
+        public static ICategoryPropertiesAvailableStatus CreateCategoryPropertiesAvailableStatus(
+            bool includeProperties)
+        {
+            return CreateCategoryPropertiesAvailableStatus(
+                includeDisplayName: includeProperties,
+                includeName: includeProperties,
+                includeOrder: includeProperties);
+        }
+
         public static IConfigurationDimensionPropertiesAvailableStatus CreateConfigurationDimensionAvailableStatus(
-            bool includeName,
-            bool includeValue)
+            bool includeName = true,
+            bool includeValue = true)
         {
             var mock = new Mock<IConfigurationDimensionPropertiesAvailableStatus>();
 
@@ -43,6 +121,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
             mock.SetupGet(m => m.Value).Returns(includeValue);
 
             return mock.Object;
+        }
+
+        public static IConfigurationDimensionPropertiesAvailableStatus CreateConfigurationDimensionAvailableStatus(
+            bool includeProperties)
+        {
+            return CreateConfigurationDimensionAvailableStatus(
+                includeName: includeProperties,
+                includeValue: includeProperties);
         }
 
         public static IPropertyPagePropertiesAvailableStatus CreatePropertyPagePropertiesAvailableStatus(
@@ -59,6 +145,46 @@ namespace Microsoft.VisualStudio.ProjectSystem
             mock.SetupGet(m => m.Kind).Returns(includeKind);
 
             return mock.Object;
+        }
+
+        public static IPropertyPagePropertiesAvailableStatus CreatePropertyPagePropertiesAvailableStatus(
+            bool includeProperties)
+        {
+            return CreatePropertyPagePropertiesAvailableStatus(
+                includeName: includeProperties,
+                includeDisplayName: includeProperties,
+                includeOrder: includeProperties,
+                includeKind: includeProperties);
+        }
+
+        public static IUIPropertyEditorPropertiesAvailableStatus CreateUIPropertyEditorPropertiesAvailableStatus(
+            bool includeName = true)
+        {
+            var mock = new Mock<IUIPropertyEditorPropertiesAvailableStatus>();
+
+            mock.SetupGet(m => m.Name).Returns(includeName);
+
+            return mock.Object;
+        }
+
+        public static IUIPropertyValuePropertiesAvailableStatus CreateUIPropertyValuePropertiesAvailableStatus(
+            bool includeEvaluatedValue = true,
+            bool includeUnevaluatedValue = true)
+        {
+            var mock = new Mock<IUIPropertyValuePropertiesAvailableStatus>();
+
+            mock.SetupGet(m => m.EvaluatedValue).Returns(includeEvaluatedValue);
+            mock.SetupGet(m => m.UnevaluatedValue).Returns(includeUnevaluatedValue);
+
+            return mock.Object;
+        }
+
+        public static IUIPropertyValuePropertiesAvailableStatus CreateUIPropertyValuePropertiesAvailableStatus(
+            bool includeProperties)
+        {
+            return CreateUIPropertyValuePropertiesAvailableStatus(
+                includeEvaluatedValue: includeProperties,
+                includeUnevaluatedValue: includeProperties);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IPropertyPageQueryCacheFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IPropertyPageQueryCacheFactory.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.VS.Query;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    public static class IPropertyPageQueryCacheFactory
+    {
+        internal static IPropertyPageQueryCache Create()
+        {
+            var mock = new Mock<IPropertyPageQueryCache>();
+
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducerTests.cs
@@ -3,7 +3,6 @@
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
-using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
 using Xunit;
 
@@ -18,14 +17,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 includeDisplayName: true,
                 includeName: true,
                 includeOrder: true);
-            var producer = new TestCategoryDataProducer(properties);
 
             var entityRuntime = IEntityRuntimeModelFactory.Create();
             var id = new EntityIdentity(key: "A", value: "B");
             var category = new Category { DisplayName = "CategoryDisplayName", Name = "CategoryName" };
             var order = 42;
 
-            var result = (CategoryValue)producer.TestCreateMetadataValue(entityRuntime, id, category, order);
+            var result = (CategoryValue)CategoryDataProducer.CreateCategoryValue(entityRuntime, id, category, order, properties);
 
             Assert.Equal(expected: "CategoryDisplayName", actual: result.DisplayName);
             Assert.Equal(expected: "CategoryName", actual: result.Name);
@@ -39,14 +37,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 includeDisplayName: true,
                 includeName: true,
                 includeOrder: true);
-            var producer = new TestCategoryDataProducer(properties);
 
             var entityRuntime = IEntityRuntimeModelFactory.Create();
             var id = new EntityIdentity(key: "A", value: "B");
             var category = new Category { DisplayName = "CategoryDisplayName", Name = "CategoryName" };
             var order = 42;
 
-            var result = (CategoryValue)producer.TestCreateMetadataValue(entityRuntime, id, category, order);
+            var result = (CategoryValue)CategoryDataProducer.CreateCategoryValue(entityRuntime, id, category, order, properties);
 
             Assert.Equal(expected: category, actual: ((IEntityValueFromProvider)result).ProviderState);
         }
@@ -58,34 +55,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 includeDisplayName: true,
                 includeName: true,
                 includeOrder: true);
-            var producer = new TestCategoryDataProducer(properties);
 
-            var entity = IEntityWithIdFactory.Create(key: "A", value: "B");
+            var parentEntity = IEntityWithIdFactory.Create(key: "A", value: "B");
             var category = new Category { DisplayName = "CategoryDisplayName", Name = "MyCategoryName" };
             var order = 42;
 
-            var result = (CategoryValue)producer.TestCreateCategoryValue(entity, category, order);
+            var result = (CategoryValue)CategoryDataProducer.CreateCategoryValue(parentEntity, category, order, properties);
 
             Assert.True(result.Id.TryGetValue(ProjectModelIdentityKeys.CategoryName, out string name));
             Assert.Equal(expected: "MyCategoryName", actual: name);
-        }
-
-        private class TestCategoryDataProducer : CategoryDataProducer
-        {
-            public TestCategoryDataProducer(ICategoryPropertiesAvailableStatus properties)
-                : base(properties)
-            {
-            }
-            
-            public IEntityValue TestCreateCategoryValue(IEntityValue entity, Category category, int order)
-            {
-                return CreateCategoryValue(entity, category, order);
-            }
-
-            public IEntityValue TestCreateMetadataValue(IEntityRuntimeModel runtimeModel, EntityIdentity id, Category category, int order)
-            {
-                return CreateCategoryValue(runtimeModel, id, category, order);
-            }
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducerTests.cs
@@ -1,0 +1,91 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    public class CategoryDataProducerTests
+    {
+        [Fact]
+        public void WhenPropertiesAreRequested_PropertyValuesAreReturned()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateCategoryPropertiesAvailableStatus(
+                includeDisplayName: true,
+                includeName: true,
+                includeOrder: true);
+            var producer = new TestCategoryDataProducer(properties);
+
+            var entityRuntime = IEntityRuntimeModelFactory.Create();
+            var id = new EntityIdentity(key: "A", value: "B");
+            var category = new Category { DisplayName = "CategoryDisplayName", Name = "CategoryName" };
+            var order = 42;
+
+            var result = (CategoryValue)producer.TestCreateMetadataValue(entityRuntime, id, category, order);
+
+            Assert.Equal(expected: "CategoryDisplayName", actual: result.DisplayName);
+            Assert.Equal(expected: "CategoryName", actual: result.Name);
+            Assert.Equal(expected: 42, actual: result.Order);
+        }
+
+        [Fact]
+        public void WhenCategoryValueCreated_TheCategoryIsTheProviderState()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateCategoryPropertiesAvailableStatus(
+                includeDisplayName: true,
+                includeName: true,
+                includeOrder: true);
+            var producer = new TestCategoryDataProducer(properties);
+
+            var entityRuntime = IEntityRuntimeModelFactory.Create();
+            var id = new EntityIdentity(key: "A", value: "B");
+            var category = new Category { DisplayName = "CategoryDisplayName", Name = "CategoryName" };
+            var order = 42;
+
+            var result = (CategoryValue)producer.TestCreateMetadataValue(entityRuntime, id, category, order);
+
+            Assert.Equal(expected: category, actual: ((IEntityValueFromProvider)result).ProviderState);
+        }
+
+        [Fact]
+        public void WhenCreatingACategory_TheIdIsTheCategoryName()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateCategoryPropertiesAvailableStatus(
+                includeDisplayName: true,
+                includeName: true,
+                includeOrder: true);
+            var producer = new TestCategoryDataProducer(properties);
+
+            var entity = IEntityWithIdFactory.Create(key: "A", value: "B");
+            var category = new Category { DisplayName = "CategoryDisplayName", Name = "MyCategoryName" };
+            var order = 42;
+
+            var result = (CategoryValue)producer.TestCreateCategoryValue(entity, category, order);
+
+            Assert.True(result.Id.TryGetValue(ProjectModelIdentityKeys.CategoryName, out string name));
+            Assert.Equal(expected: "MyCategoryName", actual: name);
+        }
+
+        private class TestCategoryDataProducer : CategoryDataProducer
+        {
+            public TestCategoryDataProducer(ICategoryPropertiesAvailableStatus properties)
+                : base(properties)
+            {
+            }
+            
+            public IEntityValue TestCreateCategoryValue(IEntityValue entity, Category category, int order)
+            {
+                return CreateCategoryValue(entity, category, order);
+            }
+
+            public IEntityValue TestCreateMetadataValue(IEntityRuntimeModel runtimeModel, EntityIdentity id, Category category, int order)
+            {
+                return CreateCategoryValue(runtimeModel, id, category, order);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducerTests.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    public class ConfigurationDimensionDataProducerTests
+    {
+        [Fact]
+        public void WhenPropertiesAreRequested_PropertyValuesAreReturned()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateConfigurationDimensionAvailableStatus(
+                includeName: true,
+                includeValue: true);
+            var producer = new TestConfigurationDimensionDataProducer(properties);
+
+            var entityRuntime = IEntityRuntimeModelFactory.Create();
+            var dimension = new KeyValuePair<string, string>("AlphaDimension", "AlphaDimensionValue");
+
+            var result = (ConfigurationDimensionValue)producer.TestCreateConfigurationDimension(entityRuntime, dimension);
+
+            Assert.Equal(expected: "AlphaDimension", actual: result.Name);
+            Assert.Equal(expected: "AlphaDimensionValue", actual: result.Value);
+        }
+
+        [Fact]
+        public void WhenPropertiesAreNotRequested_PropertyValuesAreNotReturned()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateConfigurationDimensionAvailableStatus(
+                includeName: false,
+                includeValue: false);
+            var producer = new TestConfigurationDimensionDataProducer(properties);
+
+            var entityRuntime = IEntityRuntimeModelFactory.Create();
+            var dimension = new KeyValuePair<string, string>("AlphaDimension", "AlphaDimensionValue");
+
+            var result = (ConfigurationDimensionValue)producer.TestCreateConfigurationDimension(entityRuntime, dimension);
+
+            Assert.Throws<MissingDataException>(() => result.Name);
+            Assert.Throws<MissingDataException>(() => result.Value);
+        }
+
+        private class TestConfigurationDimensionDataProducer : ConfigurationDimensionDataProducer
+        {
+            public TestConfigurationDimensionDataProducer(IConfigurationDimensionPropertiesAvailableStatus properties)
+                : base(properties)
+            {
+            }
+
+            public IEntityValue TestCreateConfigurationDimension(IEntityRuntimeModel entityRuntime, KeyValuePair<string, string> projectConfigurationDimension)
+            {
+                return CreateProjectConfigurationDimension(entityRuntime, projectConfigurationDimension);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducerTests.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using Microsoft.VisualStudio.ProjectSystem.Query;
-using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
 using Xunit;
 
@@ -16,12 +15,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             var properties = PropertiesAvailableStatusFactory.CreateConfigurationDimensionAvailableStatus(
                 includeName: true,
                 includeValue: true);
-            var producer = new TestConfigurationDimensionDataProducer(properties);
 
             var entityRuntime = IEntityRuntimeModelFactory.Create();
             var dimension = new KeyValuePair<string, string>("AlphaDimension", "AlphaDimensionValue");
 
-            var result = (ConfigurationDimensionValue)producer.TestCreateConfigurationDimension(entityRuntime, dimension);
+            var result = (ConfigurationDimensionValue)ConfigurationDimensionDataProducer.CreateProjectConfigurationDimension(entityRuntime, dimension, properties);
 
             Assert.Equal(expected: "AlphaDimension", actual: result.Name);
             Assert.Equal(expected: "AlphaDimensionValue", actual: result.Value);
@@ -33,28 +31,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             var properties = PropertiesAvailableStatusFactory.CreateConfigurationDimensionAvailableStatus(
                 includeName: false,
                 includeValue: false);
-            var producer = new TestConfigurationDimensionDataProducer(properties);
 
             var entityRuntime = IEntityRuntimeModelFactory.Create();
             var dimension = new KeyValuePair<string, string>("AlphaDimension", "AlphaDimensionValue");
 
-            var result = (ConfigurationDimensionValue)producer.TestCreateConfigurationDimension(entityRuntime, dimension);
+            var result = (ConfigurationDimensionValue)ConfigurationDimensionDataProducer.CreateProjectConfigurationDimension(entityRuntime, dimension, properties);
 
             Assert.Throws<MissingDataException>(() => result.Name);
             Assert.Throws<MissingDataException>(() => result.Value);
-        }
-
-        private class TestConfigurationDimensionDataProducer : ConfigurationDimensionDataProducer
-        {
-            public TestConfigurationDimensionDataProducer(IConfigurationDimensionPropertiesAvailableStatus properties)
-                : base(properties)
-            {
-            }
-
-            public IEntityValue TestCreateConfigurationDimension(IEntityRuntimeModel entityRuntime, KeyValuePair<string, string> projectConfigurationDimension)
-            {
-                return CreateProjectConfigurationDimension(entityRuntime, projectConfigurationDimension);
-            }
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducerTests.cs
@@ -40,5 +40,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             Assert.Throws<MissingDataException>(() => result.Name);
             Assert.Throws<MissingDataException>(() => result.Value);
         }
+
+        [Fact]
+        public void WhenCreatingEntitiesFromAProjectConfiguration_OneEntityIsCreatedPerDimension()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateConfigurationDimensionAvailableStatus(
+                includeName: true,
+                includeValue: true);
+
+            var entityRuntimeModel = IEntityRuntimeModelFactory.Create();
+            var configuration = ProjectConfigurationFactory.Create("Alpha|Beta|Gamma", "A|B|C");
+            var results = ConfigurationDimensionDataProducer.CreateProjectConfigurationDimensions(entityRuntimeModel, configuration, properties);
+
+            // We can't guarantee an order for the dimensions, so just check that all the expected values are present.
+            Assert.Contains(results, entity => entity is ConfigurationDimensionValue dimension && dimension.Name == "Alpha" && dimension.Value == "A");
+            Assert.Contains(results, entity => entity is ConfigurationDimensionValue dimension && dimension.Name == "Beta" && dimension.Value == "B");
+            Assert.Contains(results, entity => entity is ConfigurationDimensionValue dimension && dimension.Name == "Gamma" && dimension.Value == "C");
+        }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducerTests.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    public class PropertyPageDataProducerTests
+    {
+        [Fact]
+        public void WhenPropertyValuesAreRequested_PropertyValuesAreReturned()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreatePropertyPagePropertiesAvailableStatus();
+
+            var propertyPage = (PropertyPageValue)PropertyPageDataProducer.CreatePropertyPageValue(
+                IEntityRuntimeModelFactory.Create(),
+                new EntityIdentity(key: "A", value: "B"),
+                IPropertyPageQueryCacheFactory.Create(),
+                new Rule { Name = "MyRule", DisplayName = "My Rule Display Name", Order = 42, PageTemplate = "generic" },
+                properties);
+
+            Assert.Equal(expected: "MyRule", actual: propertyPage.Name);
+            Assert.Equal(expected: "My Rule Display Name", actual: propertyPage.DisplayName);
+            Assert.Equal(expected: 42, actual: propertyPage.Order);
+            Assert.Equal(expected: "generic", actual: propertyPage.Kind);
+        }
+
+        [Fact]
+        public void WhenCreatingAModel_ProviderStateConsistsOfCacheAndRule()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreatePropertyPagePropertiesAvailableStatus();
+
+            var propertyPage = (IEntityValueFromProvider)PropertyPageDataProducer.CreatePropertyPageValue(
+                IEntityRuntimeModelFactory.Create(),
+                new EntityIdentity(key: "A", value: "B"),
+                IPropertyPageQueryCacheFactory.Create(),
+                new Rule { Name = "MyRule", DisplayName = "My Rule Display Name", Order = 42, PageTemplate = "generic" },
+                properties);
+
+            Assert.IsType<(IPropertyPageQueryCache, Rule)>(propertyPage.ProviderState);
+        }
+
+        [Fact]
+        public void WhenCreatingFromAParentAndRule_TheRuleNameIsTheEntityId()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreatePropertyPagePropertiesAvailableStatus();
+
+            var propertyPage = (PropertyPageValue)PropertyPageDataProducer.CreatePropertyPageValue(
+                IEntityWithIdFactory.Create(key: "ParentKey", value: "ParentValue"),
+                IPropertyPageQueryCacheFactory.Create(),
+                new Rule { Name = "MyRule", DisplayName = "My Rule Display Name", Order = 42, PageTemplate = "generic" },
+                properties);
+
+            Assert.Equal(expected: "MyRule", actual: propertyPage.Id[ProjectModelIdentityKeys.PropertyPageName]);
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducerTests.cs
@@ -1,10 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducerTests.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
+{
+    public class SupportedValueDataProducerTests
+    {
+        [Fact]
+        public void WhenPropertiesAreRequested_PropertyValuesAreReturned()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateSupportedValuesPropertiesAvailableStatus();
+
+            var entityRuntime = IEntityRuntimeModelFactory.Create();
+            var enumValue = IEnumValueFactory.Create(displayName: "Hello", name: "MyValue");
+
+            var result = (SupportedValueValue)SupportedValueDataProducer.CreateSupportedValue(entityRuntime, enumValue, properties);
+
+            Assert.Equal(expected: "Hello", actual: result.DisplayName);
+            Assert.Equal(expected: "MyValue", actual: result.Value);
+        }
+
+        [Fact]
+        public async Task WhenCreatingValuesFromAnIProperty_WeGetOneValuePerIEnumValue()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateSupportedValuesPropertiesAvailableStatus();
+
+            var entityRuntime = IEntityRuntimeModelFactory.Create();
+            var iproperty = IPropertyFactory.CreateEnum(new[]
+            {
+                IEnumValueFactory.Create(displayName: "Alpha", name: "a"),
+                IEnumValueFactory.Create(displayName: "Beta", name: "b"),
+                IEnumValueFactory.Create(displayName: "Gamma", name: "c")
+            });
+
+            var result = await SupportedValueDataProducer.CreateSupportedValuesAsync(entityRuntime, iproperty, properties);
+
+            Assert.Collection(result, new Action<IEntityValue>[]
+            {
+                entity => assertEqual(entity, expectedDisplayName: "Alpha", expectedValue: "a"),
+                entity => assertEqual(entity, expectedDisplayName: "Beta", expectedValue: "b"),
+                entity => assertEqual(entity, expectedDisplayName: "Gamma", expectedValue: "c")
+            });
+
+            static void assertEqual(IEntityValue entity, string expectedDisplayName, string expectedValue)
+            {
+                var supportedValueEntity = (SupportedValueValue)entity;
+                Assert.Equal(expectedDisplayName, supportedValueEntity.DisplayName);
+                Assert.Equal(expectedValue, supportedValueEntity.Value);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataProducerTests.cs
@@ -2,7 +2,6 @@
 
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Query;
-using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
 using Xunit;
 
@@ -16,12 +15,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             var properties = PropertiesAvailableStatusFactory.CreateUIEditorMetadataAvailableStatus(
                 includeName: true,
                 includeValue: true);
-            var producer = new TestUIEditorMetadataProducer(properties);
 
             var entityRuntime = IEntityRuntimeModelFactory.Create();
             var metadata = new NameValuePair { Name = "Alpha", Value = "AlphaValue" };
-
-            var result = (UIEditorMetadataValue)producer.TestCreateMetadataValueAsync(entityRuntime, metadata);
+           
+            var result = (UIEditorMetadataValue)UIEditorMetadataProducer.CreateMetadataValue(entityRuntime, metadata, properties);
 
             Assert.Equal(expected: "Alpha", actual: result.Name);
             Assert.Equal(expected: "AlphaValue", actual: result.Value);
@@ -33,32 +31,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             var properties = PropertiesAvailableStatusFactory.CreateUIEditorMetadataAvailableStatus(
                 includeName: false,
                 includeValue: false);
-            var producer = new TestUIEditorMetadataProducer(properties);
 
             var entityRuntime = IEntityRuntimeModelFactory.Create();
             var metadata = new NameValuePair { Name = "Alpha", Value = "AlphaValue" };
 
-            var result = (UIEditorMetadataValue)producer.TestCreateMetadataValueAsync(entityRuntime, metadata);
+            var result = (UIEditorMetadataValue)UIEditorMetadataProducer.CreateMetadataValue(entityRuntime, metadata, properties);
 
             Assert.Throws<MissingDataException>(() => result.Name);
             Assert.Throws<MissingDataException>(() => result.Value);
-        }
-
-        /// <summary>
-        /// Derives from the abstract <see cref="UIEditorMetadataProducer"/>. Also exposes protected members for testing
-        /// purposes.
-        /// </summary>
-        private class TestUIEditorMetadataProducer : UIEditorMetadataProducer
-        {
-            public TestUIEditorMetadataProducer(IUIEditorMetadataPropertiesAvailableStatus properties)
-                : base(properties)
-            {
-            }
-
-            public IEntityValue TestCreateMetadataValueAsync(IEntityRuntimeModel entityRuntime, NameValuePair metadata)
-            {
-                return CreateMetadataValue(entityRuntime, metadata);
-            }
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataProducerTests.cs
@@ -40,5 +40,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             Assert.Throws<MissingDataException>(() => result.Name);
             Assert.Throws<MissingDataException>(() => result.Value);
         }
+
+        [Fact]
+        public void WhenCreatingMetadataFromAnEditor_AllMetadataIsReturned()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIEditorMetadataAvailableStatus(
+                includeName: true,
+                includeValue: true);
+
+            var entityRuntime = IEntityRuntimeModelFactory.Create();
+            var editor = new ValueEditor
+            {
+                Metadata =
+                { 
+                    new() { Name = "Alpha", Value = "A" },
+                    new() { Name = "Beta", Value = "B" }
+                }
+            };
+
+            var results = UIEditorMetadataProducer.CreateMetadataValues(
+                entityRuntime,
+                editor,
+                properties);
+
+            Assert.Contains(results, entity => entity is UIEditorMetadataValue metadata && metadata.Name == "Alpha" && metadata.Value == "A");
+            Assert.Contains(results, entity => entity is UIEditorMetadataValue metadata && metadata.Name == "Beta" && metadata.Value == "B");
+        }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataProducerTests.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    public class UIEditorMetadataProducerTests
+    {
+        [Fact]
+        public void WhenPropertiesAreRequested_PropertyValuesAreReturned()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIEditorMetadataAvailableStatus(
+                includeName: true,
+                includeValue: true);
+            var producer = new TestUIEditorMetadataProducer(properties);
+
+            var entityRuntime = IEntityRuntimeModelFactory.Create();
+            var metadata = new NameValuePair { Name = "Alpha", Value = "AlphaValue" };
+
+            var result = (UIEditorMetadataValue)producer.TestCreateMetadataValueAsync(entityRuntime, metadata);
+
+            Assert.Equal(expected: "Alpha", actual: result.Name);
+            Assert.Equal(expected: "AlphaValue", actual: result.Value);
+        }
+
+        [Fact]
+        public void WhenPropertiesAreNotRequested_PropertyValuesAreNotReturned()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIEditorMetadataAvailableStatus(
+                includeName: false,
+                includeValue: false);
+            var producer = new TestUIEditorMetadataProducer(properties);
+
+            var entityRuntime = IEntityRuntimeModelFactory.Create();
+            var metadata = new NameValuePair { Name = "Alpha", Value = "AlphaValue" };
+
+            var result = (UIEditorMetadataValue)producer.TestCreateMetadataValueAsync(entityRuntime, metadata);
+
+            Assert.Throws<MissingDataException>(() => result.Name);
+            Assert.Throws<MissingDataException>(() => result.Value);
+        }
+
+        /// <summary>
+        /// Derives from the abstract <see cref="UIEditorMetadataProducer"/>. Also exposes protected members for testing
+        /// purposes.
+        /// </summary>
+        private class TestUIEditorMetadataProducer : UIEditorMetadataProducer
+        {
+            public TestUIEditorMetadataProducer(IUIEditorMetadataPropertiesAvailableStatus properties)
+                : base(properties)
+            {
+            }
+
+            public IEntityValue TestCreateMetadataValueAsync(IEntityRuntimeModel entityRuntime, NameValuePair metadata)
+            {
+                return CreateMetadataValue(entityRuntime, metadata);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
@@ -1,0 +1,117 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    public class UIPropertyDataProducerTests
+    {
+        [Fact]
+        public void WhenCreatingFromAParentAndProperty_ThePropertyNameIsTheEntityId()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeProperties: false);
+
+            var parentEntity = IEntityWithIdFactory.Create(key: "parent", value: "A");
+            var cache = IPropertyPageQueryCacheFactory.Create();
+            var property = new TestProperty { Name = "MyProperty" };
+            var order = 42;
+
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(parentEntity, cache, property, order, properties);
+
+            Assert.Equal(expected: "MyProperty", actual: result.Id[ProjectModelIdentityKeys.UIPropertyName]);
+        }
+
+        [Fact]
+        public void WhenPropertiesAreRequested_PropertyValuesAreReturned()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeProperties: true);
+
+            var runtimeModel = IEntityRuntimeModelFactory.Create();
+            var id = new EntityIdentity(key: "PropertyName", value: "A");
+            var cache = IPropertyPageQueryCacheFactory.Create();
+            var property = new TestProperty
+            {
+                Name = "A",
+                DisplayName = "Page A",
+                Description = "This is the description for Page A",
+                HelpUrl = "https://mypage",
+                Category = "general",
+                DataSource = new DataSource { HasConfigurationCondition = false }
+            };
+
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+
+            Assert.Equal(expected: "A", actual: result.Name);
+            Assert.Equal(expected: "Page A", actual: result.DisplayName);
+            Assert.Equal(expected: "This is the description for Page A", actual: result.Description);
+            Assert.True(result.ConfigurationIndependent);
+            Assert.Equal(expected: "general", actual: result.CategoryName);
+            Assert.Equal(expected: 42, actual: result.Order);
+            Assert.Equal(expected: "string", actual: result.Type);
+        }
+
+        [Fact]
+        public void WhenTheEntityIsCreated_TheProviderStateIsTheExpectedType()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeProperties: false);
+
+            var runtimeModel = IEntityRuntimeModelFactory.Create();
+            var id = new EntityIdentity(key: "PropertyName", value: "A");
+            var cache = IPropertyPageQueryCacheFactory.Create();
+            var property = new TestProperty
+            {
+                Name = "A"
+            };
+            var rule = new Rule();
+            rule.BeginInit();
+            rule.Properties.Add(property);
+            rule.EndInit();
+
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+
+            Assert.IsType<(IPropertyPageQueryCache, Rule, string)>(((IEntityValueFromProvider)result).ProviderState);
+        }
+
+        [Fact]
+        public void WhenCreatingPropertiesFromARule_OneEntityIsCreatedPerProperty()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeProperties: true);
+
+            var parentEntity = IEntityWithIdFactory.Create(key: "Parent", value: "ParentRule");
+            var cache = IPropertyPageQueryCacheFactory.Create();
+            var rule = new Rule();
+            rule.BeginInit();
+            rule.Properties.AddRange(new[]
+            {
+                new TestProperty { Name = "Alpha" },
+                new TestProperty { Name = "Beta" },
+                new TestProperty { Name = "Gamma" },
+            });
+            rule.EndInit();
+
+            var result = UIPropertyDataProducer.CreateUIPropertyValues(parentEntity, cache, rule, properties);
+
+            Assert.Collection(result, new Action<IEntityValue>[]
+            {
+                entity => { assertEqual(entity, expectedName: "Alpha"); },
+                entity => { assertEqual(entity, expectedName: "Beta"); },
+                entity => { assertEqual(entity, expectedName: "Gamma"); }
+            });
+
+            static void assertEqual(IEntityValue entity, string expectedName)
+            {
+                var propertyEntity = (UIPropertyValue)entity;
+                Assert.Equal(expectedName, propertyEntity.Name);
+            }
+        }
+
+        private class TestProperty : BaseProperty
+        {
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducerTests.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
+{
+    public class UIPropertyEditorDataProducerTests
+    {
+        [Fact]
+        public void WhenCreatingAnEntityFromAParentAndEditor_TheIdIsTheEditorType()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyEditorPropertiesAvailableStatus(includeName: false);
+
+            var parentEntity = IEntityWithIdFactory.Create(key: "parentId", value: "aaa");
+            var editor = new ValueEditor { EditorType = "My.Editor.Type" };
+
+            var result = (UIPropertyEditorValue)UIPropertyEditorDataProducer.CreateEditorValue(parentEntity, editor, properties);
+
+            Assert.Equal(expected: "My.Editor.Type", actual: result.Id[ProjectModelIdentityKeys.EditorName]);
+        }
+
+        [Fact]
+        public void WhenPropertiesAreRequested_PropertyValuesAreReturned()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyEditorPropertiesAvailableStatus(includeName: true);
+
+            var entityRuntime = IEntityRuntimeModelFactory.Create();
+            var id = new EntityIdentity(key: "EditorKey", value: "bbb");
+            var editor = new ValueEditor { EditorType = "My.Editor.Type" };
+
+            var result = (UIPropertyEditorValue)UIPropertyEditorDataProducer.CreateEditorValue(entityRuntime, id, editor, properties);
+
+            Assert.Equal(expected: "My.Editor.Type", actual: result.Name);
+        }
+
+        [Fact]
+        public void WhenAnEditorValueIsCreated_TheEditorIsTheProviderState()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyEditorPropertiesAvailableStatus(includeName: true);
+
+            var entityRuntime = IEntityRuntimeModelFactory.Create();
+            var id = new EntityIdentity(key: "EditorKey", value: "bbb");
+            var editor = new ValueEditor { EditorType = "My.Editor.Type" };
+
+            var result = (UIPropertyEditorValue)UIPropertyEditorDataProducer.CreateEditorValue(entityRuntime, id, editor, properties);
+
+            Assert.Equal(expected: editor, actual: ((IEntityValueFromProvider)result).ProviderState);
+        }
+
+        [Fact]
+        public void WhenCreatingEditorsFromAProperty_OneEntityIsReturnedPerEditor()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyEditorPropertiesAvailableStatus(includeName: true);
+
+            var parentEntity = IEntityWithIdFactory.Create(key: "parentKey", value: "parentId");
+            var rule = new Rule();
+            rule.BeginInit();
+            rule.Properties.Add(
+                new TestProperty
+                {
+                    Name = "MyProperty",
+                    ValueEditors =
+                    {
+                        new ValueEditor { EditorType = "Alpha" },
+                        new ValueEditor { EditorType = "Beta" },
+                        new ValueEditor { EditorType = "Gamma" }
+                    }
+                });
+            rule.EndInit();
+
+            var results = UIPropertyEditorDataProducer.CreateEditorValues(parentEntity, rule, "MyProperty", properties);
+
+            Assert.Collection(results, new Action<IEntityValue>[]
+            {
+                entity => assertEqual(entity, expectedName: "Alpha"),
+                entity => assertEqual(entity, expectedName: "Beta"),
+                entity => assertEqual(entity, expectedName: "Gamma")
+            });
+
+            static void assertEqual(IEntityValue entity, string expectedName)
+            {
+                var editorEntity = (UIPropertyEditorValue)entity;
+                Assert.Equal(expectedName, editorEntity.Name);
+            }
+        }
+
+        private class TestProperty : BaseProperty
+        {
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducerTests.cs
@@ -1,0 +1,142 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    public class UIPropertyValueDataProducerTests
+    {
+        [Fact]
+        public async Task WhenPropertyIsAnIEvaluatedProperty_GetUnevaluatedValueAsyncIsCalled()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyValuePropertiesAvailableStatus(
+                includeEvaluatedValue: false,
+                includeUnevaluatedValue: true);
+
+            var mockEvaluatedProperty = new Mock<IEvaluatedProperty>();
+            mockEvaluatedProperty.Setup(m => m.GetUnevaluatedValueAsync()).ReturnsAsync("unevaluated value");
+            var property = mockEvaluatedProperty.Object;
+
+            var entityRuntime = IEntityRuntimeModelFactory.Create();
+            var id = new EntityIdentity(key: "A", value: "B");
+            var configuration = ProjectConfigurationFactory.Create(configuration: "Alpha|Beta|Gamma");
+
+            var result = (UIPropertyValueValue)await UIPropertyValueDataProducer.CreateUIPropertyValueValueAsync(
+                entityRuntime,
+                id,
+                configuration,
+                property,
+                properties);
+
+            Assert.Equal(expected: "unevaluated value", actual: result.UnevaluatedValue);
+            mockEvaluatedProperty.Verify(m => m.GetUnevaluatedValueAsync());
+        }
+
+        [Fact]
+        public async Task WhenThePropertyIsAnIBoolProperty_ThenTheEvaluatedValueIsABool()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyValuePropertiesAvailableStatus(
+                includeEvaluatedValue: true,
+                includeUnevaluatedValue: false);
+
+            var mockBoolProperty = new Mock<IBoolProperty>();
+            mockBoolProperty.Setup(m => m.GetValueAsBoolAsync()).ReturnsAsync(true);
+            var property = mockBoolProperty.Object;
+
+            var entityRuntime = IEntityRuntimeModelFactory.Create();
+            var id = new EntityIdentity(key: "A", value: "B");
+            var configuration = ProjectConfigurationFactory.Create(configuration: "Alpha|Beta|Gamma");
+
+            var result = (UIPropertyValueValue)await UIPropertyValueDataProducer.CreateUIPropertyValueValueAsync(
+                entityRuntime,
+                id,
+                configuration,
+                property,
+                properties);
+
+            Assert.Equal(expected: true, actual: result.EvaluatedValue);
+        }
+
+        [Fact]
+        public async Task WhenThePropertyIsAnIStringProperty_ThenTheEvaluatedValuesIsAString()
+        {
+
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyValuePropertiesAvailableStatus(
+                includeEvaluatedValue: true,
+                includeUnevaluatedValue: false);
+
+            var mockStringProperty = new Mock<IStringProperty>();
+            mockStringProperty.Setup(m => m.GetValueAsStringAsync()).ReturnsAsync("string value");
+            var property = mockStringProperty.Object;
+
+            var entityRuntime = IEntityRuntimeModelFactory.Create();
+            var id = new EntityIdentity(key: "A", value: "B");
+            var configuration = ProjectConfigurationFactory.Create(configuration: "Alpha|Beta|Gamma");
+
+            var result = (UIPropertyValueValue)await UIPropertyValueDataProducer.CreateUIPropertyValueValueAsync(
+                entityRuntime,
+                id,
+                configuration,
+                property,
+                properties);
+
+            Assert.Equal(expected: "string value", actual: result.EvaluatedValue);
+        }
+
+        [Fact]
+        public async Task WhenThePropertyIsAnIIntProperty_ThenTheEvaluatedValueIsAnInt()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyValuePropertiesAvailableStatus(
+                includeEvaluatedValue: true,
+                includeUnevaluatedValue: false);
+
+            var mockIntProperty = new Mock<IIntProperty>();
+            mockIntProperty.Setup(m => m.GetValueAsIntAsync()).ReturnsAsync(42);
+            var property = mockIntProperty.Object;
+
+            var entityRuntime = IEntityRuntimeModelFactory.Create();
+            var id = new EntityIdentity(key: "A", value: "B");
+            var configuration = ProjectConfigurationFactory.Create(configuration: "Alpha|Beta|Gamma");
+
+            var result = (UIPropertyValueValue)await UIPropertyValueDataProducer.CreateUIPropertyValueValueAsync(
+                entityRuntime,
+                id,
+                configuration,
+                property,
+                properties);
+
+            Assert.Equal(expected: 42, actual: result.EvaluatedValue);
+        }
+
+        [Fact]
+        public async Task WhenThePropertyIsAnIEnumProperty_ThenTheEvaluatedValueIsAString()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyValuePropertiesAvailableStatus(
+                includeEvaluatedValue: true,
+                includeUnevaluatedValue: false);
+
+            var enumValue = IEnumValueFactory.Create(name: "enum value");
+            var mockEnumProperty = new Mock<IEnumProperty>();
+            mockEnumProperty.Setup(m => m.GetValueAsIEnumValueAsync()).ReturnsAsync(enumValue);
+            var property = mockEnumProperty.Object;
+
+            var entityRuntime = IEntityRuntimeModelFactory.Create();
+            var id = new EntityIdentity(key: "A", value: "B");
+            var configuration = ProjectConfigurationFactory.Create(configuration: "Alpha|Beta|Gamma");
+
+            var result = (UIPropertyValueValue)await UIPropertyValueDataProducer.CreateUIPropertyValueValueAsync(
+                entityRuntime,
+                id,
+                configuration,
+                property,
+                properties);
+
+            Assert.Equal(expected: "enum value", actual: result.EvaluatedValue);
+        }
+    }
+}


### PR DESCRIPTION
Implement the property page sections of the Project Query API defined in CPS. There's a lot of code here, but a relatively small number of patterns that I will explain shortly. First, some background.

The Project Query API defines the following types that relate to property pages and their values:

```
Project
  -> PropertyPage[]
    -> Category[]
    -> UIProperty[]
      -> UIPropertyValue[]
        -> ConfigurationDimension[]
        -> SupportedValue[]
      -> UIPropertyEditor[]
        -> UIEditorMetadata[]
```

Read this as "a `Project` has multiple `PropertyPages`, each `PropertyPage` has multiple `UIProperties`, each `UIProperty` has multiple `UIPropertyValues` (one per configuration)" and so on. Each of these types has additional properties (sometimes many) that constitute the actual data you want to retrieve using the Project Query API; for brevity they are not shown here.

The Project Query API supports two ways of retrieving one of these model types: by ID, and by relationship. In the case of ID we may be asked to produce a `UIProperty` for the property with ID "A" on the page with ID "B" that is part of project "C:\D\E\F.csproj". On the other hand, when asked to retrieve model types by relationship, we might be given a `PropertyPage` that has already been created and asked to produce all of the related `UIProperties`. CPS is responsible for examining a query and deciding which parts of the requested data to retrieve by ID, and which to retrieve by relationship. Our responsibility is to implement the actual retrieval mechanisms for each model type.

The types added here fall into one of four patterns. The `FooProvider` types exist at the boundary between the CPS parts of the implementation, and our parts. Each provider specifies, through metadata, which parts of the model it support, and which of the two retrieval mechanisms it supports. All the providers here support "by relationship" retrieval, but not all of them support by ID retrieval because not all of the model types have a meaningful ID. They delegate to other types to do the actual work, and we describe those types next.

At the bottom we have a series of static `FooProducer` types. These are responsible for taking our internal data structures--or IDs which map to internal data structures--and producing the related "Foo" model. If the model has a meaningful ID, it is also responsible for creating the hierarchical identity--usually by starting with the parent's identity and tagging on another item. Another thing to note about these types is that the Project Query API supports retrieving only some of the properties on any given model. The ones that should be retrieved are specified by a `FooPropertiesAvailableStatus` object, and a lot of what this producer does is simply check the status of each relevant property, and copy data into the model if it is requested.

The `FooByIdProducer` types implement the ID retrieval. Given a hierarchical identity, they extract the relevant pieces and pass them on to the methods on the related `FooProducer` type to produce the "FooModel". The `FooByIdProducer` type then reports the new models back to the lower layers of the Project Query API.

The `FooFromBarProducer` types implement the "by relationship" retrieval. Given some other model object "Bar", they examine the `ProviderState` field (used to pass data from one producer to another during a query execution) for the internal data representing "Bar", pass it on to `FooProducer` to handle, and again report the results back to the Project Query API.

The other interesting part of this change is the `PropertyPageQueryCache`, which serves to cache data that may be accessed multiple times in the course of the query. Please see the doc comment on that type for more details. To simplify unit tests, this is always accessed through the related `IPropertyPageQueryCache` interface.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6615)