### PR TITLE
Refactor logic to read supported frameworks

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
@@ -131,7 +131,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 If TargetFrameworksDefined() = False And vsFrameworkMultiTargeting IsNot Nothing Then
 
                     Dim supportedTargetFrameworksDescriptor = GetPropertyDescriptor("SupportedTargetFrameworks")
-                    Dim supportedFrameworks As IEnumerable(Of TargetFrameworkMoniker) = TargetFrameworkMoniker.GetSupportedTargetFrameworkMonikers(vsFrameworkMultiTargeting, DTEProject, supportedTargetFrameworksDescriptor)
+                    Dim supportedFrameworks As IEnumerable(Of TargetFrameworkMoniker) = TargetFrameworkMoniker.GetSupportedTargetFrameworkMonikers(vsFrameworkMultiTargeting, DTEProject, supportedTargetFrameworksDescriptor?.Converter)
 
                     For Each supportedFramework As TargetFrameworkMoniker In supportedFrameworks
                         targetFrameworkComboBox.Items.Add(supportedFramework)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
@@ -50,105 +50,58 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return _displayName
         End Function
 
-        'TODO: Remove this hardcoded list (Refer Bug: #795)
-        Private Shared Function AddDotNetCoreFramework(prgSupportedFrameworks As Array, supportedTargetFrameworksDescriptor As PropertyDescriptor) As Array
-            Dim _TypeConverter As TypeConverter = supportedTargetFrameworksDescriptor.Converter
-            If _TypeConverter IsNot Nothing Then
-                Dim supportedFrameworksList As List(Of String) = New List(Of String)
-                For Each moniker As String In prgSupportedFrameworks
-                    supportedFrameworksList.Add(moniker)
-                Next
-
-                For Each frameworkValue In _TypeConverter.GetStandardValues()
-                    Dim framework = CStr(frameworkValue)
-                    If framework IsNot Nothing Then
-                        supportedFrameworksList.Add(framework)
-                    End If
-                Next
-
-                Return supportedFrameworksList.ToArray
-            End If
-
-            Return prgSupportedFrameworks
-        End Function
-
         ''' <summary>
         ''' Gets the supported target framework monikers from DTAR
         ''' </summary>
-        ''' <param name="vsFrameworkMultiTargeting"></param>
         Public Shared Function GetSupportedTargetFrameworkMonikers(
-            vsFrameworkMultiTargeting As IVsFrameworkMultiTargeting,
-            currentProject As Project,
-            supportedTargetFrameworksDescriptor As PropertyDescriptor) As IEnumerable(Of TargetFrameworkMoniker)
+                frameworkMultiTargeting As IVsFrameworkMultiTargeting,
+                project As Project,
+                converter As TypeConverter) As IEnumerable(Of TargetFrameworkMoniker)
 
-            Dim supportedFrameworksArray As Array = Nothing
-            VSErrorHandler.ThrowOnFailure(vsFrameworkMultiTargeting.GetSupportedFrameworks(supportedFrameworksArray))
-            If supportedTargetFrameworksDescriptor IsNot Nothing Then
-                supportedFrameworksArray = AddDotNetCoreFramework(supportedFrameworksArray, supportedTargetFrameworksDescriptor)
-            End If
+            Dim provider = GetSupportedTargetFrameworksProvider(frameworkMultiTargeting, project, converter)
 
-            Dim targetFrameworkMonikerProperty As [Property] = currentProject.Properties.Item(ApplicationPropPage.Const_TargetFrameworkMoniker)
-            Dim currentTargetFrameworkMoniker As String = CStr(targetFrameworkMonikerProperty.Value)
-            Dim currentFrameworkName As New FrameworkName(currentTargetFrameworkMoniker)
+            Dim moniker As [Property] = project.Properties.Item(ApplicationPropPage.Const_TargetFrameworkMoniker)
 
-            Dim supportedTargetFrameworkMonikers As New List(Of TargetFrameworkMoniker)
-            Dim hashSupportedTargetFrameworkMonikers As New HashSet(Of String)
+            Dim framework = New FrameworkName(CStr(moniker.Value))
 
-            ' Determine if the project is a WAP (Web Application Project).
-            Dim isWebProject As Boolean = False
-            For i As Integer = 1 To currentProject.Properties.Count
-                If currentProject.Properties.Item(i).Name.StartsWith("WebApplication.") Then
-                    isWebProject = True
-                    Exit For
-                End If
-            Next
-
-            ' UNDONE: DTAR may currently send back duplicate monikers, so explicitly filter them out for now
-            For Each moniker As String In supportedFrameworksArray
-                If hashSupportedTargetFrameworkMonikers.Add(moniker) Then
-
-                    Dim frameworkName As New FrameworkName(moniker)
-
-                    ' Filter out frameworks with a different identifier since they are not applicable to the current project type
-                    If String.Equals(frameworkName.Identifier, currentFrameworkName.Identifier, StringComparison.OrdinalIgnoreCase) Then
-
-                        If isWebProject Then
-
-                            ' Web projects don't support profiles when targeting below 4.0, so filter those out
-                            If frameworkName.Version.Major < 4 AndAlso
-                               Not String.IsNullOrEmpty(frameworkName.Profile) Then
-                                Continue For
-                            End If
-
-                            ' For web projects, filter out frameworks that don't contain System.Web (e.g. client profiles).
-                            Dim systemWebPath As String = Nothing
-                            If VSErrorHandler.Failed(vsFrameworkMultiTargeting.ResolveAssemblyPath(
-                                  "System.Web.dll",
-                                  moniker,
-                                  systemWebPath)) OrElse
-                               String.IsNullOrEmpty(systemWebPath) Then
-                                Continue For
-                            End If
-                        End If
-
-                        ' Use DTAR to get the display name corresponding to the moniker
-                        Dim displayName As String = ""
-                        If String.Equals(frameworkName.Identifier, ".NETStandard", StringComparison.Ordinal) OrElse
-                           String.Equals(frameworkName.Identifier, ".NETCoreApp", StringComparison.Ordinal) Then
-                            displayName = CStr(supportedTargetFrameworksDescriptor.Converter?.ConvertTo(moniker, GetType(String)))
-                        Else
-                            VSErrorHandler.ThrowOnFailure(vsFrameworkMultiTargeting.GetDisplayNameForTargetFx(moniker, displayName))
-                        End If
-
-                        supportedTargetFrameworkMonikers.Add(New TargetFrameworkMoniker(moniker, displayName))
-
-                    End If
-                End If
-            Next
-
-            Return supportedTargetFrameworkMonikers
+            Return provider.GetSupportedTargetFrameworks(framework)
 
         End Function
+
+        Private Shared Function GetSupportedTargetFrameworksProvider(
+                frameworkMultiTargeting As IVsFrameworkMultiTargeting,
+                project As Project,
+                converter As TypeConverter) As ISupportedTargetFrameworksProvider
+
+            ' CPS provides a type converter via a project property that 
+            ' returns the supported frameworks, use them if available.
+            If (converter IsNot Nothing) Then
+                Return New TypeConverterTargetProvider(converter)
+            End If
+
+            ' Is this Web Application project?
+            If IsWebProject(project) Then
+                Return New WebFrameworkMultiTargetProvider(frameworkMultiTargeting)
+            End If
+
+            ' Otherwise, a legacy project
+            Return New FrameworkMultiTargetProvider(frameworkMultiTargeting)
+
+        End Function
+
+        Private Shared Function IsWebProject(project As Project) As Boolean
+
+            ' Determine if the project is a WAP (Web Application Project).
+            For i As Integer = 1 To project.Properties.Count
+                If project.Properties.Item(i).Name.StartsWith("WebApplication.") Then
+                    Return True
+                End If
+            Next
+
+            Return False
+
+        End Function
+
     End Class
 
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/FrameworkMultiTargetProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/FrameworkMultiTargetProvider.vb
@@ -1,0 +1,71 @@
+﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+Imports System.Runtime.Versioning
+Imports Microsoft.VisualStudio.Shell.Interop
+
+Namespace Microsoft.VisualStudio.Editors.PropertyPages
+
+    ''' <summary>
+    ''' Provides an implementation of <see cref="ISupportedTargetFrameworksProvider"/> that returns frameworks
+    ''' from <see cref="IVsFrameworkMultiTargeting"/> applicable to a specified framework.
+    ''' </summary>
+    Friend Class FrameworkMultiTargetProvider
+        Implements ISupportedTargetFrameworksProvider
+
+        Private ReadOnly _frameworkMultiTargeting As IVsFrameworkMultiTargeting
+
+        Public Sub New(frameworkMultiTargeting As IVsFrameworkMultiTargeting)
+            Assumes.NotNull(frameworkMultiTargeting)
+
+            _frameworkMultiTargeting = frameworkMultiTargeting
+        End Sub
+
+        Protected ReadOnly Property FrameworkMultiTargeting As IVsFrameworkMultiTargeting
+            Get
+                Return _frameworkMultiTargeting
+            End Get
+        End Property
+
+        Public Function GetSupportedTargetFrameworks(framework As FrameworkName) As ICollection(Of TargetFrameworkMoniker) Implements ISupportedTargetFrameworksProvider.GetSupportedTargetFrameworks
+
+            Requires.NotNull(framework, NameOf(framework))
+
+            Dim frameworks = GetSupportedFrameworkNames(framework)
+
+            Return frameworks.Select(Function(frameworkName)
+                                         Return New TargetFrameworkMoniker(frameworkName.FullName, GetDisplayName(frameworkName))
+                                     End Function) _
+                             .ToList()
+
+        End Function
+
+        Protected Overridable Function CanRetargetTo(current As FrameworkName, framework As FrameworkName) As Boolean
+
+            ' We don't let you retarget from one framework to another, because they are often very different project types
+            Return String.Equals(current.Identifier, framework.Identifier, StringComparison.OrdinalIgnoreCase)
+
+        End Function
+
+        Private Function GetSupportedFrameworkNames(current As FrameworkName) As IEnumerable(Of FrameworkName)
+            Dim monikers As Array = Nothing
+
+            VSErrorHandler.ThrowOnFailure(FrameworkMultiTargeting.GetSupportedFrameworks(monikers))
+
+            Return monikers.Cast(Of String) _
+                           .Select(Function(moniker) New FrameworkName(moniker)) _
+                           .Where(Function(framework) CanRetargetTo(current, framework))
+
+        End Function
+
+        Private Function GetDisplayName(frameworkName As FrameworkName) As String
+
+            Dim displayName As String = ""
+            VSErrorHandler.ThrowOnFailure(FrameworkMultiTargeting.GetDisplayNameForTargetFx(frameworkName.FullName, displayName))
+
+            Return displayName
+
+        End Function
+
+    End Class
+
+End Namespace

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/ISupportedTargetFrameworksProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/ISupportedTargetFrameworksProvider.vb
@@ -1,0 +1,13 @@
+﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+Imports System.Runtime.Versioning
+
+Namespace Microsoft.VisualStudio.Editors.PropertyPages
+
+    Friend Interface ISupportedTargetFrameworksProvider
+
+        Function GetSupportedTargetFrameworks(framework As FrameworkName) As ICollection(Of TargetFrameworkMoniker)
+
+    End Interface
+
+End Namespace

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/TypeConverterTargetProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/TypeConverterTargetProvider.vb
@@ -1,0 +1,43 @@
+﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+Imports System.ComponentModel
+Imports System.Runtime.Versioning
+
+Namespace Microsoft.VisualStudio.Editors.PropertyPages
+
+    ''' <summary>
+    ''' Provides an implementation of <see cref="ISupportedTargetFrameworksProvider"/> that returns 
+    ''' frameworks from a <see cref="TypeConverter"/>.
+    ''' </summary>
+    Friend Class TypeConverterTargetProvider
+        Implements ISupportedTargetFrameworksProvider
+
+        Private ReadOnly _converter As TypeConverter
+
+        Public Sub New(converter As TypeConverter)
+            Assumes.NotNull(converter)
+
+            _converter = converter
+        End Sub
+
+        Public Function GetSupportedTargetFrameworks(framework As FrameworkName) As ICollection(Of TargetFrameworkMoniker) Implements ISupportedTargetFrameworksProvider.GetSupportedTargetFrameworks
+
+            Requires.NotNull(framework, NameOf(framework))
+
+            ' CPS-based projects implement a enum property that ends up delegating onto
+            ' SupportedTargetFrameworksEnumProvider, which ends up reading from evaluation
+            Dim monikers As IEnumerable(Of String) = _converter.GetStandardValues() _
+                                                               .Cast(Of String)
+
+            Return monikers.Select(Function(moniker)
+                                       Dim displayName As String = CStr(_converter.ConvertTo(moniker, GetType(String)))
+
+                                       Return New TargetFrameworkMoniker(moniker, displayName)
+                                   End Function) _
+                           .ToList()
+
+        End Function
+
+    End Class
+
+End Namespace

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/WebFrameworkMultiTargetProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/WebFrameworkMultiTargetProvider.vb
@@ -1,0 +1,43 @@
+﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+Imports System.Runtime.Versioning
+Imports Microsoft.VisualStudio.Shell.Interop
+
+Namespace Microsoft.VisualStudio.Editors.PropertyPages
+
+    ''' <summary>
+    ''' Provides an implementation of <see cref="ISupportedTargetFrameworksProvider"/> that returns frameworks
+    ''' from <see cref="IVsFrameworkMultiTargeting"/> applicable to web application projects.
+    ''' </summary>
+    Friend Class WebFrameworkMultiTargetProvider
+        Inherits FrameworkMultiTargetProvider
+
+        Public Sub New(frameworkMultiTargeting As IVsFrameworkMultiTargeting)
+            MyBase.New(frameworkMultiTargeting)
+        End Sub
+
+        Protected Overrides Function CanRetargetTo(current As FrameworkName, framework As FrameworkName) As Boolean
+
+            Return MyBase.CanRetargetTo(current, framework) AndAlso CanReferenceSystemWeb(framework)
+
+        End Function
+
+        Private Function CanReferenceSystemWeb(framework As FrameworkName) As Boolean
+
+            ' Web projects don't support profiles when targeting below 4.0, so filter those out
+            If framework.Version.Major < 4 Then
+                Return String.IsNullOrEmpty(framework.Profile)
+            End If
+
+            ' For web projects, filter out frameworks that don't contain System.Web (e.g. client profiles).
+            Dim systemWebPath As String = Nothing
+            Return VSErrorHandler.Succeeded(FrameworkMultiTargeting.ResolveAssemblyPath(
+                      "System.Web.dll",
+                      framework.FullName,
+                      systemWebPath)) AndAlso Not String.IsNullOrEmpty(systemWebPath)
+
+        End Function
+
+    End Class
+
+End Namespace

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/SupportedTargetFrameworksEnumProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/SupportedTargetFrameworksEnumProviderTests.cs
@@ -32,6 +32,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         <SupportedTargetFramework Include="".NETCoreApp,Version=v1.1"" DisplayName="".NET Core 1.1"" />
         <SupportedTargetFramework Include="".NETCoreApp,Version=v2.0"" DisplayName="".NET Core 2.0"" />
     </ItemGroup>
+    <PropertyGroup>
+        <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    </PropertyGroup>
 </Project>";
 
             var projectAccessor = IProjectAccessorFactory.Create(project);


### PR DESCRIPTION
This refactors the logic to read supported frameworks, and removes the CPS implementation from parsing/understanding the "moniker" being based through from SupportedTargetFramworksEnumProvider.

This is a precursor to enabling us to bind to the "TargetFramework" property in https://github.com/dotnet/project-system/pull/6607.

Before this change;

1) The moniker returned from SupportedTargetFrameworksEnumProvider was being parsed and filtered. This breaks when we change this moniker to a "friendly identifier" in #6607 such as "net5.0-windows".

2) Web/Legacy/CPS filtering was all intertwined. This separates the logic into separate types.

3) This fixes a slight bug where the display name for .NET Framework-only targets in SDK-based projects would show as ".NETFramework,v4.5" if the TFM wasn't installed.

There is not behavior change in all scenarios except for 3).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6624)