### PR TITLE
Bug1163112

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
 using System.ComponentModel.Composition;
 using System.Globalization;
 using System.IO;
@@ -85,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             // Rename the file
             await CPSRenameAsync(context, node, value);
 
-            if (await IsAutomationFunctionAsync() || node.IsFolder || _vsOnlineServices.ConnectedToVSOnline || 
+            if (await IsAutomationFunctionAsync() || node.IsFolder || _vsOnlineServices.ConnectedToVSOnline ||
                 FileChangedExtension(oldFilePath, newFileWithExtension))
             {
                 // Do not display rename Prompt
@@ -145,7 +144,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
         }
 
         private static bool FileChangedExtension(string? oldFilePath, string newFileWithExtension)
-            => string.Compare(Path.GetExtension(oldFilePath), Path.GetExtension(newFileWithExtension), StringComparison.OrdinalIgnoreCase) != 0;
+            => !StringComparers.Paths.Equals(Path.GetExtension(oldFilePath), Path.GetExtension(newFileWithExtension));
 
         private async Task<Solution> PublishLatestSolutionAsync()
         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/RenamerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/RenamerTests.cs
@@ -105,6 +105,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
             Mock.Get(roslynServices).Verify(h => h.ApplyChangesToSolution(It.IsAny<Workspace>(), It.IsAny<Solution>()), Times.Never);
         }
 
+        [Fact]
+        public async Task Rename_Symbol_Should_ExitEarlyInFileExtensionChange()
+        {
+            string sourceCode = "class Foo { }";
+            string oldFilePath = "Foo.cs";
+            string newFilePath = "Foo.txt";
+
+            var userNotificationServices = IUserNotificationServicesFactory.Create();
+            var roslynServices = IRoslynServicesFactory.Implement(new CSharpSyntaxFactsService());
+            var vsOnlineService = IVsOnlineServicesFactory.Create(online: false);
+            var settingsManagerService = CreateSettingsManagerService(true);
+
+            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineService, LanguageNames.CSharp, settingsManagerService);
+
+            Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Never);
+            Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            Mock.Get(roslynServices).Verify(h => h.ApplyChangesToSolution(It.IsAny<Workspace>(), It.IsAny<Solution>()), Times.Never);
+        }
+
         private IVsService<SVsSettingsPersistenceManager, ISettingsManager> CreateSettingsManagerService(bool enableSymbolicRename)
         {
             var settingsManagerMock = new Mock<ISettingsManager>();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasic/RenamerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasic/RenamerTests.cs
@@ -148,6 +148,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.VisualBasic
             Mock.Get(roslynServices).Verify(h => h.ApplyChangesToSolution(It.IsAny<Workspace>(), It.IsAny<Solution>()), Times.Never);
         }
 
+        [Fact]
+        public async Task Rename_Symbol_Should_ExitEarlyInFileExtensionChange()
+        {
+            string sourceCode = 
+                @"Class Foo
+                End Class";
+            string oldFilePath = "Foo.vb";
+            string newFilePath = "Foo.txt";
+
+            var userNotificationServices = IUserNotificationServicesFactory.Create();
+            var roslynServices = IRoslynServicesFactory.Implement(new VisualBasicSyntaxFactsService());
+            var vsOnlineService = IVsOnlineServicesFactory.Create(online: false);
+            var settingsManagerService = CreateSettingsManagerService(true);
+
+            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineService, LanguageNames.VisualBasic, settingsManagerService);
+
+            Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Never);
+            Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            Mock.Get(roslynServices).Verify(h => h.ApplyChangesToSolution(It.IsAny<Workspace>(), It.IsAny<Solution>()), Times.Never);
+        }
+
         private IVsService<SVsSettingsPersistenceManager, ISettingsManager> CreateSettingsManagerService(bool enableSymbolicRename)
         {
             var settingsManagerMock = new Mock<ISettingsManager>();


### PR DESCRIPTION
[AB#1163112](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1163112) Fixes file rename crashing when a file changes its extension.

`RenameAsync()` was trying to apply symbols rename and Roslyn was failing to find the original filename.

* This change checks for changes in file extensions, and avoid calling Roslyn symbol rename.

* Apart from this, there are other few minor changes as part of the cleanup.

* Added one unit-test to test `RenamerProjectTreeActionHandler.FileChangedExtension`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6782)