### PR TITLE
Adapt to Project Query API changes

### DIFF
--- a/build/import/HostAgnostic.props
+++ b/build/import/HostAgnostic.props
@@ -6,11 +6,14 @@
   
   <ItemGroup>
     <!-- Framework -->
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="WindowsBase" />
     
     <!-- Toolset -->
     <PackageReference Include="MicroBuild.Core"                     ExcludeAssets="All" />

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -97,9 +97,9 @@
     <PackageReference Include="VSSDK.TemplateWizardInterface"                                         Version="12.0.4"                          ExcludeAssets="All" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.9.101-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.9.101-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="16.9.101-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.9.183-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.9.183-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="16.9.183-pre" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="3.8.0-2.20402.1" />

--- a/build/import/VisualStudio.props
+++ b/build/import/VisualStudio.props
@@ -4,14 +4,12 @@
 
   <ItemGroup>
     <!-- Framework -->
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
+    
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
-    <Reference Include="WindowsBase" />
     <Reference Include="WindowsFormsIntegration" />    
     
     <!-- Toolset -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
@@ -91,27 +89,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             if (requestedProperties.SearchTerms)
             {
                 string? searchTermsString = property.GetMetadataValueOrNull("SearchTerms");
-                if (searchTermsString is null)
-                {
-                    newUIProperty.SearchTerms = ImmutableList<string>.Empty;
-                }
-                else
-                {
-                    newUIProperty.SearchTerms = searchTermsString.Split(Delimiter.Semicolon, StringSplitOptions.RemoveEmptyEntries).ToImmutableList();
-                }
+                newUIProperty.SearchTerms = searchTermsString ?? string.Empty;
             }
 
             if (requestedProperties.DependsOn)
             {
                 string? dependsOnString = property.GetMetadataValueOrNull("DependsOn");
-                if (dependsOnString is null)
-                {
-                    newUIProperty.DependsOn = ImmutableList<string>.Empty;
-                }
-                else
-                {
-                    newUIProperty.DependsOn = dependsOnString.Split(Delimiter.Semicolon, StringSplitOptions.RemoveEmptyEntries).ToImmutableList();
-                }
+                newUIProperty.DependsOn = dependsOnString ?? string.Empty;
             }
 
             if (requestedProperties.VisibilityCondition)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         }
 
         [Fact]
-        public void WhenAPropertyHasNoSearchTerms_AnEmptyListIsReturned()
+        public void WhenAPropertyHasNoSearchTerms_AnEmptyStringIsReturned()
         {
             var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeSearchTerms: true);
 
@@ -126,11 +126,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
 
-            Assert.Empty(result.SearchTerms);
+            Assert.Equal(expected: "", actual: result.SearchTerms);
         }
 
         [Fact]
-        public void WhenAPropertyHasAnEmptyListOfSearchTerms_AnEmptyListIsReturned()
+        public void WhenAPropertyHasAnEmptyStringOfSearchTerms_AnEmptyStringIsReturned()
         {
             var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeSearchTerms: true);
 
@@ -147,35 +147,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
 
-            Assert.Empty(result.SearchTerms);
+            Assert.Equal(expected: "", actual: result.SearchTerms);
         }
 
         [Fact]
-        public void WhenAPropertyHasOneSearchTerm_OneItemIsReturned()
-        {
-            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeSearchTerms: true);
-
-            var runtimeModel = IEntityRuntimeModelFactory.Create();
-            var id = new EntityIdentity(key: "PropertyName", value: "A");
-            var cache = IPropertyPageQueryCacheFactory.Create();
-            var property = new TestProperty
-            {
-                Metadata = new()
-                {
-                    new() { Name = "SearchTerms", Value = "Alpha" }
-                }
-            };
-
-            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
-
-            Assert.Collection(result.SearchTerms, new Action<string>[]
-            {
-                searchTerm => Assert.Equal(expected: "Alpha", actual: searchTerm)
-            });
-        }
-
-        [Fact]
-        public void WhenAPropertyHasMultipleSearchTerms_MultipleItemsAreReturned()
+        public void WhenAPropertyHasSearchTerms_ThenTheSearchTermsAreReturned()
         {
             var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeSearchTerms: true);
 
@@ -192,16 +168,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
 
-            Assert.Collection(result.SearchTerms, new Action<string>[]
-            {
-                searchTerm => Assert.Equal(expected: "Alpha", actual: searchTerm),
-                searchTerm => Assert.Equal(expected: "Beta", actual: searchTerm),
-                searchTerm => Assert.Equal(expected: "Gamma", actual: searchTerm),
-            });
+            Assert.Equal(expected: "Alpha;Beta;Gamma", actual: result.SearchTerms);
         }
 
         [Fact]
-        public void WhenAPropertyHasNoDependencies_AnEmptyListIsReturned()
+        public void WhenAPropertyHasNoDependencies_AnEmptyStringIsReturned()
         {
             var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeDependsOn: true);
 
@@ -215,11 +186,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
 
-            Assert.Empty(result.DependsOn);
+            Assert.Equal(expected: "", actual: result.DependsOn);
         }
 
         [Fact]
-        public void WhenAPropertyHasAnEmptyListOfDependencies_AnEmptyListIsReturned()
+        public void WhenAPropertyHasAnEmptyStringOfDependencies_AnEmptyStringIsReturned()
         {
             var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeDependsOn: true);
 
@@ -236,11 +207,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
 
-            Assert.Empty(result.DependsOn);
+            Assert.Equal(expected: "", actual: result.DependsOn);
         }
 
         [Fact]
-        public void WhenAPropertyHasOneDependency_OneItemIsReturned()
+        public void WhenAPropertyHasDependencies_TheDependenciesAreReturned()
         {
             var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeDependsOn: true);
 
@@ -251,42 +222,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             {
                 Metadata = new()
                 {
-                    new() { Name = "DependsOn", Value = "SomeOtherProperty" }
+                    new() { Name = "DependsOn", Value = "Alpha;Beta;Gamma" }
                 }
             };
 
             var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
 
-            Assert.Collection(result.DependsOn, new Action<string>[]
-            {
-                searchTerm => Assert.Equal(expected: "SomeOtherProperty", actual: searchTerm)
-            });
-        }
-
-        [Fact]
-        public void WhenAPropertyHasMultipleDependencies_MultipleItemsAreReturned()
-        {
-            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeDependsOn: true);
-
-            var runtimeModel = IEntityRuntimeModelFactory.Create();
-            var id = new EntityIdentity(key: "PropertyName", value: "A");
-            var cache = IPropertyPageQueryCacheFactory.Create();
-            var property = new TestProperty
-            {
-                Metadata = new()
-                {
-                    new() { Name = "DependsOn", Value = "AlphaProperty;BetaProperty;GammaProperty" }
-                }
-            };
-
-            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
-
-            Assert.Collection(result.DependsOn, new Action<string>[]
-            {
-                searchTerm => Assert.Equal(expected: "AlphaProperty", actual: searchTerm),
-                searchTerm => Assert.Equal(expected: "BetaProperty", actual: searchTerm),
-                searchTerm => Assert.Equal(expected: "GammaProperty", actual: searchTerm),
-            });
+            Assert.Equal(expected: "Alpha;Beta;Gamma", actual: result.DependsOn);
         }
 
         [Fact]


### PR DESCRIPTION
A recent change in the Project Query API ([PR 281922](https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/281922) in CPS) changed the `SearchTerms` and `DependsOn` properties of `UIProperty` to return `string` instead of `ImmutableList<string>`. Here we adopt the latest version of the APR, and adapt the implementation to the updated return types. In practice these means that we just read these values from metadata in the .xaml file and pass it through unchanged, rather than splitting it up into a list. If the UI needs to do so, it will handle the splitting.

One odd aspect of this change is the need to move the references to PresentationCore, PresentationFramework, and WindowsBase from VisualStudio.props to HostAgnostic.props. The Microsoft.VisualStudio.ProjectSystem.Managed project has code that depends on the WPF `Control` and `UserControl` types and yet it did not have explicit references to them. I speculate that they used to be brought in by the previous version of
Microsoft.VisualStudio.ProjectSystem.SDK and the new version no longer does so. Regardless, since we need these types in both Microsoft.VisualStudio.ProjectSystem.Managed and Microsoft.VisualStudio.ProjectSystem.Managed.VS we can move the references into HostAgnostic.props, which is pulled in by both projects.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6706)