### PR TITLE
Cache more cases of Task.FromResult

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksProvider.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-
+using Microsoft.VisualStudio.Threading;
 using EnumCollection = System.Collections.Generic.ICollection<Microsoft.VisualStudio.ProjectSystem.Properties.IEnumValue>;
 using EnumCollectionProjectValue = Microsoft.VisualStudio.ProjectSystem.IProjectVersionedValue<System.Collections.Generic.ICollection<Microsoft.VisualStudio.ProjectSystem.Properties.IEnumValue>>;
 
@@ -121,7 +121,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
 
         bool IDynamicEnumValuesGenerator.AllowCustomValues => false;
 
-        Task<IEnumValue?> IDynamicEnumValuesGenerator.TryCreateEnumValueAsync(string userSuppliedValue) => Task.FromResult<IEnumValue?>(null);
-
+        Task<IEnumValue?> IDynamicEnumValuesGenerator.TryCreateEnumValueAsync(string userSuppliedValue) => TaskResult.Null<IEnumValue>();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectContextCodeModelProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectContextCodeModelProvider.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using EnvDTE;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
+using TaskResult = Microsoft.VisualStudio.Threading.TaskResult;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 {
@@ -73,7 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                 {   // Isn't a file that Roslyn knows about
                 }
 
-                return Task.FromResult<FileCodeModel?>(null);
+                return TaskResult.Null<FileCodeModel>();
             });
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AuthenticationModeEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AuthenticationModeEnumProvider.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS.Debug;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
@@ -55,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             /// <summary>
             /// The user can't add arbitrary authentication modes, so this method is unsupported.
             /// </summary>
-            public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue) => Task.FromResult<IEnumValue?>(null);
+            public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue) => TaskResult.Null<IEnumValue>();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/MapDynamicEnumValuesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/MapDynamicEnumValuesProvider.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic
 {
@@ -40,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic
                 return Task.FromResult<IEnumValue?>(value);
             }
 
-            return Task.FromResult<IEnumValue?>(null);
+            return TaskResult.Null<IEnumValue>();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/NoOpInterceptingPropertyValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/NoOpInterceptingPropertyValueProvider.cs
@@ -2,27 +2,25 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
     internal abstract class NoOpInterceptingPropertyValueProvider : InterceptingPropertyValueProviderBase
     {
-        private static readonly Task<string?> s_nullResult = Task.FromResult<string?>(null);
-        private static readonly Task<string> s_emptyStringResult = Task.FromResult("");
-
         public override Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
-            return s_nullResult;
+            return TaskResult.Null<string>();
         }
 
         public override Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            return s_emptyStringResult;
+            return TaskResult.EmptyString;
         }
 
         public override Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            return s_emptyStringResult;
+            return TaskResult.EmptyString;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchTargetPropertyPageEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchTargetPropertyPageEnumProvider.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
@@ -68,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     .ToArray<IEnumValue>();
             }
 
-            public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue) => Task.FromResult<IEnumValue?>(null);
+            public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue) => TaskResult.Null<IEnumValue>();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/NeutralLanguageEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/NeutralLanguageEnumProvider.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Properties.Package;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
@@ -36,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 return Task.FromResult<ICollection<IEnumValue>>(values);
             }
 
-            public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue) => Task.FromResult<IEnumValue?>(null);
+            public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue) => TaskResult.Null<IEnumValue>();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractFindByNameSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractFindByNameSpecialFileProvider.cs
@@ -2,6 +2,7 @@
 
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 {
@@ -30,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         {
             string? projectPath = provider.GetRootedAddNewItemDirectory(root);
             if (projectPath == null)  // Root has DisableAddItem
-                return Task.FromResult<string?>(null);
+                return TaskResult.Null<string>();
 
             string path = Path.Combine(projectPath, _fileName);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskResult.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskResult.cs
@@ -19,8 +19,14 @@ namespace Microsoft.VisualStudio.Threading
         /// </summary>
         public static Task<bool> True => TplExtensions.TrueTask;
         
+        /// <summary>
+        ///     Represents a <see cref="Task{TResult}"/> that's completed successfully with result of the empty string.
+        /// </summary>
         public static Task<string> EmptyString => Task.FromResult("");
 
+        /// <summary>
+        ///     Returns a <see cref="Task{TResult}"/> of type <typeparamref name="T" /> that's completed successfully with the result of <see langword="null"/>.
+        /// </summary>
         public static Task<T?> Null<T>() where T : class => NullTaskResult<T>.Instance;
 
         private static class NullTaskResult<T> where T : class

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskResult.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskResult.cs
@@ -18,5 +18,14 @@ namespace Microsoft.VisualStudio.Threading
         ///     Represents a <see cref="Task{TResult}"/> that's completed successfully with the result of <see langword="true"/>.
         /// </summary>
         public static Task<bool> True => TplExtensions.TrueTask;
+        
+        public static Task<string> EmptyString => Task.FromResult("");
+
+        public static Task<T?> Null<T>() where T : class => NullTaskResult<T>.Instance;
+
+        private static class NullTaskResult<T> where T : class
+        {
+            public static readonly Task<T?> Instance = Task.FromResult<T?>(null);
+        }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemProviderFactory.cs
@@ -3,6 +3,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
 using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
@@ -53,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                        }
                    }
 
-                   return Task.FromResult<IProjectItem?>(null)!; // TODO remove ! when CPS annotations updated
+                   return TaskResult.Null<IProjectItem>()!; // TODO remove ! when CPS annotations updated
                });
 
             return mock.Object;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/OnceInitializedOnceDisposedUnderLockAsyncTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/OnceInitializedOnceDisposedUnderLockAsyncTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
                 result = ct.IsCancellationRequested;
 
-                return Task.FromResult<string?>(null);
+                return TaskResult.Null<string>();
             }, cancellationTokenSource.Token);
 
             Assert.True(result);
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var instance = CreateInstance();
 
             bool called = false;
-            var result = instance.ExecuteUnderLockAsync(ct => { called = true; return Task.FromResult<string?>(null); }, cancellationToken);
+            var result = instance.ExecuteUnderLockAsync(ct => { called = true; return TaskResult.Null<string>(); }, cancellationToken);
 
             var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => result);
             Assert.False(called);
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var instance = CreateInstance();
 
             int callCount = 0;
-            await instance.ExecuteUnderLockAsync((ct) => { callCount++; return Task.FromResult<string?>(null); }, CancellationToken.None);
+            await instance.ExecuteUnderLockAsync((ct) => { callCount++; return TaskResult.Null<string>(); }, CancellationToken.None);
 
             Assert.Equal(1, callCount);
         }
@@ -168,7 +168,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             Task secondAction() => Task.Run(() => instance.ExecuteUnderLockAsync((ct) =>
             {
                 secondEntered.Set();
-                return Task.FromResult<string?>(null);
+                return TaskResult.Null<string>();
             }, CancellationToken.None));
 
             await AssertNoOverlap(firstAction, secondAction, firstEntered, firstRelease, secondEntered);
@@ -192,7 +192,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             Task secondAction() => Task.Run(() => instance.ExecuteUnderLockAsync((ct) =>
             {
                 secondEntered.Set();
-                return Task.FromResult<string?>(null);
+                return TaskResult.Null<string>();
             }, CancellationToken.None));
 
             await AssertNoOverlap(firstAction, secondAction, firstEntered, firstRelease, secondEntered);
@@ -258,7 +258,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                     await instance.ExecuteUnderLockAsync((___) =>
                     {
                         callCount++;
-                        return Task.FromResult<string?>(null);
+                        return TaskResult.Null<string>();
                     });
 
                     return string.Empty;
@@ -358,7 +358,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             var result = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
             {
-                return instance.ExecuteUnderLockAsync((ct) => { return Task.FromResult<string?>(null); }, CancellationToken.None);
+                return instance.ExecuteUnderLockAsync((ct) => { return TaskResult.Null<string>(); }, CancellationToken.None);
             });
 
             Assert.Equal(instance.DisposalToken, result.CancellationToken);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/TaskResultTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/TaskResultTests.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Threading.Tasks
+{
+    public sealed class TaskResultTests
+    {
+        [Fact]
+        public async Task True()
+        {
+            Assert.Same(TaskResult.True, TaskResult.True);
+
+            Assert.True(await TaskResult.True);
+        }
+
+        [Fact]
+        public async Task False()
+        {
+            Assert.Same(TaskResult.False, TaskResult.False);
+
+            Assert.False(await TaskResult.False);
+        }
+
+        [Fact]
+        public async Task Null()
+        {
+            Assert.Same(TaskResult.Null<string>(), TaskResult.Null<string>());
+            Assert.NotSame(TaskResult.Null<string>(), TaskResult.Null<Array>());
+
+            Assert.Null(await TaskResult.Null<string>());
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitIndicatorTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitIndicatorTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
 
                 result = token;
 
-                return Task.FromResult("");
+                return TaskResult.EmptyString;
             });
 
             Assert.True(result!.Value.IsCancellationRequested);


### PR DESCRIPTION
Tasks with null or empty string values can be reused, avoiding allocations at run time.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6765)