### PR TITLE
Update VS extensibility Packages

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -78,18 +78,18 @@
     <PackageReference Update="Microsoft.VisualStudio.Workspace.VSIntegration"                         Version="16.7.47-preview-0001" />
     <PackageReference Update="Microsoft.VisualStudio.XmlEditor"                                       Version="16.0.28321-alpha" />
     <PackageReference Update="Microsoft.VSDesigner"                                                   Version="16.0.28321-alpha" />
-    <PackageReference Update="VsWebSite.Interop"                                                      Version="16.8.30406.65"/>
-    <PackageReference Update="VSLangProj"                                                             Version="16.8.30406.65" />
-    <PackageReference Update="VSLangProj2"                                                            Version="16.8.30406.65" />
-    <PackageReference Update="VSLangProj80"                                                           Version="16.8.30406.65" />
-    <PackageReference Update="VSLangProj90"                                                           Version="16.8.30406.65" />
-    <PackageReference Update="VSLangProj100"                                                          Version="16.8.30406.65" />
-    <PackageReference Update="VSLangProj110"                                                          Version="16.8.30406.65" />
-    <PackageReference Update="VSLangProj158"                                                          Version="16.8.30406.65" />
+    <PackageReference Update="VsWebSite.Interop"                                                      Version="16.8.30523.219"/>
+    <PackageReference Update="VSLangProj"                                                             Version="16.8.30523.219" />
+    <PackageReference Update="VSLangProj2"                                                            Version="16.8.30523.219" />
+    <PackageReference Update="VSLangProj80"                                                           Version="16.8.30523.219" />
+    <PackageReference Update="VSLangProj90"                                                           Version="16.8.30523.219" />
+    <PackageReference Update="VSLangProj100"                                                          Version="16.8.30523.219" />
+    <PackageReference Update="VSLangProj110"                                                          Version="16.8.30523.219" />
+    <PackageReference Update="VSLangProj158"                                                          Version="16.8.30523.219" />
     <PackageReference Update="VSLangProj165"                                                          Version="16.5.0" />
-    <PackageReference Update="EnvDTE"                                                                 Version="16.8.30406.65" />
-    <PackageReference Update="EnvDTE80"                                                               Version="16.8.30406.65" />
-    <PackageReference Update="EnvDTE90"                                                               Version="16.8.30406.65" />
+    <PackageReference Update="EnvDTE"                                                                 Version="16.8.30523.219" />
+    <PackageReference Update="EnvDTE80"                                                               Version="16.8.30523.219" />
+    <PackageReference Update="EnvDTE90"                                                               Version="16.8.30523.219" />
     <PackageReference Update="StreamJsonRpc"                                                          Version="2.6.41-alpha" />
 
     <!-- Avoid double-writes, can remove when https://github.com/NuGet/Home/issues/8343 is fixed -->


### PR DESCRIPTION
The VSLangProj2 package includes VSLangProj2.dll. The version of the
package we currently reference has an unsigned copy of the assembly,
leading to build failures on systems that have not had signing
verification turned off. Here we update to a version of the package that
has a properly signed assembly, and update related packages for the
sake of consistency and to avoid NuGet warnings about version
mismatches.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6700)