### PR TITLE
Fix delegation to new project properties editor

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/GlobalSuppressions.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/GlobalSuppressions.vb
@@ -399,7 +399,7 @@ Imports System.Diagnostics.CodeAnalysis
 <Assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Scope:="type", Target:="~T:Microsoft.VisualStudio.Editors.PropertyPages.IPropertyPageSiteInternal")>
 <Assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Scope:="type", Target:="~T:Microsoft.VisualStudio.Editors.PropertyPages.PropertyControlData")>
 <Assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Scope:="type", Target:="~T:Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerDocData")>
-<Assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Scope:="member", Target:="~M:Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerEditorFactory.InternalCreateEditorInstance(System.String,System.Object,System.Object@,System.Object@,System.String@,System.Guid@,System.Boolean@)")>
+<Assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Scope:="member", Target:="~M:Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerEditorFactory.InternalCreateEditorInstance(System.String,System.Object,System.Object@,System.Object@,System.String@,System.Guid@)")>
 <Assembly: SuppressMessage("Code Quality", "IDE0069:Disposable fields should be disposed", Scope:="member", Target:="~F:Microsoft.VisualStudio.Editors.AppDesDesignerFramework.ErrorControl._sizingLabel")>
 <Assembly: SuppressMessage("Code Quality", "IDE0069:Disposable fields should be disposed", Scope:="member", Target:="~F:Microsoft.VisualStudio.Editors.ApplicationDesigner.ErrorControlCustomViewProvider._view")>
 <Assembly: SuppressMessage("Code Quality", "IDE0069:Disposable fields should be disposed", Scope:="member", Target:="~F:Microsoft.VisualStudio.Editors.ApplicationDesigner.ProjectDesignerTabControl._hostingPanel")>

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerEditorFactory.vb
@@ -55,15 +55,14 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="DocData">Returns DocData object</param>
         ''' <param name="Caption">Returns caption for document window</param>
         ''' <param name="CmdUIGuid">Returns guid for CMDUI</param>
-        ''' <param name="Canceled">Returns True if user canceled</param>
-        Private Sub InternalCreateEditorInstance(FileName As String,
+        Private Sub InternalCreateEditorInstance(
+                FileName As String,
                 ExistingDocData As Object,
                 ByRef DocView As Object,
                 ByRef DocData As Object,
                 ByRef Caption As String,
-                ByRef CmdUIGuid As Guid,
-                ByRef Canceled As Boolean)
-            Canceled = False
+                ByRef CmdUIGuid As Guid)
+
             CmdUIGuid = Guid.Empty
 
             Dim DesignerLoader As PropPageDesignerLoader = Nothing
@@ -149,13 +148,12 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ByRef DocDataPtr As IntPtr,
                 ByRef Caption As String,
                 ByRef CmdUIGuid As Guid,
-                ByRef FCanceled As Integer) As Integer _
+                ByRef pgrfCDW As Integer) As Integer _
         Implements IVsEditorFactory.CreateEditorInstance
 
             Dim ExistingDocData As Object = Nothing
             Dim DocView As Object = Nothing
             Dim DocData As Object = Nothing
-            Dim CanceledAsBoolean As Boolean = False
 
             DocViewPtr = IntPtr.Zero
             DocDataPtr = IntPtr.Zero
@@ -167,13 +165,9 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             Caption = Nothing
 
             InternalCreateEditorInstance(FileName, ExistingDocData,
-                DocView, DocData, Caption, CmdUIGuid, CanceledAsBoolean)
+                DocView, DocData, Caption, CmdUIGuid)
 
-            If CanceledAsBoolean Then
-                FCanceled = 1
-            Else
-                FCanceled = 0
-            End If
+            pgrfCDW = 0
 
             If DocView IsNot Nothing Then
                 DocViewPtr = Marshal.GetIUnknownForObject(DocView)

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerEditorFactory.vb
@@ -197,11 +197,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             End If
             'Site is different - set it
             _site = Site
-            If TypeOf Site Is IServiceProvider Then
-                _siteProvider = New ServiceProvider(CType(Site, IServiceProvider))
-            Else
-                Debug.Fail("Site IsNot OLE.Interop.IServiceProvider")
-            End If
+            _siteProvider = New ServiceProvider(Site)
         End Function
 
     End Class


### PR DESCRIPTION
Previously the delegation looped back through OpenSpecificEditor which caused a few bugs:

- The editor would not appear on the first request, but would on the second
- The document title would show the full path in some circumstances
- An open property editor would stop project file editing from working

This change performs delegation by obtaining an instance of the new editor factory directly and invoking it. This means that the new editor factory is directly handling requests made of the old editor factory.

---

(Includes #6731 so just review cd3befad1d005f95d8cc4dd5e2175cd6984a4cd6).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6732)