### PR TITLE
Handle code folders correctly

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/Tree/SpecialCodeFolderDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/Tree/SpecialCodeFolderDataSource.cs
@@ -10,7 +10,8 @@ using FolderSetProjectValue = Microsoft.VisualStudio.ProjectSystem.IProjectVersi
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Web.Tree
 {
     /// <summary>
-    ///     Provides a data source that produces ASP.NET special code folders.
+    ///     Provides a data source that produces ASP.NET special code folders, including well-known "App_Code" 
+    ///     and those specified by `codeSubDirectories` in web.config. These are relative to the project directory.
     /// </summary>
     [Export]
     [AppliesTo("AspNet")] // TODO:
@@ -68,12 +69,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Web.Tree
         {
             Requires.NotNullOrEmpty(relativePath, nameof(relativePath));
 
+            Assumes.True(relativePath.EndsWith("\\", StringComparison.Ordinal));
+
             PublishValue(folders => folders.Add(relativePath));
         }
 
         public void RemoveCodeFolder(string relativePath)
         {
             Requires.NotNullOrEmpty(relativePath, nameof(relativePath));
+
+            Assumes.True(relativePath.EndsWith("\\", StringComparison.Ordinal));
 
             PublishValue(folders => folders.Remove(relativePath));
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/Tree/SpecialWebFolderPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Web/Tree/SpecialWebFolderPropertiesProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -13,6 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Web.Tree
     /// </summary>
     internal class SpecialWebFolderPropertiesProvider : IProjectTreePropertiesProvider
     {
+        private static readonly ProjectTreeFlags s_projectRootOrCodeFolder = ProjectTreeFlags.ProjectRoot | SpecialWebFolder.Code.Flag;
         private static readonly IReadOnlyDictionary<string, SpecialWebFolder> s_wellKnownSpecialFolders = CreateWellKnownSpecialFolders();
 
         private readonly UnconfiguredProject _project;
@@ -26,14 +28,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Web.Tree
 
         public void CalculatePropertyValues(IProjectTreeCustomizablePropertyContext propertyContext, IProjectTreeCustomizablePropertyValues propertyValues)
         {
-            if (propertyContext.IsFolder && propertyValues.Flags.IsIncludedInProject())
+            if (IsSpecialWebFolder(propertyContext, propertyValues, out SpecialWebFolder? folder))
             {
-                if (IsSpecialWebFolder(propertyContext, propertyValues, out SpecialWebFolder? folder))
-                {
-                    propertyValues.Icon = folder.Icon.ToProjectSystemType();
-                    propertyValues.ExpandedIcon = folder.ExpandedIcon.ToProjectSystemType();
-                    propertyValues.Flags += folder.Flag;
-                }
+                propertyValues.Icon = folder.Icon.ToProjectSystemType();
+                propertyValues.ExpandedIcon = folder.ExpandedIcon.ToProjectSystemType();
+                propertyValues.Flags += folder.Flag;
             }
         }
 
@@ -41,15 +40,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Web.Tree
         {
             if (propertyContext.IsFolder && propertyValues.Flags.IsIncludedInProject())
             {
-                // Well-known folders only exist in the root
-                if (propertyContext.ParentNodeFlags.IsProjectRoot())
+                if (IsWellKnownFolder(propertyContext, out folder) || IsCodeFolder(propertyContext, out folder))
                 {
-                    return s_wellKnownSpecialFolders.TryGetValue(propertyContext.ItemName, out folder);
-                }
-
-                if (IsCodeFolder(propertyContext))
-                {
-                    folder = SpecialWebFolder.Code;
                     return true;
                 }
             }
@@ -58,25 +50,47 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Web.Tree
             return false;
         }
 
-        private bool IsCodeFolder(IProjectTreeCustomizablePropertyContext propertyContext)
+        private static bool IsWellKnownFolder(IProjectTreeCustomizablePropertyContext propertyContext, [NotNullWhen(true)] out SpecialWebFolder? folder)
         {
+            folder = null;
+
+            // Well-known folders only exist in the root
+            if (!propertyContext.ParentNodeFlags.IsProjectRoot())
+                return false;
+
+            return s_wellKnownSpecialFolders.TryGetValue(propertyContext.ItemName, out folder);
+        }
+
+        private bool IsCodeFolder(IProjectTreeCustomizablePropertyContext propertyContext, [NotNullWhen(true)] out SpecialWebFolder? folder)
+        {
+            folder = null;
+
+            // Code folders are either in the root, or within another code folder
+            if (!propertyContext.ParentNodeFlags.ContainsAny(s_projectRootOrCodeFolder))
+                return false;
+            
             if (_codeFolders.Count == 0)
                 return false;
 
             if (propertyContext.Metadata == null || !propertyContext.Metadata.TryGetValue(Folder.FullPathProperty, out string fullPath))
                 return false;
 
-            // TODO: App-Relative Path
+            Assumes.True(fullPath.EndsWith("\\", StringComparison.Ordinal));
+
             string relativePath = _project.MakeRelative(fullPath);
 
-            return _codeFolders.Contains(relativePath);
+            if (!_codeFolders.Contains(relativePath))
+                return false;
+
+            folder = SpecialWebFolder.Code;
+            return true;
         }
 
         private static IReadOnlyDictionary<string, SpecialWebFolder> CreateWellKnownSpecialFolders()
         {
+            // App_Code is provided explicitly via "code folders"
             return new Dictionary<string, SpecialWebFolder>(StringComparers.Paths)
             {
-                { "App_Code",                  SpecialWebFolder.Code},
                 { "Bin",                       SpecialWebFolder.Bin},
                 { "App_GlobalResources",       SpecialWebFolder.GlobalResources},
                 { "App_Data",                  SpecialWebFolder.Data},
@@ -96,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Web.Tree
             // TODO: Correct icons
             public static SpecialWebFolder Code             = new(SpecialWebFolderFlag.CodeFolder,              KnownMonikers.SpecialFolderClosed, KnownMonikers.SpecialFolderOpened);
             public static SpecialWebFolder Bin              = new(SpecialWebFolderFlag.BinFolder,               KnownMonikers.SpecialFolderClosed, KnownMonikers.SpecialFolderOpened);
-            public static SpecialWebFolder GlobalResources  = new(SpecialWebFolderFlag.GlobalResourcesFolder,         KnownMonikers.SpecialFolderClosed, KnownMonikers.SpecialFolderOpened);
+            public static SpecialWebFolder GlobalResources  = new(SpecialWebFolderFlag.GlobalResourcesFolder,   KnownMonikers.SpecialFolderClosed, KnownMonikers.SpecialFolderOpened);
             public static SpecialWebFolder Data             = new(SpecialWebFolderFlag.DataFolder,              KnownMonikers.SpecialFolderClosed, KnownMonikers.SpecialFolderOpened);
             public static SpecialWebFolder Themes           = new(SpecialWebFolderFlag.ThemesFolder,            KnownMonikers.SpecialFolderClosed, KnownMonikers.SpecialFolderOpened);
             public static SpecialWebFolder Browsers         = new(SpecialWebFolderFlag.BrowsersFolder,          KnownMonikers.SpecialFolderClosed, KnownMonikers.SpecialFolderOpened);


### PR DESCRIPTION
App_Code and other code folders are passed specifically by IVsWebProjectSupport2.CodeFolderAdded, no need to specially look for them.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6711)