### PR TITLE
Extract boilerplate

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryByIdDataProducer.cs
@@ -1,68 +1,62 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
-using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {
     /// <summary>
     /// Handles retrieving an <see cref="ICategory"/> based on an ID.
     /// </summary>
-    internal class CategoryByIdDataProducer : QueryDataProducerBase<IEntityValue>, IQueryDataProducer<IReadOnlyCollection<EntityIdentity>, IEntityValue>
+    internal class CategoryByIdDataProducer : QueryDataByIdProducerBase<CategoryByIdDataProducer.KeyData>
     {
-        private readonly IProjectService2 _projectService;
         private readonly ICategoryPropertiesAvailableStatus _properties;
+        private readonly IProjectService2 _projectService;
 
         public CategoryByIdDataProducer(ICategoryPropertiesAvailableStatus properties, IProjectService2 projectService)
         {
-            Requires.NotNull(properties, nameof(properties));
-            Requires.NotNull(projectService, nameof(projectService));
-
             _properties = properties;
             _projectService = projectService;
-
         }
 
-        public async Task SendRequestAsync(QueryProcessRequest<IReadOnlyCollection<EntityIdentity>> request)
+        protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, KeyData keyData)
         {
-            Requires.NotNull(request, nameof(request));
+            return CategoryDataProducer.CreateCategoryValueAsync(
+                runtimeModel,
+                id,
+                _projectService,
+                keyData.ProjectPath,
+                keyData.PropertyPageName,
+                keyData.CategoryName,
+                _properties);
+        }
 
-            foreach (EntityIdentity requestId in request.RequestData)
+        protected override KeyData? TryExtactKeyDataOrNull(EntityIdentity requestId)
+        {
+            if (requestId.KeysCount == 3
+                && requestId.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string projectPath)
+                && requestId.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName)
+                && requestId.TryGetValue(ProjectModelIdentityKeys.CategoryName, out string categoryName))
             {
-                if (requestId.KeysCount == 3
-                    && requestId.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string projectPath)
-                    && requestId.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName)
-                    && requestId.TryGetValue(ProjectModelIdentityKeys.CategoryName, out string categoryName))
-                {
-                    try
-                    {
-                        IEntityValue? categoryValue = await CategoryDataProducer.CreateCategoryValueAsync(
-                            request.QueryExecutionContext.EntityRuntime,
-                            requestId,
-                            _projectService,
-                            projectPath,
-                            propertyPageName,
-                            categoryName,
-                            _properties);
-
-                        if (categoryValue != null)
-                        {
-                            await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(categoryValue, request, ProjectModelZones.Cps));
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        request.QueryExecutionContext.ReportError(ex);
-                    }
-                }
+                return new KeyData(projectPath, propertyPageName, categoryName);
             }
 
-            await ResultReceiver.OnRequestProcessFinishedAsync(request);
+            return null;
+        }
+        internal class KeyData
+        {
+            public KeyData(string projectPath, string propertyPageName, string categoryName)
+            {
+                ProjectPath = projectPath;
+                PropertyPageName = propertyPageName;
+                CategoryName = categoryName;
+            }
+
+            public string ProjectPath { get; }
+            public string PropertyPageName { get; }
+            public string CategoryName { get; }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageByIdDataProducer.cs
@@ -1,19 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
-using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {
     /// <summary>
     /// Handles retrieving an <see cref="IPropertyPage"/> based on an ID.
     /// </summary>
-    internal class PropertyPageByIdDataProducer : QueryDataProducerBase<IEntityValue>, IQueryDataProducer<IReadOnlyCollection<EntityIdentity>, IEntityValue>
+    internal class PropertyPageByIdDataProducer : QueryDataByIdProducerBase<PropertyPageByIdDataProducer.KeyData>
     {
         private readonly IPropertyPagePropertiesAvailableStatus _properties;
         private readonly IProjectService2 _projectService;
@@ -30,40 +27,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _queryCacheProvider = queryCacheProvider;
         }
 
-        public async Task SendRequestAsync(QueryProcessRequest<IReadOnlyCollection<EntityIdentity>> request)
+        protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, KeyData keyData)
         {
-            Requires.NotNull(request, nameof(request));
+            return PropertyPageDataProducer.CreatePropertyPageValueAsync(
+                runtimeModel,
+                id,
+                _projectService,
+                _queryCacheProvider,
+                keyData.ProjectPath,
+                keyData.PropertyPageName,
+                _properties);
+        }
 
-            foreach (EntityIdentity requestId in request.RequestData)
+        protected override KeyData? TryExtactKeyDataOrNull(EntityIdentity requestId)
+        {
+            if (requestId.KeysCount == 2
+                && requestId.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string path)
+                && requestId.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName))
             {
-                if (requestId.KeysCount == 2
-                    && requestId.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string path)
-                    && requestId.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName))
-                {
-                    try
-                    {
-                        IEntityValue? propertyPageValue = await PropertyPageDataProducer.CreatePropertyPageValueAsync(
-                            request.QueryExecutionContext.EntityRuntime,
-                            requestId,
-                            _projectService,
-                            _queryCacheProvider,
-                            path,
-                            propertyPageName,
-                            _properties);
-
-                        if (propertyPageValue is not null)
-                        {
-                            await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(propertyPageValue, request, ProjectModelZones.Cps));
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        request.QueryExecutionContext.ReportError(ex);
-                    }
-                }
+                return new KeyData(path, propertyPageName);
             }
 
-            await ResultReceiver.OnRequestProcessFinishedAsync(request);
+            return null;
+        }
+
+        internal class KeyData
+        {
+            public KeyData(string projectPath, string propertyPageName)
+            {
+                ProjectPath = projectPath;
+                PropertyPageName = propertyPageName;
+            }
+
+            public string ProjectPath { get; }
+            public string PropertyPageName { get; }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryDataByIdProducerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryDataByIdProducerBase.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Handles the boilerplate of retrieving an <see cref="IEntityValue"/> based on an ID.
+    /// </summary>
+    internal abstract class QueryDataByIdProducerBase<T> : QueryDataProducerBase<IEntityValue>, IQueryDataProducer<IReadOnlyCollection<EntityIdentity>, IEntityValue>
+    {
+        public async Task SendRequestAsync(QueryProcessRequest<IReadOnlyCollection<EntityIdentity>> request)
+        {
+            foreach (EntityIdentity requestId in request.RequestData)
+            {
+                if (TryExtactKeyDataOrNull(requestId) is T keyData)
+                {
+                    try
+                    {
+                        IEntityValue? entityValue = await TryCreateEntityOrNullAsync(request.QueryExecutionContext.EntityRuntime, requestId, keyData);
+                        if (entityValue is not null)
+                        {
+                            await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(entityValue, request, ProjectModelZones.Cps));
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        request.QueryExecutionContext.ReportError(ex);
+                    }
+                }
+            }
+
+            await ResultReceiver.OnRequestProcessFinishedAsync(request);
+        }
+
+        protected abstract T? TryExtactKeyDataOrNull(EntityIdentity requestId);
+        protected abstract Task<IEntityValue?> TryCreateEntityOrNullAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, T keyData);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyByIdProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyByIdProducer.cs
@@ -1,20 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
-using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {
     /// <summary>
     /// Handles retrieving an <see cref="IUIProperty"/> based on an ID.
     /// </summary>
-    internal class UIPropertyByIdProducer : QueryDataProducerBase<IEntityValue>, IQueryDataProducer<IReadOnlyCollection<EntityIdentity>, IEntityValue>
-    {
+    internal class UIPropertyByIdProducer : QueryDataByIdProducerBase<UIPropertyByIdProducer.KeyData>
+    { 
         private readonly IUIPropertyPropertiesAvailableStatus _properties;
         private readonly IProjectService2 _projectService;
         private readonly IPropertyPageQueryCacheProvider _queryCacheProvider;
@@ -28,42 +25,44 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _queryCacheProvider = queryCacheProvider;
         }
 
-        public async Task SendRequestAsync(QueryProcessRequest<IReadOnlyCollection<EntityIdentity>> request)
+        protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, KeyData keyData)
         {
-            Requires.NotNull(request, nameof(request));
+            return UIPropertyDataProducer.CreateUIPropertyValueAsync(
+                runtimeModel,
+                id,
+                _projectService,
+                _queryCacheProvider,
+                keyData.ProjectPath,
+                keyData.PropertyPageName,
+                keyData.PropertyName,
+                _properties);
+        }
 
-            foreach (EntityIdentity requestId in request.RequestData)
+        protected override KeyData? TryExtactKeyDataOrNull(EntityIdentity requestId)
+        {
+            if (requestId.KeysCount == 3
+                && requestId.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string path)
+                && requestId.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName)
+                && requestId.TryGetValue(ProjectModelIdentityKeys.UIPropertyName, out string propertyName))
             {
-                if (requestId.KeysCount == 3
-                    && requestId.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string path)
-                    && requestId.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName)
-                    && requestId.TryGetValue(ProjectModelIdentityKeys.UIPropertyName, out string propertyName))
-                {
-                    try
-                    {
-                        IEntityValue? propertyValue = await UIPropertyDataProducer.CreateUIPropertyValueAsync(
-                            request.QueryExecutionContext.EntityRuntime,
-                            requestId,
-                            _projectService,
-                            _queryCacheProvider,
-                            path,
-                            propertyPageName,
-                            propertyName,
-                            _properties);
-
-                        if (propertyValue is not null)
-                        {
-                            await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(propertyValue, request, ProjectModelZones.Cps));
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        request.QueryExecutionContext.ReportError(ex);
-                    }
-                }
+                return new KeyData(path, propertyPageName, propertyName);
             }
 
-            await ResultReceiver.OnRequestProcessFinishedAsync(request);
+            return null;
+        }
+
+        internal sealed class KeyData
+        {
+            public KeyData(string projectPath, string propertyPageName, string propertyName)
+            {
+                ProjectPath = projectPath;
+                PropertyPageName = propertyPageName;
+                PropertyName = propertyName;
+            }
+
+            public string ProjectPath { get; }
+            public string PropertyPageName { get; }
+            public string PropertyName { get; }
         }
     }
 }


### PR DESCRIPTION
When asked to retrieve an `IEntityValue` (for a property, page, etc.) given an `EntityIdentity` we always do the same two basic operations: first, we expand the `EntityIdentity` into the relevant pieces. If that works, we then pass those pieces along to another method to actually create the `IEntityValue`. Here we extract out the duplicated code into a base class for the four producers that can handle retrieving a value by key.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6761)