### PR TITLE
Implement DependsOn and VisibilityCondition

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -97,9 +97,9 @@
     <PackageReference Include="VSSDK.TemplateWizardInterface"                                         Version="12.0.4"                          ExcludeAssets="All" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.9.34-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.9.34-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="16.9.34-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.9.101-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.9.101-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="16.9.101-pre" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="3.8.0-2.20402.1" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicNamespaceImportsList.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicNamespaceImportsList.cs
@@ -113,11 +113,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
             }
         }
 
-        protected override Task<IProjectVersionedValue<ImmutableList<string>>> PreprocessAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> input, IProjectVersionedValue<ImmutableList<string>>? previousOutput)
+        protected override Task<IProjectVersionedValue<ImmutableList<string>>?> PreprocessAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> input, IProjectVersionedValue<ImmutableList<string>>? previousOutput)
         {
             IProjectChangeDescription projectChange = input.Value.ProjectChanges[NamespaceImport.SchemaName];
 
-            return Task.FromResult<IProjectVersionedValue<ImmutableList<string>>>(
+            return Task.FromResult<IProjectVersionedValue<ImmutableList<string>>?>(
                 new ProjectVersionedValue<ImmutableList<string>>(
                     projectChange.After.Items.Keys.ToImmutableList(),
                     input.DataSourceVersions));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
@@ -101,6 +101,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 }
             }
 
+            if (requestedProperties.DependsOn)
+            {
+                string? dependsOnString = property.GetMetadataValueOrNull("DependsOn");
+                if (dependsOnString is null)
+                {
+                    newUIProperty.DependsOn = ImmutableList<string>.Empty;
+                }
+                else
+                {
+                    newUIProperty.DependsOn = dependsOnString.Split(Delimiter.Semicolon, StringSplitOptions.RemoveEmptyEntries).ToImmutableList();
+                }
+            }
+
+            if (requestedProperties.VisibilityCondition)
+            {
+                string? visibilityCondition = property.GetMetadataValueOrNull("VisibilityCondition");
+                if (visibilityCondition is null)
+                {
+                    newUIProperty.VisibilityCondition = string.Empty;
+                }
+                else
+                {
+                    newUIProperty.VisibilityCondition = visibilityCondition;
+                }
+            }
+
             ((IEntityValueFromProvider)newUIProperty).ProviderState = (cache, property.ContainingRule, property.Name);
 
             return newUIProperty;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridge.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridge.cs
@@ -124,10 +124,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         /// Preprocess gets called as each data flow block updates and its job is to take the input from those blocks and do whatever work needed
         /// so that ApplyAsync has all of the info it needs to do its job.
         /// </summary>
-        protected override Task<IProjectVersionedValue<DesignTimeInputSnapshot>> PreprocessAsync(IProjectVersionedValue<DesignTimeInputSnapshot> input, IProjectVersionedValue<DesignTimeInputSnapshot>? previousOutput)
+        protected override Task<IProjectVersionedValue<DesignTimeInputSnapshot>?> PreprocessAsync(IProjectVersionedValue<DesignTimeInputSnapshot> input, IProjectVersionedValue<DesignTimeInputSnapshot>? previousOutput)
         {
             // No need to manipulate the data
-            return Task.FromResult(input);
+            return Task.FromResult<IProjectVersionedValue<DesignTimeInputSnapshot>?>(input);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/PropertiesAvailableStatusFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/PropertiesAvailableStatusFactory.cs
@@ -8,189 +8,131 @@ namespace Microsoft.VisualStudio.ProjectSystem
     internal static class PropertiesAvailableStatusFactory
     {
         public static IUIEditorMetadataPropertiesAvailableStatus CreateUIEditorMetadataAvailableStatus(
-            bool includeName = true,
-            bool includeValue = true)
+            bool includeAllProperties = false,
+            bool? includeName = null,
+            bool? includeValue = null)
         {
             var mock = new Mock<IUIEditorMetadataPropertiesAvailableStatus>();
 
-            mock.SetupGet(m => m.Name).Returns(includeName);
-            mock.SetupGet(m => m.Value).Returns(includeValue);
+            mock.SetupGet(m => m.Name).Returns(includeName ?? includeAllProperties);
+            mock.SetupGet(m => m.Value).Returns(includeValue ?? includeAllProperties);
 
             return mock.Object;
         }
 
-        public static IUIEditorMetadataPropertiesAvailableStatus CreateUIEditorMetadataAvailableStatus(
-            bool includeProperties)
-        {
-            return CreateUIEditorMetadataAvailableStatus(
-                includeName: includeProperties,
-                includeValue: includeProperties);
-        }
-
         public static IUIPropertyPropertiesAvailableStatus CreateUIPropertyPropertiesAvailableStatus(
-            bool includeName = true,
-            bool includeDisplayName = true,
-            bool includeDescription = true,
-            bool includeConfigurationIndependent = true,
-            bool includeHelpUrl = true,
-            bool includeCategoryName = true,
-            bool includeOrder = true,
-            bool includeType = true,
-            bool includeSearchTerms = true,
-            bool includeDependsOn = true,
-            bool includeVisibilityCondition = true)
+            bool includeAllProperties = false,
+            bool? includeName = null,
+            bool? includeDisplayName = null,
+            bool? includeDescription = null,
+            bool? includeConfigurationIndependent = null,
+            bool? includeHelpUrl = null,
+            bool? includeCategoryName = null,
+            bool? includeOrder = null,
+            bool? includeType = null,
+            bool? includeSearchTerms = null,
+            bool? includeDependsOn = null,
+            bool? includeVisibilityCondition = null)
         {
             var mock = new Mock<IUIPropertyPropertiesAvailableStatus>();
 
-            mock.SetupGet(m => m.Name).Returns(includeName);
-            mock.SetupGet(m => m.DisplayName).Returns(includeDisplayName);
-            mock.SetupGet(m => m.Description).Returns(includeDescription);
-            mock.SetupGet(m => m.ConfigurationIndependent).Returns(includeConfigurationIndependent);
-            mock.SetupGet(m => m.HelpUrl).Returns(includeHelpUrl);
-            mock.SetupGet(m => m.CategoryName).Returns(includeCategoryName);
-            mock.SetupGet(m => m.Order).Returns(includeOrder);
-            mock.SetupGet(m => m.Type).Returns(includeType);
-            mock.SetupGet(m => m.SearchTerms).Returns(includeSearchTerms);
-            mock.SetupGet(m => m.DependsOn).Returns(includeDependsOn);
-            mock.SetupGet(m => m.VisibilityCondition).Returns(includeVisibilityCondition);
+            mock.SetupGet(m => m.Name).Returns(includeName ?? includeAllProperties);
+            mock.SetupGet(m => m.DisplayName).Returns(includeDisplayName ?? includeAllProperties);
+            mock.SetupGet(m => m.Description).Returns(includeDescription ?? includeAllProperties);
+            mock.SetupGet(m => m.ConfigurationIndependent).Returns(includeConfigurationIndependent ?? includeAllProperties);
+            mock.SetupGet(m => m.HelpUrl).Returns(includeHelpUrl ?? includeAllProperties);
+            mock.SetupGet(m => m.CategoryName).Returns(includeCategoryName ?? includeAllProperties);
+            mock.SetupGet(m => m.Order).Returns(includeOrder ?? includeAllProperties);
+            mock.SetupGet(m => m.Type).Returns(includeType ?? includeAllProperties);
+            mock.SetupGet(m => m.SearchTerms).Returns(includeSearchTerms ?? includeAllProperties);
+            mock.SetupGet(m => m.DependsOn).Returns(includeDependsOn ?? includeAllProperties);
+            mock.SetupGet(m => m.VisibilityCondition).Returns(includeVisibilityCondition ?? includeAllProperties);
 
             return mock.Object;
         }
 
-        public static IUIPropertyPropertiesAvailableStatus CreateUIPropertyPropertiesAvailableStatus(
-            bool includeProperties)
-        {
-            return CreateUIPropertyPropertiesAvailableStatus(
-                includeName: includeProperties,
-                includeDisplayName: includeProperties,
-                includeDescription: includeProperties,
-                includeConfigurationIndependent: includeProperties,
-                includeHelpUrl: includeProperties,
-                includeCategoryName: includeProperties,
-                includeOrder: includeProperties,
-                includeType: includeProperties,
-                includeSearchTerms: includeProperties,
-                includeDependsOn: includeProperties,
-                includeVisibilityCondition: includeProperties);
-        }
-
         public static ISupportedValuePropertiesAvailableStatus CreateSupportedValuesPropertiesAvailableStatus(
-            bool includeDisplayName = true,
-            bool includeValue = true)
+            bool includeAllProperties = false,
+            bool? includeDisplayName = null,
+            bool? includeValue = null)
         {
             var mock = new Mock<ISupportedValuePropertiesAvailableStatus>();
 
-            mock.SetupGet(m => m.DisplayName).Returns(includeDisplayName);
-            mock.SetupGet(m => m.Value).Returns(includeValue);
+            mock.SetupGet(m => m.DisplayName).Returns(includeDisplayName ?? includeAllProperties);
+            mock.SetupGet(m => m.Value).Returns(includeValue ?? includeAllProperties);
 
             return mock.Object;
         }
 
-        public static ISupportedValuePropertiesAvailableStatus CreateSupportedValuesPropertiesAvailableStatus(
-            bool includeProperties)
-        {
-            return CreateSupportedValuesPropertiesAvailableStatus(
-                includeDisplayName: includeProperties,
-                includeValue: includeProperties);
-        }
-
         public static ICategoryPropertiesAvailableStatus CreateCategoryPropertiesAvailableStatus(
-            bool includeDisplayName = true, 
-            bool includeName = true, 
-            bool includeOrder = true)
+            bool includeAllProperties = false,
+            bool? includeDisplayName = null, 
+            bool? includeName = null, 
+            bool? includeOrder = null)
         {
             var mock = new Mock<ICategoryPropertiesAvailableStatus>();
 
-            mock.SetupGet(m => m.DisplayName).Returns(includeDisplayName);
-            mock.SetupGet(m => m.Name).Returns(includeName);
-            mock.SetupGet(m => m.Order).Returns(includeOrder);
+            mock.SetupGet(m => m.DisplayName).Returns(includeDisplayName ?? includeAllProperties);
+            mock.SetupGet(m => m.Name).Returns(includeName ?? includeAllProperties);
+            mock.SetupGet(m => m.Order).Returns(includeOrder ?? includeAllProperties);
 
             return mock.Object;
         }
 
-        public static ICategoryPropertiesAvailableStatus CreateCategoryPropertiesAvailableStatus(
-            bool includeProperties)
-        {
-            return CreateCategoryPropertiesAvailableStatus(
-                includeDisplayName: includeProperties,
-                includeName: includeProperties,
-                includeOrder: includeProperties);
-        }
-
         public static IConfigurationDimensionPropertiesAvailableStatus CreateConfigurationDimensionAvailableStatus(
-            bool includeName = true,
-            bool includeValue = true)
+            bool includeAllProperties = false,
+            bool? includeName = null,
+            bool? includeValue = null)
         {
             var mock = new Mock<IConfigurationDimensionPropertiesAvailableStatus>();
 
-            mock.SetupGet(m => m.Name).Returns(includeName);
-            mock.SetupGet(m => m.Value).Returns(includeValue);
+            mock.SetupGet(m => m.Name).Returns(includeName ?? includeAllProperties);
+            mock.SetupGet(m => m.Value).Returns(includeValue ?? includeAllProperties);
 
             return mock.Object;
         }
 
-        public static IConfigurationDimensionPropertiesAvailableStatus CreateConfigurationDimensionAvailableStatus(
-            bool includeProperties)
-        {
-            return CreateConfigurationDimensionAvailableStatus(
-                includeName: includeProperties,
-                includeValue: includeProperties);
-        }
-
         public static IPropertyPagePropertiesAvailableStatus CreatePropertyPagePropertiesAvailableStatus(
-            bool includeName = true,
-            bool includeDisplayName = true,
-            bool includeOrder = true,
-            bool includeKind = true)
+            bool includeAllProperties = false,
+            bool? includeName = null,
+            bool? includeDisplayName = null,
+            bool? includeOrder = null,
+            bool? includeKind = null)
         {
             var mock = new Mock<IPropertyPagePropertiesAvailableStatus>();
 
-            mock.SetupGet(m => m.Name).Returns(includeName);
-            mock.SetupGet(m => m.DisplayName).Returns(includeDisplayName);
-            mock.SetupGet(m => m.Order).Returns(includeOrder);
-            mock.SetupGet(m => m.Kind).Returns(includeKind);
+            mock.SetupGet(m => m.Name).Returns(includeName ?? includeAllProperties);
+            mock.SetupGet(m => m.DisplayName).Returns(includeDisplayName ?? includeAllProperties);
+            mock.SetupGet(m => m.Order).Returns(includeOrder ?? includeAllProperties);
+            mock.SetupGet(m => m.Kind).Returns(includeKind ?? includeAllProperties);
 
             return mock.Object;
-        }
-
-        public static IPropertyPagePropertiesAvailableStatus CreatePropertyPagePropertiesAvailableStatus(
-            bool includeProperties)
-        {
-            return CreatePropertyPagePropertiesAvailableStatus(
-                includeName: includeProperties,
-                includeDisplayName: includeProperties,
-                includeOrder: includeProperties,
-                includeKind: includeProperties);
         }
 
         public static IUIPropertyEditorPropertiesAvailableStatus CreateUIPropertyEditorPropertiesAvailableStatus(
-            bool includeName = true)
+            bool includeAllProperties = false,
+            bool? includeName = null,
+            bool? includeMetadata = null)
         {
             var mock = new Mock<IUIPropertyEditorPropertiesAvailableStatus>();
 
-            mock.SetupGet(m => m.Name).Returns(includeName);
+            mock.SetupGet(m => m.Name).Returns(includeName ?? includeAllProperties);
+            mock.SetupGet(m => m.Metadata).Returns(includeMetadata ?? includeAllProperties);
 
             return mock.Object;
         }
 
         public static IUIPropertyValuePropertiesAvailableStatus CreateUIPropertyValuePropertiesAvailableStatus(
-            bool includeEvaluatedValue = true,
-            bool includeUnevaluatedValue = true)
+            bool includeAllProperties = false,
+            bool? includeEvaluatedValue = null,
+            bool? includeUnevaluatedValue = null)
         {
             var mock = new Mock<IUIPropertyValuePropertiesAvailableStatus>();
 
-            mock.SetupGet(m => m.EvaluatedValue).Returns(includeEvaluatedValue);
-            mock.SetupGet(m => m.UnevaluatedValue).Returns(includeUnevaluatedValue);
+            mock.SetupGet(m => m.EvaluatedValue).Returns(includeEvaluatedValue ?? includeAllProperties);
+            mock.SetupGet(m => m.UnevaluatedValue).Returns(includeUnevaluatedValue ?? includeAllProperties);
 
             return mock.Object;
-        }
-
-        public static IUIPropertyValuePropertiesAvailableStatus CreateUIPropertyValuePropertiesAvailableStatus(
-            bool includeProperties)
-        {
-            return CreateUIPropertyValuePropertiesAvailableStatus(
-                includeEvaluatedValue: includeProperties,
-                includeUnevaluatedValue: includeProperties);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/PropertiesAvailableStatusFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/PropertiesAvailableStatusFactory.cs
@@ -36,7 +36,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             bool includeCategoryName = true,
             bool includeOrder = true,
             bool includeType = true,
-            bool includeSearchTerms = true)
+            bool includeSearchTerms = true,
+            bool includeDependsOn = true,
+            bool includeVisibilityCondition = true)
         {
             var mock = new Mock<IUIPropertyPropertiesAvailableStatus>();
 
@@ -49,6 +51,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             mock.SetupGet(m => m.Order).Returns(includeOrder);
             mock.SetupGet(m => m.Type).Returns(includeType);
             mock.SetupGet(m => m.SearchTerms).Returns(includeSearchTerms);
+            mock.SetupGet(m => m.DependsOn).Returns(includeDependsOn);
+            mock.SetupGet(m => m.VisibilityCondition).Returns(includeVisibilityCondition);
 
             return mock.Object;
         }
@@ -65,7 +69,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 includeCategoryName: includeProperties,
                 includeOrder: includeProperties,
                 includeType: includeProperties,
-                includeSearchTerms: includeProperties);
+                includeSearchTerms: includeProperties,
+                includeDependsOn: includeProperties,
+                includeVisibilityCondition: includeProperties);
         }
 
         public static ISupportedValuePropertiesAvailableStatus CreateSupportedValuesPropertiesAvailableStatus(

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/VisualBasicNamespaceImportsListFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/VisualBasicNamespaceImportsListFactory.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
 
                 var result = PreprocessAsync(projectVersionedValue, null);
 
-                _ = ApplyAsync(result.Result);
+                _ = ApplyAsync(result.Result!);
             }
 
             internal void TestApply(string[] list)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducerTests.cs
@@ -14,10 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenPropertiesAreRequested_PropertyValuesAreReturned()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateCategoryPropertiesAvailableStatus(
-                includeDisplayName: true,
-                includeName: true,
-                includeOrder: true);
+            var properties = PropertiesAvailableStatusFactory.CreateCategoryPropertiesAvailableStatus(includeAllProperties: true);
 
             var entityRuntime = IEntityRuntimeModelFactory.Create();
             var id = new EntityIdentity(key: "A", value: "B");
@@ -34,10 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenCategoryValueCreated_TheCategoryIsTheProviderState()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateCategoryPropertiesAvailableStatus(
-                includeDisplayName: true,
-                includeName: true,
-                includeOrder: true);
+            var properties = PropertiesAvailableStatusFactory.CreateCategoryPropertiesAvailableStatus(includeAllProperties: true);
 
             var entityRuntime = IEntityRuntimeModelFactory.Create();
             var id = new EntityIdentity(key: "A", value: "B");
@@ -52,10 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenCreatingACategory_TheIdIsTheCategoryName()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateCategoryPropertiesAvailableStatus(
-                includeDisplayName: true,
-                includeName: true,
-                includeOrder: true);
+            var properties = PropertiesAvailableStatusFactory.CreateCategoryPropertiesAvailableStatus(includeAllProperties: true);
 
             var parentEntity = IEntityWithIdFactory.Create(key: "A", value: "B");
             var category = new Category { DisplayName = "CategoryDisplayName", Name = "MyCategoryName" };
@@ -70,10 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenCreatingCategoriesFromARule_OneEntityIsCreatedPerCategory()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateCategoryPropertiesAvailableStatus(
-                includeDisplayName: true,
-                includeName: true,
-                includeOrder: true);
+            var properties = PropertiesAvailableStatusFactory.CreateCategoryPropertiesAvailableStatus(includeAllProperties: true);
 
             var parentEntity = IEntityWithIdFactory.Create(key: "A", value: "B");
             var rule = new Rule

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducerTests.cs
@@ -12,9 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenPropertiesAreRequested_PropertyValuesAreReturned()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateConfigurationDimensionAvailableStatus(
-                includeName: true,
-                includeValue: true);
+            var properties = PropertiesAvailableStatusFactory.CreateConfigurationDimensionAvailableStatus(includeAllProperties: true);
 
             var entityRuntime = IEntityRuntimeModelFactory.Create();
             var dimension = new KeyValuePair<string, string>("AlphaDimension", "AlphaDimensionValue");
@@ -28,9 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenPropertiesAreNotRequested_PropertyValuesAreNotReturned()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateConfigurationDimensionAvailableStatus(
-                includeName: false,
-                includeValue: false);
+            var properties = PropertiesAvailableStatusFactory.CreateConfigurationDimensionAvailableStatus();
 
             var entityRuntime = IEntityRuntimeModelFactory.Create();
             var dimension = new KeyValuePair<string, string>("AlphaDimension", "AlphaDimensionValue");
@@ -44,9 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenCreatingEntitiesFromAProjectConfiguration_OneEntityIsCreatedPerDimension()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateConfigurationDimensionAvailableStatus(
-                includeName: true,
-                includeValue: true);
+            var properties = PropertiesAvailableStatusFactory.CreateConfigurationDimensionAvailableStatus(includeAllProperties: true);
 
             var entityRuntimeModel = IEntityRuntimeModelFactory.Create();
             var configuration = ProjectConfigurationFactory.Create("Alpha|Beta|Gamma", "A|B|C");

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducerTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenPropertyValuesAreRequested_PropertyValuesAreReturned()
         {
-            var properties = PropertiesAvailableStatusFactory.CreatePropertyPagePropertiesAvailableStatus();
+            var properties = PropertiesAvailableStatusFactory.CreatePropertyPagePropertiesAvailableStatus(includeAllProperties: true);
 
             var propertyPage = (PropertyPageValue)PropertyPageDataProducer.CreatePropertyPageValue(
                 IEntityRuntimeModelFactory.Create(),
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenCreatingAModel_ProviderStateConsistsOfCacheAndRule()
         {
-            var properties = PropertiesAvailableStatusFactory.CreatePropertyPagePropertiesAvailableStatus();
+            var properties = PropertiesAvailableStatusFactory.CreatePropertyPagePropertiesAvailableStatus(includeAllProperties: true);
 
             var propertyPage = (IEntityValueFromProvider)PropertyPageDataProducer.CreatePropertyPageValue(
                 IEntityRuntimeModelFactory.Create(),
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenCreatingFromAParentAndRule_TheRuleNameIsTheEntityId()
         {
-            var properties = PropertiesAvailableStatusFactory.CreatePropertyPagePropertiesAvailableStatus();
+            var properties = PropertiesAvailableStatusFactory.CreatePropertyPagePropertiesAvailableStatus(includeAllProperties: true);
 
             var propertyPage = (PropertyPageValue)PropertyPageDataProducer.CreatePropertyPageValue(
                 IEntityWithIdFactory.Create(key: "ParentKey", value: "ParentValue"),

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducerTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
         [Fact]
         public void WhenPropertiesAreRequested_PropertyValuesAreReturned()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateSupportedValuesPropertiesAvailableStatus();
+            var properties = PropertiesAvailableStatusFactory.CreateSupportedValuesPropertiesAvailableStatus(includeAllProperties: true);
 
             var entityRuntime = IEntityRuntimeModelFactory.Create();
             var enumValue = IEnumValueFactory.Create(displayName: "Hello", name: "MyValue");
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
         [Fact]
         public async Task WhenCreatingValuesFromAnIProperty_WeGetOneValuePerIEnumValue()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateSupportedValuesPropertiesAvailableStatus();
+            var properties = PropertiesAvailableStatusFactory.CreateSupportedValuesPropertiesAvailableStatus(includeAllProperties: true);
 
             var entityRuntime = IEntityRuntimeModelFactory.Create();
             var iproperty = IPropertyFactory.CreateEnum(new[]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataProducerTests.cs
@@ -28,9 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenPropertiesAreNotRequested_PropertyValuesAreNotReturned()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateUIEditorMetadataAvailableStatus(
-                includeName: false,
-                includeValue: false);
+            var properties = PropertiesAvailableStatusFactory.CreateUIEditorMetadataAvailableStatus(includeAllProperties: false);
 
             var entityRuntime = IEntityRuntimeModelFactory.Create();
             var metadata = new NameValuePair { Name = "Alpha", Value = "AlphaValue" };

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
@@ -200,6 +200,134 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             });
         }
 
+        [Fact]
+        public void WhenAPropertyHasNoDependencies_AnEmptyListIsReturned()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeDependsOn: true);
+
+            var runtimeModel = IEntityRuntimeModelFactory.Create();
+            var id = new EntityIdentity(key: "PropertyName", value: "A");
+            var cache = IPropertyPageQueryCacheFactory.Create();
+            var property = new TestProperty
+            {
+                Metadata = new List<NameValuePair>()
+            };
+
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+
+            Assert.Empty(result.DependsOn);
+        }
+
+        [Fact]
+        public void WhenAPropertyHasAnEmptyListOfDependencies_AnEmptyListIsReturned()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeDependsOn: true);
+
+            var runtimeModel = IEntityRuntimeModelFactory.Create();
+            var id = new EntityIdentity(key: "PropertyName", value: "A");
+            var cache = IPropertyPageQueryCacheFactory.Create();
+            var property = new TestProperty
+            {
+                Metadata = new()
+                {
+                    new() { Name = "DependsOn", Value = "" }
+                }
+            };
+
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+
+            Assert.Empty(result.DependsOn);
+        }
+
+        [Fact]
+        public void WhenAPropertyHasOneDependency_OneItemIsReturned()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeDependsOn: true);
+
+            var runtimeModel = IEntityRuntimeModelFactory.Create();
+            var id = new EntityIdentity(key: "PropertyName", value: "A");
+            var cache = IPropertyPageQueryCacheFactory.Create();
+            var property = new TestProperty
+            {
+                Metadata = new()
+                {
+                    new() { Name = "DependsOn", Value = "SomeOtherProperty" }
+                }
+            };
+
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+
+            Assert.Collection(result.DependsOn, new Action<string>[]
+            {
+                searchTerm => Assert.Equal(expected: "SomeOtherProperty", actual: searchTerm)
+            });
+        }
+
+        [Fact]
+        public void WhenAPropertyHasMultipleDependencies_MultipleItemsAreReturned()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeDependsOn: true);
+
+            var runtimeModel = IEntityRuntimeModelFactory.Create();
+            var id = new EntityIdentity(key: "PropertyName", value: "A");
+            var cache = IPropertyPageQueryCacheFactory.Create();
+            var property = new TestProperty
+            {
+                Metadata = new()
+                {
+                    new() { Name = "DependsOn", Value = "AlphaProperty;BetaProperty;GammaProperty" }
+                }
+            };
+
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+
+            Assert.Collection(result.DependsOn, new Action<string>[]
+            {
+                searchTerm => Assert.Equal(expected: "AlphaProperty", actual: searchTerm),
+                searchTerm => Assert.Equal(expected: "BetaProperty", actual: searchTerm),
+                searchTerm => Assert.Equal(expected: "GammaProperty", actual: searchTerm),
+            });
+        }
+
+        [Fact]
+        public void WhenAPropertyHasNoVisibilityCondition_AnEmptyStringIsReturned()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeVisibilityCondition: true);
+
+            var runtimeModel = IEntityRuntimeModelFactory.Create();
+            var id = new EntityIdentity(key: "PropertyName", value: "A");
+            var cache = IPropertyPageQueryCacheFactory.Create();
+            var property = new TestProperty
+            {
+                Metadata = new List<NameValuePair>()
+            };
+
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+
+            Assert.Equal(expected: string.Empty, actual: result.VisibilityCondition);
+        }
+
+        [Fact]
+        public void WhenAPropertyHasAVisibilityCondition_ItIsReturned()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeVisibilityCondition: true);
+
+            var runtimeModel = IEntityRuntimeModelFactory.Create();
+            var id = new EntityIdentity(key: "PropertyName", value: "A");
+            var cache = IPropertyPageQueryCacheFactory.Create();
+            var property = new TestProperty
+            {
+                Metadata = new()
+                {
+                    new() { Name = "VisibilityCondition", Value = "true or false"}
+                }
+            };
+
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+
+            Assert.Equal(expected: "true or false", actual: result.VisibilityCondition);
+        }
+
         private class TestProperty : BaseProperty
         {
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
@@ -123,7 +123,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 includeCategoryName: false,
                 includeOrder: false,
                 includeType: false,
-                includeSearchTerms: true);
+                includeSearchTerms: true,
+                includeDependsOn: false,
+                includeVisibilityCondition: false);
 
             var runtimeModel = IEntityRuntimeModelFactory.Create();
             var id = new EntityIdentity(key: "PropertyName", value: "A");
@@ -150,7 +152,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 includeCategoryName: false,
                 includeOrder: false,
                 includeType: false,
-                includeSearchTerms: true);
+                includeSearchTerms: true,
+                includeDependsOn: false,
+                includeVisibilityCondition: false);
 
             var runtimeModel = IEntityRuntimeModelFactory.Create();
             var id = new EntityIdentity(key: "PropertyName", value: "A");
@@ -180,7 +184,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 includeCategoryName: false,
                 includeOrder: false,
                 includeType: false,
-                includeSearchTerms: true);
+                includeSearchTerms: true,
+                includeDependsOn: false,
+                includeVisibilityCondition: false);
 
             var runtimeModel = IEntityRuntimeModelFactory.Create();
             var id = new EntityIdentity(key: "PropertyName", value: "A");
@@ -213,7 +219,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 includeCategoryName: false,
                 includeOrder: false,
                 includeType: false,
-                includeSearchTerms: true);
+                includeSearchTerms: true,
+                includeDependsOn: false,
+                includeVisibilityCondition: false);
 
             var runtimeModel = IEntityRuntimeModelFactory.Create();
             var id = new EntityIdentity(key: "PropertyName", value: "A");

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenCreatingFromAParentAndProperty_ThePropertyNameIsTheEntityId()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeProperties: false);
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus();
 
             var parentEntity = IEntityWithIdFactory.Create(key: "parent", value: "A");
             var cache = IPropertyPageQueryCacheFactory.Create();
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenPropertiesAreRequested_PropertyValuesAreReturned()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeProperties: true);
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeAllProperties: true);
 
             var runtimeModel = IEntityRuntimeModelFactory.Create();
             var id = new EntityIdentity(key: "PropertyName", value: "A");
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenTheEntityIsCreated_TheProviderStateIsTheExpectedType()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeProperties: false);
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus();
 
             var runtimeModel = IEntityRuntimeModelFactory.Create();
             var id = new EntityIdentity(key: "PropertyName", value: "A");
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenCreatingPropertiesFromARule_OneEntityIsCreatedPerProperty()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeProperties: true);
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeAllProperties: true);
 
             var parentEntity = IEntityWithIdFactory.Create(key: "Parent", value: "ParentRule");
             var cache = IPropertyPageQueryCacheFactory.Create();
@@ -114,18 +114,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenAPropertyHasNoSearchTerms_AnEmptyListIsReturned()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(
-                includeName: false,
-                includeDisplayName: false,
-                includeDescription: false,
-                includeConfigurationIndependent: false,
-                includeHelpUrl: false,
-                includeCategoryName: false,
-                includeOrder: false,
-                includeType: false,
-                includeSearchTerms: true,
-                includeDependsOn: false,
-                includeVisibilityCondition: false);
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeSearchTerms: true);
 
             var runtimeModel = IEntityRuntimeModelFactory.Create();
             var id = new EntityIdentity(key: "PropertyName", value: "A");
@@ -143,18 +132,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenAPropertyHasAnEmptyListOfSearchTerms_AnEmptyListIsReturned()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(
-                includeName: false,
-                includeDisplayName: false,
-                includeDescription: false,
-                includeConfigurationIndependent: false,
-                includeHelpUrl: false,
-                includeCategoryName: false,
-                includeOrder: false,
-                includeType: false,
-                includeSearchTerms: true,
-                includeDependsOn: false,
-                includeVisibilityCondition: false);
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeSearchTerms: true);
 
             var runtimeModel = IEntityRuntimeModelFactory.Create();
             var id = new EntityIdentity(key: "PropertyName", value: "A");
@@ -175,18 +153,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenAPropertyHasOneSearchTerm_OneItemIsReturned()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(
-                includeName: false,
-                includeDisplayName: false,
-                includeDescription: false,
-                includeConfigurationIndependent: false,
-                includeHelpUrl: false,
-                includeCategoryName: false,
-                includeOrder: false,
-                includeType: false,
-                includeSearchTerms: true,
-                includeDependsOn: false,
-                includeVisibilityCondition: false);
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeSearchTerms: true);
 
             var runtimeModel = IEntityRuntimeModelFactory.Create();
             var id = new EntityIdentity(key: "PropertyName", value: "A");
@@ -210,18 +177,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public void WhenAPropertyHasMultipleSearchTerms_MultipleItemsAreReturned()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(
-                includeName: false,
-                includeDisplayName: false,
-                includeDescription: false,
-                includeConfigurationIndependent: false,
-                includeHelpUrl: false,
-                includeCategoryName: false,
-                includeOrder: false,
-                includeType: false,
-                includeSearchTerms: true,
-                includeDependsOn: false,
-                includeVisibilityCondition: false);
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeSearchTerms: true);
 
             var runtimeModel = IEntityRuntimeModelFactory.Create();
             var id = new EntityIdentity(key: "PropertyName", value: "A");

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducerTests.cs
@@ -14,9 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public async Task WhenPropertyIsAnIEvaluatedProperty_GetUnevaluatedValueAsyncIsCalled()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyValuePropertiesAvailableStatus(
-                includeEvaluatedValue: false,
-                includeUnevaluatedValue: true);
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyValuePropertiesAvailableStatus(includeUnevaluatedValue: true);
 
             var mockEvaluatedProperty = new Mock<IEvaluatedProperty>();
             mockEvaluatedProperty.Setup(m => m.GetUnevaluatedValueAsync()).ReturnsAsync("unevaluated value");
@@ -40,9 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public async Task WhenThePropertyIsAnIBoolProperty_ThenTheEvaluatedValueIsABool()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyValuePropertiesAvailableStatus(
-                includeEvaluatedValue: true,
-                includeUnevaluatedValue: false);
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyValuePropertiesAvailableStatus(includeEvaluatedValue: true);
 
             var mockBoolProperty = new Mock<IBoolProperty>();
             mockBoolProperty.Setup(m => m.GetValueAsBoolAsync()).ReturnsAsync(true);
@@ -66,9 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         public async Task WhenThePropertyIsAnIStringProperty_ThenTheEvaluatedValuesIsAString()
         {
 
-            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyValuePropertiesAvailableStatus(
-                includeEvaluatedValue: true,
-                includeUnevaluatedValue: false);
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyValuePropertiesAvailableStatus(includeEvaluatedValue: true);
 
             var mockStringProperty = new Mock<IStringProperty>();
             mockStringProperty.Setup(m => m.GetValueAsStringAsync()).ReturnsAsync("string value");
@@ -91,9 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public async Task WhenThePropertyIsAnIIntProperty_ThenTheEvaluatedValueIsAnInt()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyValuePropertiesAvailableStatus(
-                includeEvaluatedValue: true,
-                includeUnevaluatedValue: false);
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyValuePropertiesAvailableStatus(includeEvaluatedValue: true);
 
             var mockIntProperty = new Mock<IIntProperty>();
             mockIntProperty.Setup(m => m.GetValueAsIntAsync()).ReturnsAsync(42);
@@ -116,9 +108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         [Fact]
         public async Task WhenThePropertyIsAnIEnumProperty_ThenTheEvaluatedValueIsAString()
         {
-            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyValuePropertiesAvailableStatus(
-                includeEvaluatedValue: true,
-                includeUnevaluatedValue: false);
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyValuePropertiesAvailableStatus(includeEvaluatedValue: true);
 
             var enumValue = IEnumValueFactory.Create(name: "enum value");
             var mockEnumProperty = new Mock<IEnumProperty>();


### PR DESCRIPTION
Add support for the `DependsOn` and `VisibilityCondition` properties. `DependsOn` returns a list of other property names that the current property depends on for its value; the UI can use this to determine if it needs to requery the value or metadata of one property when another one changes. `VisibilityCondition`, meanwhile, represents an expression that the UI will evaluate to determine if the related UI elements should be shown or not. This would allow us to show or hide properties in response to other property values changing without requiring a round trip to the server.

Note that the type of `DependsOn` (and the existing property, `SearchTerms`) will switch from `ImmutableList<string>` to just `string` in a future update from CPS. However, I want to get the basic functionality implemented sooner rather than later, even if it means taking further changes in the near future.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6696)