### PR TITLE
Refactor BuildUtilities

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildExtensions.cs
@@ -3,6 +3,7 @@
 using System;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
 
 namespace Microsoft.VisualStudio.Build
 {
@@ -19,6 +20,27 @@ namespace Microsoft.VisualStudio.Build
             Requires.NotNull(element, nameof(element));
 
             return ProjectCollection.Unescape(element.Value);
+        }
+
+        /// <summary>
+        ///     Returns a value indicating if the specified <see cref="ProjectItemInstance"/>
+        ///     originated in an imported file.
+        /// </summary>
+        /// <returns>
+        ///     <see langword="true"/> if <paramref name="item"/> originated in an imported file;
+        ///     otherwise, <see langword="false"/> if it was defined in the project being built.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="item"/> is <see langword="null"/>.
+        /// </exception>
+        public static bool IsImported(this ProjectItemInstance item)
+        {
+            Requires.NotNull(item, nameof(item));
+
+            string definingProjectFullPath = item.GetMetadataValue("DefiningProjectFullPath");
+            string projectFullPath = item.Project.FullPath; // NOTE: This returns project being built, not owning target
+
+            return !StringComparers.Paths.Equals(definingProjectFullPath, projectFullPath);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.Build.Construction;
-using Microsoft.Build.Execution;
 using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.Text;
 
@@ -238,27 +237,6 @@ namespace Microsoft.VisualStudio.Build
 
                 return propertyGroup.AddProperty(propertyName, string.Empty);
             }
-        }
-
-        /// <summary>
-        ///     Returns a value indicating if the specified <see cref="ProjectItemInstance"/>
-        ///     originated in an imported file.
-        /// </summary>
-        /// <returns>
-        ///     <see langword="true"/> if <paramref name="item"/> originated in an imported file;
-        ///     otherwise, <see langword="false"/> if it was defined in the project being built.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        ///     <paramref name="item"/> is <see langword="null"/>.
-        /// </exception>
-        public static bool IsImported(this ProjectItemInstance item)
-        {
-            Requires.NotNull(item, nameof(item));
-
-            string definingProjectFullPath = item.GetMetadataValue("DefiningProjectFullPath");
-            string projectFullPath = item.Project.FullPath; // NOTE: This returns project being built, not owning target
-
-            return !StringComparers.Paths.Equals(definingProjectFullPath, projectFullPath);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             }
             else
             {
-                return ConfigUtilities.GetPropertyValues(propertyValue).ToImmutableArray();
+                return ConfigUtilities.EnumerateDimensionValues(propertyValue).ToImmutableArray();
             }
 
             async Task<string?> GetPropertyValueAsync(UnconfiguredProject project)
@@ -162,11 +162,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                     {
                         case ConfigurationDimensionChange.Add:
                             return UpdateUnderLockAsync(args.Project, (msbuildProject, evaluatedPropertyValue) =>
-                                ConfigUtilities.AppendPropertyValue(msbuildProject, evaluatedPropertyValue, PropertyName, args.DimensionValue));
+                                ConfigUtilities.AppendDimensionValue(msbuildProject, evaluatedPropertyValue, PropertyName, args.DimensionValue));
 
                         case ConfigurationDimensionChange.Delete:
                             return UpdateUnderLockAsync(args.Project, (msbuildProject, evaluatedPropertyValue) =>
-                                ConfigUtilities.RemovePropertyValue(msbuildProject, evaluatedPropertyValue, PropertyName, args.DimensionValue));
+                                ConfigUtilities.RemoveDimensionValue(msbuildProject, evaluatedPropertyValue, PropertyName, args.DimensionValue));
 
                         case ConfigurationDimensionChange.Rename:
                             // Need to wait until the core rename changes happen before renaming the property.
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                     if (args.Change == ConfigurationDimensionChange.Rename)
                     {
                         return UpdateUnderLockAsync(args.Project, (msbuildProject, evaluatedPropertyValue) =>
-                            ConfigUtilities.RenamePropertyValue(msbuildProject, evaluatedPropertyValue, PropertyName, args.OldDimensionValue, args.DimensionValue));
+                            ConfigUtilities.RenameDimensionValue(msbuildProject, evaluatedPropertyValue, PropertyName, args.OldDimensionValue, args.DimensionValue));
                     }
                 }
             }
@@ -211,7 +211,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             if (Strings.IsNullOrEmpty(values))
                 return null;
 
-            foreach (string defaultValue in ConfigUtilities.GetPropertyValues(values))
+            foreach (string defaultValue in ConfigUtilities.EnumerateDimensionValues(values))
             {
                 // If this property is derived from another property, skip it and just
                 // pull default from next known values. This is better than picking a 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             }
             else
             {
-                return BuildUtilities.GetPropertyValues(propertyValue).ToImmutableArray();
+                return ConfigUtilities.GetPropertyValues(propertyValue).ToImmutableArray();
             }
 
             async Task<string?> GetPropertyValueAsync(UnconfiguredProject project)
@@ -162,11 +162,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                     {
                         case ConfigurationDimensionChange.Add:
                             return UpdateUnderLockAsync(args.Project, (msbuildProject, evaluatedPropertyValue) =>
-                                BuildUtilities.AppendPropertyValue(msbuildProject, evaluatedPropertyValue, PropertyName, args.DimensionValue));
+                                ConfigUtilities.AppendPropertyValue(msbuildProject, evaluatedPropertyValue, PropertyName, args.DimensionValue));
 
                         case ConfigurationDimensionChange.Delete:
                             return UpdateUnderLockAsync(args.Project, (msbuildProject, evaluatedPropertyValue) =>
-                                BuildUtilities.RemovePropertyValue(msbuildProject, evaluatedPropertyValue, PropertyName, args.DimensionValue));
+                                ConfigUtilities.RemovePropertyValue(msbuildProject, evaluatedPropertyValue, PropertyName, args.DimensionValue));
 
                         case ConfigurationDimensionChange.Rename:
                             // Need to wait until the core rename changes happen before renaming the property.
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                     if (args.Change == ConfigurationDimensionChange.Rename)
                     {
                         return UpdateUnderLockAsync(args.Project, (msbuildProject, evaluatedPropertyValue) =>
-                            BuildUtilities.RenamePropertyValue(msbuildProject, evaluatedPropertyValue, PropertyName, args.OldDimensionValue, args.DimensionValue));
+                            ConfigUtilities.RenamePropertyValue(msbuildProject, evaluatedPropertyValue, PropertyName, args.OldDimensionValue, args.DimensionValue));
                     }
                 }
             }
@@ -211,7 +211,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             if (Strings.IsNullOrEmpty(values))
                 return null;
 
-            foreach (string defaultValue in BuildUtilities.GetPropertyValues(values))
+            foreach (string defaultValue in ConfigUtilities.GetPropertyValues(values))
             {
                 // If this property is derived from another property, skip it and just
                 // pull default from next known values. This is better than picking a 
@@ -245,7 +245,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             return properties.Reverse()
                              .FirstOrDefault(
                                 p => StringComparers.PropertyNames.Equals(PropertyName, p.Name) &&
-                                BuildUtilities.HasWellKnownConditionsThatAlwaysEvaluateToTrue(p));
+                                ConfigUtilities.HasWellKnownConditionsThatAlwaysEvaluateToTrue(p));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ConfigUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ConfigUtilities.cs
@@ -8,7 +8,7 @@ using Microsoft.Build.Construction;
 using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.Text;
 
-namespace Microsoft.VisualStudio.Build
+namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 {
     /// <summary>
     /// Provides methods for manipulating configuration dimension properties and property values.
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.Build
                 {
                     if (seen == null)
                     {
-                        seen = new HashSet<string>(StringComparers.PropertyValues) { s };
+                        seen = new HashSet<string>(StringComparers.ConfigurationDimensionValues) { s };
                         yield return s;
                     }
                     else
@@ -123,12 +123,12 @@ namespace Microsoft.VisualStudio.Build
         /// <param name="project">Xml representation of the MsBuild project.</param>
         /// <param name="values">Original evaluated value of the property.</param>
         /// <param name="name">Property name.</param>
-        /// <param name="valuesToRemove">Value to remove from the property.</param>
+        /// <param name="valueToRemove">Value to remove from the property.</param>
         /// <remarks>
         /// If the property is not present it will be added. This means that the evaluated property
         /// value came from one of the project imports.
         /// </remarks>
-        public static void RemoveDimensionValue(ProjectRootElement project, string values, string name, string valuesToRemove)
+        public static void RemoveDimensionValue(ProjectRootElement project, string values, string name, string valueToRemove)
         {
             Requires.NotNull(project, nameof(project));
             Requires.NotNull(values, nameof(values));
@@ -139,7 +139,7 @@ namespace Microsoft.VisualStudio.Build
             bool valueFound = false;
             foreach (string value in EnumerateDimensionValues(values))
             {
-                if (!string.Equals(value, valuesToRemove, StringComparisons.PropertyValues))
+                if (!string.Equals(value, valueToRemove, StringComparisons.ConfigurationDimensionValues))
                 {
                     if (newValue.Length != 0)
                     {
@@ -158,7 +158,7 @@ namespace Microsoft.VisualStudio.Build
 
             if (!valueFound)
             {
-                throw new ArgumentException(string.Format(Resources.MsBuildMissingValueToRemove, valuesToRemove, name), nameof(valuesToRemove));
+                throw new ArgumentException(string.Format(Resources.MsBuildMissingValueToRemove, valueToRemove, name), nameof(valueToRemove));
             }
         }
 
@@ -190,7 +190,7 @@ namespace Microsoft.VisualStudio.Build
                     value.Append(Delimiter);
                 }
 
-                if (string.Equals(propertyValue, oldValue, StringComparisons.PropertyValues))
+                if (string.Equals(propertyValue, oldValue, StringComparisons.ConfigurationDimensionValues))
                 {
                     value.Append(newValue);
                     valueFound = true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ConfigUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ConfigUtilities.cs
@@ -11,9 +11,9 @@ using Microsoft.VisualStudio.Text;
 namespace Microsoft.VisualStudio.Build
 {
     /// <summary>
-    /// Utility class to manipulate MsBuild projects.
+    /// Provides methods for manipulating configuration dimension properties and property values.
     /// </summary>
-    internal static class BuildUtilities
+    internal static class ConfigUtilities
     {
         private const char Delimiter = ';';
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 return null;
             }
 
-            return ConfigUtilities.GetPropertyValues(targetFrameworks).ToList();
+            return ConfigUtilities.EnumerateDimensionValues(targetFrameworks).ToList();
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
@@ -5,7 +5,7 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.Build;
+using Microsoft.VisualStudio.ProjectSystem.Configuration;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 return null;
             }
 
-            return BuildUtilities.GetPropertyValues(targetFrameworks).ToList();
+            return ConfigUtilities.GetPropertyValues(targetFrameworks).ToList();
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
@@ -21,6 +21,7 @@ namespace Microsoft.VisualStudio
         public static StringComparer RuleNames => StringComparer.OrdinalIgnoreCase;
         public static StringComparer CategoryNames => StringComparer.OrdinalIgnoreCase;
         public static StringComparer ConfigurationDimensionNames => StringComparer.Ordinal;
+        public static StringComparer ConfigurationDimensionValues => StringComparer.Ordinal;
         public static StringComparer DependencyProviderTypes => StringComparer.OrdinalIgnoreCase;
         public static StringComparer DependencyTreeIds => StringComparer.OrdinalIgnoreCase;
         public static StringComparer ItemNames => StringComparer.OrdinalIgnoreCase;
@@ -57,6 +58,7 @@ namespace Microsoft.VisualStudio
         public static StringComparison PropertyValues => StringComparison.Ordinal;
         public static StringComparison RuleNames => StringComparison.OrdinalIgnoreCase;
         public static StringComparison ConfigurationDimensionNames => StringComparison.Ordinal;
+        public static StringComparison ConfigurationDimensionValues => StringComparison.Ordinal;
         public static StringComparison DependencyProviderTypes => StringComparison.OrdinalIgnoreCase;
         public static StringComparison DependencyTreeIds => StringComparison.OrdinalIgnoreCase;
         public static StringComparison ItemNames => StringComparison.OrdinalIgnoreCase;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigUtilitiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigUtilitiesTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.Build
     public class ConfigUtilitiesTests
     {
         [Fact]
-        public void GetProperty_MissingProperty()
+        public void GetDimension_MissingProperty()
         {
             string projectXml =
 @"<Project>
@@ -20,12 +20,12 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            var property = ConfigUtilities.GetProperty(project, "NonExistentProperty");
+            var property = ConfigUtilities.GetDimension(project, "NonExistentProperty");
             Assert.Null(property);
         }
 
         [Fact]
-        public void GetProperty_ExistentProperty()
+        public void GetDimension_ExistentProperty()
         {
             string projectXml =
 @"<Project>
@@ -35,58 +35,58 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            var property = ConfigUtilities.GetProperty(project, "MyProperty");
+            var property = ConfigUtilities.GetDimension(project, "MyProperty");
             Assert.NotNull(property);
         }
 
         [Fact]
-        public void GetPropertyValues_SingleValue()
+        public void EnumerateDimensionValues_SingleValue()
         {
-            var values = ConfigUtilities.GetPropertyValues("MyPropertyValue");
+            var values = ConfigUtilities.EnumerateDimensionValues("MyPropertyValue");
             Assert.Collection(values, firstValue => Assert.Equal("MyPropertyValue", firstValue));
         }
 
         [Fact]
-        public void GetPropertyValues_MultipleValues()
+        public void EnumerateDimensionValues_MultipleValues()
         {
-            var values = ConfigUtilities.GetPropertyValues("1;2");
+            var values = ConfigUtilities.EnumerateDimensionValues("1;2");
             Assert.Collection(values,
                 firstValue => Assert.Equal("1", firstValue),
                 secondValue => Assert.Equal("2", secondValue));
         }
 
         [Fact]
-        public void GetPropertyValues_EmptyValues()
+        public void EnumerateDimensionValues_EmptyValues()
         {
-            var values = ConfigUtilities.GetPropertyValues("1;   ;;;2");
+            var values = ConfigUtilities.EnumerateDimensionValues("1;   ;;;2");
             Assert.Collection(values,
                 firstValue => Assert.Equal("1", firstValue),
                 secondValue => Assert.Equal("2", secondValue));
         }
 
         [Fact]
-        public void GetPropertyValues_WhiteSpace()
+        public void EnumerateDimensionValues_WhiteSpace()
         {
-            var values = ConfigUtilities.GetPropertyValues("   1;   ; ; ; 2 ");
+            var values = ConfigUtilities.EnumerateDimensionValues("   1;   ; ; ; 2 ");
             Assert.Collection(values,
                 firstValue => Assert.Equal("1", firstValue),
                 secondValue => Assert.Equal("2", secondValue));
         }
 
         [Fact]
-        public void GetPropertyValues_Duplicates()
+        public void EnumerateDimensionValues_Duplicates()
         {
-            var values = ConfigUtilities.GetPropertyValues("1;2;1;1;2;2;2;1");
+            var values = ConfigUtilities.EnumerateDimensionValues("1;2;1;1;2;2;2;1");
             Assert.Collection(values,
                 firstValue => Assert.Equal("1", firstValue),
                 secondValue => Assert.Equal("2", secondValue));
         }
 
         [Fact]
-        public void GetOrAddProperty_NoGroups()
+        public void GetOrAddDimension_NoGroups()
         {
             var project = ProjectRootElementFactory.Create();
-            ConfigUtilities.GetOrAddProperty(project, "MyProperty");
+            ConfigUtilities.GetOrAddDimension(project, "MyProperty");
             Assert.Single(project.Properties);
             Assert.Collection(project.PropertyGroups,
                 group => Assert.Collection(group.Properties,
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.Build
         }
 
         [Fact]
-        public void GetOrAddProperty_FirstGroup()
+        public void GetOrAddDimension_FirstGroup()
         {
             string projectXml =
 @"<Project>
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            ConfigUtilities.GetOrAddProperty(project, "MyProperty");
+            ConfigUtilities.GetOrAddDimension(project, "MyProperty");
             Assert.Single(project.Properties);
             AssertEx.CollectionLength(project.PropertyGroups, 2);
 
@@ -115,7 +115,7 @@ namespace Microsoft.VisualStudio.Build
         }
 
         [Fact]
-        public void GetOrAddProperty_ExistingProperty()
+        public void GetOrAddDimension_ExistingProperty()
         {
             string projectXml =
 @"<Project>
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            ConfigUtilities.GetOrAddProperty(project, "MyProperty");
+            ConfigUtilities.GetOrAddDimension(project, "MyProperty");
             Assert.Single(project.Properties);
             Assert.Single(project.PropertyGroups);
 
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.Build
         }
 
         [Fact]
-        public void AppendPropertyValue_DefaultDelimiter()
+        public void AppendDimensionValue_DefaultDelimiter()
         {
             string projectXml =
 @"<Project>
@@ -147,14 +147,14 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            ConfigUtilities.AppendPropertyValue(project, "1;2", "MyProperty", "3");
-            var property = ConfigUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.AppendDimensionValue(project, "1;2", "MyProperty", "3");
+            var property = ConfigUtilities.GetDimension(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal("1;2;3", property!.Value);
         }
 
         [Fact]
-        public void AppendPropertyValue_EmptyProperty()
+        public void AppendDimensionValue_EmptyProperty()
         {
             string projectXml =
 @"<Project>
@@ -164,34 +164,34 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            ConfigUtilities.AppendPropertyValue(project, "", "MyProperty", "1");
-            var property = ConfigUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.AppendDimensionValue(project, "", "MyProperty", "1");
+            var property = ConfigUtilities.GetDimension(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal("1", property!.Value);
         }
 
         [Fact]
-        public void AppendPropertyValue_InheritedValue()
+        public void AppendDimensionValue_InheritedValue()
         {
             var project = ProjectRootElementFactory.Create();
-            ConfigUtilities.AppendPropertyValue(project, "1;2", "MyProperty", "3");
-            var property = ConfigUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.AppendDimensionValue(project, "1;2", "MyProperty", "3");
+            var property = ConfigUtilities.GetDimension(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal("1;2;3", property!.Value);
         }
 
         [Fact]
-        public void AppendPropertyValue_MissingProperty()
+        public void AppendDimensionValue_MissingProperty()
         {
             var project = ProjectRootElementFactory.Create();
-            ConfigUtilities.AppendPropertyValue(project, "", "MyProperty", "1");
-            var property = ConfigUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.AppendDimensionValue(project, "", "MyProperty", "1");
+            var property = ConfigUtilities.GetDimension(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal("1", property!.Value);
         }
 
         [Fact]
-        public void RemovePropertyValue_DefaultDelimiter()
+        public void RemoveDimensionValue_DefaultDelimiter()
         {
             string projectXml =
 @"<Project>
@@ -201,14 +201,14 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            ConfigUtilities.RemovePropertyValue(project, "1;2", "MyProperty", "2");
-            var property = ConfigUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.RemoveDimensionValue(project, "1;2", "MyProperty", "2");
+            var property = ConfigUtilities.GetDimension(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal("1", property!.Value);
         }
 
         [Fact]
-        public void RemovePropertyValue_EmptyAfterRemove()
+        public void RemoveDimensionValue_EmptyAfterRemove()
         {
             string projectXml =
 @"<Project>
@@ -218,34 +218,34 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            ConfigUtilities.RemovePropertyValue(project, "1", "MyProperty", "1");
-            var property = ConfigUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.RemoveDimensionValue(project, "1", "MyProperty", "1");
+            var property = ConfigUtilities.GetDimension(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal(string.Empty, property!.Value);
         }
 
         [Fact]
-        public void RemovePropertyValue_InheritedValue()
+        public void RemoveDimensionValue_InheritedValue()
         {
             var project = ProjectRootElementFactory.Create();
-            ConfigUtilities.RemovePropertyValue(project, "1;2", "MyProperty", "1");
-            var property = ConfigUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.RemoveDimensionValue(project, "1;2", "MyProperty", "1");
+            var property = ConfigUtilities.GetDimension(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal("2", property!.Value);
         }
 
         [Fact]
-        public void RemovePropertyValue_MissingProperty()
+        public void RemoveDimensionValue_MissingProperty()
         {
             var project = ProjectRootElementFactory.Create();
-            Assert.Throws<ArgumentException>("valueToRemove", () => ConfigUtilities.RemovePropertyValue(project, "", "MyProperty", "1"));
-            var property = ConfigUtilities.GetProperty(project, "MyProperty");
+            Assert.Throws<ArgumentException>("valueToRemove", () => ConfigUtilities.RemoveDimensionValue(project, "", "MyProperty", "1"));
+            var property = ConfigUtilities.GetDimension(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal(string.Empty, property!.Value);
         }
 
         [Fact]
-        public void RenamePropertyValue_DefaultDelimiter()
+        public void RenameDimensionValue_DefaultDelimiter()
         {
             string projectXml =
 @"<Project>
@@ -255,28 +255,28 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            ConfigUtilities.RenamePropertyValue(project, "1;2", "MyProperty", "2", "5");
-            var property = ConfigUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.RenameDimensionValue(project, "1;2", "MyProperty", "2", "5");
+            var property = ConfigUtilities.GetDimension(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal("1;5", property!.Value);
         }
 
         [Fact]
-        public void RenamePropertyValue_InheritedValue()
+        public void RenameDimensionValue_InheritedValue()
         {
             var project = ProjectRootElementFactory.Create();
-            ConfigUtilities.RenamePropertyValue(project, "1;2", "MyProperty", "1", "3");
-            var property = ConfigUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.RenameDimensionValue(project, "1;2", "MyProperty", "1", "3");
+            var property = ConfigUtilities.GetDimension(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal("3;2", property!.Value);
         }
 
         [Fact]
-        public void RenamePropertyValue_MissingProperty()
+        public void RenameDimensionValue_MissingProperty()
         {
             var project = ProjectRootElementFactory.Create();
-            Assert.Throws<ArgumentException>("oldValue", () => ConfigUtilities.RenamePropertyValue(project, "", "MyProperty", "1", "2"));
-            var property = ConfigUtilities.GetProperty(project, "MyProperty");
+            Assert.Throws<ArgumentException>("oldValue", () => ConfigUtilities.RenameDimensionValue(project, "", "MyProperty", "1", "2"));
+            var property = ConfigUtilities.GetDimension(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal(string.Empty, property!.Value);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigUtilitiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigUtilitiesTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.Build
 {
-    public class BuildUtilitiesTests
+    public class ConfigUtilitiesTests
     {
         [Fact]
         public void GetProperty_MissingProperty()
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            var property = BuildUtilities.GetProperty(project, "NonExistentProperty");
+            var property = ConfigUtilities.GetProperty(project, "NonExistentProperty");
             Assert.Null(property);
         }
 
@@ -35,21 +35,21 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            var property = BuildUtilities.GetProperty(project, "MyProperty");
+            var property = ConfigUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
         }
 
         [Fact]
         public void GetPropertyValues_SingleValue()
         {
-            var values = BuildUtilities.GetPropertyValues("MyPropertyValue");
+            var values = ConfigUtilities.GetPropertyValues("MyPropertyValue");
             Assert.Collection(values, firstValue => Assert.Equal("MyPropertyValue", firstValue));
         }
 
         [Fact]
         public void GetPropertyValues_MultipleValues()
         {
-            var values = BuildUtilities.GetPropertyValues("1;2");
+            var values = ConfigUtilities.GetPropertyValues("1;2");
             Assert.Collection(values,
                 firstValue => Assert.Equal("1", firstValue),
                 secondValue => Assert.Equal("2", secondValue));
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.Build
         [Fact]
         public void GetPropertyValues_EmptyValues()
         {
-            var values = BuildUtilities.GetPropertyValues("1;   ;;;2");
+            var values = ConfigUtilities.GetPropertyValues("1;   ;;;2");
             Assert.Collection(values,
                 firstValue => Assert.Equal("1", firstValue),
                 secondValue => Assert.Equal("2", secondValue));
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.Build
         [Fact]
         public void GetPropertyValues_WhiteSpace()
         {
-            var values = BuildUtilities.GetPropertyValues("   1;   ; ; ; 2 ");
+            var values = ConfigUtilities.GetPropertyValues("   1;   ; ; ; 2 ");
             Assert.Collection(values,
                 firstValue => Assert.Equal("1", firstValue),
                 secondValue => Assert.Equal("2", secondValue));
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.Build
         [Fact]
         public void GetPropertyValues_Duplicates()
         {
-            var values = BuildUtilities.GetPropertyValues("1;2;1;1;2;2;2;1");
+            var values = ConfigUtilities.GetPropertyValues("1;2;1;1;2;2;2;1");
             Assert.Collection(values,
                 firstValue => Assert.Equal("1", firstValue),
                 secondValue => Assert.Equal("2", secondValue));
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.Build
         public void GetOrAddProperty_NoGroups()
         {
             var project = ProjectRootElementFactory.Create();
-            BuildUtilities.GetOrAddProperty(project, "MyProperty");
+            ConfigUtilities.GetOrAddProperty(project, "MyProperty");
             Assert.Single(project.Properties);
             Assert.Collection(project.PropertyGroups,
                 group => Assert.Collection(group.Properties,
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            BuildUtilities.GetOrAddProperty(project, "MyProperty");
+            ConfigUtilities.GetOrAddProperty(project, "MyProperty");
             Assert.Single(project.Properties);
             AssertEx.CollectionLength(project.PropertyGroups, 2);
 
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            BuildUtilities.GetOrAddProperty(project, "MyProperty");
+            ConfigUtilities.GetOrAddProperty(project, "MyProperty");
             Assert.Single(project.Properties);
             Assert.Single(project.PropertyGroups);
 
@@ -147,8 +147,8 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            BuildUtilities.AppendPropertyValue(project, "1;2", "MyProperty", "3");
-            var property = BuildUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.AppendPropertyValue(project, "1;2", "MyProperty", "3");
+            var property = ConfigUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal("1;2;3", property!.Value);
         }
@@ -164,8 +164,8 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            BuildUtilities.AppendPropertyValue(project, "", "MyProperty", "1");
-            var property = BuildUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.AppendPropertyValue(project, "", "MyProperty", "1");
+            var property = ConfigUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal("1", property!.Value);
         }
@@ -174,8 +174,8 @@ namespace Microsoft.VisualStudio.Build
         public void AppendPropertyValue_InheritedValue()
         {
             var project = ProjectRootElementFactory.Create();
-            BuildUtilities.AppendPropertyValue(project, "1;2", "MyProperty", "3");
-            var property = BuildUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.AppendPropertyValue(project, "1;2", "MyProperty", "3");
+            var property = ConfigUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal("1;2;3", property!.Value);
         }
@@ -184,8 +184,8 @@ namespace Microsoft.VisualStudio.Build
         public void AppendPropertyValue_MissingProperty()
         {
             var project = ProjectRootElementFactory.Create();
-            BuildUtilities.AppendPropertyValue(project, "", "MyProperty", "1");
-            var property = BuildUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.AppendPropertyValue(project, "", "MyProperty", "1");
+            var property = ConfigUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal("1", property!.Value);
         }
@@ -201,8 +201,8 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            BuildUtilities.RemovePropertyValue(project, "1;2", "MyProperty", "2");
-            var property = BuildUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.RemovePropertyValue(project, "1;2", "MyProperty", "2");
+            var property = ConfigUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal("1", property!.Value);
         }
@@ -218,8 +218,8 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            BuildUtilities.RemovePropertyValue(project, "1", "MyProperty", "1");
-            var property = BuildUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.RemovePropertyValue(project, "1", "MyProperty", "1");
+            var property = ConfigUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal(string.Empty, property!.Value);
         }
@@ -228,8 +228,8 @@ namespace Microsoft.VisualStudio.Build
         public void RemovePropertyValue_InheritedValue()
         {
             var project = ProjectRootElementFactory.Create();
-            BuildUtilities.RemovePropertyValue(project, "1;2", "MyProperty", "1");
-            var property = BuildUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.RemovePropertyValue(project, "1;2", "MyProperty", "1");
+            var property = ConfigUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal("2", property!.Value);
         }
@@ -238,8 +238,8 @@ namespace Microsoft.VisualStudio.Build
         public void RemovePropertyValue_MissingProperty()
         {
             var project = ProjectRootElementFactory.Create();
-            Assert.Throws<ArgumentException>("valueToRemove", () => BuildUtilities.RemovePropertyValue(project, "", "MyProperty", "1"));
-            var property = BuildUtilities.GetProperty(project, "MyProperty");
+            Assert.Throws<ArgumentException>("valueToRemove", () => ConfigUtilities.RemovePropertyValue(project, "", "MyProperty", "1"));
+            var property = ConfigUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal(string.Empty, property!.Value);
         }
@@ -255,8 +255,8 @@ namespace Microsoft.VisualStudio.Build
 </Project>";
 
             var project = ProjectRootElementFactory.Create(projectXml);
-            BuildUtilities.RenamePropertyValue(project, "1;2", "MyProperty", "2", "5");
-            var property = BuildUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.RenamePropertyValue(project, "1;2", "MyProperty", "2", "5");
+            var property = ConfigUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal("1;5", property!.Value);
         }
@@ -265,8 +265,8 @@ namespace Microsoft.VisualStudio.Build
         public void RenamePropertyValue_InheritedValue()
         {
             var project = ProjectRootElementFactory.Create();
-            BuildUtilities.RenamePropertyValue(project, "1;2", "MyProperty", "1", "3");
-            var property = BuildUtilities.GetProperty(project, "MyProperty");
+            ConfigUtilities.RenamePropertyValue(project, "1;2", "MyProperty", "1", "3");
+            var property = ConfigUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal("3;2", property!.Value);
         }
@@ -275,8 +275,8 @@ namespace Microsoft.VisualStudio.Build
         public void RenamePropertyValue_MissingProperty()
         {
             var project = ProjectRootElementFactory.Create();
-            Assert.Throws<ArgumentException>("oldValue", () => BuildUtilities.RenamePropertyValue(project, "", "MyProperty", "1", "2"));
-            var property = BuildUtilities.GetProperty(project, "MyProperty");
+            Assert.Throws<ArgumentException>("oldValue", () => ConfigUtilities.RenamePropertyValue(project, "", "MyProperty", "1", "2"));
+            var property = ConfigUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
             Assert.Equal(string.Empty, property!.Value);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigUtilitiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigUtilitiesTests.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using Microsoft.Build.Construction;
 using Xunit;
 
-namespace Microsoft.VisualStudio.Build
+namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 {
     public class ConfigUtilitiesTests
     {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ProjectConfigurationDimensionProviderTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ProjectConfigurationDimensionProviderTestBase.cs
@@ -135,7 +135,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                 DimensionName,
                 "Added");
             await provider.OnDimensionValueChangedAsync(args);
-            var property = BuildUtilities.GetProperty(rootElement, PropertyName);
+            var property = ConfigUtilities.GetProperty(rootElement, PropertyName);
             Assert.NotNull(property);
             Assert.Equal("A;B;C", property!.Value);
 
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                 DimensionName,
                 "Added");
             await provider.OnDimensionValueChangedAsync(args);
-            property = BuildUtilities.GetProperty(rootElement, PropertyName);
+            property = ConfigUtilities.GetProperty(rootElement, PropertyName);
             Assert.NotNull(property);
             Assert.Equal("A;B;C;Added", property!.Value);
         }
@@ -176,7 +176,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                 DimensionName,
                 "B");
             await provider.OnDimensionValueChangedAsync(args);
-            var property = BuildUtilities.GetProperty(rootElement, PropertyName);
+            var property = ConfigUtilities.GetProperty(rootElement, PropertyName);
             Assert.NotNull(property);
             Assert.Equal("A;B;C", property!.Value);
 
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                 DimensionName,
                 "B");
             await provider.OnDimensionValueChangedAsync(args);
-            property = BuildUtilities.GetProperty(rootElement, PropertyName);
+            property = ConfigUtilities.GetProperty(rootElement, PropertyName);
             Assert.NotNull(property);
             Assert.Equal("A;C", property!.Value);
         }
@@ -216,7 +216,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                 DimensionName,
                 "Unknown");
             await Assert.ThrowsAsync<ArgumentException>(() => provider.OnDimensionValueChangedAsync(args));
-            var property = BuildUtilities.GetProperty(rootElement, PropertyName);
+            var property = ConfigUtilities.GetProperty(rootElement, PropertyName);
             Assert.NotNull(property);
             Assert.Equal("A;B;C", property!.Value);
         }
@@ -246,7 +246,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                 "Renamed",
                 "B");
             await provider.OnDimensionValueChangedAsync(args);
-            var property = BuildUtilities.GetProperty(rootElement, PropertyName);
+            var property = ConfigUtilities.GetProperty(rootElement, PropertyName);
             Assert.NotNull(property);
             Assert.Equal("A;B;C", property!.Value);
 
@@ -259,7 +259,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                 "Renamed",
                 "B");
             await provider.OnDimensionValueChangedAsync(args);
-            property = BuildUtilities.GetProperty(rootElement, PropertyName);
+            property = ConfigUtilities.GetProperty(rootElement, PropertyName);
             Assert.NotNull(property);
             Assert.Equal("A;Renamed;C", property!.Value);
         }
@@ -288,7 +288,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                 "Renamed",
                 "Unknown");
             await Assert.ThrowsAsync<ArgumentException>(() => provider.OnDimensionValueChangedAsync(args));
-            var property = BuildUtilities.GetProperty(rootElement, PropertyName);
+            var property = ConfigUtilities.GetProperty(rootElement, PropertyName);
             Assert.NotNull(property);
             Assert.Equal("A;B;C", property!.Value);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ProjectConfigurationDimensionProviderTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ProjectConfigurationDimensionProviderTestBase.cs
@@ -135,7 +135,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                 DimensionName,
                 "Added");
             await provider.OnDimensionValueChangedAsync(args);
-            var property = ConfigUtilities.GetProperty(rootElement, PropertyName);
+            var property = ConfigUtilities.GetDimension(rootElement, PropertyName);
             Assert.NotNull(property);
             Assert.Equal("A;B;C", property!.Value);
 
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                 DimensionName,
                 "Added");
             await provider.OnDimensionValueChangedAsync(args);
-            property = ConfigUtilities.GetProperty(rootElement, PropertyName);
+            property = ConfigUtilities.GetDimension(rootElement, PropertyName);
             Assert.NotNull(property);
             Assert.Equal("A;B;C;Added", property!.Value);
         }
@@ -176,7 +176,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                 DimensionName,
                 "B");
             await provider.OnDimensionValueChangedAsync(args);
-            var property = ConfigUtilities.GetProperty(rootElement, PropertyName);
+            var property = ConfigUtilities.GetDimension(rootElement, PropertyName);
             Assert.NotNull(property);
             Assert.Equal("A;B;C", property!.Value);
 
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                 DimensionName,
                 "B");
             await provider.OnDimensionValueChangedAsync(args);
-            property = ConfigUtilities.GetProperty(rootElement, PropertyName);
+            property = ConfigUtilities.GetDimension(rootElement, PropertyName);
             Assert.NotNull(property);
             Assert.Equal("A;C", property!.Value);
         }
@@ -216,7 +216,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                 DimensionName,
                 "Unknown");
             await Assert.ThrowsAsync<ArgumentException>(() => provider.OnDimensionValueChangedAsync(args));
-            var property = ConfigUtilities.GetProperty(rootElement, PropertyName);
+            var property = ConfigUtilities.GetDimension(rootElement, PropertyName);
             Assert.NotNull(property);
             Assert.Equal("A;B;C", property!.Value);
         }
@@ -246,7 +246,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                 "Renamed",
                 "B");
             await provider.OnDimensionValueChangedAsync(args);
-            var property = ConfigUtilities.GetProperty(rootElement, PropertyName);
+            var property = ConfigUtilities.GetDimension(rootElement, PropertyName);
             Assert.NotNull(property);
             Assert.Equal("A;B;C", property!.Value);
 
@@ -259,7 +259,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                 "Renamed",
                 "B");
             await provider.OnDimensionValueChangedAsync(args);
-            property = ConfigUtilities.GetProperty(rootElement, PropertyName);
+            property = ConfigUtilities.GetDimension(rootElement, PropertyName);
             Assert.NotNull(property);
             Assert.Equal("A;Renamed;C", property!.Value);
         }
@@ -288,7 +288,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                 "Renamed",
                 "Unknown");
             await Assert.ThrowsAsync<ArgumentException>(() => provider.OnDimensionValueChangedAsync(args));
-            var property = ConfigUtilities.GetProperty(rootElement, PropertyName);
+            var property = ConfigUtilities.GetDimension(rootElement, PropertyName);
             Assert.NotNull(property);
             Assert.Equal("A;B;C", property!.Value);
         }


### PR DESCRIPTION
BuildUtilities is only used by the configuration layer. In preparation for adding support for implicit configuration syntax (used by legacy) refactor and move this to configuration namespace. 

This contains no behavior changes, however, future changes will including the string comparison we use to find names & values.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6751)