### PR TITLE
Enable property ProjectAssetFile for Roslyn.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
@@ -9,6 +9,10 @@
                 SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
+  <StringProperty Name="ProjectAssetsFile"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <StringProperty Name="RootNamespace"
                   ReadOnly="True"
                   Visible="False" />


### PR DESCRIPTION
Roslyn team needs to get the path of project.assets.json for specific 
projects. This is part of the new feature Remove Unused Reference.

This change pushes to Roslyn the msbuild evaluation ProjectAssetsFile
containing the absolute path for project.assets.json so they can get
this info on their side.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6630)