### PR TITLE
Using new handler CopyAsync to hook when a file is moved to new folder.

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <RestoreSources>
       $(RestoreSources);
+      D:\microsoft\dotnet\CPS\bin\Debug\packages\nuget;
       https://dotnet.myget.org/F/msbuild/api/v3/index.json;
       https://dotnet.myget.org/F/nuget-build/api/v3/index.json;
       https://dotnet.myget.org/F/roslyn/api/v3/index.json;
@@ -97,7 +98,7 @@
 
     <!-- CPS -->
     <!-- Analyzers have a different version due to https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/266100 -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.8.145-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.8.362-pre-ga006ee01a7" />
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.7.232-pre" />
 
     <!-- Roslyn -->

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeProvider.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeProvider.cs
@@ -40,6 +40,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
             throw new NotImplementedException();
         }
 
+        public Task CopyAsync(string filename, string folderToMove)
+        {
+            throw new NotImplementedException();
+        }
+
         public bool CanRemove(IImmutableSet<IProjectTree> nodes, DeleteOptions deleteOptions = DeleteOptions.None)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
This code enables a new feature to update the namespace when a file is moved to another folder.

Here we are using the new project tree action handler CopyAsync which is executed when a copying 
a file to a new folder. This CPS code is needed before this PR
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/CPS/pullrequest/276244

How should we handle the Ux ?
This pr will enable/disable a prompt for this feature
https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/270709?path=%2Fsrc%2Fenv%2Fmsenv%2Fcore%2Fenvopts.cpp&_a=commits

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6623)