### PR TITLE
Allow the user to disable the feature symbolic renaming on File-rename

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DteEnvironmentOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DteEnvironmentOptions.cs
@@ -32,5 +32,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             return defaultValue;
         }
+
+        public void SetOption<T>(string category, string page, string option, T newValue)
+        {
+            EnvDTE.Properties? properties = _dte.Value.Properties[category, page];
+
+            if (properties != null)
+            {
+                properties.Item(option).Value = newValue;
+            }
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IEnvironmentOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IEnvironmentOptions.cs
@@ -28,6 +28,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// </param>
         T GetOption<T>(string category, string page, string option, T defaultValue);
 
+        /// <summary>
+        ///     Sets a value associated with the specified category, page and option, if it exists,
+        /// </summary>
+        /// <param name="category">
+        ///     A <see cref="string"/> containing the category of the option to return.
+        /// </param>
+        /// <param name="page">
+        ///     A <see cref="string"/> containing the page of the option to return.
+        /// </param>
+        /// <param name="option">
+        ///     A <see cref="string"/> containing the name of the option to return.
+        /// </param>
+        /// <param name="newValue">
+        ///     The value to set the property.
+        /// </param>
         void SetOption<T>(string category, string page, string option, T newValue);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IEnvironmentOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IEnvironmentOptions.cs
@@ -27,5 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         ///     The value to return if the value does not exist.
         /// </param>
         T GetOption<T>(string category, string page, string option, T defaultValue);
+
+        void SetOption<T>(string category, string page, string option, T newValue);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IEnvironmentOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IEnvironmentOptions.cs
@@ -32,13 +32,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         ///     Sets a value associated with the specified category, page and option, if it exists,
         /// </summary>
         /// <param name="category">
-        ///     A <see cref="string"/> containing the category of the option to return.
+        ///     A <see cref="string"/> containing the category of the option to set.
         /// </param>
         /// <param name="page">
-        ///     A <see cref="string"/> containing the page of the option to return.
+        ///     A <see cref="string"/> containing the page of the option to set.
         /// </param>
         /// <param name="option">
-        ///     A <see cref="string"/> containing the name of the option to return.
+        ///     A <see cref="string"/> containing the name of the option to set.
         /// </param>
         /// <param name="newValue">
         ///     The value to set the property.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IUserNotificationServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IUserNotificationServices.cs
@@ -45,6 +45,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         ///     <see langword="true"/> if the user clicked the Yes button, otherwise;
         ///     <see langword="false"/> if the user clicked the No button.
         /// </returns>
-        bool Show(string message, out bool disablePromptMessage);
+        bool Confirm(string message, out bool disablePromptMessage);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IUserNotificationServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IUserNotificationServices.cs
@@ -35,5 +35,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         ///     This method was not accessed from the UI thread.
         /// </exception>
         void ShowError(string error);
+
+        /// <summary>
+        ///     Shows a Yes/No confirmation with Don't Show Again checkbox
+        /// </summary>
+        /// <param name="message">The message related to the Yes/No question</param>
+        /// <param name="disablePromptMessage">checkbox selection</param>
+        /// <returns>
+        ///     <see langword="true"/> if the user clicked the Yes button, otherwise;
+        ///     <see langword="false"/> if the user clicked the No button.
+        /// </returns>
+        bool Show(string message, out bool disablePromptMessage);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
@@ -235,14 +235,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
         {
             ISettingsManager settings = await _settingsManagerService.GetValueAsync();
 
-            bool alwaysRenameSymbols = settings.GetValueOrDefault<bool>("SolutionNavigator.AlwaysRenameSymbols");
+            bool EnableSymbolicRename = settings.GetValueOrDefault<bool>("SolutionNavigator.EnableSymbolicRename");
 
             await _projectVsServices.ThreadingService.SwitchToUIThread();
 
             bool disablePromptMessage = false;
             bool userNeedPrompt = _environmentOptions.GetOption("Environment", "ProjectsAndSolution", "PromptForRenameSymbol", false);
 
-            if (userNeedPrompt)
+            if (EnableSymbolicRename && userNeedPrompt)
             {
                 string renamePromptMessage = string.Format(CultureInfo.CurrentCulture, VSResources.RenameSymbolPrompt, oldFileName);
 
@@ -250,12 +250,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
 
                 _environmentOptions.SetOption("Environment", "ProjectsAndSolution", "PromptForRenameSymbol", !disablePromptMessage);
 
-                await settings.SetValueAsync("SolutionNavigator.AlwaysRenameSymbols", userSelection, true);
-
                 return userSelection;
             }
 
-            return alwaysRenameSymbols;
+            return EnableSymbolicRename;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
@@ -246,7 +246,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             {
                 string renamePromptMessage = string.Format(CultureInfo.CurrentCulture, VSResources.RenameSymbolPrompt, oldFileName);
 
-                bool userSelection = _userNotificationServices.Show(renamePromptMessage, out disablePromptMessage);
+                bool userSelection = _userNotificationServices.Confirm(renamePromptMessage, out disablePromptMessage);
 
                 _environmentOptions.SetOption("Environment", "ProjectsAndSolution", "PromptForRenameSymbol", !disablePromptMessage);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
@@ -235,7 +235,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
         {
             ISettingsManager settings = await _settingsManagerService.GetValueAsync();
 
-            bool EnableSymbolicRename = settings.GetValueOrDefault<bool>("SolutionNavigator.EnableSymbolicRename");
+            bool EnableSymbolicRename = settings.GetValueOrDefault("SolutionNavigator.EnableSymbolicRename", false);
 
             await _projectVsServices.ThreadingService.SwitchToUIThread();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UserNotificationServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UserNotificationServices.cs
@@ -4,6 +4,8 @@ using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using static Microsoft.VisualStudio.VSConstants;
+using Microsoft.VisualStudio.PlatformUI;
+using System.Globalization;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
@@ -45,6 +47,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 return defaultResult;
 
             return (MessageBoxResult)VsShellUtilities.ShowMessageBox(_serviceProvider, message, null, icon, button, OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
+        }
+
+        public bool Show(string message, out bool disablePromptMessage)
+        {
+            string dontShowAgainMessage = string.Format(CultureInfo.CurrentCulture, VSResources.DontShowAgain);
+
+            var userSelection = MessageDialog.Show("Microsoft Visual Studio", message, MessageDialogCommandSet.YesNo, dontShowAgainMessage,
+                    out disablePromptMessage);
+
+            return userSelection == MessageDialogCommand.Yes;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UserNotificationServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UserNotificationServices.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             return (MessageBoxResult)VsShellUtilities.ShowMessageBox(_serviceProvider, message, null, icon, button, OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
         }
 
-        public bool Show(string message, out bool disablePromptMessage)
+        public bool Confirm(string message, out bool disablePromptMessage)
         {
             string dontShowAgainMessage = string.Format(CultureInfo.CurrentCulture, VSResources.DontShowAgain);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/RenamerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/RenamerTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.Mocks;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices.CSharp;
+using Microsoft.VisualStudio.Settings;
 using Moq;
 using Xunit;
 
@@ -28,11 +29,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
             var userNotificationServices = IUserNotificationServicesFactory.Create();
             var roslynServices = IRoslynServicesFactory.Implement(new CSharpSyntaxFactsService());
             var vsOnlineServices = IVsOnlineServicesFactory.Create(online: false);
+            var settingsManagerService = CreateSettingsManagerService(true);
 
-            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.CSharp);
+            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.CSharp, settingsManagerService);
 
             bool checkBoxSelection;
             Mock.Get(userNotificationServices).Verify(h => h.Show(It.IsAny<string>(), out checkBoxSelection), Times.Once);
+            Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Theory]
+        [InlineData("class Foo{}", "Foo.cs", "Bar.cs")]
+        [InlineData("interface Foo { void m1(); void m2();}", "Foo.cs", "Bar.cs")]
+        [InlineData("delegate int Foo(string s);", "Foo.cs", "Bar.cs")]
+        [InlineData("partial class Foo {} partial class Foo {}", "Foo.cs", "Bar.cs")]
+        [InlineData("struct Foo { decimal price; string title; string author;}", "Foo.cs", "Bar.cs")]
+        [InlineData("enum Foo { None, enum1, enum2, enum3, enum4 };", "Foo.cs", "Bar.cs")]
+        [InlineData("namespace n1 {class Foo{}} namespace n2 {class Foo{}}", "Foo.cs", "Bar.cs")]
+        public async Task Rename_Symbol_ShouldNot_TriggerUserConfirmationAsync(string sourceCode, string oldFilePath, string newFilePath)
+        {
+            var userNotificationServices = IUserNotificationServicesFactory.Create();
+            var roslynServices = IRoslynServicesFactory.Implement(new CSharpSyntaxFactsService());
+            var vsOnlineServices = IVsOnlineServicesFactory.Create(online: false);
+            var settingsManagerService = CreateSettingsManagerService(false);
+
+            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.CSharp, settingsManagerService);
+
+            bool checkBoxSelection;
+            Mock.Get(userNotificationServices).Verify(h => h.Show(It.IsAny<string>(), out checkBoxSelection), Times.Never);
             Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
@@ -53,8 +77,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
             var userNotificationServices = IUserNotificationServicesFactory.Create();
             var roslynServices = IRoslynServicesFactory.Implement(new CSharpSyntaxFactsService());
             var vsOnlineServices = IVsOnlineServicesFactory.Create(online: false);
+            var settingsManagerService = CreateSettingsManagerService(true);
 
-            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.CSharp).TimeoutAfter(TimeSpan.FromSeconds(1));
+            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.CSharp, settingsManagerService).TimeoutAfter(TimeSpan.FromSeconds(1));
 
             Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Never);
             Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -71,12 +96,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
             var userNotificationServices = IUserNotificationServicesFactory.Create();
             var roslynServices = IRoslynServicesFactory.Implement(new CSharpSyntaxFactsService());
             var vsOnlineService = IVsOnlineServicesFactory.Create(online: true);
+            var settingsManagerService = CreateSettingsManagerService(true);
 
-            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineService, LanguageNames.CSharp);
+            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineService, LanguageNames.CSharp, settingsManagerService);
 
             Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Never);
             Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
             Mock.Get(roslynServices).Verify(h => h.ApplyChangesToSolution(It.IsAny<Workspace>(), It.IsAny<Solution>()), Times.Never);
+        }
+
+        private IVsService<SVsSettingsPersistenceManager, ISettingsManager> CreateSettingsManagerService(bool enableSymbolicRename)
+        {
+            var settingsManagerMock = new Mock<ISettingsManager>();
+
+            settingsManagerMock.Setup(f => f.GetValueOrDefault("SolutionNavigator.EnableSymbolicRename", false))
+                .Returns(enableSymbolicRename);
+
+            return IVsServiceFactory.Create<SVsSettingsPersistenceManager, ISettingsManager>(settingsManagerMock.Object);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/RenamerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/RenamerTests.cs
@@ -31,7 +31,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
 
             await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.CSharp);
 
-            Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Once);
+            bool checkBoxSelection;
+            Mock.Get(userNotificationServices).Verify(h => h.Show(It.IsAny<string>(), out checkBoxSelection), Times.Once);
             Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/RenamerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/RenamerTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
             await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.CSharp, settingsManagerService);
 
             bool checkBoxSelection;
-            Mock.Get(userNotificationServices).Verify(h => h.Show(It.IsAny<string>(), out checkBoxSelection), Times.Once);
+            Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>(), out checkBoxSelection), Times.Once);
             Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
             await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.CSharp, settingsManagerService);
 
             bool checkBoxSelection;
-            Mock.Get(userNotificationServices).Verify(h => h.Show(It.IsAny<string>(), out checkBoxSelection), Times.Never);
+            Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>(), out checkBoxSelection), Times.Never);
             Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/RenamerTestsBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/RenamerTestsBase.cs
@@ -80,7 +80,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             }
         }
 
-        internal async Task RenameAsync(string sourceCode, string oldFilePath, string newFilePath, IUserNotificationServices userNotificationServices, IRoslynServices roslynServices, IVsOnlineServices vsOnlineServices, string language)
+        internal async Task RenameAsync(string sourceCode, string oldFilePath, string newFilePath, 
+            IUserNotificationServices userNotificationServices, 
+            IRoslynServices roslynServices, 
+            IVsOnlineServices vsOnlineServices, 
+            string language, 
+            IVsService<SVsSettingsPersistenceManager, ISettingsManager> settingsManagerService)
         {
             var unconfiguredProject = UnconfiguredProjectFactory.Create(fullPath: $@"C:\project1.{ProjectFileExtension}");
             var projectServices = IUnconfiguredProjectVsServicesFactory.Implement(
@@ -102,8 +107,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             mockNode.SetupGet(x => x.FilePath).Returns(oldFilePath);
             mockNode.SetupGet(x => x.IsFolder).Returns(false);
             var node = mockNode.Object;
-
-            var settingsManagerService = IVsServiceFactory.Create<SVsSettingsPersistenceManager, ISettingsManager>(Mock.Of<ISettingsManager>());
 
             var renamer = new TestRenamerProjectTreeActionHandler(unconfiguredProject,
                                                               projectServices,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/RenamerTestsBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/RenamerTestsBase.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.LanguageServices;
 using Microsoft.VisualStudio.OperationProgress;
 using Microsoft.VisualStudio.ProjectSystem.Refactor;
 using Microsoft.VisualStudio.ProjectSystem.Waiting;
+using Microsoft.VisualStudio.Settings;
 using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
 
@@ -61,9 +62,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                 IVsOnlineServices vsOnlineServices,
                 IProjectThreadingService threadingService,
                 IVsUIService<IVsExtensibility, IVsExtensibility3> extensibility,
-                IVsService<SVsOperationProgress, IVsOperationProgressStatusService> operationProgressService) :
+                IVsService<SVsOperationProgress, IVsOperationProgressStatusService> operationProgressService,
+                IVsService<SVsSettingsPersistenceManager, ISettingsManager> settingsManagerService) :
                 base(unconfiguredProject, projectVsServices, workspace, environmentOptions, userNotificationServices, roslynServices, waitService,
-                    vsOnlineServices, threadingService, extensibility, operationProgressService)
+                    vsOnlineServices, threadingService, extensibility, operationProgressService, settingsManagerService)
             {
             }
 
@@ -101,6 +103,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             mockNode.SetupGet(x => x.IsFolder).Returns(false);
             var node = mockNode.Object;
 
+            var settingsManagerServiceMock = (new Mock<IVsService<SVsSettingsPersistenceManager, ISettingsManager>>()).Object;
+
             var renamer = new TestRenamerProjectTreeActionHandler(unconfiguredProject,
                                                               projectServices,
                                                               ws,
@@ -111,7 +115,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                                                               vsOnlineServices,
                                                               projectThreadingService,
                                                               extensibility,
-                                                              operationProgressMock);
+                                                              operationProgressMock,
+                                                              settingsManagerServiceMock);
 
             await renamer.RenameAsync(context, node, newFilePath)
                          .TimeoutAfter(TimeSpan.FromSeconds(1));

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/RenamerTestsBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/RenamerTestsBase.cs
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             mockNode.SetupGet(x => x.IsFolder).Returns(false);
             var node = mockNode.Object;
 
-            var settingsManagerServiceMock = (new Mock<IVsService<SVsSettingsPersistenceManager, ISettingsManager>>()).Object;
+            var settingsManagerService = IVsServiceFactory.Create<SVsSettingsPersistenceManager, ISettingsManager>(Mock.Of<ISettingsManager>());
 
             var renamer = new TestRenamerProjectTreeActionHandler(unconfiguredProject,
                                                               projectServices,
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                                                               projectThreadingService,
                                                               extensibility,
                                                               operationProgressMock,
-                                                              settingsManagerServiceMock);
+                                                              settingsManagerService);
 
             await renamer.RenameAsync(context, node, newFilePath)
                          .TimeoutAfter(TimeSpan.FromSeconds(1));

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasic/RenamerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasic/RenamerTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.VisualBasic
             await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.VisualBasic, settingsManagerService);
 
             bool checkBoxSelection;
-            Mock.Get(userNotificationServices).Verify(h => h.Show(It.IsAny<string>(), out checkBoxSelection), Times.Once);
+            Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>(), out checkBoxSelection), Times.Once);
             Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasic/RenamerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasic/RenamerTests.cs
@@ -119,7 +119,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.VisualBasic
 
             await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.VisualBasic);
 
-            Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Once);
+            bool checkBoxSelection;
+            Mock.Get(userNotificationServices).Verify(h => h.Show(It.IsAny<string>(), out checkBoxSelection), Times.Once);
             Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasic/RenamerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasic/RenamerTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.Mocks;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices.VisualBasic;
+using Microsoft.VisualStudio.Settings;
 using Moq;
 using Xunit;
 
@@ -69,8 +70,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.VisualBasic
             var userNotificationServices = IUserNotificationServicesFactory.Create();
             var roslynServices = IRoslynServicesFactory.Implement(new VisualBasicSyntaxFactsService());
             var vsOnlineServices = IVsOnlineServicesFactory.Create(online: false);
+            var settingsManagerService = CreateSettingsManagerService(true);
 
-            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.VisualBasic);
+            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.VisualBasic, settingsManagerService);
 
             Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Never);
             Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -116,8 +118,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.VisualBasic
             var userNotificationServices = IUserNotificationServicesFactory.Create();
             var roslynServices = IRoslynServicesFactory.Implement(new VisualBasicSyntaxFactsService());
             var vsOnlineServices = IVsOnlineServicesFactory.Create(online: false);
+            var settingsManagerService = CreateSettingsManagerService(true);
 
-            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.VisualBasic);
+            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.VisualBasic, settingsManagerService);
 
             bool checkBoxSelection;
             Mock.Get(userNotificationServices).Verify(h => h.Show(It.IsAny<string>(), out checkBoxSelection), Times.Once);
@@ -136,12 +139,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.VisualBasic
             var userNotificationServices = IUserNotificationServicesFactory.Create();
             var roslynServices = IRoslynServicesFactory.Implement(new VisualBasicSyntaxFactsService());
             var vsOnlineService = IVsOnlineServicesFactory.Create(online: true);
+            var settingsManagerService = CreateSettingsManagerService(true);
 
-            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineService, LanguageNames.VisualBasic);
+            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineService, LanguageNames.VisualBasic, settingsManagerService);
 
             Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Never);
             Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
             Mock.Get(roslynServices).Verify(h => h.ApplyChangesToSolution(It.IsAny<Workspace>(), It.IsAny<Solution>()), Times.Never);
+        }
+
+        private IVsService<SVsSettingsPersistenceManager, ISettingsManager> CreateSettingsManagerService(bool enableSymbolicRename)
+        {
+            var settingsManagerMock = new Mock<ISettingsManager>();
+
+            settingsManagerMock.Setup(f => f.GetValueOrDefault("SolutionNavigator.EnableSymbolicRename", false))
+                .Returns(enableSymbolicRename);
+
+            return IVsServiceFactory.Create<SVsSettingsPersistenceManager, ISettingsManager>(settingsManagerMock.Object);
         }
     }
 }


### PR DESCRIPTION
This fixes [AB#1144262](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1144262)

It seems that this option is misleading since we are enabling the feature unconditionally. People might get confused when trying to disable the prompt and still seeing changes in your code.

This change replaces the dialog box to allow the option "Don't Ask Again" so users can disable the prompt message from here.
CheckUserConfirmation() now returns false and that means the feature is disabled by default unless there is a prompt and the user selects Yes.

This change will allow the user to disable this feature when the message prompt is disabled.

Perhaps a future enhancement is to add another checkbox in Tools |Options | Project and Solutions | General | "Always apply symbol rename" so this will allow the user to apply symbol rename without the prompt.

![image](https://user-images.githubusercontent.com/510598/94487765-56ec9700-0196-11eb-8e02-e8fd9dce772d.png)

https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/278294
![image](https://user-images.githubusercontent.com/510598/94975143-92080680-04c5-11eb-9711-a5566aad4d8d.png)

