### PR TITLE
Source all unresolved references from evaluation

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/AnalyzerReference.xaml
@@ -8,10 +8,8 @@
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="Analyzer"
-                MSBuildTarget="CollectAnalyzersDesignTime"
                 Persistence="ProjectFile"
-                SourceOfDefaultValue="AfterContext"
-                SourceType="TargetResults" />
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   
   <StringProperty Name="BrowsePath"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedFrameworkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedFrameworkReference.xaml
@@ -5,7 +5,6 @@
       DisplayName="Framework Reference"
       PageTemplate="generic"
       xmlns="http://schemas.microsoft.com/build/2009/properties">
-  
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="FrameworkReference"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/SdkReference.xaml
@@ -8,10 +8,8 @@
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="SDKReference"
-                MSBuildTarget="CollectSDKReferencesDesignTime"
                 Persistence="ProjectFile"
-                SourceOfDefaultValue="AfterContext"
-                SourceType="TargetResults" />
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
   <StringProperty Name="AppXLocation"

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/DependencyRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/DependencyRuleTests.cs
@@ -139,6 +139,75 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
         }
 
         [Theory]
+        [MemberData(nameof(GetUnresolvedDependenciesRules))]
+        public void UnresolvedRulesDataSources(string ruleName, string fullPath)
+        {
+            XElement rule = LoadXamlRule(fullPath, out var namespaceManager);
+
+            XElement? dataSource = rule.XPathSelectElement(@"/msb:Rule/msb:Rule.DataSource/msb:DataSource", namespaceManager);
+
+            Assert.NotNull(dataSource);
+
+            Assert.Null(dataSource!.Attribute("MSBuildTarget")); // Must come from evaluation
+            Assert.Null(dataSource.Attribute("SourceType"));     // Must come from evaluation
+
+            var hasConfigurationCondition = dataSource.Attribute("HasConfigurationCondition");
+            Assert.NotNull(hasConfigurationCondition);
+            Assert.Equal("False", hasConfigurationCondition!.Value, StringComparer.OrdinalIgnoreCase);
+
+            var itemType = dataSource.Attribute("ItemType");
+            Assert.NotNull(itemType);
+            Assert.False(string.IsNullOrEmpty(itemType!.Value));
+
+            var persistence = dataSource.Attribute("Persistence");
+            Assert.NotNull(persistence);
+            Assert.Equal("ProjectFile", persistence!.Value, StringComparer.Ordinal);
+
+            var sourceOfDefaultValue = dataSource.Attribute("SourceOfDefaultValue");
+            Assert.NotNull(sourceOfDefaultValue);
+            Assert.Equal("AfterContext", sourceOfDefaultValue!.Value, StringComparer.Ordinal);
+
+            Assert.Equal(4, dataSource.Attributes().Count());
+        }
+
+        [Theory]
+        [MemberData(nameof(GetResolvedDependenciesRules))]
+        public void ResolvedRulesDataSources(string ruleName, string fullPath)
+        {
+            XElement rule = LoadXamlRule(fullPath, out var namespaceManager);
+
+            XElement? dataSource = rule.XPathSelectElement(@"/msb:Rule/msb:Rule.DataSource/msb:DataSource", namespaceManager);
+
+            Assert.NotNull(dataSource);
+
+            var hasConfigurationCondition = dataSource!.Attribute("HasConfigurationCondition");
+            Assert.NotNull(hasConfigurationCondition);
+            Assert.Equal("False", hasConfigurationCondition!.Value, StringComparer.OrdinalIgnoreCase);
+
+            var itemType = dataSource.Attribute("ItemType");
+            Assert.NotNull(itemType);
+            Assert.False(string.IsNullOrEmpty(itemType!.Value));
+
+            var msBuildTarget = dataSource.Attribute("MSBuildTarget");
+            Assert.NotNull(msBuildTarget);
+            Assert.False(string.IsNullOrEmpty(msBuildTarget!.Value));
+
+            var persistence = dataSource.Attribute("Persistence");
+            Assert.NotNull(persistence);
+            Assert.Equal("ResolvedReference", persistence!.Value, StringComparer.Ordinal);
+
+            var sourceOfDefaultValue = dataSource.Attribute("SourceOfDefaultValue");
+            Assert.NotNull(sourceOfDefaultValue);
+            Assert.Equal("AfterContext", sourceOfDefaultValue!.Value, StringComparer.Ordinal);
+
+            var sourceType = dataSource.Attribute("SourceType");
+            Assert.NotNull(sourceType);
+            Assert.Equal("TargetResults", sourceType!.Value, StringComparer.Ordinal);
+
+            Assert.Equal(6, dataSource.Attributes().Count());
+        }
+
+        [Theory]
         [MemberData(nameof(GetResolvedAndUnresolvedDependencyRulePairs))]
         public void ResolvedAndUnresolvedDependencyRulesHaveSameDisplayName(string unresolvedName, string resolvedName, string unresolvedPath, string resolvedPath)
         {


### PR DESCRIPTION
Fixes #6803. Fixes #6804.

The dependencies tree consumes both unresolved and resolved versions of project dependency items.

Unresolved items are obtained quickly via evaluation in order to build the tree rapidly when a project is opened, and to quickly reflect changes to the tree as items are added, removed and updated over time.

Resolved items are obtained via design-time builds. They contain much richer information about dependencies than evaluation items, and the tree is updated with that information as it becomes available.

It's important that unresolved items are only sourced from evaluation. If their rule files request they come from design-time builds, then they the dependencies tree cannot be built until a design-time build completes.

Before this change, both SDK and Analyzer items were being sourced from design-time build targets. This meant that all other dependency types were being held up, waiting for the design-time build to complete. To the user, this means a delay in the construction of the dependencies tree when loading a project.

This change adds unit tests to validate the details of both resolved and unresolved dependency item data sources, to prevent this problem occurring again in future.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6806)