### PR TITLE
Ensure XLF strings do not contain multiple accelerator mnemonics

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Resources/XliffTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Resources/XliffTests.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using Microsoft.VisualStudio.Utilities;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Resources
+{
+    public sealed class XliffTests
+    {
+        private const string XliffNamespace = "urn:oasis:names:tc:xliff:document:1.2";
+
+        private static readonly Regex s_acceleratorPattern = new(@"&\w");
+
+        [Theory]
+        [MemberData(nameof(GetXlfFiles))]
+        public void ResourceStringsDoNotContainMultipleAcceleratorMnemonics(string fileName, string path)
+        {
+            var settings = new XmlReaderSettings { XmlResolver = null };
+            using var fileStream = File.OpenRead(path);
+            using var reader = XmlReader.Create(fileStream, settings);
+            var root = XDocument.Load(reader).Root;
+
+            var namespaceManager = new XmlNamespaceManager(reader.NameTable);
+            namespaceManager.AddNamespace("x", XliffNamespace);
+
+            var targets = root.XPathSelectElements(@"/x:xliff/x:file/x:body/x:trans-unit/x:target", namespaceManager);
+
+            foreach (var target in targets)
+            {
+                var matches = s_acceleratorPattern.Matches(target.Value);
+
+                if (matches.Count > 1)
+                {
+                    throw new Xunit.Sdk.XunitException("Translated string contains multiple accelerator mnemonics: " + target.Value);
+                }
+            }
+        }
+
+        private static IEnumerable<object[]> GetXlfFiles()
+        {
+            var root = RepoUtil.FindRepoRootPath();
+
+            var xlfFiles = Directory.EnumerateFiles(root, "*.xlf", SearchOption.AllDirectories);
+
+            return xlfFiles.Select(file => new object[] { Path.GetFileName(file), file });
+        }
+    }
+}


### PR DESCRIPTION
NOTE This PR will fail to build until #6788 is merged. That failure is exactly what this unit test is trying to catch in future.

---

The ampersand character in UI control labels generally causes the subsequent character to be treated as a keyboard accelerator.

It is irregular for a UI element to have more than one such accelerator key.

We saw such a situation in a resource file, which was addressed in #6788.

This test ensures the scenario doesn't occur again in future.

Note that not all resource strings are used as UI labels, so it's possible this test may need tweaking in future. WPF uses underscore for accelerators, but this causes too many false positives in our resource files, so has been excluded here.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6789)