### PR TITLE
Simple Debug page support

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducer.cs
@@ -17,22 +17,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal static class CategoryDataProducer
     {
-        public static IEntityValue CreateCategoryValue(IEntityValue parent, Category category, int order, ICategoryPropertiesAvailableStatus requestedProperties)
+        public static IEntityValue CreateCategoryValue(IEntityValue parent, Rule rule, Category category, int order, ICategoryPropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(parent, nameof(parent));
             Requires.NotNull(category, nameof(category));
+
+            string categoryName = rule.PageTemplate == "commandNameBasedDebugger"
+                ? DebugUtilities.ConvertRealPageAndCategoryToDebugCategory(rule.Name, category.Name)
+                : category.Name;
 
             var identity = new EntityIdentity(
                 ((IEntityWithId)parent).Id,
                 new KeyValuePair<string, string>[]
                 {
-                    new(ProjectModelIdentityKeys.CategoryName, category.Name)
+                    new(ProjectModelIdentityKeys.CategoryName, categoryName)
                 });
 
-            return CreateCategoryValue(parent.EntityRuntime, identity, category, order, requestedProperties);
+            return CreateCategoryValue(parent.EntityRuntime, identity, rule, category, order, requestedProperties);
         }
 
-        public static IEntityValue CreateCategoryValue(IEntityRuntimeModel runtimeModel, EntityIdentity id, Category category, int order, ICategoryPropertiesAvailableStatus requestedProperties)
+        public static IEntityValue CreateCategoryValue(IEntityRuntimeModel runtimeModel, EntityIdentity id, Rule rule, Category category, int order, ICategoryPropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(category, nameof(category));
             var newCategory = new CategoryValue(runtimeModel, id, new CategoryPropertiesAvailableStatus());
@@ -44,7 +48,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             if (requestedProperties.Name)
             {
-                newCategory.Name = category.Name;
+                if (rule.PageTemplate == "commandNameBasedDebugger")
+                {
+                    newCategory.Name = DebugUtilities.ConvertRealPageAndCategoryToDebugCategory(rule.Name, category.Name);
+                }
+                else
+                {
+                    newCategory.Name = category.Name;
+                }
             }
 
             if (requestedProperties.Order)
@@ -57,12 +68,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             return newCategory;
         }
 
-        public static IEnumerable<IEntityValue> CreateCategoryValues(IEntityValue parent, Rule rule, ICategoryPropertiesAvailableStatus requestedProperties)
+        public static IEnumerable<IEntityValue> CreateCategoryValues(IEntityValue parent, Rule rule, List<Rule> debugChildRules, ICategoryPropertiesAvailableStatus requestedProperties)
         {
-            foreach ((int index, Category category) in rule.EvaluatedCategories.WithIndices())
+            int index = 0;
+            foreach (Category category in rule.EvaluatedCategories)
             {
-                IEntityValue categoryValue = CreateCategoryValue(parent, category, index, requestedProperties);
+                IEntityValue categoryValue = CreateCategoryValue(parent, rule, category, index, requestedProperties);
                 yield return categoryValue;
+                index++;
+            }
+
+            foreach (Rule childRule in debugChildRules)
+            {
+                foreach (Category category in childRule.EvaluatedCategories)
+                {
+                    IEntityValue categoryValue = CreateCategoryValue(parent, childRule, category, index, requestedProperties);
+                    yield return categoryValue;
+                    index++;
+                }
             }
         }
 
@@ -75,6 +98,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             string categoryName,
             ICategoryPropertiesAvailableStatus requestedProperties)
         {
+            (propertyPageName, categoryName) = DebugUtilities.ConvertDebugPageAndCategoryToRealPageAndCategory(propertyPageName, categoryName);
+
             if (projectService.GetLoadedProject(projectPath) is UnconfiguredProject project
                 && await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
                 && projectCatalog.GetSchema(propertyPageName) is Rule rule)
@@ -89,7 +114,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 {
                     if (StringComparers.CategoryNames.Equals(category.Name, categoryName))
                     {
-                        IEntityValue categoryValue = CreateCategoryValue(runtimeModel, id, category, index, requestedProperties);
+                        IEntityValue categoryValue = CreateCategoryValue(runtimeModel, id, rule, category, index, requestedProperties);
                         return categoryValue;
                     }
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducer.cs
@@ -22,9 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             Requires.NotNull(parent, nameof(parent));
             Requires.NotNull(category, nameof(category));
 
-            string categoryName = rule.PageTemplate == "commandNameBasedDebugger"
-                ? DebugUtilities.ConvertRealPageAndCategoryToDebugCategory(rule.Name, category.Name)
-                : category.Name;
+            string categoryName = DebugUtilities.GetDebugCategoryNameOrNull(rule, category) ?? category.Name;
 
             var identity = new EntityIdentity(
                 ((IEntityWithId)parent).Id,
@@ -48,14 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             if (requestedProperties.Name)
             {
-                if (rule.PageTemplate == "commandNameBasedDebugger")
-                {
-                    newCategory.Name = DebugUtilities.ConvertRealPageAndCategoryToDebugCategory(rule.Name, category.Name);
-                }
-                else
-                {
-                    newCategory.Name = category.Name;
-                }
+                newCategory.Name = DebugUtilities.GetDebugCategoryNameOrNull(rule, category) ?? category.Name;
             }
 
             if (requestedProperties.Order)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryFromPropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryFromPropertyPageDataProducer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IEntityValue parent, PropertyPageProviderState providerState)
         {
-            return Task.FromResult(CategoryDataProducer.CreateCategoryValues(parent, providerState.Rule, _properties));
+            return Task.FromResult(CategoryDataProducer.CreateCategoryValues(parent, providerState.Rule, providerState.DebugChildRules, _properties));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/DebugUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/DebugUtilities.cs
@@ -6,13 +6,22 @@ using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {
+    /// <summary>
+    /// Helper methods to convert back and forth between the page, category, and property names
+    /// used by the Debug page in the Project Query API, and the names used by the underlying
+    /// property system.
+    /// </summary>
     internal static class DebugUtilities
     {
+        private const string CommandNameBasedDebuggerPageTemplate = "commandNameBasedDebugger";
+        private const string DebuggerParentPrefix = "#debuggerParent#";
+        private const string DebuggerChildPrefix = "#debuggerChild#";
+
         public static string ConvertDebugPageNameToRealPageName(string pageName)
         {
-            if (pageName.StartsWith("#debuggerParent#"))
+            if (pageName.StartsWith(DebuggerParentPrefix))
             {
-                return pageName.Substring("#debuggerParent#".Length);
+                return pageName.Substring(DebuggerParentPrefix.Length);
             }
             else
             {
@@ -22,14 +31,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public static string ConvertRealPageNameToDebugPageName(string pageName)
         {
-            return "#debuggerParent#" + pageName;
+            return DebuggerParentPrefix + pageName;
         }
 
         public static (string pageName, string categoryName) ConvertDebugPageAndCategoryToRealPageAndCategory(string pageName, string categoryName)
         {
-            if (categoryName.StartsWith("#debuggerChild#"))
+            if (categoryName.StartsWith(DebuggerChildPrefix))
             {
-                categoryName = categoryName.Substring("#debuggerChild#".Length);
+                categoryName = categoryName.Substring(DebuggerChildPrefix.Length);
 
                 int index = categoryName.IndexOf("#");
                 if (index >= 0)
@@ -44,14 +53,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public static string ConvertRealPageAndCategoryToDebugCategory(string pageName, string categoryName)
         {
-            return "#debuggerChild#" + pageName + "#" + categoryName;
+            return DebuggerChildPrefix + pageName + "#" + categoryName;
         }
 
         public static (string pageName, string propertyName) ConvertDebugPageAndPropertyToRealPageAndProperty(string pageName, string propertyName)
         {
-            if (propertyName.StartsWith("#debuggerChild#"))
+            if (propertyName.StartsWith(DebuggerChildPrefix))
             {
-                propertyName = propertyName.Substring("#debuggerChild#".Length);
+                propertyName = propertyName.Substring(DebuggerChildPrefix.Length);
 
                 int index = propertyName.IndexOf("#");
                 if (index >= 0)
@@ -66,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public static string ConvertRealPageAndPropertyToDebugProperty(string pageName, string propertyName)
         {
-            return "#debuggerChild#" + pageName + "#" + propertyName;
+            return DebuggerChildPrefix + pageName + "#" + propertyName;
         }
 
         public static IEnumerable<Rule> GetDebugChildRules(IPropertyPagesCatalog projectCatalog)
@@ -75,11 +84,63 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             {
                 if (projectCatalog.GetSchema(schemaName) is Rule possibleChildRule
                     && !possibleChildRule.PropertyPagesHidden
-                    && possibleChildRule.PageTemplate == "commandNameBasedDebugger")
+                    && possibleChildRule.PageTemplate == CommandNameBasedDebuggerPageTemplate)
                 {
                     yield return possibleChildRule;
                 }
             }
+        }
+
+        public static string? GetDebugCategoryNameOrNull(Rule rule, Category category)
+        {
+            return GetDebugCategoryNameOrNull(rule, category.Name);
+        }
+
+        public static string? GetDebugCategoryNameOrNull(Rule rule, string categoryName)
+        {
+            if (rule.PageTemplate == CommandNameBasedDebuggerPageTemplate)
+            {
+                return ConvertRealPageAndCategoryToDebugCategory(rule.Name, categoryName);
+            }
+
+            return null;
+        }
+
+        public static string? GetDebugPropertyNameOrNull(BaseProperty property)
+        {
+            if (property.ContainingRule.PageTemplate == CommandNameBasedDebuggerPageTemplate)
+            {
+                return ConvertRealPageAndPropertyToDebugProperty(property.ContainingRule.Name, property.Name);
+            }
+
+            return null;
+        }
+
+        public static string? UpdateDebuggerDependsOnMetadata(Rule containingRule, string? dependsOnString)
+        {
+            if (containingRule.PageTemplate == CommandNameBasedDebuggerPageTemplate)
+            {
+                dependsOnString = dependsOnString is not null
+                    ? dependsOnString + ";"
+                    : string.Empty;
+
+                dependsOnString = dependsOnString + "ParentDebugPropertyPage::ActiveLaunchProfile;ParentDebugPropertyPage::LaunchTarget";
+            }
+
+            return dependsOnString;
+        }
+
+        public static string? UpdateDebuggerVisibilityConditionMetadata(string? visibilityCondition, Rule rule)
+        {
+            if (rule.PageTemplate == CommandNameBasedDebuggerPageTemplate)
+            {
+                var commandNameCondition = $"(eq (evaluated \"ParentDebugPropertyPage\" \"LaunchTarget\") \"{rule.Name}\")";
+                visibilityCondition = visibilityCondition is not null
+                    ? $"(and {visibilityCondition} {commandNameCondition})"
+                    : commandNameCondition;
+            }
+
+            return visibilityCondition;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/DebugUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/DebugUtilities.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    internal static class DebugUtilities
+    {
+        public static string ConvertDebugPageNameToRealPageName(string pageName)
+        {
+            if (pageName.StartsWith("#debuggerParent#"))
+            {
+                return pageName.Substring("#debuggerParent#".Length);
+            }
+            else
+            {
+                return pageName;
+            }
+        }
+
+        public static string ConvertRealPageNameToDebugPageName(string pageName)
+        {
+            return "#debuggerParent#" + pageName;
+        }
+
+        public static (string pageName, string categoryName) ConvertDebugPageAndCategoryToRealPageAndCategory(string pageName, string categoryName)
+        {
+            if (categoryName.StartsWith("#debuggerChild#"))
+            {
+                categoryName = categoryName.Substring("#debuggerChild#".Length);
+
+                int index = categoryName.IndexOf("#");
+                if (index >= 0)
+                {
+                    pageName = categoryName.Substring(0, index);
+                    categoryName = categoryName.Substring(index + 1);
+                }
+            }
+
+            return (pageName, categoryName);
+        }
+
+        public static string ConvertRealPageAndCategoryToDebugCategory(string pageName, string categoryName)
+        {
+            return "#debuggerChild#" + pageName + "#" + categoryName;
+        }
+
+        public static (string pageName, string propertyName) ConvertDebugPageAndPropertyToRealPageAndProperty(string pageName, string propertyName)
+        {
+            if (propertyName.StartsWith("#debuggerChild#"))
+            {
+                propertyName = propertyName.Substring("#debuggerChild#".Length);
+
+                int index = propertyName.IndexOf("#");
+                if (index >= 0)
+                {
+                    pageName = propertyName.Substring(0, index);
+                    propertyName = propertyName.Substring(index + 1);
+                }
+            }
+
+            return (pageName, propertyName);
+        }
+
+        public static string ConvertRealPageAndPropertyToDebugProperty(string pageName, string propertyName)
+        {
+            return "#debuggerChild#" + pageName + "#" + propertyName;
+        }
+
+        public static IEnumerable<Rule> GetDebugChildRules(IPropertyPagesCatalog projectCatalog)
+        {
+            foreach (string schemaName in projectCatalog.GetProjectLevelPropertyPagesSchemas())
+            {
+                if (projectCatalog.GetSchema(schemaName) is Rule possibleChildRule
+                    && !possibleChildRule.PropertyPagesHidden
+                    && possibleChildRule.PageTemplate == "commandNameBasedDebugger")
+                {
+                    yield return possibleChildRule;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUIPropertyValueActionCore.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUIPropertyValueActionCore.cs
@@ -44,6 +44,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             IEnumerable<(string dimension, string value)> dimensions,
             Func<IProperty, Task> setValueAsync)
         {
+            (pageName, propertyName) = DebugUtilities.ConvertDebugPageAndPropertyToRealPageAndProperty(pageName, propertyName);
+
             _queryCacheProvider = queryCacheProvider;
             _pageName = pageName;
             _propertyName = propertyName;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
@@ -17,22 +17,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal static class PropertyPageDataProducer
     {
-        public static IEntityValue CreatePropertyPageValue(IEntityValue parent, IPropertyPageQueryCache cache, Rule rule, IPropertyPagePropertiesAvailableStatus requestedProperties)
+        public static IEntityValue CreatePropertyPageValue(IEntityValue parent, IPropertyPageQueryCache cache, Rule rule, List<Rule>? debugChildRules, IPropertyPagePropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(parent, nameof(parent));
             Requires.NotNull(rule, nameof(rule));
+
+            string name = rule.PageTemplate == "debuggerParent"
+                ? DebugUtilities.ConvertRealPageNameToDebugPageName(rule.Name)
+                : rule.Name;
 
             var identity = new EntityIdentity(
                 ((IEntityWithId)parent).Id,
                 new KeyValuePair<string, string>[]
                 {
-                    new(ProjectModelIdentityKeys.PropertyPageName, rule.Name)
+                    new(ProjectModelIdentityKeys.PropertyPageName, name)
                 });
 
-            return CreatePropertyPageValue(parent.EntityRuntime, identity, cache, rule, requestedProperties);
+            return CreatePropertyPageValue(parent.EntityRuntime, identity, cache, rule, debugChildRules, requestedProperties);
         }
 
-        public static IEntityValue CreatePropertyPageValue(IEntityRuntimeModel runtimeModel, EntityIdentity id, IPropertyPageQueryCache cache, Rule rule, IPropertyPagePropertiesAvailableStatus requestedProperties)
+        public static IEntityValue CreatePropertyPageValue(IEntityRuntimeModel runtimeModel, EntityIdentity id, IPropertyPageQueryCache cache, Rule rule, List<Rule>? debugChildRules, IPropertyPagePropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(rule, nameof(rule));
             var newPropertyPage = new PropertyPageValue(runtimeModel, id, new PropertyPagePropertiesAvailableStatus());
@@ -54,10 +58,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             if (requestedProperties.Kind)
             {
-                newPropertyPage.Kind = rule.PageTemplate;
+                if (rule.PageTemplate == "debuggerParent")
+                {
+                    newPropertyPage.Kind = "generic";
+                }
+                else
+                {
+                    newPropertyPage.Kind = rule.PageTemplate;
+                }
             }
 
-            ((IEntityValueFromProvider)newPropertyPage).ProviderState = new PropertyPageProviderState(cache, rule);
+            ((IEntityValueFromProvider)newPropertyPage).ProviderState = debugChildRules is not null
+                ? new PropertyPageProviderState(cache, rule, debugChildRules)
+                : new PropertyPageProviderState(cache, rule);
 
             return newPropertyPage;
         }
@@ -71,13 +84,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             string propertyPageName,
             IPropertyPagePropertiesAvailableStatus requestedProperties)
         {
+            propertyPageName = DebugUtilities.ConvertDebugPageNameToRealPageName(propertyPageName);
+
             if (projectService.GetLoadedProject(projectPath) is UnconfiguredProject project
                 && await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
                 && projectCatalog.GetSchema(propertyPageName) is Rule rule
                 && !rule.PropertyPagesHidden)
             {
+                List<Rule>? debugChildRules = null;
+                if (rule.PageTemplate == "debuggerParent")
+                {
+                    debugChildRules = DebugUtilities.GetDebugChildRules(projectCatalog).ToList();
+                }
+
                 var propertyPageQueryCache = queryCacheProvider.CreateCache(project);
-                IEntityValue propertyPageValue = CreatePropertyPageValue(runtimeModel, id, propertyPageQueryCache, rule, requestedProperties);
+                IEntityValue propertyPageValue = CreatePropertyPageValue(runtimeModel, id, propertyPageQueryCache, rule, debugChildRules, requestedProperties);
                 return propertyPageValue;
             }
 
@@ -99,15 +120,37 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             IEnumerable<IEntityValue> createPropertyPageValuesAsync()
             {
+                Rule? parentDebuggerPageRule = null;
+                
                 var propertyPageQueryContext = queryCacheProvider.CreateCache(project);
                 foreach (string schemaName in projectCatalog.GetProjectLevelPropertyPagesSchemas())
                 {
                     if (projectCatalog.GetSchema(schemaName) is Rule rule
                         && !rule.PropertyPagesHidden)
                     {
-                        IEntityValue propertyPageValue = CreatePropertyPageValue(parent, propertyPageQueryContext, rule, requestedProperties);
-                        yield return propertyPageValue;
+                        if (rule.PageTemplate == "debuggerParent")
+                        {
+                            parentDebuggerPageRule = rule;
+                        }
+                        else if (rule.PageTemplate == "commandNameBasedDebugger")
+                        {
+                            // Don't do anything here; we don't want a separate page for this Rule.
+                            // Rather, its categories and properties will be returned as though
+                            // they were part of the top-level debug page.
+                        }
+                        else
+                        {
+                            IEntityValue propertyPageValue = CreatePropertyPageValue(parent, propertyPageQueryContext, rule, debugChildRules: null, requestedProperties);
+                            yield return propertyPageValue;
+                        }
                     }
+                }
+
+                if (parentDebuggerPageRule is not null)
+                {
+                    List<Rule> childDebuggerPageRules = DebugUtilities.GetDebugChildRules(projectCatalog).ToList();
+                    IEntityValue propertyPageValue = CreatePropertyPageValue(parent, propertyPageQueryContext, parentDebuggerPageRule, debugChildRules: childDebuggerPageRules, requestedProperties);
+                    yield return propertyPageValue;
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
@@ -58,14 +58,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             if (requestedProperties.Kind)
             {
-                if (rule.PageTemplate == "debuggerParent")
-                {
-                    newPropertyPage.Kind = "generic";
-                }
-                else
-                {
-                    newPropertyPage.Kind = rule.PageTemplate;
-                }
+                newPropertyPage.Kind = rule.PageTemplate == "debuggerParent"
+                    ? "generic"
+                    : rule.PageTemplate;
             }
 
             ((IEntityValueFromProvider)newPropertyPage).ProviderState = debugChildRules is not null

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageProviderState.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageProviderState.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Collections.Generic;
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
 
@@ -12,12 +13,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     internal sealed class PropertyPageProviderState
     {
         public PropertyPageProviderState(IPropertyPageQueryCache cache, Rule rule)
+            : this(cache, rule, new List<Rule>(capacity: 0))
+        {
+        }
+
+        public PropertyPageProviderState(IPropertyPageQueryCache cache, Rule rule, List<Rule> debugChildRules)
         {
             Cache = cache;
             Rule = rule;
+            DebugChildRules = debugChildRules;
         }
 
         public IPropertyPageQueryCache Cache { get; }
         public Rule Rule { get; }
+        public List<Rule> DebugChildRules { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromPropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromPropertyPageDataProducer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IEntityValue parent, PropertyPageProviderState providerState)
         {
-            return Task.FromResult(UIPropertyDataProducer.CreateUIPropertyValues(parent, providerState.Cache, providerState.Rule, _properties));
+            return Task.FromResult(UIPropertyDataProducer.CreateUIPropertyValues(parent, providerState.Cache, providerState.Rule, providerState.DebugChildRules, _properties));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -372,6 +372,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             CurrentSnapshot = newSnapshot;
 
+            // Suppress the project execution context so the data flow doesn't accidentally
+            // capture it. This prevents us from leaking any active project system locks into
+            // the data flow, which can lead to asserts, failures, and crashes later if it
+            // causes code to execute that doesn't expect to run under a lock. Also, if a
+            // consumer of the data flow needs a lock they should be acquiring it themself
+            // rather than depending on inheriting it from the data flow.
             using (_commonProjectServices.ThreadingService.SuppressProjectExecutionContext())
             {
                 _broadcastBlock?.Post(newSnapshot);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -372,7 +372,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             CurrentSnapshot = newSnapshot;
 
-            _broadcastBlock?.Post(newSnapshot);
+            using (_commonProjectServices.ThreadingService.SuppressProjectExecutionContext())
+            {
+                _broadcastBlock?.Post(newSnapshot);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ParentDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ParentDebugPropertyPage.xaml
@@ -25,6 +25,9 @@
       <DataSource PersistedName="LaunchTargetPropertyPage"
                   HasConfigurationCondition="False" />
     </DynamicEnumProperty.DataSource>
+    <DynamicEnumProperty.Metadata>
+      <NameValuePair Name="DependsOn" Value="ParentDebugPropertyPage::ActiveLaunchProfile" />
+    </DynamicEnumProperty.Metadata>
   </DynamicEnumProperty>
 
 </Rule>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectThreadingServiceFactory.ProjectThreadingService.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectThreadingServiceFactory.ProjectThreadingService.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             public IDisposable SuppressProjectExecutionContext()
             {
-                throw new NotImplementedException();
+                return new DisposableObject();
             }
 
             public void Fork(Func<Task> asyncAction,
@@ -66,6 +66,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
                       ForkOptions options = ForkOptions.Default)
             {
                 JoinableTaskFactory.Run(asyncAction);
+            }
+
+            private class DisposableObject : IDisposable
+            {
+                public void Dispose()
+                {
+                }
             }
         }
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
@@ -16,12 +17,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         {
             var properties = PropertiesAvailableStatusFactory.CreateCategoryPropertiesAvailableStatus(includeAllProperties: true);
 
-            var entityRuntime = IEntityRuntimeModelFactory.Create();
-            var id = new EntityIdentity(key: "A", value: "B");
+            var parentEntity = IEntityWithIdFactory.Create(key: "Parent", value: "KeyValue");
+            var rule = new Rule();
             var category = new Category { DisplayName = "CategoryDisplayName", Name = "CategoryName" };
             var order = 42;
 
-            var result = (CategoryValue)CategoryDataProducer.CreateCategoryValue(entityRuntime, id, category, order, properties);
+            var result = (CategoryValue)CategoryDataProducer.CreateCategoryValue(parentEntity, rule, category, order, properties);
 
             Assert.Equal(expected: "CategoryDisplayName", actual: result.DisplayName);
             Assert.Equal(expected: "CategoryName", actual: result.Name);
@@ -33,12 +34,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         {
             var properties = PropertiesAvailableStatusFactory.CreateCategoryPropertiesAvailableStatus(includeAllProperties: true);
 
-            var entityRuntime = IEntityRuntimeModelFactory.Create();
-            var id = new EntityIdentity(key: "A", value: "B");
+            var parentEntity = IEntityWithIdFactory.Create(key: "Parent", value: "KeyValue");
+            var rule = new Rule();
             var category = new Category { DisplayName = "CategoryDisplayName", Name = "CategoryName" };
             var order = 42;
 
-            var result = (CategoryValue)CategoryDataProducer.CreateCategoryValue(entityRuntime, id, category, order, properties);
+            var result = (CategoryValue)CategoryDataProducer.CreateCategoryValue(parentEntity, rule, category, order, properties);
 
             Assert.Equal(expected: category, actual: ((IEntityValueFromProvider)result).ProviderState);
         }
@@ -48,11 +49,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         {
             var properties = PropertiesAvailableStatusFactory.CreateCategoryPropertiesAvailableStatus(includeAllProperties: true);
 
-            var parentEntity = IEntityWithIdFactory.Create(key: "A", value: "B");
+            var parentEntity = IEntityWithIdFactory.Create(key: "Parent", value: "KeyValue");
+            var rule = new Rule();
             var category = new Category { DisplayName = "CategoryDisplayName", Name = "MyCategoryName" };
             var order = 42;
 
-            var result = (CategoryValue)CategoryDataProducer.CreateCategoryValue(parentEntity, category, order, properties);
+            var result = (CategoryValue)CategoryDataProducer.CreateCategoryValue(parentEntity, rule, category, order, properties);
 
             Assert.True(result.Id.TryGetValue(ProjectModelIdentityKeys.CategoryName, out string name));
             Assert.Equal(expected: "MyCategoryName", actual: name);
@@ -82,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 }
             };
 
-            var result = CategoryDataProducer.CreateCategoryValues(parentEntity, rule, properties);
+            var result = CategoryDataProducer.CreateCategoryValues(parentEntity, rule, new List<Rule>(), properties);
 
             Assert.Collection(result, new Action<IEntityValue>[]
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducerTests.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Collections.Generic;
 using Microsoft.Build.Framework.XamlTypes;
-using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
 using Xunit;
@@ -16,10 +16,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             var properties = PropertiesAvailableStatusFactory.CreatePropertyPagePropertiesAvailableStatus(includeAllProperties: true);
 
             var propertyPage = (PropertyPageValue)PropertyPageDataProducer.CreatePropertyPageValue(
-                IEntityRuntimeModelFactory.Create(),
-                new EntityIdentity(key: "A", value: "B"),
+                IEntityWithIdFactory.Create(key: "A", value: "B"),
                 IPropertyPageQueryCacheFactory.Create(),
                 new Rule { Name = "MyRule", DisplayName = "My Rule Display Name", Order = 42, PageTemplate = "generic" },
+                debugChildRules: new List<Rule>(),
                 properties);
 
             Assert.Equal(expected: "MyRule", actual: propertyPage.Name);
@@ -34,11 +34,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             var properties = PropertiesAvailableStatusFactory.CreatePropertyPagePropertiesAvailableStatus(includeAllProperties: true);
 
             var propertyPage = (IEntityValueFromProvider)PropertyPageDataProducer.CreatePropertyPageValue(
-                IEntityRuntimeModelFactory.Create(),
-                new EntityIdentity(key: "A", value: "B"),
+                IEntityWithIdFactory.Create(key: "A", value: "B"),
                 IPropertyPageQueryCacheFactory.Create(),
                 new Rule { Name = "MyRule", DisplayName = "My Rule Display Name", Order = 42, PageTemplate = "generic" },
-                properties);
+                debugChildRules: new List<Rule>(),
+                properties) ;
 
             Assert.IsType<PropertyPageProviderState>(propertyPage.ProviderState);
         }
@@ -52,6 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 IEntityWithIdFactory.Create(key: "ParentKey", value: "ParentValue"),
                 IPropertyPageQueryCacheFactory.Create(),
                 new Rule { Name = "MyRule", DisplayName = "My Rule Display Name", Order = 42, PageTemplate = "generic" },
+                debugChildRules: new List<Rule>(),
                 properties);
 
             Assert.Equal(expected: "MyRule", actual: propertyPage.Id[ProjectModelIdentityKeys.PropertyPageName]);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             var cache = IPropertyPageQueryCacheFactory.Create();
             var property = new TestProperty { Name = "MyProperty" };
             var order = 42;
+            InitializeFakeRuleForProperty(property);
 
             var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(parentEntity, cache, property, order, properties);
 
@@ -44,6 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 Category = "general",
                 DataSource = new DataSource { HasConfigurationCondition = false }
             };
+            InitializeFakeRuleForProperty(property);
 
             var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
 
@@ -94,8 +96,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 new TestProperty { Name = "Gamma" },
             });
             rule.EndInit();
+            var debugChildRules = new List<Rule>();
 
-            var result = UIPropertyDataProducer.CreateUIPropertyValues(parentEntity, cache, rule, properties);
+            var result = UIPropertyDataProducer.CreateUIPropertyValues(parentEntity, cache, rule, debugChildRules, properties);
 
             Assert.Collection(result, new Action<IEntityValue>[]
             {
@@ -183,6 +186,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             {
                 Metadata = new List<NameValuePair>()
             };
+            InitializeFakeRuleForProperty(property);
 
             var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
 
@@ -204,6 +208,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     new() { Name = "DependsOn", Value = "" }
                 }
             };
+            InitializeFakeRuleForProperty(property);
 
             var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
 
@@ -225,6 +230,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     new() { Name = "DependsOn", Value = "Alpha;Beta;Gamma" }
                 }
             };
+            InitializeFakeRuleForProperty(property);
 
             var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
 
@@ -239,15 +245,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             var runtimeModel = IEntityRuntimeModelFactory.Create();
             var id = new EntityIdentity(key: "PropertyName", value: "A");
             var cache = IPropertyPageQueryCacheFactory.Create();
+
             var property = new TestProperty
             {
                 Metadata = new List<NameValuePair>()
             };
+            InitializeFakeRuleForProperty(property);
 
             var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
 
             Assert.Equal(expected: string.Empty, actual: result.VisibilityCondition);
         }
+
+        
 
         [Fact]
         public void WhenAPropertyHasAVisibilityCondition_ItIsReturned()
@@ -264,10 +274,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     new() { Name = "VisibilityCondition", Value = "true or false"}
                 }
             };
+            InitializeFakeRuleForProperty(property);
 
             var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
 
             Assert.Equal(expected: "true or false", actual: result.VisibilityCondition);
+        }
+
+        /// <remarks>
+        /// The only way to set the <see cref="BaseProperty.ContainingRule" /> for a property
+        /// is to actually create a rule, add the property to the rule, and go through the
+        /// initialization for the rule.
+        /// </remarks>
+        private static void InitializeFakeRuleForProperty(TestProperty property)
+        {
+            var rule = new Rule();
+            rule.BeginInit();
+            rule.Properties.Add(property);
+            rule.EndInit();
         }
 
         private class TestProperty : BaseProperty


### PR DESCRIPTION
This PR includes all the changes needed to get properties for debug pages to show up in the new project property pages. For background, we already define the ParentDebugPropertyPage.xaml which includes properties for the active launch profile, and the active launch profile's launch target. These will always be shown. In addition to that, we have individual .xaml Rule files for each launch target, specifying all the properties relevant to that target. We also have code that can read and write the values of the active launch profile to the launchSettings.json file.

Our goal in this change is to take the parent Rule and all the child Rules and combine them into a single property page, as exposed through the Project Query API. In practice what this means is re-writing the names of properties and categories on those child pages (along with their entity IDs) to make them appear as if they belong to the parent page. This re-writing also involves embedding the original page name in the category or property name so that we can retrieve the underlying data later.

This change hard-codes in this adjustment everywhere it matters. This is messy. I can imagine better architectures for this, but I expect this support for debug properties in the UI will be temporary, only lasting until we can create a dedicated UI. As such, I don't want to introduce architectural complexity when we don't have a long-term use case for it. To the extent possible, the Debug-page-specific logic has been consolidated to a single file. This should make it easier to remove later.

Beyond that, we also need to tweak the `DependsOn` and `VisibilityCondition` metadata on the properties from the child pages. `DependsOn` is updated to indicate that these properties depend on a couple of well-known properties on the parent page. The `VisibilityCondition` is updated so that the properties for a particular child page will only show when the launch target property (from the parent page) will have the correct value.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6770)