### PR TITLE
Use target-type new expressions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -378,6 +378,7 @@ dotnet_diagnostic.IDE0030WithoutSuggestion.severity = error
 dotnet_diagnostic.IDE0079.severity = warning      # Unused suppresion
 dotnet_diagnostic.IDE0083.severity = warning      # Use pattern matching
 dotnet_diagnostic.IDE0084.severity = warning      # Use IsNot
+dotnet_diagnostic.IDE0090.severity = warning      # Use new(...)
 dotnet_diagnostic.IDE1006.severity = warning      # Naming styles                                 Task Open()                                         Task OpenAsync()
 dotnet_diagnostic.IDE1006WithoutSuggestion.severity = suggestion
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/CloudEnvironment.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/CloudEnvironment.cs
@@ -18,6 +18,6 @@ namespace Microsoft.VisualStudio
         /// <summary>
         /// Guid indicating that the selected node in Solution Explorer is a project.
         /// </summary>
-        public static readonly Guid SolutionViewProjectGuid = new Guid("F9806588-A88E-4429-8BFD-228795DB3894");
+        public static readonly Guid SolutionViewProjectGuid = new("F9806588-A88E-4429-8BFD-228795DB3894");
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/ProjectType.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/ProjectType.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio
         /// <summary>
         ///     A <see cref="Guid"/> representing the legacy Visual Basic project type based on the native project system in msvbprj.dll.
         /// </summary>
-        public static readonly Guid LegacyVisualBasicGuid = new Guid(LegacyVisualBasic);
+        public static readonly Guid LegacyVisualBasicGuid = new(LegacyVisualBasic);
 
         /// <summary>
         ///     A <see cref="string"/> representing the C# project type based on the Common Project System (CPS).
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio
         /// <summary>
         ///     A <see cref="Guid"/> representing the C# project type based on the Common Project System (CPS).
         /// </summary>
-        public static readonly Guid CSharpGuid = new Guid(CSharp);
+        public static readonly Guid CSharpGuid = new(CSharp);
 
         /// <summary>
         ///     A <see cref="string"/> representing the legacy C# project type based on the native project system in csproj.dll.
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio
         /// <summary>
         ///     A <see cref="Guid"/> representing the legacy C# project type based on the native project system in csproj.dll.
         /// </summary>
-        public static readonly Guid LegacyCSharpGuid = new Guid(LegacyCSharp);
+        public static readonly Guid LegacyCSharpGuid = new(LegacyCSharp);
 
         /// <summary>
         ///     A <see cref="string"/> representing the F# project type based on the Common Project System (CPS).
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio
         /// <summary>
         ///     A <see cref="Guid"/> representing the F# project type based on the Common Project System (CPS).
         /// </summary>
-        public static readonly Guid FSharpGuid = new Guid(FSharp);
+        public static readonly Guid FSharpGuid = new(FSharp);
 
         /// <summary>
         ///     A <see cref="string"/> representing the legacy F# project type based on the Managed Package Framework (MPF).
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio
         /// <summary>
         ///     A <see cref="Guid"/> representing the legacy F# project type based on the Managed Package Framework (MPF).
         /// </summary>
-        public static readonly Guid LegacyFSharpGuid = new Guid(LegacyFSharp);
+        public static readonly Guid LegacyFSharpGuid = new(LegacyFSharp);
 
         /// <summary>
         ///     A <see cref="string"/> representing the deprecated C# (xproj) project type based on the Common Project System (CPS).

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ConnectionPoint/ConnectionPoint.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ConnectionPoint/ConnectionPoint.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.ConnectionPoint
     internal class ConnectionPoint<TSinkType> : IConnectionPoint
             where TSinkType : class
     {
-        private readonly Dictionary<uint, TSinkType> _sinks = new Dictionary<uint, TSinkType>();
+        private readonly Dictionary<uint, TSinkType> _sinks = new();
         private readonly ConnectionPointContainer _container;
         private readonly IEventSource<TSinkType> _source;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ConnectionPoint/ConnectionPointContainer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ConnectionPoint/ConnectionPointContainer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.ConnectionPoint
     [ComVisible(true)]
     public class ConnectionPointContainer : IConnectionPointContainer
     {
-        private readonly Dictionary<Guid, IConnectionPoint> _connectionPoints = new Dictionary<Guid, IConnectionPoint>();
+        private readonly Dictionary<Guid, IConnectionPoint> _connectionPoints = new();
 
         internal ConnectionPointContainer()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractAddItemCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractAddItemCommandHandler.cs
@@ -16,8 +16,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
     /// </summary>
     internal abstract partial class AbstractAddItemCommandHandler : IAsyncCommandGroupHandler
     {
-        protected static readonly Guid LegacyCSharpPackageGuid = new Guid("{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}");
-        protected static readonly Guid LegacyVBPackageGuid = new Guid("{164B10B9-B200-11d0-8C61-00A0C91E29D5}");
+        protected static readonly Guid LegacyCSharpPackageGuid = new("{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}");
+        protected static readonly Guid LegacyVBPackageGuid = new("{164B10B9-B200-11d0-8C61-00A0C91E29D5}");
         private readonly ConfiguredProject _configuredProject;
         private readonly IAddItemDialogService _addItemDialogService;
         private readonly IVsUIService<IVsShell> _vsShell;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/WPFAddItemCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/WPFAddItemCommandHandler.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
     [AppliesTo(ProjectCapability.DotNet)]
     internal class WPFAddItemCommandHandler : AbstractAddItemCommandHandler
     {
-        private static readonly Guid s_wpfPackage = new Guid("{b3bae735-386c-4030-8329-ef48eeda4036}");
+        private static readonly Guid s_wpfPackage = new("{b3bae735-386c-4030-8329-ef48eeda4036}");
 
         private static readonly ImmutableDictionary<long, ImmutableArray<TemplateDetails>> s_templateDetails = ImmutableDictionary<long, ImmutableArray<TemplateDetails>>.Empty
             //                     Command Id                             Capabilities                                          DirNamePackageGuid       DirNameResourceId                                         TemplateName  TemplateNameResourceId

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowPaneProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowPaneProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
     [Export(typeof(IProjectOutputWindowPaneProvider))]
     internal class ProjectOutputWindowPaneProvider : IProjectOutputWindowPaneProvider
     {
-        private static readonly Guid s_projectOutputWindowPaneGuid = new Guid("{A18568CC-CA90-4AEE-9D14-A7E9D753B544}");
+        private static readonly Guid s_projectOutputWindowPaneGuid = new("{A18568CC-CA90-4AEE-9D14-A7E9D753B544}");
 
         private readonly IProjectThreadingService _threadingService;
         private readonly IVsUIService<IVsOutputWindow?> _outputWindow;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/CSharp/CSharpProjectDesignerPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/CSharp/CSharpProjectDesignerPage.cs
@@ -9,13 +9,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.CSharp
     /// </summary>
     internal static class CSharpProjectDesignerPage
     {
-        public static readonly ProjectDesignerPageMetadata Application    = new ProjectDesignerPageMetadata(new Guid("{5E9A8AC2-4F34-4521-858F-4C248BA31532}"), pageOrder: 0, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata Build          = new ProjectDesignerPageMetadata(new Guid("{A54AD834-9219-4aa6-B589-607AF21C3E26}"), pageOrder: 1, hasConfigurationCondition: true);
-        public static readonly ProjectDesignerPageMetadata BuildEvents    = new ProjectDesignerPageMetadata(new Guid("{1E78F8DB-6C07-4d61-A18F-7514010ABD56}"), pageOrder: 2, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata Package        = new ProjectDesignerPageMetadata(new Guid("{21b78be8-3957-4caa-bf2f-e626107da58e}"), pageOrder: 3, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata Debug          = new ProjectDesignerPageMetadata(new Guid("{0273C280-1882-4ED0-9308-52914672E3AA}"), pageOrder: 4, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata ReferencePaths = new ProjectDesignerPageMetadata(new Guid("{031911C8-6148-4e25-B1B1-44BCA9A0C45C}"), pageOrder: 5, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata Signing        = new ProjectDesignerPageMetadata(new Guid("{F8D6553F-F752-4DBF-ACB6-F291B744A792}"), pageOrder: 6, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata CodeAnalysis   = new ProjectDesignerPageMetadata(new Guid("{c02f393c-8a1e-480d-aa82-6a75d693559d}"), pageOrder: 7, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Application    = new(new Guid("{5E9A8AC2-4F34-4521-858F-4C248BA31532}"), pageOrder: 0, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Build          = new(new Guid("{A54AD834-9219-4aa6-B589-607AF21C3E26}"), pageOrder: 1, hasConfigurationCondition: true);
+        public static readonly ProjectDesignerPageMetadata BuildEvents    = new(new Guid("{1E78F8DB-6C07-4d61-A18F-7514010ABD56}"), pageOrder: 2, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Package        = new(new Guid("{21b78be8-3957-4caa-bf2f-e626107da58e}"), pageOrder: 3, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Debug          = new(new Guid("{0273C280-1882-4ED0-9308-52914672E3AA}"), pageOrder: 4, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata ReferencePaths = new(new Guid("{031911C8-6148-4e25-B1B1-44BCA9A0C45C}"), pageOrder: 5, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Signing        = new(new Guid("{F8D6553F-F752-4DBF-ACB6-F291B744A792}"), pageOrder: 6, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata CodeAnalysis   = new(new Guid("{c02f393c-8a1e-480d-aa82-6a75d693559d}"), pageOrder: 7, hasConfigurationCondition: false);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/FSharp/FSharpProjectDesignerPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/FSharp/FSharpProjectDesignerPage.cs
@@ -9,12 +9,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.FSharp
     /// </summary>
     internal static class FSharpProjectDesignerPage
     {
-        public static readonly ProjectDesignerPageMetadata Application    = new ProjectDesignerPageMetadata(new Guid("{6D2D9B56-2691-4624-A1BF-D07A14594748}"), pageOrder: 0, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata Build          = new ProjectDesignerPageMetadata(new Guid("{FAC0A17E-2E70-4211-916A-0D34FB708BFF}"), pageOrder: 1, hasConfigurationCondition: true);
-        public static readonly ProjectDesignerPageMetadata BuildEvents    = new ProjectDesignerPageMetadata(new Guid("{DD84AA8F-71BB-462a-8EF8-C9992CB325B7}"), pageOrder: 2, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata Debug          = new ProjectDesignerPageMetadata(new Guid("{0273C280-1882-4ED0-9308-52914672E3AA}"), pageOrder: 3, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata Package        = new ProjectDesignerPageMetadata(new Guid("{21b78be8-3957-4caa-bf2f-e626107da58e}"), pageOrder: 4, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata ReferencePaths = new ProjectDesignerPageMetadata(new Guid("{DF16B1A2-0E91-4499-AE60-C7144E614BF1}"), pageOrder: 5, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata Signing        = new ProjectDesignerPageMetadata(new Guid("{F8D6553F-F752-4DBF-ACB6-F291B744A792}"), pageOrder: 6, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Application    = new(new Guid("{6D2D9B56-2691-4624-A1BF-D07A14594748}"), pageOrder: 0, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Build          = new(new Guid("{FAC0A17E-2E70-4211-916A-0D34FB708BFF}"), pageOrder: 1, hasConfigurationCondition: true);
+        public static readonly ProjectDesignerPageMetadata BuildEvents    = new(new Guid("{DD84AA8F-71BB-462a-8EF8-C9992CB325B7}"), pageOrder: 2, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Debug          = new(new Guid("{0273C280-1882-4ED0-9308-52914672E3AA}"), pageOrder: 3, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Package        = new(new Guid("{21b78be8-3957-4caa-bf2f-e626107da58e}"), pageOrder: 4, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata ReferencePaths = new(new Guid("{DF16B1A2-0E91-4499-AE60-C7144E614BF1}"), pageOrder: 5, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Signing        = new(new Guid("{F8D6553F-F752-4DBF-ACB6-F291B744A792}"), pageOrder: 6, hasConfigurationCondition: false);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/OptionStrictEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/OptionStrictEnumProvider.cs
@@ -23,8 +23,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic
                 new PageEnumValue(new EnumValue {Name = "1",    DisplayName = "On" })
             };
 
-        private readonly Dictionary<string, IEnumValue> _persistOptionStrictEnumValues = new Dictionary<string, IEnumValue>
-            {
+        private readonly Dictionary<string, IEnumValue> _persistOptionStrictEnumValues = new()
+        {
                 { "0",  new PageEnumValue(new EnumValue {Name = "Off" }) },
                 { "1",  new PageEnumValue(new EnumValue {Name = "On" }) },
             };

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/VisualBasicProjectDesignerPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/VisualBasicProjectDesignerPage.cs
@@ -9,12 +9,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic
     /// </summary>
     internal static class VisualBasicProjectDesignerPage
     {
-        public static readonly ProjectDesignerPageMetadata Application  = new ProjectDesignerPageMetadata(new Guid("{8998E48E-B89A-4034-B66E-353D8C1FDC2E}"), pageOrder: 0, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata Compile      = new ProjectDesignerPageMetadata(new Guid("{EDA661EA-DC61-4750-B3A5-F6E9C74060F5}"), pageOrder: 0, hasConfigurationCondition: true);
-        public static readonly ProjectDesignerPageMetadata Package      = new ProjectDesignerPageMetadata(new Guid("{21b78be8-3957-4caa-bf2f-e626107da58e}"), pageOrder: 0, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata References   = new ProjectDesignerPageMetadata(new Guid("{4E43F4AB-9F03-4129-95BF-B8FF870AF6AB}"), pageOrder: 1, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata Debug        = new ProjectDesignerPageMetadata(new Guid("{0273C280-1882-4ED0-9308-52914672E3AA}"), pageOrder: 2, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata Signing      = new ProjectDesignerPageMetadata(new Guid("{F8D6553F-F752-4DBF-ACB6-F291B744A792}"), pageOrder: 6, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata CodeAnalysis = new ProjectDesignerPageMetadata(new Guid("{c02f393c-8a1e-480d-aa82-6a75d693559d}"), pageOrder: 7, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Application  = new(new Guid("{8998E48E-B89A-4034-B66E-353D8C1FDC2E}"), pageOrder: 0, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Compile      = new(new Guid("{EDA661EA-DC61-4750-B3A5-F6E9C74060F5}"), pageOrder: 0, hasConfigurationCondition: true);
+        public static readonly ProjectDesignerPageMetadata Package      = new(new Guid("{21b78be8-3957-4caa-bf2f-e626107da58e}"), pageOrder: 0, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata References   = new(new Guid("{4E43F4AB-9F03-4129-95BF-B8FF870AF6AB}"), pageOrder: 1, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Debug        = new(new Guid("{0273C280-1882-4ED0-9308-52914672E3AA}"), pageOrder: 2, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Signing      = new(new Guid("{F8D6553F-F752-4DBF-ACB6-F291B744A792}"), pageOrder: 6, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata CodeAnalysis = new(new Guid("{c02f393c-8a1e-480d-aa82-6a75d693559d}"), pageOrder: 7, hasConfigurationCondition: false);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/WarningLevelEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/WarningLevelEnumProvider.cs
@@ -12,8 +12,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic
     [AppliesTo(ProjectCapability.VisualBasic)]
     internal class WarningLevelEnumProvider : IDynamicEnumValuesProvider
     {
-        private readonly Dictionary<string, IEnumValue> _persistWarningLevelEnumValues = new Dictionary<string, IEnumValue>
-            {
+        private readonly Dictionary<string, IEnumValue> _persistWarningLevelEnumValues = new()
+        {
                 { nameof(prjWarningLevel.prjWarningLevel0), new PageEnumValue(new EnumValue {Name = "0" }) },
                 { nameof(prjWarningLevel.prjWarningLevel1), new PageEnumValue(new EnumValue {Name = "1" }) },
                 { nameof(prjWarningLevel.prjWarningLevel2), new PageEnumValue(new EnumValue {Name = "2" }) },

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/UniversalRemoteAuthenticationProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/UniversalRemoteAuthenticationProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
     [Order(30)]
     internal class UniversalRemoteAuthenticationProvider : IRemoteAuthenticationProvider
     {
-        private static readonly Guid s_universalPortSupplier = new Guid("EE56E4E8-E866-4915-A18E-1DE7114BD7BB");
+        private static readonly Guid s_universalPortSupplier = new("EE56E4E8-E866-4915-A18E-1DE7114BD7BB");
 
         [ImportingConstructor]
         public UniversalRemoteAuthenticationProvider()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WindowsRemoteAuthenticationProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WindowsRemoteAuthenticationProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
     [Order(2)]
     internal class WindowsRemoteAuthenticationProvider : IRemoteAuthenticationProvider
     {
-        private static readonly Guid s_localPortSupplier = new Guid("708C1ECA-FF48-11D2-904F-00C04FA302A1");
+        private static readonly Guid s_localPortSupplier = new("708C1ECA-FF48-11D2-904F-00C04FA302A1");
 
         [ImportingConstructor]
         public WindowsRemoteAuthenticationProvider()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputSnapshot.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 {
     internal class DesignTimeInputSnapshot
     {
-        public static readonly DesignTimeInputSnapshot Empty = new DesignTimeInputSnapshot(
+        public static readonly DesignTimeInputSnapshot Empty = new(
             EmptyCollections.OrdinalStringSet,
             EmptyCollections.OrdinalStringSet,
             Enumerable.Empty<DesignTimeInputFileChange>(), string.Empty);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         private readonly IDesignTimeInputsDataSource _inputsDataSource;
         private readonly IDesignTimeInputsFileWatcher _fileWatcher;
 
-        private readonly DisposableBag _disposables = new DisposableBag();
+        private readonly DisposableBag _disposables = new();
 
         private DesignTimeInputSnapshot? _currentState;
         private int _version;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         private ITargetBlock<IProjectVersionedValue<DesignTimeInputSnapshot>>? _compileActionBlock;
         private IDisposable? _changeTrackerLink;
 
-        private readonly CompilationQueue _queue = new CompilationQueue();
+        private readonly CompilationQueue _queue = new();
         private CancellationTokenSource? _compilationCancellationSource;
 
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         private readonly IProjectThreadingService _threadingService;
         private readonly IDesignTimeInputsDataSource _designTimeInputsDataSource;
         private readonly IVsService<IVsAsyncFileChangeEx> _fileChangeService;
-        private readonly Dictionary<string, uint> _fileWatcherCookies = new Dictionary<string, uint>(StringComparers.Paths);
+        private readonly Dictionary<string, uint> _fileWatcherCookies = new(StringComparers.Paths);
 
         private int _version;
         private IDisposable? _dataSourceLink;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AttachedCollectionItemBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AttachedCollectionItemBase.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         //
         // NOTE we don't have to support ITreeDisplayItemWithImages -- it's covered by ITreeDisplayItem
 
-        private static readonly HashSet<Type> s_supportedPatterns = new HashSet<Type>
+        private static readonly HashSet<Type> s_supportedPatterns = new()
         {
             typeof(ITreeDisplayItem),
             typeof(IBrowsablePattern),

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeConfiguredProjectSearchContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeConfiguredProjectSearchContext.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public bool IsMatch(string candidateText) => _inner.IsMatch(candidateText);
 
-        private readonly Dictionary<object, IRelatableItem> _itemByKey = new Dictionary<object, IRelatableItem>();
+        private readonly Dictionary<object, IRelatableItem> _itemByKey = new();
 
         public void SubmitResult(IRelatableItem? item)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Web/DefaultHttpClient.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Web/DefaultHttpClient.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
     [Export(typeof(IHttpClient))]
     internal class DefaultHttpClient : IHttpClient
     {
-        private static readonly Lazy<HttpClient> s_client = new Lazy<HttpClient>(CreateClient);
+        private static readonly Lazy<HttpClient> s_client = new(CreateClient);
 
         [ImportingConstructor]
         public DefaultHttpClient()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     {
         private readonly IVsUIService<IVsSolution> _solution;
 
-        private TaskCompletionSource _loadedInHost = new TaskCompletionSource();
+        private TaskCompletionSource _loadedInHost = new();
         private uint _cookie = VSConstants.VSCOOKIE_NIL;
 
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/HierarchyId.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/HierarchyId.cs
@@ -13,22 +13,22 @@ namespace Microsoft.VisualStudio.Shell
         ///     Represents the root of a project hierarchy and is used to identify the entire hierarchy, as opposed
         ///     to a single item.
         /// </summary>
-        public static readonly HierarchyId Root = new HierarchyId(VSConstants.VSITEMID_ROOT);
+        public static readonly HierarchyId Root = new(VSConstants.VSITEMID_ROOT);
 
         /// <summary>
         ///     Represents the currently selected items, which can include the root of the hierarchy.
         /// </summary>
-        public static readonly HierarchyId Selection = new HierarchyId(VSConstants.VSITEMID_SELECTION);
+        public static readonly HierarchyId Selection = new(VSConstants.VSITEMID_SELECTION);
 
         /// <summary>
         ///     Represents the absence of a project item. This value is used when there is no current selection.
         /// </summary>
-        public static readonly HierarchyId Nil = new HierarchyId(VSConstants.VSITEMID_NIL);
+        public static readonly HierarchyId Nil = new(VSConstants.VSITEMID_NIL);
 
         /// <summary>
         ///     Represent an empty item.
         /// </summary>
-        public static readonly HierarchyId Empty = new HierarchyId(0);
+        public static readonly HierarchyId Empty = new(0);
 
         public HierarchyId(uint id)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/SolutionExplorerWindow.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/SolutionExplorerWindow.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.Shell
     [ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal class SolutionExplorerWindow
     {
-        private static readonly Guid s_solutionExplorer = new Guid(EnvDTE.Constants.vsWindowKindSolutionExplorer);
+        private static readonly Guid s_solutionExplorer = new(EnvDTE.Constants.vsWindowKindSolutionExplorer);
 
         private readonly Lazy<IVsUIHierarchyWindow2?> _solutionExplorer;
         private readonly IProjectThreadingService _threadingService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLogger.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.Telemetry
     {
         private readonly ITelemetryService _telemetryService;
 
-        private readonly Dictionary<int, TargetRecord> _targets = new Dictionary<int, TargetRecord>();
+        private readonly Dictionary<int, TargetRecord> _targets = new();
         private bool _succeeded;
 
         public DesignTimeTelemetryLogger(ITelemetryService telemetryService)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledStringBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledStringBuilder.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.Buffers.PooledObjects
     /// </summary>
     internal class PooledStringBuilder
     {
-        private readonly StringBuilder _builder = new StringBuilder();
+        private readonly StringBuilder _builder = new();
         private readonly ObjectPool<PooledStringBuilder> _pool;
 
         private PooledStringBuilder(ObjectPool<PooledStringBuilder> pool)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
@@ -14,8 +14,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
     internal abstract class AbstractMultiLifetimeComponent<T> : OnceInitializedOnceDisposedAsync
         where T : class, IMultiLifetimeInstance
     {
-        private readonly object _lock = new object();
-        private TaskCompletionSource<(T instance, JoinableTask initializeAsyncTask)> _instanceTaskSource = new TaskCompletionSource<(T instance, JoinableTask initializeAsyncTask)>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly object _lock = new();
+        private TaskCompletionSource<(T instance, JoinableTask initializeAsyncTask)> _instanceTaskSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         protected AbstractMultiLifetimeComponent(JoinableTaskContextNode joinableTaskContextNode)
              : base(joinableTaskContextNode)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ConfiguredProjectImplicitActivationTracking.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ConfiguredProjectImplicitActivationTracking.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private readonly IProjectAsynchronousTasksService _tasksService;
         private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
         private readonly ITargetBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> _targetBlock;
-        private TaskCompletionSource _isImplicitlyActiveSource = new TaskCompletionSource();
+        private TaskCompletionSource _isImplicitlyActiveSource = new();
         private IDisposable? _subscription;
 
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         private IProjectAccessor ProjectAccessor { get; }
 
         // Regular expression string to extract $(sometoken) elements from a string
-        private static readonly Regex s_matchTokenRegex = new Regex(@"(\$\((?<token>[^\)]+)\))", RegexOptions.IgnoreCase);
+        private static readonly Regex s_matchTokenRegex = new(@"(\$\((?<token>[^\)]+)\))", RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Walks the profile and returns a new one where all the tokens have been replaced. Tokens can consist of

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileData.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileData.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         private const string Prop_launchUrl = "launchUrl";
         private const string Prop_environmentVariables = "environmentVariables";
 
-        private static readonly HashSet<string> s_knownProfileProperties = new HashSet<string>(StringComparers.LaunchProfileProperties)
+        private static readonly HashSet<string> s_knownProfileProperties = new(StringComparers.LaunchProfileProperties)
         {
             Prop_commandName,
             Prop_executablePath,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -49,8 +49,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         private readonly IUnconfiguredProjectCommonServices _commonProjectServices;
         private readonly IActiveConfiguredProjectSubscriptionService? _projectSubscriptionService;
         private readonly IFileSystem _fileSystem;
-        private readonly TaskCompletionSource _firstSnapshotCompletionSource = new TaskCompletionSource();
-        private readonly SequentialTaskExecutor _sequentialTaskQueue = new SequentialTaskExecutor();
+        private readonly TaskCompletionSource _firstSnapshotCompletionSource = new();
+        private readonly SequentialTaskExecutor _sequentialTaskQueue = new();
         private IReceivableSourceBlock<ILaunchSettings>? _changedSourceBlock;
         private IBroadcastBlock<ILaunchSettings>? _broadcastBlock;
         private ILaunchSettings? _currentSnapshot;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/FaultExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/FaultExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     /// </summary>
     internal static class FaultExtensions
     {
-        private static readonly ErrorReportSettings s_defaultReportSettings = new ErrorReportSettings(
+        private static readonly ErrorReportSettings s_defaultReportSettings = new(
             eventName: "VisualStudioNonFatalErrors2",
             component: "ManagedProjectSystem",
             reportType: ErrorReportType.Critical,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
@@ -7,17 +7,17 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal sealed class TargetFramework : IEquatable<TargetFramework?>
     {
-        public static readonly TargetFramework Empty = new TargetFramework(string.Empty);
+        public static readonly TargetFramework Empty = new(string.Empty);
 
         /// <summary>
         /// The target framework used when a TFM short-name cannot be resolved.
         /// </summary>
-        public static readonly TargetFramework Unsupported = new TargetFramework("Unsupported,Version=v0.0");
+        public static readonly TargetFramework Unsupported = new("Unsupported,Version=v0.0");
 
         /// <summary>
         /// Any represents all TFMs, no need to be localized, used only in internal data.
         /// </summary>
-        public static readonly TargetFramework Any = new TargetFramework("any");
+        public static readonly TargetFramework Any = new("any");
 
         public TargetFramework(FrameworkName frameworkName, string? shortName = null)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/FSharp/FSharpSourcesIconProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/FSharp/FSharpSourcesIconProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging.FSharp
     [Order(Order.Default)]
     internal class FSharpSourcesIconProvider : IProjectTreePropertiesProvider
     {
-        private static readonly Dictionary<string, ProjectImageMoniker> s_fileExtensionImageMap = new Dictionary<string, ProjectImageMoniker>(StringComparers.Paths)
+        private static readonly Dictionary<string, ProjectImageMoniker> s_fileExtensionImageMap = new(StringComparers.Paths)
         {
             { ".fs",   KnownMonikers.FSFileNode.ToProjectSystemType() },
             { ".fsi",  KnownMonikers.FSSignatureFile.ToProjectSystemType() },

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
@@ -66,8 +66,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         // command-line arguments as individual item includes, such as <CscCommandLineArguments Include="/reference:Foo.dll"/>, without any 
         // metadata.
         //
-        private readonly HashSet<string> _paths = new HashSet<string>(StringComparers.Paths);
-        private readonly Queue<VersionedProjectChangeDiff> _projectEvaluations = new Queue<VersionedProjectChangeDiff>();
+        private readonly HashSet<string> _paths = new(StringComparers.Paths);
+        private readonly Queue<VersionedProjectChangeDiff> _projectEvaluations = new();
         private readonly UnconfiguredProject _project;
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         // See: https://github.com/dotnet/project-system/issues/2230
 
         private readonly UnconfiguredProject _project;
-        private readonly HashSet<string> _paths = new HashSet<string>(StringComparers.Paths);
+        private readonly HashSet<string> _paths = new(StringComparers.Paths);
 
         [ImportingConstructor]
         public AdditionalFilesItemHandler(UnconfiguredProject project)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerConfigItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerConfigItemHandler.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         // See: https://github.com/dotnet/project-system/issues/2230
 
         private readonly UnconfiguredProject _project;
-        private readonly HashSet<string> _paths = new HashSet<string>(StringComparers.Paths);
+        private readonly HashSet<string> _paths = new(StringComparers.Paths);
 
         [ImportingConstructor]
         public AnalyzerConfigItemHandler(UnconfiguredProject project)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         // See: https://github.com/dotnet/project-system/issues/2230
         private readonly UnconfiguredProject _project;
-        private readonly HashSet<string> _paths = new HashSet<string>(StringComparers.Paths);
+        private readonly HashSet<string> _paths = new(StringComparers.Paths);
 
         [ImportingConstructor]
         public AnalyzerItemHandler(UnconfiguredProject project)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/DynamicItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/DynamicItemHandler.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         private const string RazorPagesExtension = ".cshtml";
         private const string RazorComponentsExtension = ".razor";
         private readonly UnconfiguredProject _project;
-        private readonly HashSet<string> _paths = new HashSet<string>(StringComparers.Paths);
+        private readonly HashSet<string> _paths = new(StringComparers.Paths);
 
         [ImportingConstructor]
         public DynamicItemHandler(UnconfiguredProject project)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         // See: https://github.com/dotnet/project-system/issues/2230
 
         private readonly UnconfiguredProject _project;
-        private readonly Dictionary<string, MetadataReferenceProperties> _addedPathsWithMetadata = new Dictionary<string, MetadataReferenceProperties>(StringComparers.Paths);
+        private readonly Dictionary<string, MetadataReferenceProperties> _addedPathsWithMetadata = new(StringComparers.Paths);
 
         [ImportingConstructor]
         public MetadataReferenceItemHandler(UnconfiguredProject project)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/AssemblyVersionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/AssemblyVersionValueProvider.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
     [ExportInterceptingPropertyValueProvider(AssemblyVersionPropertyName, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     internal sealed class AssemblyVersionValueProvider : BaseVersionValueProvider
     {
-        private static readonly Version s_defaultAssemblyVersion = new Version(1, 0, 0, 0);
+        private static readonly Version s_defaultAssemblyVersion = new(1, 0, 0, 0);
 
         private const string AssemblyVersionPropertyName = "AssemblyVersion";
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/BaseVersionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/BaseVersionValueProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
     internal abstract class BaseVersionValueProvider : InterceptingPropertyValueProviderBase
     {
         private const string PackageVersionMSBuildProperty = "Version";
-        protected static readonly Version DefaultVersion = new Version(1, 0, 0);
+        protected static readonly Version DefaultVersion = new(1, 0, 0);
 
         protected abstract string PropertyName { get; }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/FileVersionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/FileVersionValueProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
     {
         private const string FileVersionPropertyName = "FileVersion";
 
-        private static readonly Version s_defaultFileVersion = new Version(1, 0, 0, 0);
+        private static readonly Version s_defaultFileVersion = new(1, 0, 0, 0);
 
         protected override string PropertyName => FileVersionPropertyName;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ProjectRuleSnapshotExtensions.EmptyProjectRuleSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ProjectRuleSnapshotExtensions.EmptyProjectRuleSnapshot.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     {
         private class EmptyProjectRuleSnapshot : IProjectRuleSnapshot
         {
-            public static readonly EmptyProjectRuleSnapshot Instance = new EmptyProjectRuleSnapshot();
+            public static readonly EmptyProjectRuleSnapshot Instance = new();
 
             public string RuleName
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
         [ImportMany]
         private readonly OrderPrecedenceImportCollection<IDependenciesTreeViewProvider> _viewProviders;
 
-        private readonly CancellationSeries _treeUpdateCancellationSeries = new CancellationSeries();
+        private readonly CancellationSeries _treeUpdateCancellationSeries = new();
         private readonly DependenciesSnapshotProvider _dependenciesSnapshotProvider;
         private readonly IProjectAsynchronousTasksService _tasksService;
         private readonly UnconfiguredProject _project;
@@ -545,7 +545,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
         /// </summary>
         private sealed class ProjectTreeCustomizablePropertyContext : IProjectTreeCustomizablePropertyContext
         {
-            public static readonly ProjectTreeCustomizablePropertyContext Instance = new ProjectTreeCustomizablePropertyContext();
+            public static readonly ProjectTreeCustomizablePropertyContext Instance = new();
 
             public string ItemName => string.Empty;
             public string? ItemType => null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
         private readonly ITelemetryService? _telemetryService;
         private readonly ISafeProjectGuidService _safeProjectGuidService;
         private readonly Stopwatch _projectLoadTime = Stopwatch.StartNew();
-        private readonly object _stateUpdateLock = new object();
+        private readonly object _stateUpdateLock = new();
 
         /// <summary>
         /// Holds data used for telemetry. If telemetry is disabled, or if required
@@ -216,7 +216,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
         private sealed class TargetData
         {
-            private readonly Dictionary<string, (int Total, int Unresolved)> _countsByType = new Dictionary<string, (int Total, int Unresolved)>();
+            private readonly Dictionary<string, (int Total, int Unresolved)> _countsByType = new();
 
             public string TargetFramework { get; }
             public int Total { get; private set; }
@@ -251,7 +251,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
         /// </summary>
         private sealed class TelemetryState
         {
-            private readonly Dictionary<string, bool> _observedRules = new Dictionary<string, bool>(StringComparers.RuleNames);
+            private readonly Dictionary<string, bool> _observedRules = new(StringComparers.RuleNames);
 
             public void InitializeRule(string rule)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/AnalyzerDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/AnalyzerDependencyModel.cs
@@ -10,17 +10,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
     internal class AnalyzerDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
+        private static readonly DependencyFlagCache s_flagCache = new(
             resolved: DependencyTreeFlags.AnalyzerDependency + DependencyTreeFlags.SupportsBrowse,
             unresolved: DependencyTreeFlags.AnalyzerDependency + DependencyTreeFlags.SupportsBrowse);
 
-        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+        private static readonly DependencyIconSet s_iconSet = new(
             icon: KnownMonikers.CodeInformation,
             expandedIcon: KnownMonikers.CodeInformation,
             unresolvedIcon: ManagedImageMonikers.CodeInformationWarning,
             unresolvedExpandedIcon: ManagedImageMonikers.CodeInformationWarning);
 
-        private static readonly DependencyIconSet s_implicitIconSet = new DependencyIconSet(
+        private static readonly DependencyIconSet s_implicitIconSet = new(
             icon: ManagedImageMonikers.CodeInformationPrivate,
             expandedIcon: ManagedImageMonikers.CodeInformationPrivate,
             unresolvedIcon: ManagedImageMonikers.CodeInformationWarning,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/AssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/AssemblyDependencyModel.cs
@@ -11,17 +11,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
     internal class AssemblyDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
+        private static readonly DependencyFlagCache s_flagCache = new(
             resolved: DependencyTreeFlags.AssemblyDependency + DependencyTreeFlags.SupportsBrowse,
             unresolved: DependencyTreeFlags.AssemblyDependency);
 
-        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+        private static readonly DependencyIconSet s_iconSet = new(
             icon: KnownMonikers.Reference,
             expandedIcon: KnownMonikers.Reference,
             unresolvedIcon: KnownMonikers.ReferenceWarning,
             unresolvedExpandedIcon: KnownMonikers.ReferenceWarning);
 
-        private static readonly DependencyIconSet s_implicitIconSet = new DependencyIconSet(
+        private static readonly DependencyIconSet s_implicitIconSet = new(
             icon: KnownMonikers.ReferencePrivate,
             expandedIcon: KnownMonikers.ReferencePrivate,
             unresolvedIcon: KnownMonikers.ReferenceWarning,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/ComDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/ComDependencyModel.cs
@@ -9,17 +9,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
     internal class ComDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
+        private static readonly DependencyFlagCache s_flagCache = new(
             resolved: DependencyTreeFlags.ComDependency + DependencyTreeFlags.SupportsBrowse,
             unresolved: DependencyTreeFlags.ComDependency);
 
-        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+        private static readonly DependencyIconSet s_iconSet = new(
             icon: KnownMonikers.COM,
             expandedIcon: KnownMonikers.COM,
             unresolvedIcon: KnownMonikers.COMWarning,
             unresolvedExpandedIcon: KnownMonikers.COMWarning);
 
-        private static readonly DependencyIconSet s_implicitIconSet = new DependencyIconSet(
+        private static readonly DependencyIconSet s_implicitIconSet = new(
             icon: KnownMonikers.COMPrivate,
             expandedIcon: KnownMonikers.COMPrivate,
             unresolvedIcon: KnownMonikers.COMWarning,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/FrameworkDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/FrameworkDependencyModel.cs
@@ -9,11 +9,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
     internal sealed class FrameworkDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
+        private static readonly DependencyFlagCache s_flagCache = new(
             resolved: DependencyTreeFlags.FrameworkDependency + DependencyTreeFlags.SupportsFolderBrowse,
             unresolved: DependencyTreeFlags.FrameworkDependency);
 
-        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+        private static readonly DependencyIconSet s_iconSet = new(
             icon: ManagedImageMonikers.Framework,
             expandedIcon: ManagedImageMonikers.Framework,
             unresolvedIcon: ManagedImageMonikers.FrameworkWarning,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/PackageDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/PackageDependencyModel.cs
@@ -9,17 +9,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
     internal class PackageDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
+        private static readonly DependencyFlagCache s_flagCache = new(
             resolved: DependencyTreeFlags.PackageDependency + DependencyTreeFlags.SupportsFolderBrowse,
             unresolved: DependencyTreeFlags.PackageDependency);
 
-        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+        private static readonly DependencyIconSet s_iconSet = new(
             icon: ManagedImageMonikers.NuGetGrey,
             expandedIcon: ManagedImageMonikers.NuGetGrey,
             unresolvedIcon: ManagedImageMonikers.NuGetGreyWarning,
             unresolvedExpandedIcon: ManagedImageMonikers.NuGetGreyWarning);
 
-        private static readonly DependencyIconSet s_implicitIconSet = new DependencyIconSet(
+        private static readonly DependencyIconSet s_implicitIconSet = new(
             icon: ManagedImageMonikers.NuGetGreyPrivate,
             expandedIcon: ManagedImageMonikers.NuGetGreyPrivate,
             unresolvedIcon: ManagedImageMonikers.NuGetGreyWarning,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/ProjectDependencyModel.cs
@@ -9,17 +9,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
     internal class ProjectDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
+        private static readonly DependencyFlagCache s_flagCache = new(
             resolved: DependencyTreeFlags.ProjectDependency + DependencyTreeFlags.SupportsBrowse,
             unresolved: DependencyTreeFlags.ProjectDependency + DependencyTreeFlags.SupportsBrowse);
 
-        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+        private static readonly DependencyIconSet s_iconSet = new(
             icon: KnownMonikers.Application,
             expandedIcon: KnownMonikers.Application,
             unresolvedIcon: KnownMonikers.ApplicationWarning,
             unresolvedExpandedIcon: KnownMonikers.ApplicationWarning);
 
-        private static readonly DependencyIconSet s_implicitIconSet = new DependencyIconSet(
+        private static readonly DependencyIconSet s_implicitIconSet = new(
             icon: KnownMonikers.ApplicationPrivate,
             expandedIcon: KnownMonikers.ApplicationPrivate,
             unresolvedIcon: KnownMonikers.ApplicationWarning,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/SdkDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/SdkDependencyModel.cs
@@ -12,17 +12,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
     internal class SdkDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
+        private static readonly DependencyFlagCache s_flagCache = new(
             resolved: DependencyTreeFlags.SdkDependency + DependencyTreeFlags.SupportsFolderBrowse,
             unresolved: DependencyTreeFlags.SdkDependency);
 
-        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+        private static readonly DependencyIconSet s_iconSet = new(
             icon: KnownMonikers.SDK,
             expandedIcon: KnownMonikers.SDK,
             unresolvedIcon: KnownMonikers.SDKWarning,
             unresolvedExpandedIcon: KnownMonikers.SDKWarning);
 
-        private static readonly DependencyIconSet s_implicitIconSet = new DependencyIconSet(
+        private static readonly DependencyIconSet s_implicitIconSet = new(
             icon: KnownMonikers.SDKPrivate,
             expandedIcon: KnownMonikers.SDKPrivate,
             unresolvedIcon: KnownMonikers.SDKWarning,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
@@ -9,18 +9,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
     internal class SharedProjectDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
+        private static readonly DependencyFlagCache s_flagCache = new(
             resolved: DependencyTreeFlags.ProjectDependency + DependencyTreeFlags.SharedProjectDependency + DependencyTreeFlags.SupportsBrowse,
             unresolved: DependencyTreeFlags.ProjectDependency + DependencyTreeFlags.SharedProjectDependency + DependencyTreeFlags.SupportsBrowse,
             remove: DependencyTreeFlags.SupportsRuleProperties);
 
-        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+        private static readonly DependencyIconSet s_iconSet = new(
             icon: KnownMonikers.SharedProject,
             expandedIcon: KnownMonikers.SharedProject,
             unresolvedIcon: KnownMonikers.SharedProjectWarning,
             unresolvedExpandedIcon: KnownMonikers.SharedProjectWarning);
 
-        private static readonly DependencyIconSet s_implicitIconSet = new DependencyIconSet(
+        private static readonly DependencyIconSet s_implicitIconSet = new(
             icon: KnownMonikers.SharedProjectPrivate,
             expandedIcon: KnownMonikers.SharedProjectPrivate,
             unresolvedIcon: KnownMonikers.SharedProjectWarning,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/SDKVersionTelemetryServiceComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/SDKVersionTelemetryServiceComponent.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
         }
 
         protected override SDKVersionTelemetryServiceInstance CreateInstance()
-            => new SDKVersionTelemetryServiceInstance(
+            => new(
                 _projectVsServices,
                 _projectGuidService,
                 _telemetryService,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.SnapshotUpdater.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.SnapshotUpdater.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
         /// </summary>
         private sealed class SnapshotUpdater : IDisposable
         {
-            private readonly object _lock = new object();
+            private readonly object _lock = new();
 
             private readonly IBroadcastBlock<SnapshotChangedEventArgs> _source;
             private readonly ITaskDelayScheduler _debounce;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -29,8 +29,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
     [AppliesTo(ProjectCapability.DependenciesTree)]
     internal sealed partial class DependenciesSnapshotProvider : OnceInitializedOnceDisposedAsync
     {
-        private readonly SemaphoreSlim _contextUpdateGate = new SemaphoreSlim(initialCount: 1);
-        private readonly object _lock = new object();
+        private readonly SemaphoreSlim _contextUpdateGate = new(initialCount: 1);
+        private readonly object _lock = new();
 
         private readonly SnapshotUpdater _snapshot;
         private readonly ContextTracker _context;
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
         /// Disposable items related to the current subscriptions. This collection may be replaced
         /// from time to time (e.g. when target frameworks change).
         /// </summary>
-        private DisposableBag _subscriptions = new DisposableBag();
+        private DisposableBag _subscriptions = new();
 
         /// <summary>
         /// Lazily populated set of subscribers. May be <see cref="ImmutableArray{T}.IsDefault" /> if <see cref="Subscribers"/>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/AnalyzerRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/AnalyzerRuleHandler.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
     {
         public const string ProviderTypeString = "Analyzer";
 
-        private static readonly DependencyGroupModel s_groupModel = new DependencyGroupModel(
+        private static readonly DependencyGroupModel s_groupModel = new(
             ProviderTypeString,
             Resources.AnalyzersNodeName,
             new DependencyIconSet(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/AssemblyRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/AssemblyRuleHandler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
     {
         public const string ProviderTypeString = "Assembly";
 
-        private static readonly DependencyGroupModel s_groupModel = new DependencyGroupModel(
+        private static readonly DependencyGroupModel s_groupModel = new(
             ProviderTypeString,
             Resources.AssembliesNodeName,
             new DependencyIconSet(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/ComRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/ComRuleHandler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
     {
         public const string ProviderTypeString = "Com";
 
-        private static readonly DependencyGroupModel s_groupModel = new DependencyGroupModel(
+        private static readonly DependencyGroupModel s_groupModel = new(
             ProviderTypeString,
             Resources.ComNodeName,
             new DependencyIconSet(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/FrameworkRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/FrameworkRuleHandler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
     {
         public const string ProviderTypeString = "Framework";
 
-        private static readonly DependencyGroupModel s_groupModel = new DependencyGroupModel(
+        private static readonly DependencyGroupModel s_groupModel = new(
             ProviderTypeString,
             Resources.FrameworkNodeName,
             new DependencyIconSet(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
     {
         public const string ProviderTypeString = "Package";
 
-        private static readonly DependencyGroupModel s_groupModel = new DependencyGroupModel(
+        private static readonly DependencyGroupModel s_groupModel = new(
             ProviderTypeString,
             Resources.PackagesNodeName,
             new DependencyIconSet(
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
 
         public override IDependencyModel CreateRootDependencyNode() => s_groupModel;
 
-        private static readonly InternPool<string> s_targetFrameworkInternPool = new InternPool<string>(StringComparer.Ordinal);
+        private static readonly InternPool<string> s_targetFrameworkInternPool = new(StringComparer.Ordinal);
 
         private bool TryCreatePackageDependencyModel(
             string itemSpec,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/ProjectRuleHandler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
     {
         public const string ProviderTypeString = "Project";
 
-        private static readonly DependencyGroupModel s_groupModel = new DependencyGroupModel(
+        private static readonly DependencyGroupModel s_groupModel = new(
             ProviderTypeString,
             Resources.ProjectsNodeName,
             new DependencyIconSet(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/SdkRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/SdkRuleHandler.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
     {
         public const string ProviderTypeString = "Sdk";
 
-        private static readonly DependencyGroupModel s_groupModel = new DependencyGroupModel(
+        private static readonly DependencyGroupModel s_groupModel = new(
             ProviderTypeString,
             Resources.SdkNodeName,
             new DependencyIconSet(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
         private static readonly ProjectTreeFlags s_projectImportFlags = ProjectImport | ProjectTreeFlags.FileOnDisk | ProjectTreeFlags.FileSystemEntity;
         private static readonly ProjectTreeFlags s_projectImportImplicitFlags = s_projectImportFlags + ProjectImportImplicit;
 
-        private readonly ImplicitProjectCheck _importPathCheck = new ImplicitProjectCheck();
+        private readonly ImplicitProjectCheck _importPathCheck = new();
         private readonly UnconfiguredProject _project;
         private readonly IActiveConfiguredProjectSubscriptionService _projectSubscriptionService;
         private readonly IUnconfiguredProjectTasksService _unconfiguredProjectTasksService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
@@ -18,8 +18,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private readonly IProjectThreadingService _threadingService;
         private readonly ILoadedInHostListener? _loadedInHostListener;
         private readonly ISolutionService? _solutionService;
-        private readonly TaskCompletionSource _projectLoadedInHost = new TaskCompletionSource();
-        private readonly TaskCompletionSource _prioritizedProjectLoadedInHost = new TaskCompletionSource();
+        private readonly TaskCompletionSource _projectLoadedInHost = new();
+        private readonly TaskCompletionSource _prioritizedProjectLoadedInHost = new();
         private readonly JoinableTaskCollection _prioritizedTasks;
 
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.ItemComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.ItemComparer.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
     {
         private sealed class ItemComparer : IEqualityComparer<(string path, string? link, CopyType copyType)>
         {
-            public static readonly ItemComparer Instance = new ItemComparer();
+            public static readonly ItemComparer Instance = new();
 
             private ItemComparer()
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private readonly ITelemetryService _telemetryService;
         private readonly IFileSystem _fileSystem;
 
-        private readonly object _stateLock = new object();
+        private readonly object _stateLock = new();
 
         private State _state = State.Empty;
 
@@ -673,7 +673,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         /// <summary>For unit testing only.</summary>
 #pragma warning disable RS0043 // Do not call 'GetTestAccessor()'
-        internal TestAccessor TestAccess => new TestAccessor(this);
+        internal TestAccessor TestAccess => new(this);
 #pragma warning restore RS0043
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/TraceUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/TraceUtilities.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         /// <summary>
         /// The CPS trace source.
         /// </summary>
-        internal static readonly TraceSource Source = new TraceSource("CPS");
+        internal static readonly TraceSource Source = new("CPS");
 
         /// <summary>
         /// Buffer to preserve latest set of error messages to help diagnosing Watson bugs.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/WaitIndicatorResult.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/WaitIndicatorResult.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Waiting
         where T : class?
     {
 #pragma warning disable RS0038 // Prefer null literal
-        public static readonly WaitIndicatorResult<T> Cancelled = new WaitIndicatorResult<T>(isCancelled: true, result: default!);
+        public static readonly WaitIndicatorResult<T> Cancelled = new(isCancelled: true, result: default!);
 #pragma warning restore RS0038 
 
         private readonly bool _isCancelled;
@@ -45,6 +45,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Waiting
             }
         }
 
-        public static WaitIndicatorResult<T> FromResult(T result) => new WaitIndicatorResult<T>(isCancelled: false, result: result);
+        public static WaitIndicatorResult<T> FromResult(T result) => new(isCancelled: false, result: result);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources/ManagedImageMonikers.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources/ManagedImageMonikers.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     public static class ManagedImageMonikers
     {
         // These GUIDs and IDs are defined in src\Microsoft.VisualStudio.ProjectSystem.Managed.VS\ManagedImages.imagemanifest
-        private static readonly Guid s_manifestGuid = new Guid("{259567C1-AA6B-46BF-811C-C145DD9F3B48}");
+        private static readonly Guid s_manifestGuid = new("{259567C1-AA6B-46BF-811C-C145DD9F3B48}");
 
         [Obsolete("Please use Microsoft.VisualStudio.Imaging.KnownMonikers")]
         public static ImageMoniker ApplicationPrivate => KnownMonikers.ApplicationPrivate;
@@ -70,15 +70,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         public static ImageMoniker WarningSmall => throw new NotSupportedException();
 
         // Everything below this, still needs to be moved to the ImageCatalog
-        public static ImageMoniker NuGetGrey => new ImageMoniker { Guid = s_manifestGuid, Id = 9 };
-        public static ImageMoniker NuGetGreyPrivate => new ImageMoniker { Guid = s_manifestGuid, Id = 10 };
-        public static ImageMoniker NuGetGreyWarning => new ImageMoniker { Guid = s_manifestGuid, Id = 11 };
-        public static ImageMoniker Framework => new ImageMoniker { Guid = s_manifestGuid, Id = 22 };
-        public static ImageMoniker FrameworkPrivate => new ImageMoniker { Guid = s_manifestGuid, Id = 23 };
-        public static ImageMoniker FrameworkWarning => new ImageMoniker { Guid = s_manifestGuid, Id = 24 };
-        public static ImageMoniker ProjectImports => new ImageMoniker { Guid = s_manifestGuid, Id = 25 };
-        public static ImageMoniker CodeInformationPrivate => new ImageMoniker { Guid = s_manifestGuid, Id = 2 };
-        public static ImageMoniker CodeInformationWarning => new ImageMoniker { Guid = s_manifestGuid, Id = 3 };
+        public static ImageMoniker NuGetGrey => new() { Guid = s_manifestGuid, Id = 9 };
+        public static ImageMoniker NuGetGreyPrivate => new() { Guid = s_manifestGuid, Id = 10 };
+        public static ImageMoniker NuGetGreyWarning => new() { Guid = s_manifestGuid, Id = 11 };
+        public static ImageMoniker Framework => new() { Guid = s_manifestGuid, Id = 22 };
+        public static ImageMoniker FrameworkPrivate => new() { Guid = s_manifestGuid, Id = 23 };
+        public static ImageMoniker FrameworkWarning => new() { Guid = s_manifestGuid, Id = 24 };
+        public static ImageMoniker ProjectImports => new() { Guid = s_manifestGuid, Id = 25 };
+        public static ImageMoniker CodeInformationPrivate => new() { Guid = s_manifestGuid, Id = 2 };
+        public static ImageMoniker CodeInformationWarning => new() { Guid = s_manifestGuid, Id = 3 };
 
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Text/LazyStringSplit.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Text/LazyStringSplit.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.Text
             _delimiter = delimiter;
         }
 
-        public Enumerator GetEnumerator() => new Enumerator(this);
+        public Enumerator GetEnumerator() => new(this);
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/CancellationSeries.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/CancellationSeries.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
     /// </remarks>
     internal sealed class CancellationSeries : IDisposable
     {
-        private CancellationTokenSource? _cts = new CancellationTokenSource();
+        private CancellationTokenSource? _cts = new();
 
         private readonly CancellationToken _superToken;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/SequentialTaskExecutor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/SequentialTaskExecutor.cs
@@ -15,15 +15,15 @@ namespace Microsoft.VisualStudio.Threading.Tasks
     {
         private bool _disposed;
         private Task _taskAdded = Task.CompletedTask;
-        private readonly object _syncObject = new object();
-        private readonly CancellationTokenSource _disposedCancelTokenSource = new CancellationTokenSource();
+        private readonly object _syncObject = new();
+        private readonly CancellationTokenSource _disposedCancelTokenSource = new();
 
         /// <summary>
         /// Deadlocks will occur if a task returned from ExecuteTask , awaits a task which also calls ExecuteTask. The 2nd one will never get started since
         /// it will be backed up behind the first one completing. The AsyncLocal is used to detect when a task is being executed, and if a downstream one gets
         /// added, it will be executed directly, rather than get queued
         /// </summary>
-        private readonly System.Threading.AsyncLocal<bool> _executingTask = new System.Threading.AsyncLocal<bool>();
+        private readonly System.Threading.AsyncLocal<bool> _executingTask = new();
 
         /// <summary>
         /// Adds a new task to the continuation chain and returns it so that it can be awaited.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Utilities/SetDiff.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Utilities/SetDiff.cs
@@ -13,9 +13,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         private readonly Dictionary<T, byte> _dic;
 
-        public Part Removed => new Part(_dic, FlagBefore);
+        public Part Removed => new(_dic, FlagBefore);
 
-        public Part Added => new Part(_dic, FlagAfter);
+        public Part Added => new(_dic, FlagAfter);
 
         public SetDiff(IEnumerable<T> before, IEnumerable<T> after)
         {
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 _flag = flag;
             }
 
-            public PartEnumerator GetEnumerator() => new PartEnumerator(_dic, _flag);
+            public PartEnumerator GetEnumerator() => new(_dic, _flag);
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/Solution.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/Solution.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     /// </summary>
     public sealed class Solution : IEnumerable
     {
-        private readonly List<Project> _projects = new List<Project>();
+        private readonly List<Project> _projects = new();
 
         public IEnumerable<Project> Projects => _projects;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal class ProjectTreeWriter
     {
-        private readonly StringBuilder _builder = new StringBuilder();
+        private readonly StringBuilder _builder = new();
         private readonly ProjectTreeWriterOptions _options;
         private readonly IProjectTree _parent;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.IO
             }
         }
 
-        private readonly HashSet<string> _folders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _folders = new(StringComparer.OrdinalIgnoreCase);
 
         private string? _currentDirectory;
         private string? _tempFile;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     public class DebugTokenReplacerTests
     {
-        private readonly Dictionary<string, string> _envVars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        private readonly Dictionary<string, string> _envVars = new(StringComparer.OrdinalIgnoreCase)
         {
             { "%env1%","envVariable1" },
             { "%env2%","envVariable2" },

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
@@ -15,8 +15,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 {
     public sealed class DependenciesTreeViewProviderTests
     {
-        private readonly TargetFramework _tfm1 = new TargetFramework("tfm1");
-        private readonly TargetFramework _tfm2 = new TargetFramework("tfm2");
+        private readonly TargetFramework _tfm1 = new("tfm1");
+        private readonly TargetFramework _tfm2 = new("tfm2");
 
         private readonly ITestOutputHelper _output;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/DependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/DependencyModelTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
         {
             public override string ProviderType => "someProvider";
 
-            public override DependencyIconSet IconSet => new DependencyIconSet(Icon, ExpandedIcon, UnresolvedIcon, UnresolvedExpandedIcon);
+            public override DependencyIconSet IconSet => new(Icon, ExpandedIcon, UnresolvedIcon, UnresolvedExpandedIcon);
 
             public TestableDependencyModel(
                 string caption,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -627,8 +627,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         {
             private enum FilterAction { Reject, Accept }
 
-            private readonly Dictionary<(string ProviderType, string Id), (FilterAction, IDependency?)> _beforeAdd    = new Dictionary<(string ProviderType, string Id), (FilterAction, IDependency?)>();
-            private readonly Dictionary<(string ProviderType, string Id), (FilterAction, IDependency?)> _beforeRemove = new Dictionary<(string ProviderType, string Id), (FilterAction, IDependency?)>();
+            private readonly Dictionary<(string ProviderType, string Id), (FilterAction, IDependency?)> _beforeAdd    = new();
+            private readonly Dictionary<(string ProviderType, string Id), (FilterAction, IDependency?)> _beforeRemove = new();
 
             public TestDependenciesSnapshotFilter BeforeAddAccept(string providerType, string id, IDependency? dependency = null)
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
     [DebuggerDisplay("{" + nameof(Id) + ",nq}")]
     internal sealed class TestDependency : IDependency
     {
-        private static readonly DependencyIconSet s_defaultIconSet = new DependencyIconSet(
+        private static readonly DependencyIconSet s_defaultIconSet = new(
             KnownMonikers.Accordian,
             KnownMonikers.Bug,
             KnownMonikers.CrashDumpFile,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             .Add(new ItemType("Compile", true))
             .Add(new ItemType("Resource", true));
 
-        private readonly List<ITelemetryServiceFactory.TelemetryParameters> _telemetryEvents = new List<ITelemetryServiceFactory.TelemetryParameters>();
+        private readonly List<ITelemetryServiceFactory.TelemetryParameters> _telemetryEvents = new();
         private readonly BuildUpToDateCheck _buildUpToDateCheck;
         private readonly ITestOutputHelper _output;
         private readonly IFileSystemMock _fileSystem;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsAsyncFileChangeExMock.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsAsyncFileChangeExMock.cs
@@ -12,8 +12,8 @@ namespace Microsoft.VisualStudio.Shell
     public class IVsAsyncFileChangeExMock : IVsAsyncFileChangeEx
     {
         private uint _lastCookie;
-        private readonly Dictionary<uint, string> _watchedFiles = new Dictionary<uint, string>();
-        private readonly HashSet<string> _uniqueFilesWatched = new HashSet<string>();
+        private readonly Dictionary<uint, string> _watchedFiles = new();
+        private readonly HashSet<string> _uniqueFilesWatched = new();
 
         public IEnumerable<string> UniqueFilesWatched => _uniqueFilesWatched;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOutputWindow2Factory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOutputWindow2Factory.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
         private class VsOutputWindowMock : IVsOutputWindow, IVsOutputWindow2
         {
             private readonly Guid _activePaneGuid = Guid.NewGuid();
-            private readonly Dictionary<Guid, IVsOutputWindowPane> _panes = new Dictionary<Guid, IVsOutputWindowPane>();
+            private readonly Dictionary<Guid, IVsOutputWindowPane> _panes = new();
 
             public VsOutputWindowMock(IVsOutputWindowPane activePane)
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOutputWindowFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOutputWindowFactory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
 
         private class VsOutputWindowMock : IVsOutputWindow
         {
-            private readonly Dictionary<Guid, IVsOutputWindowPane> _panes = new Dictionary<Guid, IVsOutputWindowPane>();
+            private readonly Dictionary<Guid, IVsOutputWindowPane> _panes = new();
 
             public int GetPane(ref Guid rguidPane, out IVsOutputWindowPane ppPane)
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentComposition.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentComposition.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             typeof(VsContainedLanguageComponentsFactory).Assembly,          // Microsoft.VisualStudio.ProjectSystem.Managed.VS
         };
 
-        public static readonly ComponentComposition Instance = new ComponentComposition();
+        public static readonly ComponentComposition Instance = new();
 
         public ComponentComposition()
         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/DebugProfileEnumValuesGeneratorTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/DebugProfileEnumValuesGeneratorTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 {
     public class DebugProfileEnumValuesGeneratorTests
     {
-        private readonly List<ILaunchProfile> _profiles = new List<ILaunchProfile>
+        private readonly List<ILaunchProfile> _profiles = new()
         {
             new LaunchProfile { Name = "Profile1", LaunchBrowser = true },
             new LaunchProfile { Name = "MyCommand" },

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProviderTests.cs
@@ -11,17 +11,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 {
     public class LaunchProfilesDebugLaunchProviderTests
     {
-        private readonly Mock<IDebugProfileLaunchTargetsProvider> _mockWebProvider = new Mock<IDebugProfileLaunchTargetsProvider>();
-        private readonly Mock<IDebugProfileLaunchTargetsProvider> _mockDockerProvider = new Mock<IDebugProfileLaunchTargetsProvider>();
-        private readonly Mock<IDebugProfileLaunchTargetsProvider> _mockExeProvider = new Mock<IDebugProfileLaunchTargetsProvider>();
+        private readonly Mock<IDebugProfileLaunchTargetsProvider> _mockWebProvider = new();
+        private readonly Mock<IDebugProfileLaunchTargetsProvider> _mockDockerProvider = new();
+        private readonly Mock<IDebugProfileLaunchTargetsProvider> _mockExeProvider = new();
         private readonly OrderPrecedenceImportCollection<IDebugProfileLaunchTargetsProvider> _launchProviders =
-            new OrderPrecedenceImportCollection<IDebugProfileLaunchTargetsProvider>(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst);
+            new(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst);
 
-        private readonly Mock<ConfiguredProject> _configuredProjectMoq = new Mock<ConfiguredProject>();
-        private readonly Mock<ILaunchSettingsProvider> _LaunchSettingsProviderMoq = new Mock<ILaunchSettingsProvider>();
-        private readonly List<IDebugLaunchSettings> _webProviderSettings = new List<IDebugLaunchSettings>();
-        private readonly List<IDebugLaunchSettings> _dockerProviderSettings = new List<IDebugLaunchSettings>();
-        private readonly List<IDebugLaunchSettings> _exeProviderSettings = new List<IDebugLaunchSettings>();
+        private readonly Mock<ConfiguredProject> _configuredProjectMoq = new();
+        private readonly Mock<ILaunchSettingsProvider> _LaunchSettingsProviderMoq = new();
+        private readonly List<IDebugLaunchSettings> _webProviderSettings = new();
+        private readonly List<IDebugLaunchSettings> _dockerProviderSettings = new();
+        private readonly List<IDebugLaunchSettings> _exeProviderSettings = new();
 
         // Set this to have ILaunchSettingsProvider return this profile (null by default)
         private ILaunchProfile? _activeProfile;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     {
         private readonly string _ProjectFile = @"c:\test\project\project.csproj";
         private readonly string _Path = @"c:\program files\dotnet;c:\program files\SomeDirectory";
-        private readonly IFileSystemMock _mockFS = new IFileSystemMock();
+        private readonly IFileSystemMock _mockFS = new();
 
         [Fact]
         public void GetExeAndArguments()

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     public class PostBuildEventValueProviderTests
     {
         private static readonly PostBuildEventValueProvider.PostBuildEventHelper systemUnderTest =
-            new PostBuildEventValueProvider.PostBuildEventHelper();
+            new();
 
         [Fact]
         public static void GetPropertyAsync_AllTargetsPresent()

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     public class PreBuildEventValueProviderTests
     {
         private static readonly PreBuildEventValueProvider.PreBuildEventHelper systemUnderTest =
-            new PreBuildEventValueProvider.PreBuildEventHelper();
+            new();
 
         [Fact]
         public static void GetPropertyAsync_AllTargetsPresent()

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTrackerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTrackerTests.cs
@@ -22,8 +22,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         private string _intermediateOutputPath = "MyOutput";
         private readonly DesignTimeInputsChangeTracker _changeTracker;
 
-        private readonly List<DesignTimeInputSnapshot> _outputProduced = new List<DesignTimeInputSnapshot>();
-        private readonly TaskCompletionSource _outputProducedSource = new TaskCompletionSource();
+        private readonly List<DesignTimeInputSnapshot> _outputProduced = new();
+        private readonly TaskCompletionSource _outputProducedSource = new();
         private int _expectedOutput;
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
 {
     public class TreeItemOrderPropertyProviderTests
     {
-        private readonly List<(string type, string include)> _simpleOrderFile = new List<(string type, string include)>
+        private readonly List<(string type, string include)> _simpleOrderFile = new()
         {
             ("Compile", "Order.fs"),
             ("Compile", "Customer.fs"),
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
             Assert.Equal(expectedOrder, values.DisplayOrder);
         }
 
-        private readonly List<(string type, string include)> _simpleOrderFileDuplicate = new List<(string type, string include)>
+        private readonly List<(string type, string include)> _simpleOrderFileDuplicate = new()
         {
             ("Compile", "Order.fs"),
             ("Compile", "Customer.fs"),
@@ -183,7 +183,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
             }
         }
 
-        private readonly List<(string type, string include)> _orderedWithDups = new List<(string type, string include)>
+        private readonly List<(string type, string include)> _orderedWithDups = new()
         {
             ("Compile", "Common.fs"),
             ("Compile", "Tables\\Order.fs"),
@@ -218,7 +218,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
             Assert.Equal(expectedOrder, values.DisplayOrder);
         }
 
-        private readonly List<(string type, string include, string? linkPath)> _orderedWithLinkPaths = new List<(string type, string include, string? linkPath)>
+        private readonly List<(string type, string include, string? linkPath)> _orderedWithLinkPaths = new()
         {
             ("Compile", "Common.fs",         "Tables/Test.fs"),
             ("Compile", "Tables\\Order.fs",  null),
@@ -267,6 +267,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
                 metadata: metadata);
 
         private static ReferencesProjectTreeCustomizablePropertyValues GetInitialValues() =>
-            new ReferencesProjectTreeCustomizablePropertyValues();
+            new();
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Setup/SwrTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Setup/SwrTests.cs
@@ -14,9 +14,9 @@ namespace Microsoft.VisualStudio.Setup
 {
     public sealed class SwrTests
     {
-        private static readonly Regex _swrFolderPattern = new Regex(@"^\s*folder\s+""(?<path>[^""]+)""\s*$", RegexOptions.Compiled);
-        private static readonly Regex _swrFilePattern = new Regex(@"^\s*file\s+source=""(?<path>[^""]+)""\s*$", RegexOptions.Compiled);
-        private static readonly Regex _xlfFilePattern = new Regex(@"^(?<filename>.+\.xaml)\.(?<culture>[^.]+)\.xlf$", RegexOptions.Compiled);
+        private static readonly Regex _swrFolderPattern = new(@"^\s*folder\s+""(?<path>[^""]+)""\s*$", RegexOptions.Compiled);
+        private static readonly Regex _swrFilePattern = new(@"^\s*file\s+source=""(?<path>[^""]+)""\s*$", RegexOptions.Compiled);
+        private static readonly Regex _xlfFilePattern = new(@"^(?<filename>.+\.xaml)\.(?<culture>[^.]+)\.xlf$", RegexOptions.Compiled);
 
         private readonly ITestOutputHelper _output;
 


### PR DESCRIPTION
This turns on target-type new expressions (new for C# 9.0), and promotes the analyzer as a warning.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6646)