### PR TITLE
Enable high contrast for Debug page

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
@@ -19,6 +19,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             InitializeComponent();
             DataContextChanged += DebugPageControlControl_DataContextChanged;
             LayoutUpdated += DebugPageControl_LayoutUpdated;
+            // This isn't a themed UI, but we want to enable high contrast mode.
+            SetResourceReference(BackgroundProperty, SystemColors.ControlBrushKey);
         }
 
         private void DebugPageControlControl_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
The Debug page was not being responsive to high contrast changes. This resulted in an accessibility bug reported here [AzDO#1172163](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1172163).

The Debug page is a special case in the Properties pages: it's a WPF control inside the WinForms window. The approach taken was to use the `SetResourceReference` to set the `BackgroundProperty` to `SystemColors.ControlBrushKey` value. In that way, we pass down the [ControlBrushKey](https://docs.microsoft.com/en-us/dotnet/api/system.windows.systemcolors.controlbrushkey?view=netcore-3.1#System_Windows_SystemColors_ControlBrushKey) dynamically.

**Before:**
![image](https://user-images.githubusercontent.com/8518253/95936287-0ece9680-0d8a-11eb-98d0-508f7a910277.png)

**After:**
![image](https://user-images.githubusercontent.com/8518253/95936130-beefcf80-0d89-11eb-988d-3ffa45de7409.png)

There are rough edges when toggling back and forth the high contrast setting, but I think this is a good start.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6676)