### PR TITLE
update build property page to include all available warning levels

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
@@ -975,6 +975,9 @@
   <data name="cboWarningLevel.Items4" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="cboWarningLevel.Items5" xml:space="preserve">
+    <value>5</value>
+  </data>
   <data name="cboWarningLevel.Location" type="System.Drawing.Point, System.Drawing">
     <value>184, 248</value>
   </data>
@@ -1431,9 +1434,9 @@
   <data name="&gt;&gt;chkDefineDebug.ZOrder" xml:space="preserve">
     <value>23</value>
   </data>
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
-  </data>
+  </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
@@ -1448,8 +1451,5 @@
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase, Microsoft.VisualStudio.AppDesigner, Version=42.42.42.42, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="cboWarningLevel.Items5" xml:space="preserve">
-    <value>5</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
@@ -512,14 +512,17 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Dim warningLevel = CType(value, Integer)
                 Dim indexAsString = warningLevel.ToString()
                 ' Lookup the index of the given warning level in the combobox
-                Dim indexLocation = cboWarningLevel.Items.Cast(Of String).ToList().FindIndex(Function(s)
-                                                                                                 Return s = indexAsString
-                                                                                             End Function)
-                ' If there is an existing entry use that
+                Dim indexLocation = If(warningLevel = 9999, GetIndexLocation(My.Resources.Strings.preview), GetIndexLocation(indexAsString))
+
                 If indexLocation <> -1 Then
+                    ' If there is an existing entry use that
                     cboWarningLevel.SelectedIndex = indexLocation
-                Else
+                ElseIf warningLevel = 9999 Then
                     ' Otherwise add a new entry
+                    ' 9999 is a special value meaning use the preview warning level
+                    cboWarningLevel.Items.Add(My.Resources.Strings.preview)
+                    cboWarningLevel.SelectedIndex = cboWarningLevel.Items.Count - 1
+                Else
                     ' any non - negative number can be specified but we only want to show them in the combo box if the value is set
                     cboWarningLevel.Items.Add(indexAsString)
                     cboWarningLevel.SelectedIndex = cboWarningLevel.Items.Count - 1
@@ -532,8 +535,19 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Function
 
+        Private Function GetIndexLocation(indexToSearchFor As String) As Integer
+            Return cboWarningLevel.Items.Cast(Of String).ToList().FindIndex(Function(s)
+                                                                                Return s = indexToSearchFor
+                                                                            End Function)
+        End Function
+
         Private Function WarningLevelGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
-            value = CType(cboWarningLevel.SelectedIndex, Integer)
+            Dim selectedItem = cboWarningLevel.Items.Cast(Of String).ToList()(cboWarningLevel.SelectedIndex)
+            If selectedItem = My.Resources.Strings.preview Then
+                value = 9999
+            Else
+                value = CType(selectedItem, Integer)
+            End If
             Return True
         End Function
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
@@ -509,7 +509,21 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         Private Function WarningLevelSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
             If Not PropertyControlData.IsSpecialValue(value) Then
-                cboWarningLevel.SelectedIndex = CType(value, Integer)
+                Dim warningLevel = CType(value, Integer)
+                Dim indexAsString = warningLevel.ToString()
+                ' Lookup the index of the given warning level in the combobox
+                Dim indexLocation = cboWarningLevel.Items.Cast(Of String).ToList().FindIndex(Function(s)
+                                                                                                 Return s = indexAsString
+                                                                                             End Function)
+                ' If there is an existing entry use that
+                If indexLocation <> -1 Then
+                    cboWarningLevel.SelectedIndex = indexLocation
+                Else
+                    ' Otherwise add a new entry
+                    ' any non - negative number can be specified but we only want to show them in the combo box if the value is set
+                    cboWarningLevel.Items.Add(indexAsString)
+                    cboWarningLevel.SelectedIndex = cboWarningLevel.Items.Count - 1
+                End If
                 Return True
             Else
                 ' Indeterminate. Let the architecture handle

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.vb
@@ -78,10 +78,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         Private Sub PopulateAnalysisLevelComboBoxItems()
             If AnalysisLevelComboBox.Items.Count = 0 Then
-                AnalysisLevelComboBox.Items.Add("preview")
-                AnalysisLevelComboBox.Items.Add("latest")
+                AnalysisLevelComboBox.Items.Add(My.Resources.Strings.preview)
+                AnalysisLevelComboBox.Items.Add(My.Resources.Strings.latest)
                 AnalysisLevelComboBox.Items.Add("5.0")
-                AnalysisLevelComboBox.Items.Add("none")
+                AnalysisLevelComboBox.Items.Add(My.Resources.Strings.none)
             End If
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/Strings.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/Strings.Designer.vb
@@ -130,6 +130,15 @@ Namespace My.Resources
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to latest.
+        '''</summary>
+        Friend Shared ReadOnly Property latest() As String
+            Get
+                Return ResourceManager.GetString("latest", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to No Authentication.
         '''</summary>
         Friend Shared ReadOnly Property NoAuthentication() As String
@@ -139,11 +148,29 @@ Namespace My.Resources
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to none.
+        '''</summary>
+        Friend Shared ReadOnly Property none() As String
+            Get
+                Return ResourceManager.GetString("none", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to (not installed).
         '''</summary>
         Friend Shared ReadOnly Property NotInstalledText() As String
             Get
                 Return ResourceManager.GetString("NotInstalledText", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to preview.
+        '''</summary>
+        Friend Shared ReadOnly Property preview() As String
+            Get
+                Return ResourceManager.GetString("preview", resourceCulture)
             End Get
         End Property
         

--- a/src/Microsoft.VisualStudio.Editors/PropPages/Strings.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/Strings.resx
@@ -157,4 +157,13 @@
   <data name="WindowsAuthentication" xml:space="preserve">
     <value>Windows Authentication</value>
   </data>
+  <data name="latest" xml:space="preserve">
+    <value>latest</value>
+  </data>
+  <data name="none" xml:space="preserve">
+    <value>none</value>
+  </data>
+  <data name="preview" xml:space="preserve">
+    <value>preview</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.cs.xlf
@@ -55,6 +55,21 @@
         <target state="translated">Ověřování systému Windows</target>
         <note />
       </trans-unit>
+      <trans-unit id="latest">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="none">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="preview">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.de.xlf
@@ -55,6 +55,21 @@
         <target state="translated">Windows-Authentifizierung</target>
         <note />
       </trans-unit>
+      <trans-unit id="latest">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="none">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="preview">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.es.xlf
@@ -55,6 +55,21 @@
         <target state="translated">Autenticación de Windows</target>
         <note />
       </trans-unit>
+      <trans-unit id="latest">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="none">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="preview">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.fr.xlf
@@ -55,6 +55,21 @@
         <target state="translated">Authentification Windows</target>
         <note />
       </trans-unit>
+      <trans-unit id="latest">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="none">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="preview">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.it.xlf
@@ -55,6 +55,21 @@
         <target state="translated">Autenticazione di Windows</target>
         <note />
       </trans-unit>
+      <trans-unit id="latest">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="none">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="preview">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.ja.xlf
@@ -55,6 +55,21 @@
         <target state="translated">Windows 認証</target>
         <note />
       </trans-unit>
+      <trans-unit id="latest">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="none">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="preview">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.ko.xlf
@@ -55,6 +55,21 @@
         <target state="translated">Windows 인증</target>
         <note />
       </trans-unit>
+      <trans-unit id="latest">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="none">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="preview">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.pl.xlf
@@ -55,6 +55,21 @@
         <target state="translated">Uwierzytelnianie systemu Windows</target>
         <note />
       </trans-unit>
+      <trans-unit id="latest">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="none">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="preview">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.pt-BR.xlf
@@ -55,6 +55,21 @@
         <target state="translated">Autenticação do Windows</target>
         <note />
       </trans-unit>
+      <trans-unit id="latest">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="none">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="preview">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.ru.xlf
@@ -55,6 +55,21 @@
         <target state="translated">Аутентификация Windows</target>
         <note />
       </trans-unit>
+      <trans-unit id="latest">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="none">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="preview">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.tr.xlf
@@ -55,6 +55,21 @@
         <target state="translated">Windows Kimlik Doğrulaması</target>
         <note />
       </trans-unit>
+      <trans-unit id="latest">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="none">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="preview">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.zh-Hans.xlf
@@ -55,6 +55,21 @@
         <target state="translated">Windows 身份验证</target>
         <note />
       </trans-unit>
+      <trans-unit id="latest">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="none">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="preview">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.zh-Hant.xlf
@@ -55,6 +55,21 @@
         <target state="translated">Windows 驗證</target>
         <note />
       </trans-unit>
+      <trans-unit id="latest">
+        <source>latest</source>
+        <target state="new">latest</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="none">
+        <source>none</source>
+        <target state="new">none</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="preview">
+        <source>preview</source>
+        <target state="new">preview</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Today if you open a .NET Core project and set **Analysis Level** to be `preview`

![image](https://user-images.githubusercontent.com/9797472/95898929-a27d7400-0d44-11eb-82c2-4feef0282931.png)


The build property page will fail to load:

![image](https://user-images.githubusercontent.com/9797472/95898894-9a253900-0d44-11eb-8b05-7bd50521f2ae.png)
 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6673)