### PR TITLE
Map from flavors -> capabilities

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/ProjectType.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/ProjectType.cs
@@ -74,5 +74,29 @@ namespace Microsoft.VisualStudio
         ///     A <see cref="string"/> representing the deprecated C# (xproj) project type based on the Common Project System (CPS).
         /// </summary>
         public const string LegacyXProj = "8BB2217D-0F2D-49D1-97BC-3654ED321F3B";
+
+        /// <summary>
+        ///     A <see cref="string"/> representing the legacy web application project type, a flavor of
+        ///     <see cref="LegacyCSharp"/> and <see cref="LegacyVisualBasic"/> project types.
+        /// </summary>
+        public const string LegacyWebApplicationProject = "349c5851-65df-11da-9384-00065b846f21";
+
+        /// <summary>
+        ///     A <see cref="Guid"/> representing the legacy web application project type, a flavor of
+        ///     <see cref="LegacyCSharp"/> and <see cref="LegacyVisualBasic"/> project types.
+        /// </summary>
+        public static readonly Guid LegacyWebApplicationProjectGuid = new(LegacyWebApplicationProject);
+
+        /// <summary>
+        ///     A <see cref="string"/> representing the legacy test project type, a flavor of
+        ///     <see cref="LegacyCSharp"/> and <see cref="LegacyVisualBasic"/> project types.
+        /// </summary>
+        public const string LegacyTestProject = "3AC096D0-A1C2-E12C-1390-A8335801FDAB";
+
+        /// <summary>
+        ///     A <see cref="Guid"/> representing the legacy test project type, a flavor of
+        ///     <see cref="LegacyCSharp"/> and <see cref="LegacyVisualBasic"/> project types.
+        /// </summary>
+        public static readonly Guid LegacyTestProjectGuid = new(LegacyTestProject);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/ProjectTypeCapabilitiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/ProjectTypeCapabilitiesProvider.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks.Dataflow;
+
+using ProjectCapabilitiesProjectValue = Microsoft.VisualStudio.ProjectSystem.IProjectVersionedValue<Microsoft.VisualStudio.ProjectSystem.IProjectCapabilitiesSnapshot>;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Web
+{
+    /// <summary>
+    ///     Produces capabilities from project type GUIDs.
+    /// </summary>
+    [Export(ExportContractNames.Scopes.ConfiguredProject, typeof(IProjectCapabilitiesProvider))]
+    [AppliesTo(ProjectCapability.DotNet)]
+    internal class ProjectTypeCapabilitiesProvider : ChainedProjectValueDataSourceBase<IProjectCapabilitiesSnapshot>, IProjectCapabilitiesProvider
+    {
+        private readonly ProjectTypeGuidsDataSource _dataSource;
+
+        [ImportingConstructor]
+        protected ProjectTypeCapabilitiesProvider(ConfiguredProject configuredProject, ProjectTypeGuidsDataSource dataSource)
+            : base(configuredProject)
+        {
+            _dataSource = dataSource;
+        }
+
+        public ProjectCapabilitiesProjectValue? Current { get; private set; }
+
+        protected override IDisposable LinkExternalInput(ITargetBlock<ProjectCapabilitiesProjectValue> targetBlock)
+        {
+            JoinUpstreamDataSources(_dataSource);
+
+            DisposableValue<ISourceBlock<ProjectCapabilitiesProjectValue>> block = _dataSource.SourceBlock.Transform(
+                snapshot => Current = snapshot.Derive(s => CreateCapabilitiesSnapshot(s)));
+
+            block.Value.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
+
+            return block;
+        }
+
+        private IProjectCapabilitiesSnapshot CreateCapabilitiesSnapshot(IImmutableList<Guid> projectTypes)
+        {
+            ImmutableHashSet<string> capabilities = Empty.CapabilitiesSet;
+
+            // TODO: Maybe pull this from a specific item type, or metadata on a capability?
+            if (projectTypes.Contains(ProjectType.LegacyWebApplicationProjectGuid))
+            {
+                capabilities = capabilities.Add("AspNet");
+            }
+            
+            if (projectTypes.Contains(ProjectType.LegacyTestProjectGuid))
+            {
+                capabilities = capabilities.Add("TestContainer");
+            }
+
+            return Current == null
+                ? new ProjectCapabilitiesSnapshot(capabilities)
+                : ((ProjectCapabilitiesSnapshot)Current.Value).Update(capabilities);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/ProjectTypeGuidsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/ProjectTypeGuidsDataSource.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using Microsoft.VisualStudio.Text;
+
+using GuidCollectionProjectValue = Microsoft.VisualStudio.ProjectSystem.IProjectVersionedValue<System.Collections.Immutable.IImmutableList<System.Guid>>;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Web
+{
+    /// <summary>
+    ///     Provides project type <see cref="Guid"/> instances from the ProjectTypeGuids property.
+    /// </summary>
+    [Export]
+    internal class ProjectTypeGuidsDataSource : ChainedProjectValueDataSourceBase<IImmutableList<Guid>>
+    {
+        private readonly IProjectSnapshotService _snapshotService;
+
+        [ImportingConstructor]
+        public ProjectTypeGuidsDataSource(UnconfiguredProject project, IProjectSnapshotService snapshotService)
+            : base(project, synchronousDisposal: true)
+        {
+            ItemTypeGuidProviders = new OrderPrecedenceImportCollection<IItemTypeGuidProvider>(projectCapabilityCheckProvider: project);
+
+            _snapshotService = snapshotService;
+        }
+
+        [ImportMany]
+        private OrderPrecedenceImportCollection<IItemTypeGuidProvider> ItemTypeGuidProviders { get; }
+
+        public async Task<IImmutableList<Guid>> GetProjectTypeGuids()
+        {
+            using (JoinableCollection.Join())
+            {
+                GuidCollectionProjectValue snapshot = await SourceBlock.ReceiveAsync();
+
+                return snapshot.Value;
+            }
+        }
+
+        protected override IDisposable? LinkExternalInput(ITargetBlock<GuidCollectionProjectValue> targetBlock)
+        {
+            JoinUpstreamDataSources(_snapshotService);
+
+            DisposableValue<ISourceBlock<GuidCollectionProjectValue>> block = 
+                _snapshotService.SourceBlock.Transform(
+                    snapshot => snapshot.Derive(CreateSnapshot));
+
+            block.Value.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
+
+            return block;
+        }
+
+        private IImmutableList<Guid> CreateSnapshot(IProjectSnapshot snapshot)
+        {
+            string propertyValue = snapshot.ProjectInstance.GetPropertyValue(ConfigurationGeneral.ProjectTypeGuidsProperty);
+
+            // Legacy reads ProjectTypeGuids via evaluation for IVsAggregateProject.GetAggregateProjectTypeGuids
+            // and so therefore we do to. Order has meaning and matters.
+
+            ImmutableList<Guid>.Builder builder = ImmutableList.CreateBuilder<Guid>();
+            foreach (string value in new LazyStringSplit(propertyValue, ';'))
+            {
+                if (Guid.TryParse(value, out Guid result))
+                {
+                    builder.Add(result);
+                }
+            }
+
+            if (builder.Count == 0 && TryGetDefaultProjectType(out Guid? defaultProjectType))
+            {   
+                // We always return at least the default
+                builder.Add(defaultProjectType.Value);
+            }
+
+            return builder.ToImmutable();
+        }
+
+        private bool TryGetDefaultProjectType([NotNullWhen(true)]out Guid? projectType)
+        {
+            IItemTypeGuidProvider? provider = ItemTypeGuidProviders.FirstOrDefault()?.Value;
+            if (provider != null)
+            {
+                projectType = provider.ProjectTypeGuid;
+                return true;
+            }
+
+            projectType = null;
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/VsAggregatableProject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/VsAggregatableProject.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.VisualStudio.Shell.Flavor;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Web
+{
+    /// <summary>
+    ///     Provides an implementation of <see cref="IVsAggregatableProjectCorrected"/> to handle 
+    ///     designers and features that sniff for the project type via 
+    ///     <see cref="IVsAggregatableProjectCorrected.GetAggregateProjectTypeGuids"/>.
+    /// </summary>
+    [ExportProjectNodeComService(typeof(IVsAggregatableProjectCorrected))]
+    [AppliesTo(ProjectCapability.DotNet)]
+    internal class VsAggregatableProject : IVsAggregatableProjectCorrected, IDisposable
+    {
+        private IProjectThreadingService? _threadingService;
+        private IActiveConfiguredValue<ProjectTypeGuidsDataSource>? _dataSource;
+
+        [ImportingConstructor]
+        public VsAggregatableProject(IProjectThreadingService projectThreadingService, IActiveConfiguredValue<ProjectTypeGuidsDataSource> dataSource)
+        {
+            _threadingService = projectThreadingService;
+            _dataSource = dataSource;
+        }
+
+        public int SetInnerProject(IntPtr punkInnerIUnknown)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int InitializeForOuter(string pszFilename, string pszLocation, string pszName, uint grfCreateFlags, ref Guid iidProject, out IntPtr ppvProject, out int pfCanceled)
+        {
+            ppvProject = default;
+            pfCanceled = 0;
+            return HResult.NotImplemented;
+        }
+
+        public int OnAggregationComplete()
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int GetAggregateProjectTypeGuids(out string? pbstrProjTypeGuids)
+        {
+            IImmutableList<Guid>? projectTypes = _threadingService?.ExecuteSynchronously(() =>
+            {
+                return _dataSource?.Value.GetProjectTypeGuids()!;
+            });
+
+            if (projectTypes != null)
+            {
+                pbstrProjTypeGuids = string.Join(";", projectTypes.Select(projectType => projectType.ToString("B")));
+                return HResult.OK;
+            }
+
+            // Disposed
+            pbstrProjTypeGuids = null;
+            return HResult.Unexpected;
+        }
+
+        public int SetAggregateProjectTypeGuids(string lpstrProjTypeGuids)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public void Dispose()
+        {
+            // Important for ProjectNodeComServices to null out fields to reduce the amount 
+            // of data we leak when extensions incorrectly holds onto the IVsHierarchy.
+            _threadingService = null;
+            _dataSource = null;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataFlowUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataFlowUtilities.cs
@@ -377,6 +377,47 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         /// <summary>
+        ///     Creates a source block that produces multiple transformed values for each value from original source block,
+        ///     skipping intermediate input and output states, and hence is not suitable for producing or consuming
+        ///     deltas.
+        /// </summary>
+        /// <typeparam name="TInput">
+        ///     The type of the input value produced by <paramref name="source"/>.
+        /// </typeparam>
+        /// <typeparam name="TOut">
+        ///     The type of value produced by <paramref name="transform"/>.
+        ///  </typeparam>
+        /// <param name="source">
+        ///     The source block whose values are to be transformed.
+        /// </param>
+        /// <param name="transform">
+        ///     The function to execute on each value from <paramref name="source"/>.
+        /// </param>
+        /// <returns>
+        ///     The transformed source block and a disposable value that terminates the link.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="source"/> is <see langword="null"/>.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="transform"/> is <see langword="null"/>.
+        /// </exception>
+        public static DisposableValue<ISourceBlock<TOut>> TransformManyWithNoDelta<TInput, TOut>(
+            this ISourceBlock<IProjectVersionedValue<TInput>> source,
+            Func<IProjectVersionedValue<TInput>, IEnumerable<TOut>> transform)
+        {
+            Requires.NotNull(source, nameof(source));
+            Requires.NotNull(transform, nameof(transform));
+
+            IPropagatorBlock<IProjectVersionedValue<TInput>, TOut> transformBlock = DataflowBlockSlim.CreateTransformManyBlock(transform, skipIntermediateInputData: true, skipIntermediateOutputData: true);
+
+            IDisposable link = source.LinkTo(transformBlock, DataflowOption.PropagateCompletion);
+
+            return new DisposableValue<ISourceBlock<TOut>>(transformBlock, link);
+        }
+
+        /// <summary>
         ///     Creates a source block that produces a transformed value for each value from original source block,
         ///     skipping intermediate input and output states, and hence is not suitable for producing or consuming
         ///     deltas.


### PR DESCRIPTION
This maps from flavor project type GUIDs -> capabilities, so that we can tie specific components that light up ASP.NET full framework support behind a capability. Also adds an incomplete implementation of IVsAggregatableProject for components that sniff support based on the GUIDs it returns.

This currently maps:

Web Application Projects (not a complete list of them) -> "AspNet"
Test Projects (Legacy) -> "TestContainer"

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6671)