### PR TITLE
Use appropriate pool in rich nav pipeline

### DIFF
--- a/build/ci/richnav.yml
+++ b/build/ci/richnav.yml
@@ -24,8 +24,9 @@ pr:
 resources:
 - repo: self
   clean: true
-queue:
-  name: VSEng-MicroBuildVS2019
+pool:
+  name: NetCorePublic-Pool
+  queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
   demands: Cmd
   timeoutInMinutes: 15
 variables:

--- a/build/ci/richnav.yml
+++ b/build/ci/richnav.yml
@@ -36,12 +36,6 @@ variables:
   EnableRichCodeNavigation: true
   
 steps:
-- task: NuGetRestore@1
-  displayName: Restore 'Microsoft.DotNet.IBCMerge' package
-  inputs:
-    solution: 'build\proj\internal\RestoreIBCMerge.csproj'
-    feed: '8f470c7e-ac49-4afe-a6ee-cf784e438b93'
-
 - script: $(Build.SourcesDirectory)\build.cmd /build /ci /no-deploy /no-integration /ibc /no-clearnugetcache /configuration $(BuildConfiguration)
   displayName: Build ProjectSystem.sln
 


### PR DESCRIPTION
I pulled the pool for the new rich nav pipeline from /build/ci/official.yml (not /build/ci/unit-tests.yml) and it looks like the agent isn't available for the public CI (or else I don't have permission to authorize it). 

Link to failing build: https://dnceng.visualstudio.com/public/_build/results?buildId=853138&view=results

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6680)