### PR TITLE
Use new missing folder icon for properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/AbstractSpecialFolderProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/AbstractSpecialFolderProjectTreePropertiesProvider.cs
@@ -87,12 +87,16 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             propertyValues.Flags = propertyValues.Flags.Union(FolderFlags);
 
-            ProjectImageMoniker? icon = _imageProvider.GetProjectImage(FolderImageKey);
-            ProjectImageMoniker? expandedIcon = _imageProvider.GetProjectImage(ExpandedFolderImageKey);
+            // Use default icon if missing
+            if (!propertyValues.Flags.IsMissingOnDisk())
+            {
+                ProjectImageMoniker? icon = _imageProvider.GetProjectImage(FolderImageKey);
+                ProjectImageMoniker? expandedIcon = _imageProvider.GetProjectImage(ExpandedFolderImageKey);
 
-            // Avoid overwriting icon if the image provider didn't provide one
-            propertyValues.Icon = icon ?? propertyValues.Icon;
-            propertyValues.ExpandedIcon = expandedIcon ?? propertyValues.ExpandedIcon;
+                // Avoid overwriting icon if the image provider didn't provide one
+                propertyValues.Icon = icon ?? propertyValues.Icon;
+                propertyValues.ExpandedIcon = expandedIcon ?? propertyValues.ExpandedIcon;
+            }
         }
 
         private static void ApplySpecialFolderItemProperties(IProjectTreeCustomizablePropertyValues propertyValues)


### PR DESCRIPTION
This falls back to the new missing default folder icon when the folder is missing. This is counter change to https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/287315?_a=files.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6749)