### PR TITLE
Use snapshot data in WindowsFormsEditorProvider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectTreeExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectTreeExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Diagnostics.Contracts;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
@@ -33,6 +34,35 @@ namespace Microsoft.VisualStudio.ProjectSystem
             }
 
             return null;
+        }
+
+        /// <summary>
+        ///     Returns the properties of a <see cref="IProjectTree"/>, returning the result from a 
+        ///     project snapshot if it is available, otherwise, returns the live results.
+        /// </summary>
+        /// <remarks>
+        ///     Prefer this method over <see cref="IProjectTree.BrowseObjectProperties"/> to avoid 
+        ///     needing to take a project lock to read properties, which can avoid UI delays but
+        ///     with possibility of out-of-date data.
+        /// </remarks>
+        internal static IRule? GetBrowseObjectPropertiesViaSnapshotIfAvailable(this IProjectTree node, ConfiguredProject project)
+        {
+            Assumes.Present(project.Services.PropertyPagesCatalog);
+
+            IRule? properties = node.BrowseObjectProperties;
+
+            if (properties == null || properties.Schema == null || !project.Services.PropertyPagesCatalog.SourceBlock.TryReceive(null, out IProjectVersionedValue<IProjectCatalogSnapshot> catalogSnapshot))
+                return properties;
+
+            // We let the snapshot be out of date with the "live" project
+            if (!catalogSnapshot.Value.NamedCatalogs.TryGetValue(PropertyPageContexts.BrowseObject, out IPropertyPagesCatalog pagesCatalog))
+                return properties;
+
+            Assumes.NotNull(catalogSnapshot.Value.Project);
+
+            IRule? snapshop = pagesCatalog.BindToContext(properties.Schema.Name, catalogSnapshot.Value.Project.ProjectInstance, properties.ItemType, properties.ItemName);
+
+            return snapshop ?? properties;
         }
     }
 }


### PR DESCRIPTION
Fixes: #6726

Under high project lock contention, such as during a branch switch or a change to a props/targets shared by an entire solution, we can hit UI delays selecting items in Solution Explorer trying to figure out if we can "preview" files.

Use snapshot data if available in WindowsFormsEditorProvider to prevent that.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6734)