### PR TITLE
Add some property page search terms

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -73,7 +73,7 @@
   <EnumProperty Name="ApplicationManifest"
                 DisplayName="Manifest"
                 Description="Selects a manifest generation option when the application runs on Windows Vista or later under User Account Control (UAC). Options include a default manifest, no manifest, or a custom manifest provided by your project. Note you must specify the icon and manifest -or- a resource file."
-                Category="Resources" >
+                Category="Resources">
     <EnumProperty.DataSource>
       <DataSource PersistedName="ApplicationManifest"
                   Persistence="ProjectFileWithInterception"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -49,7 +49,7 @@
                 DisplayName="Nullable"
                 Description="Specifies the project-wide C# nullable context. Only available for projects that use C# 8.0 or later."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2146796"
-                Category="General" >
+                Category="General">
     <EnumProperty.DataSource>
       <DataSource HasConfigurationCondition="False" />
     </EnumProperty.DataSource>
@@ -67,13 +67,21 @@
                 DisplayName="Allow unsafe code"
                 Description="Allows code that uses the 'unsafe' keyword to compile."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2146797"
-                Category="General" />
+                Category="General">
+    <BoolProperty.Metadata>
+      <NameValuePair Name="SearchTerms" Value="pointers" />
+    </BoolProperty.Metadata>
+  </BoolProperty>
 
   <BoolProperty Name="Optimize"
                 DisplayName="Optimize code"
                 Description="Enables or disables optimizations performed by the compiler to make your output file smaller, faster, and more efficient."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147080"
-                Category="General" />
+                Category="General">
+    <BoolProperty.Metadata>
+      <NameValuePair Name="SearchTerms" Value="optimise;optimisation" />
+    </BoolProperty.Metadata>
+  </BoolProperty>
 
   <EnumProperty Name="WarningLevel"
                 DisplayName="Warning level"


### PR DESCRIPTION
Increases the chance of finding properties using related words or alternate spellings.

It seems SearchTerms metadata is not localised. This defeats their purpose in other cultures. @tmeschter do you have a sense of what's involved here? Should I file an issue for this?

I'd like some examples of this feature in the data for testing/demo purposes. I hit this organically typing "optimise" and getting different results to "optimize".

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6741)