### PR TITLE
Improve first up-to-date failure log message

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -158,6 +158,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return log.Fail("Disabled", "The 'DisableFastUpToDateCheck' property is true, not up to date.");
             }
 
+            if (state.LastCheckedAtUtc == DateTime.MinValue)
+            {
+                return log.Fail("FirstRun", "The up-to-date check has not yet run for this project. Not up-to-date.");
+            }
+
             string copyAlwaysItemPath = state.ItemsByItemType.SelectMany(kvp => kvp.Value).FirstOrDefault(item => item.copyType == CopyType.CopyAlways).path;
 
             if (copyAlwaysItemPath != null)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -117,6 +117,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         item => item.FilePath,
                         item => item.Time,
                         StringComparers.Paths));
+
+            // Flush the first false
+            await AssertNotUpToDateAsync(
+                "The up-to-date check has not yet run for this project. Not up-to-date.",
+                "FirstRun");
         }
 
         private void BroadcastChange(

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -1327,12 +1327,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         {
             var writer = new AssertWriter(_output);
 
-            if (logMessages != null)
+            foreach (var logMessage in logMessages)
             {
-                foreach (var logMessage in logMessages)
-                {
-                    writer.Add(logMessage);
-                }
+                writer.Add(logMessage);
             }
 
             writer.Add("Project is up to date.");


### PR DESCRIPTION
The up-to-date check must return false for the first time it is executed against a project. This ensures that changes made to the project since it was last loaded (such as items being deleted) are not missed.

Previously these failures were accompanied by a message resembling:

 > Input 'MyFile' (2/10/2020 12:34:56) has been modified since the last up-to-date check (01/01/0001 00:00:00), not up to date.

The "zero" date is DateTime.MinValue, and it's not clear that this indicates the up-to-date check has not yet run.

With the change in this commit, this scenario now logs a more explicit message:

> The up-to-date check has not yet run for this project. Not up-to-date.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6645)