### PR TITLE
Only set config-independent properties once

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUIPropertyValueActionCore.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUIPropertyValueActionCore.cs
@@ -3,11 +3,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Microsoft.VisualStudio.ProjectSystem.Query;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUIPropertyValueActionCore.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUIPropertyValueActionCore.cs
@@ -79,9 +79,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                         // all matching configurations.
                         if (await propertyPageCache.GetKnownConfigurationsAsync() is IImmutableSet<ProjectConfiguration> knownConfigurations)
                         {
-                            foreach (ProjectConfiguration knownConfiguration in knownConfigurations.Where(config => config.MatchesDimensions(_dimensions)))
+                            foreach (ProjectConfiguration knownConfiguration in knownConfigurations)
                             {
-                                if (await propertyPageCache.BindToRule(knownConfiguration, _pageName) is IRule boundRule)
+                                if (knownConfiguration.MatchesDimensions(_dimensions)
+                                    && await propertyPageCache.BindToRule(knownConfiguration, _pageName) is IRule boundRule)
                                 {
                                     projectRules.Add(boundRule);
                                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUIPropertyValueActionCore.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUIPropertyValueActionCore.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 
@@ -64,19 +65,37 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         {
             foreach (UnconfiguredProject project in targetProjects)
             {
-                if (!_rules.TryGetValue(project.FullPath, out List<IRule> projectRules))
+                if (!_rules.TryGetValue(project.FullPath, out List<IRule> projectRules)
+                    && await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
+                    && projectCatalog.GetSchema(_pageName) is Rule rule
+                    && rule.GetProperty(_propertyName) is BaseProperty property)
                 {
+                    bool configurationDependent = property.IsConfigurationDependent();
                     projectRules = new List<IRule>();
-
                     IPropertyPageQueryCache propertyPageCache = _queryCacheProvider.CreateCache(project);
-                    if (await propertyPageCache.GetKnownConfigurationsAsync() is IImmutableSet<ProjectConfiguration> knownConfigurations)
+                    if (configurationDependent)
                     {
-                        foreach (ProjectConfiguration knownConfiguration in knownConfigurations.Where(config => config.MatchesDimensions(_dimensions)))
+                        // The property is configuration-dependent; we need to collect the bound rules for
+                        // all matching configurations.
+                        if (await propertyPageCache.GetKnownConfigurationsAsync() is IImmutableSet<ProjectConfiguration> knownConfigurations)
                         {
-                            if (await propertyPageCache.BindToRule(knownConfiguration, _pageName) is IRule boundRule)
+                            foreach (ProjectConfiguration knownConfiguration in knownConfigurations.Where(config => config.MatchesDimensions(_dimensions)))
                             {
-                                projectRules.Add(boundRule);
+                                if (await propertyPageCache.BindToRule(knownConfiguration, _pageName) is IRule boundRule)
+                                {
+                                    projectRules.Add(boundRule);
+                                }
                             }
+                        }
+                    }
+                    else
+                    {
+                        // The property is configuration-independent; we only need the bound rule for a single
+                        // configuration.
+                        if (await propertyPageCache.GetSuggestedConfigurationAsync() is ProjectConfiguration suggestedConfiguration
+                            && await propertyPageCache.BindToRule(suggestedConfiguration, _pageName) is IRule boundRule)
+                        {
+                            projectRules.Add(boundRule);
                         }
                     }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IRuleFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IRuleFactory.cs
@@ -41,5 +41,15 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             return rule.Object;
         }
+
+        public static IRule Create(Rule schema)
+        {
+            var rule = new Mock<IRule>();
+
+            rule.Setup(o => o.Schema)
+                .Returns(schema);
+
+            return rule.Object;
+        }
     }
 }


### PR DESCRIPTION
Currently, when setting a property value through the Project Query API we first find all the applicable `ConfiguredProject`s, then bind the requested rule in each, and finally retrieve and set the property in each bound rule.

This makes sense for configuration-dependent properties, where we may want to set the values in some configurations but not others. However, most of our properties are configuration-independent and it doesn't matter which `ConfiguredProject` we go through or how many: ultimately, we'll end up with just one definition in the project file, with no configuration conditions. To avoid unnecessary work we should only set the value of a configuration-independent property once.

This commit adds the necessary checks before we start retrieving the `ConfiguredProject`s.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6775)