### PR TITLE
Version two of project unload dependency telemetry

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
@@ -33,6 +33,11 @@ namespace Microsoft.VisualStudio.Telemetry
         public static readonly string ProjectUnloadDependenciesProject = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "Project");
 
         /// <summary>
+        ///     Identifies the version of project unload dependencies telemetry being sent.
+        /// </summary>
+        public static readonly string ProjectUnloadDependenciesVersion = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "Version");
+
+        /// <summary>
         ///     Identifies the time between project load and unload, in milliseconds.
         /// </summary>
         public static readonly string ProjectUnloadProjectAgeMillis = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "ProjectAgeMillis");


### PR DESCRIPTION
- Change the format to be easier to query
- Include totals at the TFM level
- Include a version number so we can exclude earlier representations

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6626)