### PR TITLE
Replace tuples with named types

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryFromPropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryFromPropertyPageDataProducer.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
@@ -27,11 +25,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
         {
-            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (IPropertyPageQueryCache _, Rule rule))
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is PropertyPageProviderState propertyPageState)
             {
                 try
                 {
-                    foreach (IEntityValue categoryValue in CategoryDataProducer.CreateCategoryValues(request.RequestData, rule, _properties))
+                    foreach (IEntityValue categoryValue in CategoryDataProducer.CreateCategoryValues(request.RequestData, propertyPageState.Rule, _properties))
                     {
                         await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(categoryValue, request, ProjectModelZones.Cps));
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionFromPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionFromPropertyDataProducer.cs
@@ -29,11 +29,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
         {
             Requires.NotNull(request, nameof(request));
-            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property))
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is PropertyValueProviderState providerState)
             {
                 try
                 {
-                    foreach (IEntityValue dimension in ConfigurationDimensionDataProducer.CreateProjectConfigurationDimensions(request.QueryExecutionContext.EntityRuntime, configuration, property, _properties))
+                    IEnumerable<IEntityValue> dimensions = ConfigurationDimensionDataProducer.CreateProjectConfigurationDimensions(
+                        request.QueryExecutionContext.EntityRuntime,
+                        providerState.ProjectConfiguration,
+                        providerState.Property,
+                        _properties);
+
+                    foreach (IEntityValue dimension in dimensions)
                     {
                         await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(dimension, request, ProjectModelZones.Cps));
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 newPropertyPage.Kind = rule.PageTemplate;
             }
 
-            ((IEntityValueFromProvider)newPropertyPage).ProviderState = (cache, rule);
+            ((IEntityValueFromProvider)newPropertyPage).ProviderState = new PropertyPageProviderState(cache, rule);
 
             return newPropertyPage;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageProviderState.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageProviderState.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Holds the state we need to pass from producers of <see cref="PropertyPageValue"/> instances
+    /// to other producers that will create the <see cref="PropertyPageValue"/>s' child entities.
+    /// </summary>
+    internal sealed class PropertyPageProviderState
+    {
+        public PropertyPageProviderState(IPropertyPageQueryCache cache, Rule rule)
+        {
+            Cache = cache;
+            Rule = rule;
+        }
+
+        public IPropertyPageQueryCache Cache { get; }
+        public Rule Rule { get; }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyProviderState.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyProviderState.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Holds the state we need to pass from producers of <see cref="UIPropertyValue"/> instances
+    /// to other producers that will create the <see cref="UIPropertyValue"/>s' child entities.
+    /// </summary>
+    internal sealed class PropertyProviderState
+    {
+        public PropertyProviderState(IPropertyPageQueryCache cache, Rule containingRule, string propertyName)
+        {
+            Cache = cache;
+            ContainingRule = containingRule;
+            PropertyName = propertyName;
+        }
+
+        public IPropertyPageQueryCache Cache { get; }
+        public Rule ContainingRule { get; }
+        public string PropertyName { get; }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyValueProviderState.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyValueProviderState.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Holds the state we need to pass from producers of <see cref="UIPropertyValueValue"/> instances
+    /// to other producers that will create the <see cref="UIPropertyValueValue"/>s' child entities.
+    /// </summary>
+    internal sealed class PropertyValueProviderState
+    {
+        public PropertyValueProviderState(ProjectConfiguration projectConfiguration, ProjectSystem.Properties.IProperty property)
+        {
+            ProjectConfiguration = projectConfiguration;
+            Property = property;
+        }
+
+        public ProjectConfiguration ProjectConfiguration { get; }
+        public ProjectSystem.Properties.IProperty Property { get; }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueFromPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueFromPropertyDataProducer.cs
@@ -27,7 +27,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         {
             Requires.NotNull(request, nameof(request));
 
-            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (ProjectConfiguration _, ProjectSystem.Properties.IEnumProperty enumProperty))
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is PropertyValueProviderState providerState
+                && providerState.Property is ProjectSystem.Properties.IEnumProperty enumProperty)
             {
                 try
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 }
             }
 
-            ((IEntityValueFromProvider)newUIProperty).ProviderState = (cache, property.ContainingRule, property.Name);
+            ((IEntityValueFromProvider)newUIProperty).ProviderState = new PropertyProviderState(cache, property.ContainingRule, property.Name);
 
             return newUIProperty;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorFromUIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorFromUIPropertyDataProducer.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
@@ -26,11 +25,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
         {
             Requires.NotNull(request, nameof(request));
-            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (IPropertyPageQueryCache, Rule schema, string propertyName))
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is PropertyProviderState propertyState)
             {
                 try
                 {
-                    foreach (IEntityValue propertyEditor in UIPropertyEditorDataProducer.CreateEditorValues(request.RequestData, schema, propertyName, _properties))
+                    foreach (IEntityValue propertyEditor in UIPropertyEditorDataProducer.CreateEditorValues(request.RequestData, propertyState.ContainingRule, propertyState.PropertyName, _properties))
                     {
                         await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(propertyEditor, request, ProjectModelZones.Cps));
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromPropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromPropertyPageDataProducer.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
@@ -28,11 +26,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         {
             Requires.NotNull(request, nameof(request));
 
-            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (IPropertyPageQueryCache cache, Rule rule))
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is PropertyPageProviderState propertyPageState)
             {
                 try
                 {
-                    foreach (IEntityValue propertyValue in UIPropertyDataProducer.CreateUIPropertyValues(request.RequestData, cache, rule, _properties))
+                    foreach (IEntityValue propertyValue in UIPropertyDataProducer.CreateUIPropertyValues(request.RequestData, propertyPageState.Cache, propertyPageState.Rule, _properties))
                     {
                         await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(propertyValue, request, ProjectModelZones.Cps));
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 };
             }
 
-            ((IEntityValueFromProvider)newUIPropertyValue).ProviderState = (configuration, property);
+            ((IEntityValueFromProvider)newUIPropertyValue).ProviderState = new PropertyValueProviderState(configuration, property);
 
             return newUIPropertyValue;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueFromUIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueFromUIPropertyDataProducer.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
@@ -26,15 +25,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public async Task SendRequestAsync(QueryProcessRequest<IEntityValue> request)
         {
-            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is (IPropertyPageQueryCache cache, Rule schema, string propertyName))
+            if ((request.RequestData as IEntityValueFromProvider)?.ProviderState is PropertyProviderState propertyState)
             {
                 try
                 {
                     IEnumerable<IEntityValue> propertyValues = await UIPropertyValueDataProducer.CreateUIPropertyValueValuesAsync(
                         request.RequestData,
-                        cache,
-                        schema,
-                        propertyName,
+                        propertyState.Cache,
+                        propertyState.ContainingRule,
+                        propertyState.PropertyName,
                         _properties);
 
                     foreach (IEntityValue propertyValue in propertyValues)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducerTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         }
 
         [Fact]
-        public void WhenCreatingAModel_ProviderStateConsistsOfCacheAndRule()
+        public void WhenCreatingAModel_ProviderStateIsTheCorrectType()
         {
             var properties = PropertiesAvailableStatusFactory.CreatePropertyPagePropertiesAvailableStatus(includeAllProperties: true);
 
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 new Rule { Name = "MyRule", DisplayName = "My Rule Display Name", Order = 42, PageTemplate = "generic" },
                 properties);
 
-            Assert.IsType<(IPropertyPageQueryCache, Rule)>(propertyPage.ProviderState);
+            Assert.IsType<PropertyPageProviderState>(propertyPage.ProviderState);
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
 
-            Assert.IsType<(IPropertyPageQueryCache, Rule, string)>(((IEntityValueFromProvider)result).ProviderState);
+            Assert.IsType<PropertyProviderState>(((IEntityValueFromProvider)result).ProviderState);
         }
 
         [Fact]


### PR DESCRIPTION
Currently, when we create a Project Query API entity (representing a property page, property, etc.) we communicate the important state to the producers of the child entities using a tuple. As we add more producers and further refactor this code it has become clear that the use of a tuple here will lead to errors as different producers may accidentally come to expect different tuple shapes. Remembering the correct shape often means going back to the point where the tuple is created, if you can find it.

This commit replaces the tuples with simple named types.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6760)