### PR TITLE
Temporarily save property values

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationManifestKindValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationManifestKindValueProvider.cs
@@ -76,22 +76,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             if (string.Equals(unevaluatedPropertyValue, DefaultManifestValue, StringComparison.InvariantCultureIgnoreCase))
             {
-                await SaveCurrentApplicationManifestValueAsync(defaultProperties);
-
+                await defaultProperties.RememberValueIfCurrentlySet(ApplicationManifestMSBuildProperty, _temporaryPropertyStorage);
                 await defaultProperties.DeletePropertyAsync(ApplicationManifestMSBuildProperty);
                 await defaultProperties.DeletePropertyAsync(NoManifestMSBuildProperty);
             }
             else if (string.Equals(unevaluatedPropertyValue, NoManifestValue, StringComparison.InvariantCultureIgnoreCase))
             {
-                await SaveCurrentApplicationManifestValueAsync(defaultProperties);
-
+                await defaultProperties.RememberValueIfCurrentlySet(ApplicationManifestMSBuildProperty, _temporaryPropertyStorage);
                 await defaultProperties.DeletePropertyAsync(ApplicationManifestMSBuildProperty);
                 await defaultProperties.SetPropertyValueAsync(NoManifestMSBuildProperty, "true");
             }
             else if (string.Equals(unevaluatedPropertyValue, CustomManifestValue, StringComparison.InvariantCultureIgnoreCase))
             {
-                await RestoreApplicationManifestValueAsync(defaultProperties);
-
+                await defaultProperties.RestoreValueIfNotCurrentlySet(ApplicationManifestMSBuildProperty, _temporaryPropertyStorage);
                 await defaultProperties.DeletePropertyAsync(NoManifestMSBuildProperty);
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationManifestKindValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationManifestKindValueProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
@@ -56,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             }
 
             string noManifestPropertyValue = await defaultProperties.GetEvaluatedPropertyValueAsync(NoManifestMSBuildProperty);
-            if (noManifestPropertyValue?.Equals("true", StringComparison.InvariantCultureIgnoreCase) == true)
+            if (StringComparers.PropertyLiteralValues.Equals(noManifestPropertyValue, "true"))
             {
                 return NoManifestValue;
             }
@@ -74,52 +73,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             IProjectProperties defaultProperties,
             IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
-            if (string.Equals(unevaluatedPropertyValue, DefaultManifestValue, StringComparison.InvariantCultureIgnoreCase))
+            if (StringComparers.PropertyLiteralValues.Equals(unevaluatedPropertyValue, DefaultManifestValue))
             {
-                await defaultProperties.RememberValueIfCurrentlySet(ApplicationManifestMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.SaveValueIfCurrentlySetAsync(ApplicationManifestMSBuildProperty, _temporaryPropertyStorage);
                 await defaultProperties.DeletePropertyAsync(ApplicationManifestMSBuildProperty);
                 await defaultProperties.DeletePropertyAsync(NoManifestMSBuildProperty);
             }
-            else if (string.Equals(unevaluatedPropertyValue, NoManifestValue, StringComparison.InvariantCultureIgnoreCase))
+            else if (StringComparers.PropertyLiteralValues.Equals(unevaluatedPropertyValue, NoManifestValue))
             {
-                await defaultProperties.RememberValueIfCurrentlySet(ApplicationManifestMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.SaveValueIfCurrentlySetAsync(ApplicationManifestMSBuildProperty, _temporaryPropertyStorage);
                 await defaultProperties.DeletePropertyAsync(ApplicationManifestMSBuildProperty);
                 await defaultProperties.SetPropertyValueAsync(NoManifestMSBuildProperty, "true");
             }
-            else if (string.Equals(unevaluatedPropertyValue, CustomManifestValue, StringComparison.InvariantCultureIgnoreCase))
+            else if (StringComparers.PropertyLiteralValues.Equals(unevaluatedPropertyValue, CustomManifestValue))
             {
-                await defaultProperties.RestoreValueIfNotCurrentlySet(ApplicationManifestMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.RestoreValueIfNotCurrentlySetAsync(ApplicationManifestMSBuildProperty, _temporaryPropertyStorage);
                 await defaultProperties.DeletePropertyAsync(NoManifestMSBuildProperty);
             }
 
             // We don't want to store a value for this so return null.
             return null;
-        }
-
-        /// <summary>
-        /// Save the current value of the "ApplicationManifest" MSBuild property, if any.
-        /// </summary>
-        private async Task SaveCurrentApplicationManifestValueAsync(IProjectProperties defaultProperties)
-        {
-            string? currentApplicationManifestPropertyValue = await defaultProperties.GetUnevaluatedPropertyValueAsync(ApplicationManifestMSBuildProperty);
-            if (!string.IsNullOrEmpty(currentApplicationManifestPropertyValue))
-            {
-                _temporaryPropertyStorage.AddOrUpdatePropertyValue(ApplicationManifestMSBuildProperty, currentApplicationManifestPropertyValue!);
-            }
-        }
-
-        /// <summary>
-        /// If the "ApplicationManifest" MSBuild property does not currently have a value
-        /// then restore the previously saved value, if any.
-        /// </summary>
-        private async Task RestoreApplicationManifestValueAsync(IProjectProperties defaultProperties)
-        {
-            string? currentApplicationManifestPropertyValue = await defaultProperties.GetUnevaluatedPropertyValueAsync(ApplicationManifestMSBuildProperty);
-            if (string.IsNullOrEmpty(currentApplicationManifestPropertyValue)
-                && _temporaryPropertyStorage.GetPropertyValue(ApplicationManifestMSBuildProperty) is string previousValue)
-            {
-                await defaultProperties.SetPropertyValueAsync(ApplicationManifestMSBuildProperty, previousValue);
-            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ResourceSpecificationKindValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ResourceSpecificationKindValueProvider.cs
@@ -25,20 +25,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
-            if (unevaluatedPropertyValue == IconAndManifestValue)
+            if (StringComparers.PropertyLiteralValues.Equals(unevaluatedPropertyValue, IconAndManifestValue))
             {
-                await defaultProperties.RememberValueIfCurrentlySet(Win32ResourceMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.SaveValueIfCurrentlySetAsync(Win32ResourceMSBuildProperty, _temporaryPropertyStorage);
                 await defaultProperties.DeletePropertyAsync(Win32ResourceMSBuildProperty);
-                await defaultProperties.RestoreValueIfNotCurrentlySet(ApplicationIconMSBuildProperty, _temporaryPropertyStorage);
-                await defaultProperties.RestoreValueIfNotCurrentlySet(ApplicationManifestMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.RestoreValueIfNotCurrentlySetAsync(ApplicationIconMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.RestoreValueIfNotCurrentlySetAsync(ApplicationManifestMSBuildProperty, _temporaryPropertyStorage);
             }
-            else if (unevaluatedPropertyValue == ResourceFileValue)
+            else if (StringComparers.PropertyLiteralValues.Equals(unevaluatedPropertyValue, ResourceFileValue))
             {
-                await defaultProperties.RememberValueIfCurrentlySet(ApplicationIconMSBuildProperty, _temporaryPropertyStorage);
-                await defaultProperties.RememberValueIfCurrentlySet(ApplicationManifestMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.SaveValueIfCurrentlySetAsync(ApplicationIconMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.SaveValueIfCurrentlySetAsync(ApplicationManifestMSBuildProperty, _temporaryPropertyStorage);
                 await defaultProperties.DeletePropertyAsync(ApplicationIconMSBuildProperty);
                 await defaultProperties.DeletePropertyAsync(ApplicationManifestMSBuildProperty);
-                await defaultProperties.RestoreValueIfNotCurrentlySet(Win32ResourceMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.RestoreValueIfNotCurrentlySetAsync(Win32ResourceMSBuildProperty, _temporaryPropertyStorage);
             }
 
             return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ResourceSpecificationKindValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ResourceSpecificationKindValueProvider.cs
@@ -9,9 +9,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [ExportInterceptingPropertyValueProvider("ResourceSpecificationKind", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     internal sealed class ResourceSpecificationKindValueProvider : InterceptingPropertyValueProviderBase
     {
-        // TODO should the rule file generate property and enum value constants that we can use here instead of these string literals?
-
         private readonly ITemporaryPropertyStorage _temporaryPropertyStorage;
+
+        private const string Win32ResourceMSBuildProperty = "Win32Resource";
+        private const string ApplicationIconMSBuildProperty = "ApplicationIcon";
+        private const string ApplicationManifestMSBuildProperty = "ApplicationManifest";
+        private const string IconAndManifestValue = "IconAndManifest";
+        private const string ResourceFileValue = "ResourceFile";
 
         [ImportingConstructor]
         public ResourceSpecificationKindValueProvider(ITemporaryPropertyStorage temporaryPropertyStorage)
@@ -21,20 +25,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
-            if (unevaluatedPropertyValue == "IconAndManifest")
+            if (unevaluatedPropertyValue == IconAndManifestValue)
             {
-                await defaultProperties.RememberValueIfCurrentlySet("Win32Resource", _temporaryPropertyStorage);
-                await defaultProperties.DeletePropertyAsync("Win32Resource");
-                await defaultProperties.RestoreValueIfNotCurrentlySet("ApplicationIcon", _temporaryPropertyStorage);
-                await defaultProperties.RestoreValueIfNotCurrentlySet("ApplicationManifest", _temporaryPropertyStorage);
+                await defaultProperties.RememberValueIfCurrentlySet(Win32ResourceMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.DeletePropertyAsync(Win32ResourceMSBuildProperty);
+                await defaultProperties.RestoreValueIfNotCurrentlySet(ApplicationIconMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.RestoreValueIfNotCurrentlySet(ApplicationManifestMSBuildProperty, _temporaryPropertyStorage);
             }
-            else if (unevaluatedPropertyValue == "ResourceFile")
+            else if (unevaluatedPropertyValue == ResourceFileValue)
             {
-                await defaultProperties.RememberValueIfCurrentlySet("ApplicationIcon", _temporaryPropertyStorage);
-                await defaultProperties.RememberValueIfCurrentlySet("ApplicationManifest", _temporaryPropertyStorage);
-                await defaultProperties.DeletePropertyAsync("ApplicationIcon");
-                await defaultProperties.DeletePropertyAsync("ApplicationManifest");
-                await defaultProperties.RestoreValueIfNotCurrentlySet("Win32Resource", _temporaryPropertyStorage);
+                await defaultProperties.RememberValueIfCurrentlySet(ApplicationIconMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.RememberValueIfCurrentlySet(ApplicationManifestMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.DeletePropertyAsync(ApplicationIconMSBuildProperty);
+                await defaultProperties.DeletePropertyAsync(ApplicationManifestMSBuildProperty);
+                await defaultProperties.RestoreValueIfNotCurrentlySet(Win32ResourceMSBuildProperty, _temporaryPropertyStorage);
             }
 
             return null;
@@ -42,21 +46,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            string win32Resource = await defaultProperties.GetEvaluatedPropertyValueAsync("Win32Resource");
+            string win32Resource = await defaultProperties.GetEvaluatedPropertyValueAsync(Win32ResourceMSBuildProperty);
 
             return ComputeValue(win32Resource);
         }
 
         public override async Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            string? win32Resource = await defaultProperties.GetUnevaluatedPropertyValueAsync("Win32Resource");
+            string? win32Resource = await defaultProperties.GetUnevaluatedPropertyValueAsync(Win32ResourceMSBuildProperty);
 
             return ComputeValue(win32Resource);
         }
 
         private static string ComputeValue(string? win32Resource)
         {
-            return string.IsNullOrEmpty(win32Resource) ? "IconAndManifest" : "ResourceFile";
+            return string.IsNullOrEmpty(win32Resource) ? IconAndManifestValue : ResourceFileValue;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/GenerateDocumentationFileValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/GenerateDocumentationFileValueProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
+using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
@@ -8,13 +9,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [ExportInterceptingPropertyValueProvider("GenerateDocumentationFile", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     internal sealed class GenerateDocumentationFileValueProvider : InterceptingPropertyValueProviderBase
     {
+        private readonly ITemporaryPropertyStorage _temporaryPropertyStorage;
+
+        [ImportingConstructor]
+        public GenerateDocumentationFileValueProvider(ITemporaryPropertyStorage temporaryPropertyStorage)
+        {
+            _temporaryPropertyStorage = temporaryPropertyStorage;
+        }
+
         public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
             if (bool.TryParse(unevaluatedPropertyValue, out bool value))
             {
                 if (!value)
                 {
+                    await defaultProperties.RememberValueIfCurrentlySet("DocumentationFile", _temporaryPropertyStorage);
                     await defaultProperties.DeletePropertyAsync("DocumentationFile");
+                }
+                else
+                {
+                    await defaultProperties.RestoreValueIfNotCurrentlySet("DocumentationFile", _temporaryPropertyStorage);
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/GenerateDocumentationFileValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/GenerateDocumentationFileValueProvider.cs
@@ -25,12 +25,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             {
                 if (!value)
                 {
-                    await defaultProperties.RememberValueIfCurrentlySet(DocumentationFileMSBuildProperty, _temporaryPropertyStorage);
+                    await defaultProperties.SaveValueIfCurrentlySetAsync(DocumentationFileMSBuildProperty, _temporaryPropertyStorage);
                     await defaultProperties.DeletePropertyAsync(DocumentationFileMSBuildProperty);
                 }
                 else
                 {
-                    await defaultProperties.RestoreValueIfNotCurrentlySet(DocumentationFileMSBuildProperty, _temporaryPropertyStorage);
+                    await defaultProperties.RestoreValueIfNotCurrentlySetAsync(DocumentationFileMSBuildProperty, _temporaryPropertyStorage);
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/GenerateDocumentationFileValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/GenerateDocumentationFileValueProvider.cs
@@ -11,6 +11,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     {
         private readonly ITemporaryPropertyStorage _temporaryPropertyStorage;
 
+        private const string DocumentationFileMSBuildProperty = "DocumentationFile";
+
         [ImportingConstructor]
         public GenerateDocumentationFileValueProvider(ITemporaryPropertyStorage temporaryPropertyStorage)
         {
@@ -23,12 +25,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             {
                 if (!value)
                 {
-                    await defaultProperties.RememberValueIfCurrentlySet("DocumentationFile", _temporaryPropertyStorage);
-                    await defaultProperties.DeletePropertyAsync("DocumentationFile");
+                    await defaultProperties.RememberValueIfCurrentlySet(DocumentationFileMSBuildProperty, _temporaryPropertyStorage);
+                    await defaultProperties.DeletePropertyAsync(DocumentationFileMSBuildProperty);
                 }
                 else
                 {
-                    await defaultProperties.RestoreValueIfNotCurrentlySet("DocumentationFile", _temporaryPropertyStorage);
+                    await defaultProperties.RestoreValueIfNotCurrentlySet(DocumentationFileMSBuildProperty, _temporaryPropertyStorage);
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/PackageLicenseKindValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/PackageLicenseKindValueProvider.cs
@@ -27,25 +27,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
-            if (unevaluatedPropertyValue == ExpressionValue)
+            if (StringComparers.PropertyLiteralValues.Equals(unevaluatedPropertyValue, ExpressionValue))
             {
-                await defaultProperties.RememberValueIfCurrentlySet(PackageLicenseFileMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.SaveValueIfCurrentlySetAsync(PackageLicenseFileMSBuildProperty, _temporaryPropertyStorage);
                 await defaultProperties.DeletePropertyAsync(PackageLicenseFileMSBuildProperty);
-                await defaultProperties.RestoreValueIfNotCurrentlySet(PackageLicenseExpressionMSBuildProperty, _temporaryPropertyStorage);
-                await defaultProperties.RestoreValueIfNotCurrentlySet(PackageRequireLicenseAcceptanceMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.RestoreValueIfNotCurrentlySetAsync(PackageLicenseExpressionMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.RestoreValueIfNotCurrentlySetAsync(PackageRequireLicenseAcceptanceMSBuildProperty, _temporaryPropertyStorage);
             }
-            else if (unevaluatedPropertyValue == FileValue)
+            else if (StringComparers.PropertyLiteralValues.Equals(unevaluatedPropertyValue, FileValue))
             {
-                await defaultProperties.RememberValueIfCurrentlySet(PackageLicenseExpressionMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.SaveValueIfCurrentlySetAsync(PackageLicenseExpressionMSBuildProperty, _temporaryPropertyStorage);
                 await defaultProperties.DeletePropertyAsync(PackageLicenseExpressionMSBuildProperty);
-                await defaultProperties.RestoreValueIfNotCurrentlySet(PackageLicenseFileMSBuildProperty, _temporaryPropertyStorage);
-                await defaultProperties.RestoreValueIfNotCurrentlySet(PackageRequireLicenseAcceptanceMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.RestoreValueIfNotCurrentlySetAsync(PackageLicenseFileMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.RestoreValueIfNotCurrentlySetAsync(PackageRequireLicenseAcceptanceMSBuildProperty, _temporaryPropertyStorage);
             }
-            else if (unevaluatedPropertyValue == NoneValue)
+            else if (StringComparers.PropertyLiteralValues.Equals(unevaluatedPropertyValue, NoneValue))
             {
-                await defaultProperties.RememberValueIfCurrentlySet(PackageLicenseFileMSBuildProperty, _temporaryPropertyStorage);
-                await defaultProperties.RememberValueIfCurrentlySet(PackageLicenseExpressionMSBuildProperty, _temporaryPropertyStorage);
-                await defaultProperties.RememberValueIfCurrentlySet(PackageRequireLicenseAcceptanceMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.SaveValueIfCurrentlySetAsync(PackageLicenseFileMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.SaveValueIfCurrentlySetAsync(PackageLicenseExpressionMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.SaveValueIfCurrentlySetAsync(PackageRequireLicenseAcceptanceMSBuildProperty, _temporaryPropertyStorage);
                 await defaultProperties.DeletePropertyAsync(PackageLicenseFileMSBuildProperty);
                 await defaultProperties.DeletePropertyAsync(PackageLicenseExpressionMSBuildProperty);
                 await defaultProperties.DeletePropertyAsync(PackageRequireLicenseAcceptanceMSBuildProperty);
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             if (!string.IsNullOrEmpty(await getValue(PackageLicenseFileMSBuildProperty)))
             {
-                return "File";
+                return FileValue;
             }
                 
             return NoneValue;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/PackageLicenseKindValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/PackageLicenseKindValueProvider.cs
@@ -12,7 +12,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     {
         private readonly ITemporaryPropertyStorage _temporaryPropertyStorage;
 
-        // TODO should the rule file generate property and enum value constants that we can use here instead of these string literals?
+        private const string PackageLicenseFileMSBuildProperty = "PackageLicenseFile";
+        private const string PackageLicenseExpressionMSBuildProperty = "PackageLicenseExpression";
+        private const string PackageRequireLicenseAcceptanceMSBuildProperty = "PackageRequireLicenseAcceptance";
+        private const string ExpressionValue = "Expression";
+        private const string FileValue = "File";
+        private const string NoneValue = "None";
 
         [ImportingConstructor]
         public PackageLicenseKindValueProvider(ITemporaryPropertyStorage temporaryPropertyStorage)
@@ -22,28 +27,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
-            if (unevaluatedPropertyValue == "Expression")
+            if (unevaluatedPropertyValue == ExpressionValue)
             {
-                await defaultProperties.RememberValueIfCurrentlySet("PackageLicenseFile", _temporaryPropertyStorage);
-                await defaultProperties.DeletePropertyAsync("PackageLicenseFile");
-                await defaultProperties.RestoreValueIfNotCurrentlySet("PackageLicenseExpression", _temporaryPropertyStorage);
-                await defaultProperties.RestoreValueIfNotCurrentlySet("PackageRequireLicenseAcceptance", _temporaryPropertyStorage);
+                await defaultProperties.RememberValueIfCurrentlySet(PackageLicenseFileMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.DeletePropertyAsync(PackageLicenseFileMSBuildProperty);
+                await defaultProperties.RestoreValueIfNotCurrentlySet(PackageLicenseExpressionMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.RestoreValueIfNotCurrentlySet(PackageRequireLicenseAcceptanceMSBuildProperty, _temporaryPropertyStorage);
             }
-            else if (unevaluatedPropertyValue == "File")
+            else if (unevaluatedPropertyValue == FileValue)
             {
-                await defaultProperties.RememberValueIfCurrentlySet("PackageLicenseExpression", _temporaryPropertyStorage);
-                await defaultProperties.DeletePropertyAsync("PackageLicenseExpression");
-                await defaultProperties.RestoreValueIfNotCurrentlySet("PackageLicenseFile", _temporaryPropertyStorage);
-                await defaultProperties.RestoreValueIfNotCurrentlySet("PackageRequireLicenseAcceptance", _temporaryPropertyStorage);
+                await defaultProperties.RememberValueIfCurrentlySet(PackageLicenseExpressionMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.DeletePropertyAsync(PackageLicenseExpressionMSBuildProperty);
+                await defaultProperties.RestoreValueIfNotCurrentlySet(PackageLicenseFileMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.RestoreValueIfNotCurrentlySet(PackageRequireLicenseAcceptanceMSBuildProperty, _temporaryPropertyStorage);
             }
-            else if (unevaluatedPropertyValue == "None")
+            else if (unevaluatedPropertyValue == NoneValue)
             {
-                await defaultProperties.RememberValueIfCurrentlySet("PackageLicenseFile", _temporaryPropertyStorage);
-                await defaultProperties.RememberValueIfCurrentlySet("PackageLicenseExpression", _temporaryPropertyStorage);
-                await defaultProperties.RememberValueIfCurrentlySet("PackageRequireLicenseAcceptance", _temporaryPropertyStorage);
-                await defaultProperties.DeletePropertyAsync("PackageLicenseFile");
-                await defaultProperties.DeletePropertyAsync("PackageLicenseExpression");
-                await defaultProperties.DeletePropertyAsync("PackageRequireLicenseAcceptance");
+                await defaultProperties.RememberValueIfCurrentlySet(PackageLicenseFileMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.RememberValueIfCurrentlySet(PackageLicenseExpressionMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.RememberValueIfCurrentlySet(PackageRequireLicenseAcceptanceMSBuildProperty, _temporaryPropertyStorage);
+                await defaultProperties.DeletePropertyAsync(PackageLicenseFileMSBuildProperty);
+                await defaultProperties.DeletePropertyAsync(PackageLicenseExpressionMSBuildProperty);
+                await defaultProperties.DeletePropertyAsync(PackageRequireLicenseAcceptanceMSBuildProperty);
             }
 
             return null;
@@ -61,17 +66,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         private static async Task<string> ComputeValueAsync(Func<string, Task<string?>> getValue)
         {
-            if (!string.IsNullOrEmpty(await getValue("PackageLicenseExpression")))
+            if (!string.IsNullOrEmpty(await getValue(PackageLicenseExpressionMSBuildProperty)))
             {
-                return "Expression";
+                return ExpressionValue;
             }
 
-            if (!string.IsNullOrEmpty(await getValue("PackageLicenseFile")))
+            if (!string.IsNullOrEmpty(await getValue(PackageLicenseFileMSBuildProperty)))
             {
                 return "File";
             }
                 
-            return "None";
+            return NoneValue;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ProjectPropertiesExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ProjectPropertiesExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    internal static class ProjectPropertiesExtensions
+    {
+        /// <summary>
+        /// Saves the unevaluated value of <paramref name="propertyName"/>, if any, to <paramref name="storage"/>.
+        /// </summary>
+        public static async Task RememberValueIfCurrentlySet(this IProjectProperties properties, string propertyName, ITemporaryPropertyStorage storage)
+        {
+            string? currentPropertyValue = await properties.GetUnevaluatedPropertyValueAsync(propertyName);
+            if (!Strings.IsNullOrEmpty(currentPropertyValue))
+            {
+                storage.AddOrUpdatePropertyValue(propertyName, currentPropertyValue);
+            }
+        }
+
+        /// <summary>
+        /// If <paramref name="propertyName"/> is not currently set restores the saved value, if any, from <paramref name="storage"/>.
+        /// </summary>
+        public static async Task RestoreValueIfNotCurrentlySet(this IProjectProperties properties, string propertyName, ITemporaryPropertyStorage storage)
+        {
+            string? currentPropertyValue = await properties.GetUnevaluatedPropertyValueAsync(propertyName);
+            if (string.IsNullOrEmpty(currentPropertyValue)
+                && storage.GetPropertyValue(propertyName) is string previousValue)
+            {
+                await properties.SetPropertyValueAsync(propertyName, previousValue);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ProjectPropertiesExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ProjectPropertiesExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// <summary>
         /// Saves the unevaluated value of <paramref name="propertyName"/>, if any, to <paramref name="storage"/>.
         /// </summary>
-        public static async Task RememberValueIfCurrentlySet(this IProjectProperties properties, string propertyName, ITemporaryPropertyStorage storage)
+        public static async Task SaveValueIfCurrentlySetAsync(this IProjectProperties properties, string propertyName, ITemporaryPropertyStorage storage)
         {
             string? currentPropertyValue = await properties.GetUnevaluatedPropertyValueAsync(propertyName);
             if (!Strings.IsNullOrEmpty(currentPropertyValue))
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// <summary>
         /// If <paramref name="propertyName"/> is not currently set restores the saved value, if any, from <paramref name="storage"/>.
         /// </summary>
-        public static async Task RestoreValueIfNotCurrentlySet(this IProjectProperties properties, string propertyName, ITemporaryPropertyStorage storage)
+        public static async Task RestoreValueIfNotCurrentlySetAsync(this IProjectProperties properties, string propertyName, ITemporaryPropertyStorage storage)
         {
             string? currentPropertyValue = await properties.GetUnevaluatedPropertyValueAsync(propertyName);
             if (string.IsNullOrEmpty(currentPropertyValue)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -137,6 +137,7 @@
                   Description="Sets the .ico file that you want to use as your program icon."
                   Subtype="file">
     <StringProperty.Metadata>
+      <NameValuePair Name="DependsOn" Value="Application::ResourceSpecificationKind" />
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>(eq (evaluated "Application" "ResourceSpecificationKind") "IconAndManifest")</NameValuePair.Value>
       </NameValuePair>
@@ -153,6 +154,7 @@
                   HasConfigurationCondition="False" />
     </EnumProperty.DataSource>
     <EnumProperty.Metadata>
+      <NameValuePair Name="DependsOn" Value="Application::ResourceSpecificationKind" />
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>(eq (evaluated "Application" "ResourceSpecificationKind") "IconAndManifest")</NameValuePair.Value>
       </NameValuePair>
@@ -176,6 +178,7 @@
                   HasConfigurationCondition="False" />
     </StringProperty.DataSource>
     <StringProperty.Metadata>
+      <NameValuePair Name="DependsOn" Value="Application::ResourceSpecificationKind;Application::ApplicationManifestKind" />
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
           (and 
@@ -183,7 +186,6 @@
             (eq (evaluated "Application" "ResourceSpecificationKind") "IconAndManifest"))
         </NameValuePair.Value>
       </NameValuePair>
-      <NameValuePair Name="DependsOn" Value="Application::ApplicationManifestKind" />
     </StringProperty.Metadata>
   </StringProperty>
 
@@ -194,6 +196,7 @@
                   Category="Resources"
                   Subtype="file">
     <StringProperty.Metadata>
+      <NameValuePair Name="DependsOn" Value="Application::ResourceSpecificationKind" />
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>(eq (evaluated "Application" "ResourceSpecificationKind") "ResourceFile")</NameValuePair.Value>
       </NameValuePair>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
@@ -159,6 +159,7 @@
                   HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147239"
                   Category="License">
     <StringProperty.Metadata>
+      <NameValuePair Name="DependsOn" Value="Package::PackageLicenseKind" />
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>(eq "Expression" (evaluated "Package" "PackageLicenseKind"))</NameValuePair.Value>
       </NameValuePair>
@@ -195,6 +196,7 @@
                   Category="License"
                   Subtype="file">
     <StringProperty.Metadata>
+      <NameValuePair Name="DependsOn" Value="Package::PackageLicenseKind" />
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>(eq "File" (evaluated "Package" "PackageLicenseKind"))</NameValuePair.Value>
       </NameValuePair>
@@ -206,6 +208,7 @@
                 Description="Prompt the user to accept the license when installing this package."
                 Category="License">
     <BoolProperty.Metadata>
+      <NameValuePair Name="DependsOn" Value="Package::PackageLicenseKind" />
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>(ne "None" (evaluated "Package" "PackageLicenseKind"))</NameValuePair.Value>
       </NameValuePair>


### PR DESCRIPTION
Temporarily save certain property values when:
- toggling between icons/manifests and resource files
- toggling documentation file generation
- toggling between package license files and package license expressions

The idea here is that these operations should be non-destructive. That is, if you toggle documentation file generation off, and then back on, we should also restore the provided doc file path (if any). Similarly, if you switch from a package license expression to a file and then back, we should restore the license expression.

We accomplish this by saving the values of the properties to `ITemporaryPropertyStorage` before deleting them, and restore them if/when they later become applicable again.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6754)