### PR TITLE
Support special ASP.NET folders

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/GlobalSuppressions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/GlobalSuppressions.cs
@@ -72,3 +72,5 @@ using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("Design", "CA1036:Override methods on comparable types", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AttachedCollectionItemBase")]
 [assembly: SuppressMessage("Style", "IDE0008:Use explicit type", Justification = "<Pending>", Scope = "member", Target = "~M:Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore.PackageRestoreUnconfiguredInputDataSource.LinkExternalInput(System.Threading.Tasks.Dataflow.ITargetBlock{Microsoft.VisualStudio.ProjectSystem.IProjectVersionedValue{Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore.PackageRestoreUnconfiguredInput}})~System.IDisposable")]
+
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "https://github.com/dotnet/roslyn/issues/48782", Scope = "type", Target = "~T:Microsoft.VisualStudio.ProjectSystem.VS.Web.Tree.SpecialWebFolderPropertiesProvider.SpecialWebFolder")]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/Tree/SpecialCodeFolderDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/Tree/SpecialCodeFolderDataSource.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks.Dataflow;
+
+using FolderSetProjectValue = Microsoft.VisualStudio.ProjectSystem.IProjectVersionedValue<System.Collections.Immutable.IImmutableSet<string>>;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Web.Tree
+{
+    /// <summary>
+    ///     Provides a data source that produces ASP.NET special code folders.
+    /// </summary>
+    [Export]
+    [AppliesTo("AspNet")] // TODO:
+    internal class SpecialCodeFolderDataSource : ProjectValueDataSourceBase<IImmutableSet<string>>
+    {
+        private IBroadcastBlock<FolderSetProjectValue>? _broadcastBlock;
+        private IReceivableSourceBlock<FolderSetProjectValue>? _publicBlock;
+        private readonly object _lock = new();
+
+        private ImmutableHashSet<string> _folders = Empty.FileSet;
+        private int _version;
+
+        [ImportingConstructor]
+        public SpecialCodeFolderDataSource(UnconfiguredProject project)
+            : base(project.Services, synchronousDisposal: true, registerDataSource: true)
+        {
+        }
+
+        public override NamedIdentity DataSourceKey { get; } = new NamedIdentity(nameof(SpecialCodeFolderDataSource));
+
+        public override IComparable DataSourceVersion => _version;
+
+        public override IReceivableSourceBlock<FolderSetProjectValue> SourceBlock
+        {
+            get
+            {
+                EnsureInitialized();
+                return _publicBlock!;
+            }
+        }
+
+        protected override void Initialize()
+        {
+#pragma warning disable RS0030 // False positive
+            base.Initialize();
+#pragma warning restore RS0030
+
+            _broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<FolderSetProjectValue>(nameFormat: nameof(SpecialCodeFolderDataSource) + " {1}");
+            _publicBlock = _broadcastBlock.SafePublicize();
+
+            PublishValue();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _broadcastBlock?.Complete();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public void AddCodeFolder(string relativePath)
+        {
+            Requires.NotNullOrEmpty(relativePath, nameof(relativePath));
+
+            PublishValue(folders => folders.Add(relativePath));
+        }
+
+        public void RemoveCodeFolder(string relativePath)
+        {
+            Requires.NotNullOrEmpty(relativePath, nameof(relativePath));
+
+            PublishValue(folders => folders.Remove(relativePath));
+        }
+
+        private void PublishValue(Func<ImmutableHashSet<string>, ImmutableHashSet<string>>? action = null)
+        {
+            lock (_lock)
+            {
+                _folders = action?.Invoke(_folders) ?? _folders;
+                _version++;
+                _broadcastBlock.Post(new ProjectVersionedValue<IImmutableSet<string>>(
+                    _folders,
+                    Empty.ProjectValueVersions.Add(DataSourceKey, _version)));
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/Tree/SpecialWebFolderFlag.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/Tree/SpecialWebFolderFlag.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Web.Tree
+{
+    internal static class SpecialWebFolderFlag
+    {
+        public static readonly ProjectTreeFlags CodeFolder = ProjectTreeFlags.Create("App_Code");
+        public static readonly ProjectTreeFlags BinFolder = ProjectTreeFlags.Create("AspNet_Bin");
+        public static readonly ProjectTreeFlags ResourcesFolder = ProjectTreeFlags.Create("App_GlobalResources");
+        public static readonly ProjectTreeFlags DataFolder = ProjectTreeFlags.Create("App_Data");
+        public static readonly ProjectTreeFlags ThemesFolder = ProjectTreeFlags.Create("App_Themes");
+        public static readonly ProjectTreeFlags BrowsersFolder = ProjectTreeFlags.Create("App_Browsers");
+        public static readonly ProjectTreeFlags LocalResourcesFolder = ProjectTreeFlags.Create("App_LocalResources");
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/Tree/SpecialWebFolderPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/Tree/SpecialWebFolderPropertiesProvider.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Web.Tree
+{
+    /// <summary>
+    ///     Responsible for identifying and marking ASP.NET special folders.
+    /// </summary>
+    internal class SpecialWebFolderPropertiesProvider : IProjectTreePropertiesProvider
+    {
+        private static readonly Dictionary<string, SpecialWebFolder> s_knownSpecialFolders = CreateKnownSpecialFolders();
+        private readonly IImmutableSet<string> _codeFolders;
+
+        public SpecialWebFolderPropertiesProvider(IImmutableSet<string> codeFolders)
+        {
+            _codeFolders = codeFolders;
+        }
+
+        public void CalculatePropertyValues(IProjectTreeCustomizablePropertyContext propertyContext, IProjectTreeCustomizablePropertyValues propertyValues)
+        {
+            if (propertyContext.ParentNodeFlags.IsProjectRoot() && 
+                propertyContext.IsFolder && 
+                propertyValues.Flags.IsIncludedInProject())
+            {
+                if (s_knownSpecialFolders.TryGetValue(propertyContext.ItemName, out SpecialWebFolder folder))
+                {
+                    propertyValues.Icon = folder.Icon.ToProjectSystemType();
+                    propertyValues.ExpandedIcon = folder.ExpandedIcon.ToProjectSystemType();
+                    propertyValues.Flags += folder.Flag;
+                }
+
+                // TODO: Handle CodeFolders
+                Assumes.NotNull(_codeFolders);
+            }
+        }
+
+        private static Dictionary<string, SpecialWebFolder> CreateKnownSpecialFolders()
+        {
+            // TODO: Correct icons
+            return new Dictionary<string, SpecialWebFolder>(StringComparers.Paths)
+            {
+                { "App_Code",                  new(SpecialWebFolderFlag.CodeFolder,            KnownMonikers.SpecialFolderClosed, KnownMonikers.SpecialFolderOpened)},
+                { "Bin",                       new(SpecialWebFolderFlag.BinFolder,             KnownMonikers.SpecialFolderClosed, KnownMonikers.SpecialFolderOpened)},
+                { "App_GlobalResources",       new(SpecialWebFolderFlag.ResourcesFolder,       KnownMonikers.SpecialFolderClosed, KnownMonikers.SpecialFolderOpened)},
+                { "App_Data",                  new(SpecialWebFolderFlag.DataFolder,            KnownMonikers.SpecialFolderClosed, KnownMonikers.SpecialFolderOpened)},
+                { "App_Themes",                new(SpecialWebFolderFlag.ThemesFolder,          KnownMonikers.SpecialFolderClosed, KnownMonikers.SpecialFolderOpened)},
+                { "App_Browsers",              new(SpecialWebFolderFlag.BrowsersFolder,        KnownMonikers.SpecialFolderClosed, KnownMonikers.SpecialFolderOpened)},
+                { "App_LocalResources",        new(SpecialWebFolderFlag.LocalResourcesFolder,  KnownMonikers.SpecialFolderClosed, KnownMonikers.SpecialFolderOpened)},
+            };
+        }
+
+        private record SpecialWebFolder
+        (
+            ProjectTreeFlags Flag,
+            ImageMoniker Icon,
+            ImageMoniker ExpandedIcon
+        );
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/Tree/SpecialWebFolderPropertiesProviderDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/Tree/SpecialWebFolderPropertiesProviderDataSource.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks.Dataflow;
+
+using PropertiesProviderProjectValue = Microsoft.VisualStudio.ProjectSystem.IProjectVersionedValue<Microsoft.VisualStudio.ProjectSystem.IProjectTreePropertiesProvider>;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Web.Tree
+{
+    /// <summary>
+    ///     Provides a data source that produces a new <see cref="IProjectTreePropertiesProvider"/> 
+    ///     everytime the ASP.NET code folders change.
+    /// </summary>
+    [Export(typeof(IProjectTreePropertiesProviderDataSource))]
+    [AppliesTo("AspNet")] // TODO:
+    internal class SpecialWebFolderPropertiesProviderDataSource : ChainedProjectValueDataSourceBase<IProjectTreePropertiesProvider>, IProjectTreePropertiesProviderDataSource
+    {
+        private readonly SpecialCodeFolderDataSource _codeFolderDataSource;
+
+        [ImportingConstructor]
+        public SpecialWebFolderPropertiesProviderDataSource(
+            UnconfiguredProject project,
+            SpecialCodeFolderDataSource codeFolderDataSource)
+            : base(project, synchronousDisposal: true, registerDataSource: true)
+        {
+            _codeFolderDataSource = codeFolderDataSource;
+        }
+
+        protected override IDisposable? LinkExternalInput(ITargetBlock<PropertiesProviderProjectValue> targetBlock)
+        {
+            JoinUpstreamDataSources(_codeFolderDataSource);
+
+            DisposableValue<ISourceBlock<PropertiesProviderProjectValue>> block =
+                _codeFolderDataSource.SourceBlock.Transform(
+                    snapshot => snapshot.Derive(CreateProvider));
+
+            block.Value.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
+
+            return block;
+        }
+
+        private IProjectTreePropertiesProvider CreateProvider(IImmutableSet<string> folders)
+        {
+            return new SpecialWebFolderPropertiesProvider(folders);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Annotations.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Annotations.cs
@@ -86,3 +86,10 @@ namespace System.Diagnostics.CodeAnalysis
         public bool ParameterValue { get; }
     }
 }
+
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit
+    {
+    }
+}


### PR DESCRIPTION
- Marks ASP.NET folders with a specific flag based on its name.
- Gives them an icon to visiblity distinguish from normal folders. Note we need to request icons for folders as they are missing.
- Code folders support isn't completely hooked as we're missing the right hooks in CPS to determine where in the tree we are in a property provider.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6691)