### PR TITLE
Fix package reference removal

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -102,18 +102,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
             TargetFramework targetFramework,
             Func<string, bool>? isEvaluatedItemSpec)
         {
-            if (TryCreatePackageDependencyModel(
-                projectFullPath,
-                removedItem,
-                resolved,
-                properties: projectChange.Before.GetProjectItemProperties(removedItem)!,
-                evaluationRuleSnapshot,
-                isEvaluatedItemSpec,
-                targetFramework,
-                out PackageDependencyModel? dependencyModel))
-            {
-                changesBuilder.Removed(ProviderTypeString, dependencyModel.OriginalItemSpec);
-            }
+            string originalItemSpec = resolved
+                ? projectChange.Before.GetProjectItemProperties(removedItem)?.GetStringProperty(ProjectItemMetadata.Name) ?? removedItem
+                : removedItem;
+
+            changesBuilder.Removed(ProviderTypeString, originalItemSpec);
         }
 
         public override IDependencyModel CreateRootDependencyNode() => s_groupModel;


### PR DESCRIPTION
Fixes #6813.

PR #6781 added a condition to `TryCreatePackageDependencyModel` that required the evaluation snapshot to contain the item before continuing. This logic does not make sense in the case of removal, as that dependency will not be in the snapshot by definition.

When removing, we do not need to create the `PackageDependencyModel`. We only need the (original) item spec.

In addition to fixing the bug, this change also cuts down on the amount of code that runs and memory that's allocated during package reference removal.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6814)