### PR TITLE
Extend up-to-date check telemetry

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.TimestampCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.TimestampCache.cs
@@ -22,6 +22,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 _timestampCache = new Dictionary<string, DateTime>(StringComparers.Paths);
             }
 
+            /// <summary>
+            /// Gets the number of unique files added to this cache.
+            /// </summary>
+            public int Count => _timestampCache.Count;
+
             public DateTime? GetTimestampUtc(string path)
             {
                 if (!_timestampCache.TryGetValue(path, out DateTime time))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
@@ -18,6 +18,16 @@ namespace Microsoft.VisualStudio.Telemetry
         public static readonly string UpToDateCheckFailReason = BuildPropertyName(TelemetryEventName.UpToDateCheckFail, "Reason");
 
         /// <summary>
+        ///     Indicates the duration of the up-to-date check, in milliseconds.
+        /// </summary>
+        public const string UpToDateCheckDurationMillis = Prefix + ".uptodatecheck.durationmillis";
+
+        /// <summary>
+        ///     Indicates the number of file system timestamps that were queried during the up-to-date check.
+        /// </summary>
+        public const string UpToDateCheckFileCount = Prefix + ".uptodatecheck.filecount";
+
+        /// <summary>
         ///     Indicates the project when the dependency tree is updated with all resolved dependencies.
         /// </summary>
         public static readonly string TreeUpdatedResolvedProject = BuildPropertyName(TelemetryEventName.TreeUpdatedResolved, "Project");

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ITelemetryServiceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ITelemetryServiceFactory.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Moq;
 
 namespace Microsoft.VisualStudio.Telemetry
@@ -19,7 +20,7 @@ namespace Microsoft.VisualStudio.Telemetry
         {
             public string? EventName { get; set; }
 
-            public IEnumerable<(string propertyName, object propertyValue)>? Properties { get; set; }
+            public List<(string propertyName, object propertyValue)>? Properties { get; set; }
         }
 
         public static ITelemetryService Create(TelemetryParameters callParameters)
@@ -43,7 +44,7 @@ namespace Microsoft.VisualStudio.Telemetry
                 .Callback((string e, IEnumerable<(string propertyName, object propertyValue)> p) =>
                 {
                     callParameters.EventName = e;
-                    callParameters.Properties = p;
+                    callParameters.Properties = p.ToList();
                 });
 
             return telemetryService.Object;
@@ -83,7 +84,7 @@ namespace Microsoft.VisualStudio.Telemetry
                     var callParameters = new TelemetryParameters
                     {
                         EventName = e,
-                        Properties = p
+                        Properties = p.ToList()
                     };
                     onTelemetryLogged(callParameters);
                 });

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -1351,20 +1351,42 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         private void AssertTelemetryFailureEvent(string reason)
         {
-            Assert.Single(_telemetryEvents);
-            Assert.Equal(TelemetryEventName.UpToDateCheckFail, _telemetryEvents.Single().EventName);
-            Assert.Single(_telemetryEvents.Single().Properties);
-            Assert.Equal(TelemetryPropertyName.UpToDateCheckFailReason, _telemetryEvents.Single().Properties.Single().propertyName);
-            Assert.Equal(reason, _telemetryEvents.Single().Properties.Single().propertyValue);
+            var telemetryEvent = Assert.Single(_telemetryEvents);
+
+            Assert.Equal(TelemetryEventName.UpToDateCheckFail, telemetryEvent.EventName);
+            Assert.NotNull(telemetryEvent.Properties);
+            Assert.Equal(3, telemetryEvent.Properties!.Count);
+
+            var reasonProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckFailReason));
+            Assert.Equal(reason, reasonProp.propertyValue);
+
+            var durationProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckDurationMillis));
+            var duration = Assert.IsType<double>(durationProp.propertyValue);
+            Assert.True(duration > 0.0);
+
+            var fileCountProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckFileCount));
+            var fileCount = Assert.IsType<int>(fileCountProp.propertyValue);
+            Assert.True(fileCount >= 0);
 
             _telemetryEvents.Clear();
         }
 
         private void AssertTelemetrySuccessEvent()
         {
-            Assert.Single(_telemetryEvents);
-            Assert.Equal(TelemetryEventName.UpToDateCheckSuccess, _telemetryEvents.Single().EventName);
-            Assert.Null(_telemetryEvents.Single().Properties);
+            var telemetryEvent = Assert.Single(_telemetryEvents);
+
+            Assert.Equal(TelemetryEventName.UpToDateCheckSuccess, telemetryEvent.EventName);
+
+            Assert.NotNull(telemetryEvent.Properties);
+            Assert.Equal(2, telemetryEvent.Properties!.Count);
+
+            var durationProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckDurationMillis));
+            var duration = Assert.IsType<double>(durationProp.propertyValue);
+            Assert.True(duration > 0.0);
+
+            var fileCountProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckFileCount));
+            var fileCount = Assert.IsType<int>(fileCountProp.propertyValue);
+            Assert.True(fileCount >= 0);
 
             _telemetryEvents.Clear();
         }


### PR DESCRIPTION
Fixes #6776.

Extends the existing telemetry events for pass/fail to include two new properties each:

1. The duration of the check, in milliseconds
2. The number of file system timestamp queries

## Not up-to-date

Event `vs/projectsystem/managed/uptodatecheck/fail`:

| property | value |
|----|---|
|vs.projectsystem.managed.uptodatecheck.durationmillis|22.5333|
|vs.projectsystem.managed.uptodatecheck.fail.reason|Outputs|
|vs.projectsystem.managed.uptodatecheck.filecount|6|

## Up-to-date

Event `vs/projectsystem/managed/uptodatecheck/success`:

| property | value |
|----|---|
|vs.projectsystem.managed.uptodatecheck.durationmillis|16.1586|
|vs.projectsystem.managed.uptodatecheck.filecount|157|


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6778)