### PR TITLE
Add metadata to filter MEF exports until needed

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesAttachedCollectionSourceProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesAttachedCollectionSourceProviderBase.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     /// Base class for attaching <see cref="IRelatableItem"/> children to <see cref="IVsHierarchyItem"/>s in the tree.
     /// </summary>
     /// <remarks>
-    /// See also <see cref="RelationAttachedCollectionSourceProviderBase"/> which attaches children and parents
+    /// See also <see cref="RelationAttachedCollectionSourceProvider"/> which attaches children and parents
     /// to <see cref="IRelatableItem"/> objects that already exist in the tree.
     /// </remarks>
     public abstract class DependenciesAttachedCollectionSourceProviderBase : IAttachedCollectionSourceProvider

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyAttachedCollectionSourceProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyAttachedCollectionSourceProvider.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.Implementation
 {
+    [AppliesTo(ProjectCapability.DependenciesTree)]
     [Export(typeof(IAttachedCollectionSourceProvider))]
     [Name(nameof(FrameworkReferenceAssemblyAttachedCollectionSourceProvider))]
     [VisualStudio.Utilities.Order(Before = HierarchyItemsProviderNames.Contains)]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyAttachedCollectionSourceProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyAttachedCollectionSourceProvider.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.Implementation
 {
-    [AppliesTo(ProjectCapability.DependenciesTree)]
+    [AppliesToProject(ProjectCapability.DependenciesTree)]
     [Export(typeof(IAttachedCollectionSourceProvider))]
     [Name(nameof(FrameworkReferenceAssemblyAttachedCollectionSourceProvider))]
     [VisualStudio.Utilities.Order(Before = HierarchyItemsProviderNames.Contains)]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/RelationAttachedCollectionSourceProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/RelationAttachedCollectionSourceProvider.cs
@@ -17,9 +17,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     /// </remarks>
     [AppliesToProject(ProjectCapability.DependenciesTree)]
     [Export(typeof(IAttachedCollectionSourceProvider))]
-    [Name(nameof(RelationAttachedCollectionSourceProviderBase))]
+    [Name(nameof(RelationAttachedCollectionSourceProvider))]
     [VisualStudio.Utilities.Order(Before = HierarchyItemsProviderNames.Contains)]
-    internal sealed class RelationAttachedCollectionSourceProviderBase : IAttachedCollectionSourceProvider
+    internal sealed class RelationAttachedCollectionSourceProvider : IAttachedCollectionSourceProvider
     {
         [Import] private IRelationProvider RelationProvider { get; set; } = null!;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/RelationAttachedCollectionSourceProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/RelationAttachedCollectionSourceProviderBase.cs
@@ -15,6 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     /// See also <see cref="DependenciesAttachedCollectionSourceProviderBase"/> which attaches children
     /// to the <see cref="IVsHierarchyItem"/> objects that represent top-level project dependencies.
     /// </remarks>
+    [AppliesTo(ProjectCapability.DependenciesTree)]
     [Export(typeof(IAttachedCollectionSourceProvider))]
     [Name(nameof(RelationAttachedCollectionSourceProviderBase))]
     [VisualStudio.Utilities.Order(Before = HierarchyItemsProviderNames.Contains)]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/RelationAttachedCollectionSourceProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/RelationAttachedCollectionSourceProviderBase.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     /// See also <see cref="DependenciesAttachedCollectionSourceProviderBase"/> which attaches children
     /// to the <see cref="IVsHierarchyItem"/> objects that represent top-level project dependencies.
     /// </remarks>
-    [AppliesTo(ProjectCapability.DependenciesTree)]
+    [AppliesToProject(ProjectCapability.DependenciesTree)]
     [Export(typeof(IAttachedCollectionSourceProvider))]
     [Name(nameof(RelationAttachedCollectionSourceProviderBase))]
     [VisualStudio.Utilities.Order(Before = HierarchyItemsProviderNames.Contains)]


### PR DESCRIPTION
Fixes #6617

Previously the import of `IAttachedCollectionSourceProvider` parts did not filter exports based on metadata. This meant that all exports were loaded, which resulted in DLLs being loaded even when the dependencies tree was unused.

This filtering is now supported by Solution Explorer, and this commit adds the relevant condition to ensure DLLs are not loaded unnecessarily.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6618)