### PR TITLE
Fix a11y issue: Name must not include LocalizedControlType.

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx
@@ -757,7 +757,7 @@
     <value>3</value>
   </data>
   <data name="LicenseExpressionRadioButton.AccessibleName" xml:space="preserve">
-    <value>Package License Expression Radio Button</value>
+    <value>Package License Expression</value>
   </data>
   <data name="LicenseExpressionRadioButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>None</value>
@@ -880,7 +880,7 @@
     <value>3</value>
   </data>
   <data name="LicenseFileRadioButton.AccessibleName" xml:space="preserve">
-    <value>Package License File Radio Button</value>
+    <value>Package License File</value>
   </data>
   <data name="LicenseFileRadioButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>None</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.cs.xlf
@@ -258,13 +258,13 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseExpressionRadioButton.AccessibleName">
-        <source>Package License Expression Radio Button</source>
-        <target state="translated">Přepínač výrazu licence na balíček</target>
+        <source>Package License Expression</source>
+        <target state="needs-review-translation">Přepínač výrazu licence na balíček</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseFileRadioButton.AccessibleName">
-        <source>Package License File Radio Button</source>
-        <target state="translated">Přepínač souboru licence na balíček</target>
+        <source>Package License File</source>
+        <target state="needs-review-translation">Přepínač souboru licence na balíček</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.de.xlf
@@ -258,13 +258,13 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseExpressionRadioButton.AccessibleName">
-        <source>Package License Expression Radio Button</source>
-        <target state="translated">Optionsfeld für Paketlizenzausdruck</target>
+        <source>Package License Expression</source>
+        <target state="needs-review-translation">Optionsfeld für Paketlizenzausdruck</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseFileRadioButton.AccessibleName">
-        <source>Package License File Radio Button</source>
-        <target state="translated">Optionsfeld für Paketlizenzdatei</target>
+        <source>Package License File</source>
+        <target state="needs-review-translation">Optionsfeld für Paketlizenzdatei</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.es.xlf
@@ -258,13 +258,13 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseExpressionRadioButton.AccessibleName">
-        <source>Package License Expression Radio Button</source>
-        <target state="translated">Botón de selección para la expresión de la licencia del paquete</target>
+        <source>Package License Expression</source>
+        <target state="needs-review-translation">Botón de selección para la expresión de la licencia del paquete</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseFileRadioButton.AccessibleName">
-        <source>Package License File Radio Button</source>
-        <target state="translated">Botón de selección del archivo de licencia del paquete</target>
+        <source>Package License File</source>
+        <target state="needs-review-translation">Botón de selección del archivo de licencia del paquete</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.fr.xlf
@@ -258,13 +258,13 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseExpressionRadioButton.AccessibleName">
-        <source>Package License Expression Radio Button</source>
-        <target state="translated">Case d'option de l'expression de licence du package</target>
+        <source>Package License Expression</source>
+        <target state="needs-review-translation">Case d'option de l'expression de licence du package</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseFileRadioButton.AccessibleName">
-        <source>Package License File Radio Button</source>
-        <target state="translated">Case d'option du fichier de licence du package</target>
+        <source>Package License File</source>
+        <target state="needs-review-translation">Case d'option du fichier de licence du package</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.it.xlf
@@ -258,13 +258,13 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseExpressionRadioButton.AccessibleName">
-        <source>Package License Expression Radio Button</source>
-        <target state="translated">Pulsante di opzione Espressione della licenza del pacchetto</target>
+        <source>Package License Expression</source>
+        <target state="needs-review-translation">Pulsante di opzione Espressione della licenza del pacchetto</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseFileRadioButton.AccessibleName">
-        <source>Package License File Radio Button</source>
-        <target state="translated">Pulsante di opzione File di licenza del pacchetto</target>
+        <source>Package License File</source>
+        <target state="needs-review-translation">Pulsante di opzione File di licenza del pacchetto</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ja.xlf
@@ -258,13 +258,13 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseExpressionRadioButton.AccessibleName">
-        <source>Package License Expression Radio Button</source>
-        <target state="translated">パッケージ ライセンス式ラジオ ボタン</target>
+        <source>Package License Expression</source>
+        <target state="needs-review-translation">パッケージ ライセンス式ラジオ ボタン</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseFileRadioButton.AccessibleName">
-        <source>Package License File Radio Button</source>
-        <target state="translated">パッケージ ライセンス ファイル ラジオ ボタン</target>
+        <source>Package License File</source>
+        <target state="needs-review-translation">パッケージ ライセンス ファイル ラジオ ボタン</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ko.xlf
@@ -258,13 +258,13 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseExpressionRadioButton.AccessibleName">
-        <source>Package License Expression Radio Button</source>
-        <target state="translated">패키지 라이선스 식 라디오 단추</target>
+        <source>Package License Expression</source>
+        <target state="needs-review-translation">패키지 라이선스 식 라디오 단추</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseFileRadioButton.AccessibleName">
-        <source>Package License File Radio Button</source>
-        <target state="translated">패키지 라이선스 파일 라디오 단추</target>
+        <source>Package License File</source>
+        <target state="needs-review-translation">패키지 라이선스 파일 라디오 단추</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pl.xlf
@@ -258,13 +258,13 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseExpressionRadioButton.AccessibleName">
-        <source>Package License Expression Radio Button</source>
-        <target state="translated">Wyrażenie licencji pakietu — przycisk radiowy</target>
+        <source>Package License Expression</source>
+        <target state="needs-review-translation">Wyrażenie licencji pakietu — przycisk radiowy</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseFileRadioButton.AccessibleName">
-        <source>Package License File Radio Button</source>
-        <target state="translated">Pakiet — przycisk radiowy pliku licencji</target>
+        <source>Package License File</source>
+        <target state="needs-review-translation">Pakiet — przycisk radiowy pliku licencji</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pt-BR.xlf
@@ -258,13 +258,13 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseExpressionRadioButton.AccessibleName">
-        <source>Package License Expression Radio Button</source>
-        <target state="translated">Botão de opção da Licença do Pacote Expression</target>
+        <source>Package License Expression</source>
+        <target state="needs-review-translation">Botão de opção da Licença do Pacote Expression</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseFileRadioButton.AccessibleName">
-        <source>Package License File Radio Button</source>
-        <target state="translated">Botão de Opção do Arquivo de Licença do Pacote</target>
+        <source>Package License File</source>
+        <target state="needs-review-translation">Botão de Opção do Arquivo de Licença do Pacote</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ru.xlf
@@ -258,13 +258,13 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseExpressionRadioButton.AccessibleName">
-        <source>Package License Expression Radio Button</source>
-        <target state="translated">Переключатель "Выражение лицензии пакета"</target>
+        <source>Package License Expression</source>
+        <target state="needs-review-translation">Переключатель "Выражение лицензии пакета"</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseFileRadioButton.AccessibleName">
-        <source>Package License File Radio Button</source>
-        <target state="translated">Переключатель "Файл лицензии пакета"</target>
+        <source>Package License File</source>
+        <target state="needs-review-translation">Переключатель "Файл лицензии пакета"</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.tr.xlf
@@ -258,13 +258,13 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseExpressionRadioButton.AccessibleName">
-        <source>Package License Expression Radio Button</source>
-        <target state="translated">Paket Lisans İfadesi Radyo Düğmesi</target>
+        <source>Package License Expression</source>
+        <target state="needs-review-translation">Paket Lisans İfadesi Radyo Düğmesi</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseFileRadioButton.AccessibleName">
-        <source>Package License File Radio Button</source>
-        <target state="translated">Paket Lisans Dosyası Radyo Düğmesi</target>
+        <source>Package License File</source>
+        <target state="needs-review-translation">Paket Lisans Dosyası Radyo Düğmesi</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hans.xlf
@@ -258,13 +258,13 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseExpressionRadioButton.AccessibleName">
-        <source>Package License Expression Radio Button</source>
-        <target state="translated">包许可证表达式单选按钮</target>
+        <source>Package License Expression</source>
+        <target state="needs-review-translation">包许可证表达式单选按钮</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseFileRadioButton.AccessibleName">
-        <source>Package License File Radio Button</source>
-        <target state="translated">包许可证文件单选按钮</target>
+        <source>Package License File</source>
+        <target state="needs-review-translation">包许可证文件单选按钮</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hant.xlf
@@ -258,13 +258,13 @@
         <note />
       </trans-unit>
       <trans-unit id="LicenseExpressionRadioButton.AccessibleName">
-        <source>Package License Expression Radio Button</source>
-        <target state="translated">套件授權運算式選項按鈕</target>
+        <source>Package License Expression</source>
+        <target state="needs-review-translation">套件授權運算式選項按鈕</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseFileRadioButton.AccessibleName">
-        <source>Package License File Radio Button</source>
-        <target state="translated">套件授權檔案選項按鈕</target>
+        <source>Package License File</source>
+        <target state="needs-review-translation">套件授權檔案選項按鈕</target>
         <note />
       </trans-unit>
       <trans-unit id="LicenseUrlWarning.Text">


### PR DESCRIPTION
This fixes two accessibility bugs reported in AzDO: [1245123](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1245123), [1245125](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1245125).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6815)