### PR TITLE
Preserve values of a synthetic property

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ResourceSpecificationKindValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ResourceSpecificationKindValueProvider.cs
@@ -6,16 +6,17 @@ using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
-    [ExportInterceptingPropertyValueProvider("ResourceSpecificationKind", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    [ExportInterceptingPropertyValueProvider(ResourceSpecificationKindProperty, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     internal sealed class ResourceSpecificationKindValueProvider : InterceptingPropertyValueProviderBase
     {
         private readonly ITemporaryPropertyStorage _temporaryPropertyStorage;
 
-        private const string Win32ResourceMSBuildProperty = "Win32Resource";
-        private const string ApplicationIconMSBuildProperty = "ApplicationIcon";
-        private const string ApplicationManifestMSBuildProperty = "ApplicationManifest";
-        private const string IconAndManifestValue = "IconAndManifest";
-        private const string ResourceFileValue = "ResourceFile";
+        internal const string ResourceSpecificationKindProperty = "ResourceSpecificationKind";
+        internal const string Win32ResourceMSBuildProperty = "Win32Resource";
+        internal const string ApplicationIconMSBuildProperty = "ApplicationIcon";
+        internal const string ApplicationManifestMSBuildProperty = "ApplicationManifest";
+        internal const string IconAndManifestValue = "IconAndManifest";
+        internal const string ResourceFileValue = "ResourceFile";
 
         [ImportingConstructor]
         public ResourceSpecificationKindValueProvider(ITemporaryPropertyStorage temporaryPropertyStorage)
@@ -27,6 +28,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             if (StringComparers.PropertyLiteralValues.Equals(unevaluatedPropertyValue, IconAndManifestValue))
             {
+                _temporaryPropertyStorage.AddOrUpdatePropertyValue(ResourceSpecificationKindProperty, IconAndManifestValue);
+
                 await defaultProperties.SaveValueIfCurrentlySetAsync(Win32ResourceMSBuildProperty, _temporaryPropertyStorage);
                 await defaultProperties.DeletePropertyAsync(Win32ResourceMSBuildProperty);
                 await defaultProperties.RestoreValueIfNotCurrentlySetAsync(ApplicationIconMSBuildProperty, _temporaryPropertyStorage);
@@ -34,6 +37,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             }
             else if (StringComparers.PropertyLiteralValues.Equals(unevaluatedPropertyValue, ResourceFileValue))
             {
+                _temporaryPropertyStorage.AddOrUpdatePropertyValue(ResourceSpecificationKindProperty, ResourceFileValue);
+
                 await defaultProperties.SaveValueIfCurrentlySetAsync(ApplicationIconMSBuildProperty, _temporaryPropertyStorage);
                 await defaultProperties.SaveValueIfCurrentlySetAsync(ApplicationManifestMSBuildProperty, _temporaryPropertyStorage);
                 await defaultProperties.DeletePropertyAsync(ApplicationIconMSBuildProperty);
@@ -47,20 +52,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             string win32Resource = await defaultProperties.GetEvaluatedPropertyValueAsync(Win32ResourceMSBuildProperty);
+            string applicationIconResource = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationIconMSBuildProperty);
+            string applicationManifestResource = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationManifestMSBuildProperty);
 
-            return ComputeValue(win32Resource);
+            return ComputeValue(win32Resource, applicationIconResource, applicationManifestResource);
         }
 
         public override async Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             string? win32Resource = await defaultProperties.GetUnevaluatedPropertyValueAsync(Win32ResourceMSBuildProperty);
+            string? applicationIconResource = await defaultProperties.GetUnevaluatedPropertyValueAsync(ApplicationIconMSBuildProperty);
+            string? applicationManifestResource = await defaultProperties.GetUnevaluatedPropertyValueAsync(ApplicationManifestMSBuildProperty);
 
-            return ComputeValue(win32Resource);
+            return ComputeValue(win32Resource, applicationIconResource, applicationManifestResource);
         }
 
-        private static string ComputeValue(string? win32Resource)
+        private string ComputeValue(string? win32Resource, string? applicationIconResource, string? applicationManifestResource)
         {
-            return string.IsNullOrEmpty(win32Resource) ? IconAndManifestValue : ResourceFileValue;
+            if (!string.IsNullOrEmpty(applicationIconResource)
+                || !string.IsNullOrEmpty(applicationManifestResource))
+            {
+                return IconAndManifestValue;
+            }
+
+            if (!string.IsNullOrEmpty(win32Resource))
+            {
+                return ResourceFileValue;
+            }
+
+            if (_temporaryPropertyStorage.GetPropertyValue(ResourceSpecificationKindProperty) is string savedValue)
+            {
+                return savedValue;
+            }
+
+            return IconAndManifestValue;
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ITemporaryPropertyStorageFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ITemporaryPropertyStorageFactory.cs
@@ -10,10 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     {
         public static ITemporaryPropertyStorage Create(Dictionary<string, string>? values = null)
         {
-            if (values is null)
-            {
-                values = new();
-            }
+            values ??= new();
 
             var mock = new Mock<ITemporaryPropertyStorage>();
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ITemporaryPropertyStorageFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ITemporaryPropertyStorageFactory.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class ITemporaryPropertyStorageFactory
+    {
+        public static ITemporaryPropertyStorage Create(Dictionary<string, string>? values = null)
+        {
+            if (values is null)
+            {
+                values = new();
+            }
+
+            var mock = new Mock<ITemporaryPropertyStorage>();
+
+            mock.Setup(o => o.AddOrUpdatePropertyValue(It.IsAny<string>(), It.IsAny<string>()))
+                .Callback<string, string>((name, value) => values[name] = value);
+
+            mock.Setup(o => o.GetPropertyValue(It.IsAny<string>()))
+                .Returns<string>(name => { values.TryGetValue(name, out string value); return value; });
+
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ResourceSpecificationKindValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ResourceSpecificationKindValueProviderTests.cs
@@ -1,0 +1,97 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    public class ResourceSpecificationKindValueProviderTests
+    {
+        [Fact]
+        public async Task WhenSettingTheValue_TheNewValueIsStoredInTemporaryStorage()
+        {
+            var storageDictionary = new Dictionary<string, string>();
+            var provider = new ResourceSpecificationKindValueProvider(ITemporaryPropertyStorageFactory.Create(storageDictionary));
+
+            var result = await provider.OnSetPropertyValueAsync(
+                ResourceSpecificationKindValueProvider.ResourceSpecificationKindProperty,
+                ResourceSpecificationKindValueProvider.ResourceFileValue,
+                Mock.Of<IProjectProperties>());
+
+            Assert.Null(result);
+            Assert.True(storageDictionary.TryGetValue(ResourceSpecificationKindValueProvider.ResourceSpecificationKindProperty, out string savedValue));
+            Assert.Equal(expected: ResourceSpecificationKindValueProvider.ResourceFileValue, actual: savedValue);
+        }
+
+        [Fact]
+        public async Task WhenGettingTheValue_DefaultsToIconAndManifest()
+        {
+            var provider = new ResourceSpecificationKindValueProvider(ITemporaryPropertyStorageFactory.Create());
+
+            var result = await provider.OnGetEvaluatedPropertyValueAsync(
+                ResourceSpecificationKindValueProvider.ResourceSpecificationKindProperty,
+                string.Empty,
+                Mock.Of<IProjectProperties>());
+
+            Assert.Equal(expected: ResourceSpecificationKindValueProvider.IconAndManifestValue, actual: result);
+        }
+
+        [Fact]
+        public async Task WhenGettingTheValue_TheValueIsRetrievedFromTemporaryStorageIfAvailable()
+        {
+            var storageDictionary = new Dictionary<string, string> { [ResourceSpecificationKindValueProvider.ResourceSpecificationKindProperty] = ResourceSpecificationKindValueProvider.ResourceFileValue };
+            var provider = new ResourceSpecificationKindValueProvider(ITemporaryPropertyStorageFactory.Create(storageDictionary));
+
+            var result = await provider.OnGetEvaluatedPropertyValueAsync(
+                ResourceSpecificationKindValueProvider.ResourceSpecificationKindProperty,
+                string.Empty,
+                Mock.Of<IProjectProperties>());
+
+            Assert.Equal(expected: ResourceSpecificationKindValueProvider.ResourceFileValue, actual: result);
+        }
+
+        [Fact]
+        public async Task WhenGettingTheValue_ReturnsResourceFileIfWin32ResourceIsSet()
+        {
+            var provider = new ResourceSpecificationKindValueProvider(ITemporaryPropertyStorageFactory.Create());
+            var defaultProperties = IProjectPropertiesFactory.CreateWithPropertyAndValue(ResourceSpecificationKindValueProvider.Win32ResourceMSBuildProperty, @"C:\alpha\beta\gamma.res");
+
+            var result = await provider.OnGetEvaluatedPropertyValueAsync(
+                ResourceSpecificationKindValueProvider.ResourceSpecificationKindProperty,
+                string.Empty,
+                defaultProperties);
+
+            Assert.Equal(expected: ResourceSpecificationKindValueProvider.ResourceFileValue, actual: result);
+        }
+
+        [Fact]
+        public async Task WhenGettingTheValue_ReturnsIconAndManifestIfIconSet()
+        {
+            var provider = new ResourceSpecificationKindValueProvider(ITemporaryPropertyStorageFactory.Create());
+            var defaultProperties = IProjectPropertiesFactory.CreateWithPropertyAndValue(ResourceSpecificationKindValueProvider.ApplicationIconMSBuildProperty, @"C:\alpha\beta\gamma.ico");
+
+            var result = await provider.OnGetEvaluatedPropertyValueAsync(
+                ResourceSpecificationKindValueProvider.ResourceSpecificationKindProperty,
+                string.Empty,
+                defaultProperties);
+
+            Assert.Equal(expected: ResourceSpecificationKindValueProvider.IconAndManifestValue, actual: result);
+        }
+
+        [Fact]
+        public async Task WhenGettingTheValue_ReturnsIconAndManifestIfManifestSet()
+        {
+            var provider = new ResourceSpecificationKindValueProvider(ITemporaryPropertyStorageFactory.Create());
+            var defaultProperties = IProjectPropertiesFactory.CreateWithPropertyAndValue(ResourceSpecificationKindValueProvider.ApplicationManifestMSBuildProperty, @"C:\alpha\beta\app.config");
+
+            var result = await provider.OnGetEvaluatedPropertyValueAsync(
+                ResourceSpecificationKindValueProvider.ResourceSpecificationKindProperty,
+                string.Empty,
+                defaultProperties);
+
+            Assert.Equal(expected: ResourceSpecificationKindValueProvider.IconAndManifestValue, actual: result);
+        }
+    }
+}


### PR DESCRIPTION
In the new project property pages we allow the user to specify if they want to supply separate icon and manifest files for their application, or if they want to supply a resource file containing the information. This selection is done via a drop down. Depending on which option the user chooses, we show or hide the controls for the relevant properties.

This "resource specification kind" is a "synthetic" property that has no representation of its own in the project file (or any other storage). Instead, we assume that if the "Win32Resource" property has a value, the user has opted to use a resource file; otherwise, they have opted to use an icon and manifest.

This currently leads to problems when trying to switch between the two. If the project does not specify the "Win32Resource" property and the user tries to change the drop down from "Icon and Manifest" to "Resource file" the property page will send the new value ("ResourceFile") to the server. It then refreshes its value--and gets back "IconAndManifest". At this point the drop down reverts to its original value, and the controls for the resource file path are hidden.

To fix this, we need to remember the user's choice for the resource specification kind when they have made an explicit change. Here we make use of `ITemporaryProjectStorage` to do so, and we use the following logic when the resource specification kind is retrieved:

1. If the application icon or application manifest are specified, return "IconAndManifest".
2. If the resource file is specified, return "ResourceFile".
3. If none of those properties are specified but we have a saved value, use that.
4. If all else fails, return "IconAndManifest" as the default.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6772)