### PR TITLE
Return null rather than throw

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AuthenticationModeEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AuthenticationModeEnumProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
@@ -56,10 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             /// <summary>
             /// The user can't add arbitrary authentication modes, so this method is unsupported.
             /// </summary>
-            public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue)
-            {
-                throw new NotImplementedException();
-            }
+            public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue) => Task.FromResult<IEnumValue?>(null);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchTargetPropertyPageEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchTargetPropertyPageEnumProvider.cs
@@ -68,10 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     .ToArray<IEnumValue>();
             }
 
-            public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue)
-            {
-                throw new NotImplementedException();
-            }
+            public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue) => Task.FromResult<IEnumValue?>(null);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/NeutralLanguageEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/NeutralLanguageEnumProvider.cs
@@ -36,10 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 return Task.FromResult<ICollection<IEnumValue>>(values);
             }
 
-            public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue)
-            {
-                throw new NotImplementedException();
-            }
+            public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue) => Task.FromResult<IEnumValue?>(null);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
@@ -71,10 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             /// persisted value in the project. So this method should never be called.
             /// </summary>
             /// <param name="userSuppliedValue"></param>
-            public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue)
-            {
-                throw new NotImplementedException();
-            }
+            public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue) => Task.FromResult<IEnumValue?>(null);
 
             private static bool CanRetargetTo(string identifier, string moniker)
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/NeutralLanguageEnumProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/NeutralLanguageEnumProviderTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Properties.Package;
@@ -31,15 +30,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         [Fact]
-        public async Task TryCreateEnumValueAsync_ThrowsNotImplemented()
+        public async Task TryCreateEnumValueAsync_ReturnsNull()
         {
             var provider = new NeutralLanguageEnumProvider();
             var generator = await provider.GetProviderAsync(options: null);
 
-            Assert.Throws<NotImplementedException>(() =>
-            {
-                generator.TryCreateEnumValueAsync("abc-abc");
-            });
+            Assert.Null(await generator.TryCreateEnumValueAsync("abc-abc"));
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/SupportedTargetFrameworksEnumProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/SupportedTargetFrameworksEnumProviderTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -51,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         [Fact]
-        public async Task TryCreateEnumValueAsync_ThrowsNotImplemented()
+        public async Task TryCreateEnumValueAsync_ReturnsNull()
         {
             var projectAccessor = IProjectAccessorFactory.Create();
             var configuredProject = ConfiguredProjectFactory.Create();
@@ -59,10 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var provider = new SupportedTargetFrameworksEnumProvider(projectAccessor, configuredProject);
             var generator = await provider.GetProviderAsync(null);
 
-            Assert.Throws<NotImplementedException>(() =>
-            {
-                generator.TryCreateEnumValueAsync("foo");
-            });
+            Assert.Null(await generator.TryCreateEnumValueAsync("foo"));
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/AuthenticationModeEnumProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/AuthenticationModeEnumProviderTests.cs
@@ -22,14 +22,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public async Task TryCreateEnumValueAsync_Throws()
+        public async Task TryCreateEnumValueAsync_ReturnsNull()
         {
             var remoteDebuggerAuthenticationService = IRemoteDebuggerAuthenticationServiceFactory.Create();
 
             var provider = new AuthenticationModeEnumProvider(remoteDebuggerAuthenticationService);
             var generator = await provider.GetProviderAsync(options: null);
 
-            await Assert.ThrowsAsync<NotImplementedException>(() => generator.TryCreateEnumValueAsync("MyMode"));
+            Assert.Null(await generator.TryCreateEnumValueAsync("MyMode"));
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/LaunchTargetPropertyPageEnumProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/LaunchTargetPropertyPageEnumProviderTests.cs
@@ -22,14 +22,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public async Task TryCreateEnumValueAsync_Throws()
+        public async Task TryCreateEnumValueAsync_ReturnsNull()
         {
             var project = ConfiguredProjectFactory.Create();
 
             var provider = new LaunchTargetPropertyPageEnumProvider(project);
             var generator = await provider.GetProviderAsync(options: null);
 
-            await Assert.ThrowsAsync<NotImplementedException>(() => generator.TryCreateEnumValueAsync("MyTarget"));
+            Assert.Null(await generator.TryCreateEnumValueAsync("MyTarget"));
         }
 
         [Fact]


### PR DESCRIPTION
A null return value is equivalent to throwing NotImplementedException but is less disruptive during debugging.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6662)