### PR TITLE
Set editor for StringProperty with subtype "file" or "path"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
@@ -64,6 +64,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     IEntityValue editorValue = CreateEditorValue(parent, editor, properties);
                     yield return editorValue;
                 }
+
+                if (property is StringProperty stringProperty)
+                {
+                    if (stringProperty.Subtype == "file")
+                    {
+                        yield return CreateEditorValue(parent, new ValueEditor { EditorType = "FilePath" }, properties);
+                    }
+                    else if (stringProperty.Subtype == "directory")
+                    {
+                        yield return CreateEditorValue(parent, new ValueEditor { EditorType = "DirectoryPath" }, properties);
+                    }
+                }
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -121,12 +121,12 @@
                   DisplayName="Output path"
                   Description="Specifies the location of the output files for this project's configuration."
                   Category="Output"
-                  Subtype="file"/>
+                  Subtype="directory" />
 
   <StringProperty Name="DocumentationFile"
                   DisplayName="XML documentation file path"
                   Description="Specifies the name of a file into which documentation comments will be processed."
                   HelpUrl="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/doc-compiler-option"
                   Category="Output"
-                  Subtype="file"/>
+                  Subtype="file" />
 </Rule>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducerTests.cs
@@ -89,6 +89,60 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
             }
         }
 
+        [Fact]
+        public void WhenCreatingEditorsFromAStringPropertyWithFileSubtype_FileBrowseEditorIsCreated()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyEditorPropertiesAvailableStatus(includeName: true);
+
+            var parentEntity = IEntityWithIdFactory.Create(key: "parentKey", value: "parentId");
+            var rule = new Rule();
+            rule.BeginInit();
+            rule.Properties.Add(
+                new StringProperty
+                {
+                    Name = "MyProperty",
+                    Subtype = "file"
+                });
+            rule.EndInit();
+
+            var results = UIPropertyEditorDataProducer.CreateEditorValues(parentEntity, rule, "MyProperty", properties);
+
+            Assert.Collection(results, entity => assertEqual(entity, expectedName: "FilePath"));
+
+            static void assertEqual(IEntityValue entity, string expectedName)
+            {
+                var editorEntity = (UIPropertyEditorValue)entity;
+                Assert.Equal(expectedName, editorEntity.Name);
+            }
+        }
+
+        [Fact]
+        public void WhenCreatingEditorsFromAStringPropertyWithPathSubtype_PathBrowseEditorIsCreated()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyEditorPropertiesAvailableStatus(includeName: true);
+
+            var parentEntity = IEntityWithIdFactory.Create(key: "parentKey", value: "parentId");
+            var rule = new Rule();
+            rule.BeginInit();
+            rule.Properties.Add(
+                new StringProperty
+                {
+                    Name = "MyProperty",
+                    Subtype = "directory"
+                });
+            rule.EndInit();
+
+            var results = UIPropertyEditorDataProducer.CreateEditorValues(parentEntity, rule, "MyProperty", properties);
+
+            Assert.Collection(results, entity => assertEqual(entity, expectedName: "DirectoryPath"));
+
+            static void assertEqual(IEntityValue entity, string expectedName)
+            {
+                var editorEntity = (UIPropertyEditorValue)entity;
+                Assert.Equal(expectedName, editorEntity.Name);
+            }
+        }
+
         private class TestProperty : BaseProperty
         {
         }


### PR DESCRIPTION
Properties may specify `ValueEditor`s to control how they are edited in the UI. However for `StringProperty` it's more common to specify the `Subtype` property with a value such as `"file"` to indicate that the property expects a file path.

We don't currently plumb `Subtype` through the Project Query API project model. This value only applies to `StringProperty` and we want the shape to be identical across property types.

The solution is to maps common `StringProperty.Subtype` values to `ValueEditor` values.

- Subtype `file` becomes editor `FileBrowse`
- Subtype `path` becomes editor `PathBrowse`

This causes, for example, the icon path property to show a "browse" button:

![image](https://user-images.githubusercontent.com/350947/96100372-08722300-0f20-11eb-8094-77978def3c7e.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6685)