### PR TITLE
Fix tab stops to follow top to bottom order.

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
@@ -910,7 +910,7 @@
     <value>274, 20</value>
   </data>
   <data name="txtSupressWarnings.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+    <value>15</value>
   </data>
   <data name="&gt;&gt;txtSupressWarnings.Name" xml:space="preserve">
     <value>txtSupressWarnings</value>
@@ -940,7 +940,7 @@
     <value>99, 13</value>
   </data>
   <data name="lblSupressWarnings.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
+    <value>14</value>
   </data>
   <data name="lblSupressWarnings.Text" xml:space="preserve">
     <value>&amp;Suppress warnings:</value>
@@ -988,7 +988,7 @@
     <value>125, 21</value>
   </data>
   <data name="cboWarningLevel.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
+    <value>13</value>
   </data>
   <data name="&gt;&gt;cboWarningLevel.Name" xml:space="preserve">
     <value>cboWarningLevel</value>
@@ -1018,7 +1018,7 @@
     <value>75, 13</value>
   </data>
   <data name="lblWarningLevel.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+    <value>12</value>
   </data>
   <data name="lblWarningLevel.Text" xml:space="preserve">
     <value>W&amp;arning level:</value>
@@ -1075,7 +1075,7 @@
     <value>93, 17</value>
   </data>
   <data name="chkOptimizeCode.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>11</value>
   </data>
   <data name="chkOptimizeCode.Text" xml:space="preserve">
     <value>Optimi&amp;ze code</value>
@@ -1108,7 +1108,7 @@
     <value>113, 17</value>
   </data>
   <data name="chkAllowUnsafeCode.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>10</value>
   </data>
   <data name="chkAllowUnsafeCode.Text" xml:space="preserve">
     <value>Allow unsa&amp;fe code</value>
@@ -1141,7 +1141,7 @@
     <value>83, 17</value>
   </data>
   <data name="chkPrefer32Bit.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>9</value>
   </data>
   <data name="chkPrefer32Bit.Text" xml:space="preserve">
     <value>&amp;Prefer 32-bit</value>
@@ -1336,7 +1336,7 @@
     <value>48, 13</value>
   </data>
   <data name="lblNullable.TabIndex" type="System.Int32, mscorlib">
-    <value>32</value>
+    <value>7</value>
   </data>
   <data name="lblNullable.Text" xml:space="preserve">
     <value>Nulla&amp;ble:</value>
@@ -1363,7 +1363,7 @@
     <value>125, 21</value>
   </data>
   <data name="cboNullable.TabIndex" type="System.Int32, mscorlib">
-    <value>33</value>
+    <value>8</value>
   </data>
   <data name="&gt;&gt;cboNullable.Name" xml:space="preserve">
     <value>cboNullable</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.resx
@@ -133,7 +133,7 @@
     <value>222, 17</value>
   </data>
   <data name="EnforceCodeStyleInBuildCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
+    <value>5</value>
   </data>
   <data name="EnforceCodeStyleInBuildCheckBox.Text" xml:space="preserve">
     <value>Enforce CodeStyle on build (experimental)</value>
@@ -163,7 +163,7 @@
     <value>132, 13</value>
   </data>
   <data name="NETAnalyzersLinkLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>22</value>
+    <value>4</value>
   </data>
   <data name="NETAnalyzersLinkLabel.Text" xml:space="preserve">
     <value>What are .NET analyzers?</value>
@@ -193,7 +193,7 @@
     <value>134, 17</value>
   </data>
   <data name="EnableNETAnalyzersCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
+    <value>6</value>
   </data>
   <data name="EnableNETAnalyzersCheckBox.Text" xml:space="preserve">
     <value>Enable .NET analyzers</value>
@@ -310,7 +310,7 @@
     <value>121, 21</value>
   </data>
   <data name="AnalysisLevelComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
+    <value>7</value>
   </data>
   <data name="&gt;&gt;AnalysisLevelComboBox.Name" xml:space="preserve">
     <value>AnalysisLevelComboBox</value>


### PR DESCRIPTION
Minor fixes for user to navigate all the interactive elements in the properties pages in a predictable order (in this case, top to bottom).

### Build page
**Before:**
![tabstops-build-before](https://user-images.githubusercontent.com/8518253/103721908-af94b280-4f83-11eb-8b97-6b6414f0e463.gif)

**After:**
![tabstops-build-after](https://user-images.githubusercontent.com/8518253/103721914-b3283980-4f83-11eb-987c-5785984798e0.gif)

### Code Analysis page
**Before:**
![tabstops-codeanalysis-before](https://user-images.githubusercontent.com/8518253/103721996-de128d80-4f83-11eb-87ab-4bff3fe07b4b.gif)

**After:**
![tabstops-codeanalysis-after](https://user-images.githubusercontent.com/8518253/103722006-e4a10500-4f83-11eb-80d0-a0f73539478d.gif)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6818)