### PR TITLE
Properly support configuration-independent properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducer.cs
@@ -33,8 +33,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             return newProjectConfigurationDimension;
         }
 
-        public static IEnumerable<IEntityValue> CreateProjectConfigurationDimensions(IEntityRuntimeModel runtimeModel, ProjectConfiguration configuration, IConfigurationDimensionPropertiesAvailableStatus requestedProperties)
+        public static IEnumerable<IEntityValue> CreateProjectConfigurationDimensions(IEntityRuntimeModel runtimeModel, ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property, IConfigurationDimensionPropertiesAvailableStatus requestedProperties)
         {
+            // If the property is configuration-independent then report no dimensions;
+            // the parent property value applies to all configurations.
+            if (!property.DataSource.HasConfigurationCondition)
+            {
+                yield break;
+            }
+
             foreach (KeyValuePair<string, string> dimension in configuration.Dimensions)
             {
                 IEntityValue projectConfigurationDimension = CreateProjectConfigurationDimension(runtimeModel, dimension, requestedProperties);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionFromPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionFromPropertyDataProducer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             {
                 try
                 {
-                    foreach (IEntityValue dimension in ConfigurationDimensionDataProducer.CreateProjectConfigurationDimensions(request.QueryExecutionContext.EntityRuntime, configuration, _properties))
+                    foreach (IEntityValue dimension in ConfigurationDimensionDataProducer.CreateProjectConfigurationDimensions(request.QueryExecutionContext.EntityRuntime, configuration, property, _properties))
                     {
                         await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(dimension, request, ProjectModelZones.Cps));
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/IPropertyPageQueryCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/IPropertyPageQueryCache.cs
@@ -41,5 +41,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     {
         Task<IRule?> BindToRule(ProjectConfiguration projectConfiguration, string schemaName);
         Task<IImmutableSet<ProjectConfiguration>?> GetKnownConfigurationsAsync();
+        Task<ProjectConfiguration?> GetDefaultConfigurationAsync();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/IPropertyPageQueryCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/IPropertyPageQueryCache.cs
@@ -41,6 +41,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     {
         Task<IRule?> BindToRule(ProjectConfiguration projectConfiguration, string schemaName);
         Task<IImmutableSet<ProjectConfiguration>?> GetKnownConfigurationsAsync();
-        Task<ProjectConfiguration?> GetDefaultConfigurationAsync();
+        Task<ProjectConfiguration?> GetSuggestedConfigurationAsync();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryCache.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         /// <summary>
         /// Retrieves the set of <see cref="ProjectConfiguration"/>s for the project.
         /// Use this when you actually need all of the <see cref="ProjectConfiguration"/>s;
-        /// use <see cref="GetDefaultConfigurationAsync"/> when you just need any
+        /// use <see cref="GetSuggestedConfigurationAsync"/> when you just need any
         /// <see cref="ProjectConfiguration"/>.
         /// </summary>
         public Task<IImmutableSet<ProjectConfiguration>?> GetKnownConfigurationsAsync() => _knownProjectConfigurations.GetValueAsync();
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         /// <summary>
         /// Retrieves a default <see cref="ProjectConfiguration"/> for the project.
         /// </summary>
-        public Task<ProjectConfiguration?> GetDefaultConfigurationAsync() => _defaultProjectConfiguration.GetValueAsync();
+        public Task<ProjectConfiguration?> GetSuggestedConfigurationAsync() => _defaultProjectConfiguration.GetValueAsync();
 
         private async Task<IImmutableSet<ProjectConfiguration>?> CreateKnownConfigurationsAsync()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryCache.cs
@@ -15,6 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         private readonly Dictionary<(ProjectConfiguration, string), IRule?> _ruleCache;
 
         private readonly AsyncLazy<IImmutableSet<ProjectConfiguration>?> _knownProjectConfigurations;
+        private readonly AsyncLazy<ProjectConfiguration?> _defaultProjectConfiguration;
 
         public PropertyPageQueryCache(UnconfiguredProject project)
         {
@@ -22,14 +23,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             JoinableTaskFactory joinableTaskFactory = project.Services.ThreadingPolicy.JoinableTaskFactory;
 
             _knownProjectConfigurations = new AsyncLazy<IImmutableSet<ProjectConfiguration>?>(CreateKnownConfigurationsAsync, joinableTaskFactory);
+            _defaultProjectConfiguration = new AsyncLazy<ProjectConfiguration?>(CreateDefaultConfigurationAsync, joinableTaskFactory);
             _catalogCache = new Dictionary<ProjectConfiguration, IPropertyPagesCatalog?>();
             _ruleCache = new Dictionary<(ProjectConfiguration, string), IRule?>();
         }
 
         /// <summary>
         /// Retrieves the set of <see cref="ProjectConfiguration"/>s for the project.
+        /// Use this when you actually need all of the <see cref="ProjectConfiguration"/>s;
+        /// use <see cref="GetDefaultConfigurationAsync"/> when you just need any
+        /// <see cref="ProjectConfiguration"/>.
         /// </summary>
         public Task<IImmutableSet<ProjectConfiguration>?> GetKnownConfigurationsAsync() => _knownProjectConfigurations.GetValueAsync();
+
+        /// <summary>
+        /// Retrieves a default <see cref="ProjectConfiguration"/> for the project.
+        /// </summary>
+        public Task<ProjectConfiguration?> GetDefaultConfigurationAsync() => _defaultProjectConfiguration.GetValueAsync();
 
         private async Task<IImmutableSet<ProjectConfiguration>?> CreateKnownConfigurationsAsync()
         {
@@ -39,6 +49,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             }
 
             return null;
+        }
+
+        private async Task<ProjectConfiguration?> CreateDefaultConfigurationAsync()
+        {
+            if (_unconfiguredProject.Services.ProjectConfigurationsService is IProjectConfigurationsService2 configurationsService2)
+            {
+                return await configurationsService2.GetSuggestedProjectConfigurationAsync();
+            }
+            else if (_unconfiguredProject.Services.ProjectConfigurationsService is IProjectConfigurationsService configurationsService)
+            {
+                return configurationsService.SuggestedProjectConfiguration;
+            }
+            else
+            {
+                return null;
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
@@ -54,8 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             if (requestedProperties.ConfigurationIndependent)
             {
-                bool hasConfigurationCondition = property.DataSource?.HasConfigurationCondition ?? property.ContainingRule.DataSource?.HasConfigurationCondition ?? false;
-                newUIProperty.ConfigurationIndependent = !hasConfigurationCondition;
+                newUIProperty.ConfigurationIndependent = !property.IsConfigurationDependent();
             }
 
             if (requestedProperties.HelpUrl)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             else
             {
                 // Return the value from any one configuration.
-                if (await cache.GetDefaultConfigurationAsync() is ProjectConfiguration defaultConfiguration)
+                if (await cache.GetSuggestedConfigurationAsync() is ProjectConfiguration defaultConfiguration)
                 {
                     configurations = CreateSingleItemEnumerable(defaultConfiguration);
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -74,22 +74,49 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             string propertyName,
             IUIPropertyValuePropertiesAvailableStatus requestedProperties)
         {
+            BaseProperty? unboundProperty = schema.GetProperty(propertyName);
+            if (unboundProperty is null)
+            {
+                return ImmutableList<IEntityValue>.Empty;
+            }
+
             ImmutableList<IEntityValue>.Builder builder = ImmutableList.CreateBuilder<IEntityValue>();
 
-            if (await cache.GetKnownConfigurationsAsync() is IImmutableSet<ProjectConfiguration> knownConfigurations)
+            IEnumerable<ProjectConfiguration> configurations;
+            if (unboundProperty.IsConfigurationDependent())
             {
-                foreach (ProjectConfiguration knownConfiguration in knownConfigurations)
+                // Return the values across all configurations.
+                configurations = await cache.GetKnownConfigurationsAsync() ?? Enumerable.Empty<ProjectConfiguration>();
+            }
+            else
+            {
+                // Return the value from any one configuration.
+                if (await cache.GetDefaultConfigurationAsync() is ProjectConfiguration defaultConfiguration)
                 {
-                    if (await cache.BindToRule(knownConfiguration, schema.Name) is IRule rule
-                        && rule.GetProperty(propertyName) is ProjectSystem.Properties.IProperty property)
-                    {
-                        IEntityValue propertyValue = await CreateUIPropertyValueValueAsync(parent, knownConfiguration, property, requestedProperties);
-                        builder.Add(propertyValue);
-                    }
+                    configurations = CreateSingleItemEnumerable(defaultConfiguration);
+                }
+                else
+                {
+                    configurations = Enumerable.Empty<ProjectConfiguration>();
+                }
+            }
+
+            foreach (ProjectConfiguration configuration in configurations)
+            {
+                if (await cache.BindToRule(configuration, schema.Name) is IRule rule
+                    && rule.GetProperty(propertyName) is ProjectSystem.Properties.IProperty property)
+                {
+                    IEntityValue propertyValue = await CreateUIPropertyValueValueAsync(parent, configuration, property, requestedProperties);
+                    builder.Add(propertyValue);
                 }
             }
 
             return builder.ToImmutable();
+
+            static IEnumerable<ProjectConfiguration> CreateSingleItemEnumerable(ProjectConfiguration singleProjectConfiguration)
+            {
+                yield return singleProjectConfiguration;
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/BasePropertyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/BasePropertyExtensions.cs
@@ -33,5 +33,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             return property.Metadata.FirstOrDefault(nvp => nvp.Name == metadataName)?.Value;
         }
+
+        /// <summary>
+        ///     Whether or not the the <paramref name="property"/> is configuration-dependent or not.
+        /// </summary>
+        /// <param name="property">The property to examine.</param>
+        /// <returns>
+        ///     <see langword="true"/> if the property's <see cref="DataSource"/> (or the <see cref="Rule"/>'s
+        ///     <see cref="DataSource"/>) indicates that it is configuration-dependent; <see langword="false"/>
+        ///     otherwise.
+        /// </returns>
+        public static bool IsConfigurationDependent(this BaseProperty property)
+        {
+            return property.DataSource?.HasConfigurationCondition
+                ?? property.ContainingRule.DataSource?.HasConfigurationCondition
+                ?? false;
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -41,7 +41,8 @@
                        MultipleValuesAllowed="False">
     <DynamicEnumProperty.DataSource>
       <DataSource PersistedName="TargetFrameworkMoniker"
-                  Persistence="ProjectFileWithInterception" />
+                  Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False"/>
     </DynamicEnumProperty.DataSource>
   </DynamicEnumProperty>
 
@@ -74,9 +75,9 @@
                 Description="Selects a manifest generation option when the application runs on Windows Vista or later under User Account Control (UAC). Options include a default manifest, no manifest, or a custom manifest provided by your project. Note you must specify the icon and manifest -or- a resource file."
                 Category="Resources" >
     <EnumProperty.DataSource>
-      <DataSource HasConfigurationCondition="false"
-                  PersistedName="ApplicationManifest"
-                  Persistence="ProjectFileWithInterception" />
+      <DataSource PersistedName="ApplicationManifest"
+                  Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False" />
     </EnumProperty.DataSource>
     
     <EnumValue Name="NoManifest"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ParentDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ParentDebugPropertyPage.xaml
@@ -22,7 +22,8 @@
                        DisplayName="Launch"
                        EnumProvider="LaunchTargetPropertyPageEnumProvider">
     <DynamicEnumProperty.DataSource>
-      <DataSource PersistedName="LaunchTargetPropertyPage" />
+      <DataSource PersistedName="LaunchTargetPropertyPage"
+                  HasConfigurationCondition="False" />
     </DynamicEnumProperty.DataSource>
   </DynamicEnumProperty>
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPropertyFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPropertyFactory.cs
@@ -24,6 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public static IProperty Create(
             string? name = null,
+            IDataSource? dataSource = null,
             Action<object?>? setValue = null)
         {
             var mock = new Mock<IProperty>();
@@ -31,6 +32,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
             if (name is not null)
             {
                 mock.SetupGet(m => m.Name).Returns(name);
+            }
+
+            if (dataSource is not null)
+            {
+                mock.SetupGet(m => m.DataSource).Returns(dataSource);
             }
 
             if (setValue is not null)
@@ -42,4 +48,20 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return mock.Object;
         }
     }
+
+    internal static class IDataSourceFactory
+    {
+        public static IDataSource Create(bool? hasConfigurationCondition = false)
+        {
+            var mock = new Mock<IDataSource>();
+
+            if (hasConfigurationCondition is not null)
+            {
+                mock.SetupGet(m => m.HasConfigurationCondition).Returns(hasConfigurationCondition.Value);
+            }
+
+            return mock.Object;
+        }
+    }
+
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IPropertyPageQueryCacheFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IPropertyPageQueryCacheFactory.cs
@@ -13,6 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     {
         internal static IPropertyPageQueryCache Create(
             IImmutableSet<ProjectConfiguration>? projectConfigurations = null,
+            ProjectConfiguration? defaultConfiguration = null,
             Func<ProjectConfiguration, string, IRule>? bindToRule = null)
         {
             var mock = new Mock<IPropertyPageQueryCache>();
@@ -20,6 +21,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
             if (projectConfigurations is not null)
             {
                 mock.Setup(cache => cache.GetKnownConfigurationsAsync()).ReturnsAsync(projectConfigurations);
+            }
+
+            if (defaultConfiguration is not null)
+            {
+                mock.Setup(cache => cache.GetDefaultConfigurationAsync()).ReturnsAsync(defaultConfiguration);
             }
 
             if (bindToRule is not null)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IPropertyPageQueryCacheFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IPropertyPageQueryCacheFactory.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             if (defaultConfiguration is not null)
             {
-                mock.Setup(cache => cache.GetDefaultConfigurationAsync()).ReturnsAsync(defaultConfiguration);
+                mock.Setup(cache => cache.GetSuggestedConfigurationAsync()).ReturnsAsync(defaultConfiguration);
             }
 
             if (bindToRule is not null)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionDataProducerTests.cs
@@ -38,18 +38,36 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         }
 
         [Fact]
-        public void WhenCreatingEntitiesFromAProjectConfiguration_OneEntityIsCreatedPerDimension()
+        public void WhenThePropertyIsConfigurationDependent_OneEntityIsCreatedPerDimension()
         {
             var properties = PropertiesAvailableStatusFactory.CreateConfigurationDimensionAvailableStatus(includeAllProperties: true);
 
             var entityRuntimeModel = IEntityRuntimeModelFactory.Create();
             var configuration = ProjectConfigurationFactory.Create("Alpha|Beta|Gamma", "A|B|C");
-            var results = ConfigurationDimensionDataProducer.CreateProjectConfigurationDimensions(entityRuntimeModel, configuration, properties);
+            var property = IPropertyFactory.Create(
+                dataSource: IDataSourceFactory.Create(hasConfigurationCondition: true));
+
+            var results = ConfigurationDimensionDataProducer.CreateProjectConfigurationDimensions(entityRuntimeModel, configuration, property, properties);
 
             // We can't guarantee an order for the dimensions, so just check that all the expected values are present.
             Assert.Contains(results, entity => entity is ConfigurationDimensionValue dimension && dimension.Name == "Alpha" && dimension.Value == "A");
             Assert.Contains(results, entity => entity is ConfigurationDimensionValue dimension && dimension.Name == "Beta" && dimension.Value == "B");
             Assert.Contains(results, entity => entity is ConfigurationDimensionValue dimension && dimension.Name == "Gamma" && dimension.Value == "C");
+        }
+
+        [Fact]
+        public void WhenThePropertyIsConfigurationIndependent_ThenNoDimensionsAreProduced()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateConfigurationDimensionAvailableStatus(includeAllProperties: true);
+
+            var entityRuntimeModel = IEntityRuntimeModelFactory.Create();
+            var configuration = ProjectConfigurationFactory.Create("Alpha|Beta|Gamma", "A|B|C");
+            var property = IPropertyFactory.Create(
+                dataSource: IDataSourceFactory.Create(hasConfigurationCondition: false));
+
+            var results = ConfigurationDimensionDataProducer.CreateProjectConfigurationDimensions(entityRuntimeModel, configuration, property, properties);
+
+            Assert.Empty(results);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/ProjectActionProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/ProjectActionProviderTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
             var queryCacheProvider = IPropertyPageQueryCacheProviderFactory.Create(
                 IPropertyPageQueryCacheFactory.Create(
                     projectConfigurations,
-                    (config, schemaName) => IRuleFactory.Create(
+                    bindToRule: (config, schemaName) => IRuleFactory.Create(
                         name: "MyPage",
                         properties: new[]
                         {
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
             var queryCacheProvider = IPropertyPageQueryCacheProviderFactory.Create(
                 IPropertyPageQueryCacheFactory.Create(
                     projectConfigurations,
-                    (config, schemaName) => IRuleFactory.Create(
+                    bindToRule: (config, schemaName) => IRuleFactory.Create(
                         name: "MyPage",
                         properties: new[]
                         {
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
             var queryCacheProvider = IPropertyPageQueryCacheProviderFactory.Create(
                 IPropertyPageQueryCacheFactory.Create(
                     projectConfigurations,
-                    (config, schemaName) => IRuleFactory.Create(
+                    bindToRule: (config, schemaName) => IRuleFactory.Create(
                         name: "MyPage",
                         properties: new[]
                         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/ProjectActionProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/ProjectActionProviderTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
                         name: "MyPage",
                         properties: new[]
                         {
-                            IPropertyFactory.Create("MyProperty", o => affectedConfigs.Add(config.Name))
+                            IPropertyFactory.Create("MyProperty", setValue: o => affectedConfigs.Add(config.Name))
                         })));
             var emptyTargetDimensions = Enumerable.Empty<(string dimension, string value)>();
 
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
                         name: "MyPage",
                         properties: new[]
                         {
-                            IPropertyFactory.Create("MyProperty", o => affectedConfigs.Add(config.Name))
+                            IPropertyFactory.Create("MyProperty", setValue: o => affectedConfigs.Add(config.Name))
                         })));
             var targetDimensions = new List<(string dimension, string value)>
             {
@@ -102,8 +102,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
                         name: "MyPage",
                         properties: new[]
                         {
-                            IPropertyFactory.Create("MyProperty", o => { }),
-                            IPropertyFactory.Create("NotTheCorrectProperty", o => unrelatedPropertySet = true)
+                            IPropertyFactory.Create("MyProperty", setValue: o => { }),
+                            IPropertyFactory.Create("NotTheCorrectProperty", setValue: o => unrelatedPropertySet = true)
                         })));
             var targetDimensions = new List<(string dimension, string value)>
             {


### PR DESCRIPTION
Currently when retrieving the values for a property we get them across all configurations, even for properties that are configuration-independent. At best this is inefficient as we will retrieve and transmit many duplicate values that the UI will not use. At worse it breaks the query when a particular property implementation expects to only be asked about its value (or supported values) in the currently active configuration (I'm looking at you, `TargetFrameworkMoniker`).

Here we update the `UIPropertyValueDataProducer` to only return a single value for these properties. The `IPropertyPageQueryCache` has been updated to return the "suggested" `ProjectConfiguration`, and this is the one we use to retrieve the property value as it is likely to have already been loaded.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6709)