### PR TITLE
Use FWLinks for HelpUrls

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -35,7 +35,7 @@
   <DynamicEnumProperty Name="TargetFrameworkMoniker"
                        DisplayName="Target framework"
                        Description="Specifies the version of .NET that the application targets. This option can have different values depending on which versions of .NET are installed on your computer."
-                       HelpUrl="https://docs.microsoft.com/en-us/visualstudio/ide/visual-studio-multi-targeting-overview"
+                       HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147236"
                        Category="General"
                        EnumProvider="SupportedTargetFrameworksEnumProvider"
                        MultipleValuesAllowed="False">
@@ -89,7 +89,7 @@
   <StringProperty Name="Win32Resource"
                   DisplayName="Resource file"
                   Description="Specifies a resource file for the project. Note you must specify the icon and manifest -or- a resource file."
-                  HelpUrl="https://docs.microsoft.com/en-us/dotnet/framework/resources/creating-resource-files-for-desktop-apps"
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147078"
                   Category="Resources"
                   Subtype="file" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -29,13 +29,13 @@
   <StringProperty Name="DefineConstants"
                   DisplayName="Conditional compilation symbols"
                   Description="Specifies symbols on which to perform conditional compilation. Separate symbols with a semi-colon (';')."
-                  HelpUrl="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/define-compiler-option"
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147079"
                   Category="General" />
 
   <EnumProperty Name="PlatformTarget"
                 DisplayName="Platform target"
                 Description="Specifies the processor to be targeted by the output file. Choose 'x86' for any 32-bit Intel-compatible processor, choose 'x64' for any 64-bit Intel-compatible processor, or choose 'Any CPU' to specify that any processor is acceptable. 'Any CPU' is the default value for projects, because it allows the application to run on the broadest range of hardware."
-                HelpUrl="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/platform-compiler-option"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147129"
                 Category="General">
     <EnumValue Name="AnyCPU"
                DisplayName="Any CPU" />
@@ -48,7 +48,7 @@
   <EnumProperty Name="Nullable"
                 DisplayName="Nullable"
                 Description="Specifies the project-wide C# nullable context. Only available for projects that use C# 8.0 or later."
-                HelpUrl="https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references#nullable-contexts"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2146796"
                 Category="General" >
     <EnumProperty.DataSource>
       <DataSource HasConfigurationCondition="False" />
@@ -66,19 +66,19 @@
   <BoolProperty Name="AllowUnsafeBlocks"
                 DisplayName="Allow unsafe code"
                 Description="Allows code that uses the 'unsafe' keyword to compile."
-                HelpUrl="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/unsafe-compiler-option"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2146797"
                 Category="General" />
 
   <BoolProperty Name="Optimize"
                 DisplayName="Optimize code"
                 Description="Enables or disables optimizations performed by the compiler to make your output file smaller, faster, and more efficient."
-                HelpUrl="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/optimize-compiler-option"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147080"
                 Category="General" />
 
   <EnumProperty Name="WarningLevel"
                 DisplayName="Warning level"
                 Description="Specifies the level to display for compiler warnings."
-                HelpUrl="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/warn-compiler-option"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2146798"
                 Category="ErrorsAndWarnings">
     <EnumValue Name="0"
                DisplayName="0" />
@@ -97,11 +97,11 @@
   <StringProperty Name="NoWarn"
                   DisplayName="Suppress warnings"
                   Description="Blocks the compiler's ability to generate one or more warnings. Separate multiple warning numbers with a comma (',') or semicolon (';')."
-                  HelpUrl="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/nowarn-compiler-option"
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147300"
                   Category="ErrorsAndWarnings" />
 
   <EnumProperty Name="TreatWarningsAsErrors"
-                HelpUrl="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/warnaserror-compiler-option"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147301"
                 DisplayName="Treat warnings as errors"
                 Description="Used to specify which warnings are treated as errors."
                 Category="ErrorsAndWarnings" >
@@ -113,7 +113,7 @@
 
   <StringProperty Name="WarningsAsErrors"
                   DisplayName="Treat specific warnings as errors"
-                  HelpUrl="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/warnaserror-compiler-option"
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147301"
                   Description="Treats the specified warnings as errors. Separate multiple warning numbers with a comma (',') or semicolon (';')."
                   Category="ErrorsAndWarnings" />
 
@@ -126,7 +126,7 @@
   <StringProperty Name="DocumentationFile"
                   DisplayName="XML documentation file path"
                   Description="Specifies the name of a file into which documentation comments will be processed."
-                  HelpUrl="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/doc-compiler-option"
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147081"
                   Category="Output"
                   Subtype="file" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
@@ -24,17 +24,17 @@
   <StringProperty Name="PackageId"
                   DisplayName="Package ID"
                   Description="The case-insensitive package identifier, which must be unique across nuget.org or whatever gallery the package resides in. IDs may not contain spaces or characters that are not valid for a URL, and generally follow .NET namespace rules."
-                  HelpUrl="https://docs.microsoft.com/nuget/create-packages/creating-a-package#choose-a-unique-package-identifier-and-setting-the-version-number" />
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147131" />
 
   <StringProperty Name="Version"
                   DisplayName="Package Version"
                   Description="The version of the package, following the major.minor.patch pattern. Version numbers may include a pre-release suffix."
-                  HelpUrl="https://docs.microsoft.com/nuget/concepts/package-versioning" />
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147132" />
 
   <StringProperty Name="Authors"
                   DisplayName="Authors"
                   Description="A comma-separated list of packages authors, matching the profile names on nuget.org. These are displayed in the NuGet Gallery on nuget.org and are used to cross-reference packages by the same authors."
-                  HelpUrl="https://docs.microsoft.com/en-us/nuget/reference/nuspec#authors" />
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147237" />
 
   <StringProperty Name="Company"
                   DisplayName="Company" />
@@ -45,26 +45,26 @@
   <StringProperty Name="Description"
                   DisplayName="Description"
                   Description="A description of the package for UI display."
-                  HelpUrl="https://docs.microsoft.com/en-us/nuget/reference/nuspec#description" />
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147238" />
 
   <StringProperty Name="Copyright"
                   DisplayName="Copyright"
                   Description="Copyright details for the package."
-                  HelpUrl="https://docs.microsoft.com/en-us/nuget/reference/nuspec#copyright"/>
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147133"/>
 
   <StringProperty Name="PackageLicenseExpression"
                   DisplayName="License expression"
                   Description="An SPDX license expression, often shown in UIs like nuget.org."
-                  HelpUrl="https://docs.microsoft.com/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file" />
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147239" />
   
   <StringProperty Name="PackageLicenseFile"
                   DisplayName="License file"
-                  HelpUrl="https://docs.microsoft.com/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file" />
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147239" />
 
   <StringProperty Name="PackageProjectUrl"
                   DisplayName="Project URL"
                   Description="A URL for the package's home page, often shown in UI displays as well as nuget.org."
-                  HelpUrl="https://docs.microsoft.com/en-us/nuget/reference/nuspec#projecturl" />
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147240" />
 
   <!-- TODO (tomescht): 
        We should re-think this. This property is the relative path to the icon file _within the package_; setting it does not guarantee
@@ -74,27 +74,27 @@
   <StringProperty Name="PackageIcon"
                   DisplayName="Icon file"
                   Description="The relative path from the package root to the icon file. In addition to setting this property you need to make sure that the file is included in the package. Image file size is limited to 1 MB. Supported file formats include JPEG and PNG. An image resolution of 128x128 is recommended."
-                  HelpUrl="https://docs.microsoft.com/nuget/reference/msbuild-targets#packing-an-icon-image-file" />
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147134" />
 
   <StringProperty Name="RepositoryUrl"
                   DisplayName="Repository URL"
                   Description="Specifies the URL for the repository where the source code for the package resides and/or from which it's being built. For linking to the project page, use the 'Project URL' field, instead."
-                  HelpUrl="https://docs.microsoft.com/nuget/reference/nuspec#repository" />
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147241" />
 
   <StringProperty Name="RepositoryType"
                   DisplayName="Repository type"
                   Description="Specifies the type of the repository. Default is 'git'."
-                  HelpUrl="https://docs.microsoft.com/nuget/reference/nuspec#repository" />
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147241" />
 
   <StringProperty Name="PackageTags"
                   DisplayName="Tags"
                   Description="A semicolon-delimited list of tags and keywords that describe the package and aid discoverability of packages through search and filtering."
-                  HelpUrl="https://docs.microsoft.com/en-us/nuget/reference/nuspec#tags" />
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147135" />
 
   <StringProperty Name="PackageReleaseNotes"
                   DisplayName="Release notes"
                   Description="A description of the changes made in this release of the package, often used in UI like the Updates tab of the Visual Studio Package Manager in place of the package description."
-                  HelpUrl="https://docs.microsoft.com/en-us/nuget/reference/nuspec#releasenotes" />
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147242" />
 
   <DynamicEnumProperty Name="NeutralLanguage"
                        DisplayName="Assembly neutral language"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/SigningPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/SigningPropertyPage.xaml
@@ -15,7 +15,7 @@
 
   <BoolProperty Name="SignAssembly"
                 Description="Sign the output assembly to give it a strong name."
-                HelpUrl="https://docs.microsoft.com/en-us/dotnet/standard/assembly/strong-named"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147136"
                 DisplayName="Sign the assembly" />
 
   <StringProperty Name="AssemblyOriginatorKeyFile"
@@ -24,6 +24,6 @@
 
   <BoolProperty Name="DelaySign"
                 Description="Use delayed signing when access to the private key is restricted. The public key will be used during the build, and addition of the private key information deferred until the assembly is handed off."
-                HelpUrl="https://docs.microsoft.com/en-us/dotnet/standard/assembly/delay-sign"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147243"
                 DisplayName="Delay sign only" />
 </Rule>


### PR DESCRIPTION
Fixes #6541.

Properties declared in .xaml `Rule` files may include a `HelpUrl` field providing the web address of documentation for that property. Here we update the existing `HelpUrl`s to go through our redirection service (FWLink). This will allow us to update the URLs in the future without needing to service the product; we can just update the entry in the FWLink redirection service instead.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6715)