### PR TITLE
Avoid failing to load property pages on missing prop page

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
@@ -720,12 +720,15 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                         .TabTitle = .EditorCaption
                         .TabAutomationName = PROP_PAGE_TAB_PREFIX & PropertyPages(Index).Guid.ToString("N")
 
-                        Dim SpecialTabsTelemetryEvent As TelemetryEvent = New TelemetryEvent(TelemetryEventRootPath + "TabInfo")
-                        SpecialTabsTelemetryEvent.Properties(TelemetryPropertyPrefix + "TabInfo.TabTitle") = New TelemetryPiiProperty(.EditorCaption)
-                        SpecialTabsTelemetryEvent.Properties(TelemetryPropertyPrefix + "TabInfo.GUID") = PropertyPages(Index).Guid.ToString("B")
-                        SpecialTabsTelemetryEvent.Properties(TelemetryPropertyPrefix + "Project.Extension") = IO.Path.GetExtension(_projectFilePath)
-                        SpecialTabsTelemetryEvent.Properties(TelemetryPropertyPrefix + "Project.GUID") = _projectGuid.ToString("B")
-                        TelemetryService.DefaultSession.PostEvent(SpecialTabsTelemetryEvent)
+                        ' Load fails are reported earlier
+                        If (.PropertyPageInfo.LoadException Is Nothing) Then
+                            Dim SpecialTabsTelemetryEvent As TelemetryEvent = New TelemetryEvent(TelemetryEventRootPath + "TabInfo")
+                            SpecialTabsTelemetryEvent.Properties(TelemetryPropertyPrefix + "TabInfo.TabTitle") = New TelemetryPiiProperty(.EditorCaption)
+                            SpecialTabsTelemetryEvent.Properties(TelemetryPropertyPrefix + "TabInfo.GUID") = PropertyPages(Index).Guid.ToString("B")
+                            SpecialTabsTelemetryEvent.Properties(TelemetryPropertyPrefix + "Project.Extension") = IO.Path.GetExtension(_projectFilePath)
+                            SpecialTabsTelemetryEvent.Properties(TelemetryPropertyPrefix + "Project.GUID") = _projectGuid.ToString("B")
+                            TelemetryService.DefaultSession.PostEvent(SpecialTabsTelemetryEvent)
+                        End If
 
                     Else
                         Dim FileName As String = DirectCast(AppDesignerItems(Index - PropertyPages.Length), String)


### PR DESCRIPTION
When encountering a property page that cannot be found, we'd skip it from the list of pages. https://github.com/dotnet/project-system/pull/5575 regressed  this however, by throwing an an ArgumentNullException while trying to report telemetry for the tab title. Skip that in that case.

Fixes: https://github.com/dotnet/project-system/issues/6192

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6653)