### PR TITLE
Add search terms support

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
@@ -19,8 +19,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal static class UIPropertyDataProducer
     {
-        private static readonly char[] s_searchTermsSeparators = new[] { ';' };
-
         public static IEntityValue CreateUIPropertyValue(IEntityValue parent, IPropertyPageQueryCache cache, BaseProperty property, int order, IUIPropertyPropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(parent, nameof(parent));
@@ -92,14 +90,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             if (requestedProperties.SearchTerms)
             {
-                string? searchTermsString = property.GetMetadataValue("SearchTerms");
+                string? searchTermsString = property.GetMetadataValueOrNull("SearchTerms");
                 if (searchTermsString is null)
                 {
                     newUIProperty.SearchTerms = ImmutableList<string>.Empty;
                 }
                 else
                 {
-                    newUIProperty.SearchTerms = searchTermsString.Split(s_searchTermsSeparators, StringSplitOptions.RemoveEmptyEntries).ToImmutableList();
+                    newUIProperty.SearchTerms = searchTermsString.Split(Delimiter.Semicolon, StringSplitOptions.RemoveEmptyEntries).ToImmutableList();
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
@@ -18,6 +19,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal static class UIPropertyDataProducer
     {
+        private static readonly char[] s_searchTermsSeparators = new[] { ';' };
+
         public static IEntityValue CreateUIPropertyValue(IEntityValue parent, IPropertyPageQueryCache cache, BaseProperty property, int order, IUIPropertyPropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(parent, nameof(parent));
@@ -89,8 +92,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             if (requestedProperties.SearchTerms)
             {
-                // TODO: extract search terms from property metadata.
-                newUIProperty.SearchTerms = ImmutableList<string>.Empty;
+                string? searchTermsString = property.GetMetadataValue("SearchTerms");
+                if (searchTermsString is null)
+                {
+                    newUIProperty.SearchTerms = ImmutableList<string>.Empty;
+                }
+                else
+                {
+                    newUIProperty.SearchTerms = searchTermsString.Split(s_searchTermsSeparators, StringSplitOptions.RemoveEmptyEntries).ToImmutableList();
+                }
             }
 
             ((IEntityValueFromProvider)newUIProperty).ProviderState = (cache, property.ContainingRule, property.Name);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/BasePropertyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/BasePropertyExtensions.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Linq;
+using Microsoft.Build.Framework.XamlTypes;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    /// <summary>
+    ///     Provides extension methods for <see cref="BaseProperty"/> instances.
+    /// </summary>
+    internal static class BasePropertyExtensions
+    {
+        /// <summary>
+        ///     Returns the value of the metadata item identified by <paramref name="metadataName"/>.
+        /// </summary>
+        /// <param name="property">The property to examine.</param>
+        /// <param name="metadataName">The name of the metadata item to return.</param>
+        /// <returns>
+        ///     The value of the corresponding metadata item, or <see langword="null"/> if it is not
+        ///     found.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="property"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="property"/> is <see langword="null"/> or empty.
+        /// </exception>
+        public static string? GetMetadataValue(this BaseProperty property, string metadataName)
+        {
+            Requires.NotNull(property, nameof(property));
+            Requires.NotNullOrEmpty(metadataName, nameof(metadataName));
+
+            return property.Metadata.FirstOrDefault(nvp => nvp.Name == metadataName)?.Value;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/BasePropertyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/BasePropertyExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// <exception cref="ArgumentException">
         ///     <paramref name="property"/> is <see langword="null"/> or empty.
         /// </exception>
-        public static string? GetMetadataValue(this BaseProperty property, string metadataName)
+        public static string? GetMetadataValueOrNull(this BaseProperty property, string metadataName)
         {
             Requires.NotNull(property, nameof(property));
             Requires.NotNullOrEmpty(metadataName, nameof(metadataName));

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/BasePropertyExtensionTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/BasePropertyExtensionTests.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Build.Framework.XamlTypes;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    public class BasePropertyExtensionTests
+    {
+        [Fact]
+        public void WhenThePropertyIsNull_GetMetadataValueThrows()
+        {
+            TestProperty testProperty = null!;
+
+            Assert.Throws<ArgumentNullException>(() => testProperty.GetMetadataValue(metadataName: "DoesntMatter"));
+        }
+
+        [Fact]
+        public void WhenTheMetadataNameIsNull_GetMetadataValueThrows()
+        {
+
+            TestProperty testProperty = new TestProperty(new List<NameValuePair>());
+            string metadataName = null!;
+
+            Assert.Throws<ArgumentNullException>(() => testProperty.GetMetadataValue(metadataName));
+        }
+
+        [Fact]
+        public void WhenTheMetadataNameIsTheEmptyString_GetMetadataValueThrows()
+        {
+            TestProperty testProperty = new TestProperty(new List<NameValuePair>());
+            string metadataName = string.Empty;
+
+            Assert.Throws<ArgumentException>(() => testProperty.GetMetadataValue(metadataName));
+        }
+
+        [Fact]
+        public void WhenTheRequestedMetadataIsNotFound_GetMetadataValueReturnsNull()
+        {
+            TestProperty testProperty = new TestProperty(new List<NameValuePair>());
+            string metadataName = "MyMetadata";
+
+            Assert.Null(testProperty.GetMetadataValue(metadataName));
+        }
+
+        [Fact]
+        public void WhenTheRequestedMetadataIsFound_GetMetadataValueReturnsTheValue()
+        {
+            TestProperty testProperty = new TestProperty(
+                new List<NameValuePair>
+                {
+                    new() { Name = "Alpha", Value = "Kangaroo" },
+                    new() { Name = "Beta", Value = "Wallaby" }
+                });
+            string metadataName = "Beta";
+
+            Assert.Equal(expected: "Wallaby", actual: testProperty.GetMetadataValue(metadataName));
+        }
+
+        [Fact]
+        public void WhenTheRequestedMetadataIsSpecifiedMoreThanOnce_GetMetadataValueReturnsTheFirstValue()
+        {
+            TestProperty testProperty = new TestProperty(
+                new List<NameValuePair>
+                {
+                    new() { Name = "Beta", Value = "Wallaby" },
+                    new() { Name = "Alpha", Value = "Dingo" },
+                    new() { Name = "Alpha", Value = "Kangaroo" }
+                });
+            string metadataName = "Alpha";
+
+            Assert.Equal(expected: "Dingo", actual: testProperty.GetMetadataValue(metadataName));
+        }
+
+        /// <summary>
+        /// <see cref="BaseProperty" /> is abstract, so we need a concrete implementation
+        /// even though there is nothing interesting to implement.
+        /// </summary>
+        private class TestProperty : BaseProperty
+        {
+            public TestProperty(List<NameValuePair> metadata)
+            {
+                Metadata = metadata;
+            }
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/BasePropertyExtensionTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/BasePropertyExtensionTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Build.Framework.XamlTypes;
 using Xunit;
 
@@ -14,64 +13,70 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             TestProperty testProperty = null!;
 
-            Assert.Throws<ArgumentNullException>(() => testProperty.GetMetadataValue(metadataName: "DoesntMatter"));
+            Assert.Throws<ArgumentNullException>(() => testProperty.GetMetadataValueOrNull(metadataName: "DoesntMatter"));
         }
 
         [Fact]
         public void WhenTheMetadataNameIsNull_GetMetadataValueThrows()
         {
 
-            TestProperty testProperty = new TestProperty(new List<NameValuePair>());
+            TestProperty testProperty = new TestProperty() { Metadata = new() };
             string metadataName = null!;
 
-            Assert.Throws<ArgumentNullException>(() => testProperty.GetMetadataValue(metadataName));
+            Assert.Throws<ArgumentNullException>(() => testProperty.GetMetadataValueOrNull(metadataName));
         }
 
         [Fact]
         public void WhenTheMetadataNameIsTheEmptyString_GetMetadataValueThrows()
         {
-            TestProperty testProperty = new TestProperty(new List<NameValuePair>());
+            TestProperty testProperty = new TestProperty() { Metadata = new() };
             string metadataName = string.Empty;
 
-            Assert.Throws<ArgumentException>(() => testProperty.GetMetadataValue(metadataName));
+            Assert.Throws<ArgumentException>(() => testProperty.GetMetadataValueOrNull(metadataName));
         }
 
         [Fact]
         public void WhenTheRequestedMetadataIsNotFound_GetMetadataValueReturnsNull()
         {
-            TestProperty testProperty = new TestProperty(new List<NameValuePair>());
+            TestProperty testProperty = new TestProperty() { Metadata = new() };
             string metadataName = "MyMetadata";
 
-            Assert.Null(testProperty.GetMetadataValue(metadataName));
+            Assert.Null(testProperty.GetMetadataValueOrNull(metadataName));
         }
 
         [Fact]
         public void WhenTheRequestedMetadataIsFound_GetMetadataValueReturnsTheValue()
         {
-            TestProperty testProperty = new TestProperty(
-                new List<NameValuePair>
+            TestProperty testProperty = new TestProperty()
+            {
+                Metadata = new()
                 {
                     new() { Name = "Alpha", Value = "Kangaroo" },
                     new() { Name = "Beta", Value = "Wallaby" }
-                });
+                }
+            };
+
             string metadataName = "Beta";
 
-            Assert.Equal(expected: "Wallaby", actual: testProperty.GetMetadataValue(metadataName));
+            Assert.Equal(expected: "Wallaby", actual: testProperty.GetMetadataValueOrNull(metadataName));
         }
 
         [Fact]
         public void WhenTheRequestedMetadataIsSpecifiedMoreThanOnce_GetMetadataValueReturnsTheFirstValue()
         {
-            TestProperty testProperty = new TestProperty(
-                new List<NameValuePair>
+            TestProperty testProperty = new TestProperty()
+            {
+                Metadata = new()
                 {
                     new() { Name = "Beta", Value = "Wallaby" },
                     new() { Name = "Alpha", Value = "Dingo" },
                     new() { Name = "Alpha", Value = "Kangaroo" }
-                });
+                }
+            };
+
             string metadataName = "Alpha";
 
-            Assert.Equal(expected: "Dingo", actual: testProperty.GetMetadataValue(metadataName));
+            Assert.Equal(expected: "Dingo", actual: testProperty.GetMetadataValueOrNull(metadataName));
         }
 
         /// <summary>
@@ -80,10 +85,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// </summary>
         private class TestProperty : BaseProperty
         {
-            public TestProperty(List<NameValuePair> metadata)
-            {
-                Metadata = metadata;
-            }
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Build.Framework.XamlTypes;
-using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;


### PR DESCRIPTION
Update our Project Query API implementation to return search terms from .xaml `Rule` files.

The new property page UI will support searching across the properties, and we expect that the terms searched for will generally appear in the name, description, or other displayable text associated with the property. However, there may be times we want to associate a search term with a property even when it does _not_ appear in the displayable text. To support this, the `IUIProperty` type in the Project Query API includes a `SearchTerms` member that returns a list of strings.

This change populates the `SeachTerms` by examining the property's metadata for an item named "SearchTerms". If found the value is split on semi-colons into individual terms and returned.

Note that this is something of a temporary approach. This kind of metadata does not appear to be localizable, and so we will not be able to provide localizable search terms. This is acceptable for the time being as the display text is localizable, and we don't expect to make significant use of the search terms. I see two options we can pursue to support localizable search terms in the future:

1. Update our localization tooling to understand that this particular piece of metadata is localizable.
2. Make search terms a first-class property of the `BaseProperty`, and then update the localization tooling to understand that it is localizable.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6670)