### PR TITLE
Code cleanup - handle key not found

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandler.cs
@@ -41,9 +41,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             VerifyInitialized();
 
-            if (projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.MSBuildProjectFullPathProperty))
+            if (projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.MSBuildProjectFullPathProperty) &&
+                projectChange.After.Properties.TryGetKey(ConfigurationGeneral.MSBuildProjectFullPathProperty, out string projectFilePath))
             {
-                string projectFilePath = projectChange.After.Properties[ConfigurationGeneral.MSBuildProjectFullPathProperty];
                 string displayName = GetDisplayName(projectFilePath);
 
                 logger.WriteLine("DisplayName: {0}", displayName);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandler.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             VerifyInitialized();
 
             if (projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.MSBuildProjectFullPathProperty) &&
-                projectChange.After.Properties.TryGetKey(ConfigurationGeneral.MSBuildProjectFullPathProperty, out string projectFilePath))
+                projectChange.After.Properties.TryGetValue(ConfigurationGeneral.MSBuildProjectFullPathProperty, out string projectFilePath))
             {
                 string displayName = GetDisplayName(projectFilePath);
 


### PR DESCRIPTION
The map Properties may not contain the key value.
The current logic checks for existing key is present in ChangedProperties, but it gets the value from Properties causing to throw an exception.

This change only adds logic to check if Properties contains the key before getting the value.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6736)