### PR TITLE
Delegate to new project properties editor via feature flag

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -39,6 +39,7 @@
     <PackageReference Update="Microsoft.DevDiv.Validation.MediaRecorder"                              Version="15.0.199" />
 
     <!-- VS SDK -->
+    <PackageReference Update="Microsoft.Internal.VisualStudio.Shell.Interop.14.0.DesignTime"          Version="14.3.25407-alpha" />
     <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="16.7.3069" />
     <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost"                              Version="16.6.255"/>
     <PackageReference Update="Microsoft.VisualStudio.Composition"                                     Version="16.5.13"/>

--- a/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
+++ b/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
@@ -13,6 +13,9 @@
     <PackageTags>Roslyn Project AppDesigner VisualStudio</PackageTags>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Interop.14.0.DesignTime" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="..\Common\ManagedCodeMarkers.vb">
       <Link>ManagedCodeMarkers.vb</Link>
     </Compile>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorFromUIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorFromUIPropertyDataProducer.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Query;
@@ -27,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
         {
             Requires.NotNull(request, nameof(request));
-            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (IPropertyPageQueryCache _, Rule schema, string propertyName))
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (IPropertyPageQueryCache, Rule schema, string propertyName))
             {
                 try
                 {


### PR DESCRIPTION
CPS [PR 281509](https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/281509) registers a new Project Properties editor.

When the user opts in to feature `CPS.UpdatedProjectPropertiesDesigner.Local` we redirect requests for the legacy project editor to the new project editor.

There is currently a bug where the editor only appears on the second launch.

Codespaces support is currently blocked on [AB#1178677](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1178677).

