### PR TITLE
Update Microsoft.VSSDK.BuildTools

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -40,7 +40,7 @@
 
     <!-- VS SDK -->
     <PackageReference Update="Microsoft.Internal.VisualStudio.Shell.Interop.14.0.DesignTime"          Version="14.3.25407-alpha" />
-    <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="16.7.3069" />
+    <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="16.8.1015" />
     <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost"                              Version="16.6.255"/>
     <PackageReference Update="Microsoft.VisualStudio.Composition"                                     Version="16.5.13"/>
     <PackageReference Update="Microsoft.VisualStudio.Data.Core"                                       Version="9.0.21023" />


### PR DESCRIPTION
Update Microsoft.VSSDK.BuildTools to a version that properly runs
32-bit-only tasks in a 32-bit environment. In the past this hasn't
mattered, as they were run inside the VS process and VS was always
32-bit. In Codespaces the VS server process is 64-bit, and these tasks
would fail to load. In the new SDK the tasks/targets have been updated
to properly indicate that they need to run in a 32-bit MSBuild process.

This should allow us to properly build our repo within a Codespace.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6698)