### PR TITLE
BuildUpToDateCheck subscribes for updates lazily

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Subscription.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Subscription.cs
@@ -1,0 +1,182 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
+{
+    internal sealed partial class BuildUpToDateCheck
+    {
+        /// <summary>
+        /// Contains and tracks state related to a lifetime instance of <see cref="BuildUpToDateCheck"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// As the parent <see cref="BuildUpToDateCheck"/> is an <see cref="IProjectDynamicLoadComponent"/>, it may have multiple lifetimes.
+        /// This class contains all the state associated with such a lifetime: it's Dataflow subscription, tracking the first value to arrive,
+        /// and the <see cref="BuildUpToDateCheck.State"/> instance.
+        /// </para>
+        /// <para>
+        /// Initialization of the Dataflow subscription happens lazily, upon the first up-to-date check request.
+        /// </para>
+        /// <para>
+        /// Destruction of the Dataflow subscription happens when the parent component is disposed or unloaded.
+        /// </para>
+        /// </remarks>
+        private sealed class Subscription : IDisposable
+        {
+            /// <summary>
+            /// Completes when the first project update is received. Cancelled if the subscription is disposed.
+            /// </summary>
+            /// <remarks>
+            /// This field is also used to synchronise updates to <see cref="_link"/> and <see cref="State"/>.
+            /// </remarks>
+            private readonly TaskCompletionSource<byte> _dataReceived = new();
+
+            /// <summary>
+            /// Prevent overlapping requests.
+            /// </summary>
+            private readonly AsyncSemaphore _semaphore = new(1);
+
+            /// <summary>
+            /// Current <see cref="BuildUpToDateCheck.State"/> of the instance.
+            /// </summary>
+            /// <remarks>
+            /// Internal to support unit testing only.
+            /// </remarks>
+            internal State State { get; set; } = State.Empty;
+
+            /// <summary>
+            /// Lazily constructed Dataflow subscription. Set back to <see langword="null"/> in <see cref="Dispose"/>.
+            /// </summary>
+            private IDisposable? _link;
+
+            /// <summary>
+            /// Cancelled when this instance is disposed.
+            /// </summary>
+            private readonly CancellationTokenSource _disposeTokenSource = new();
+
+            public async Task<bool> RunAsync(
+                Func<State, CancellationToken, Task<bool>> func,
+                ConfiguredProject configuredProject,
+                IProjectItemSchemaService projectItemSchemaService,
+                CancellationToken cancellationToken)
+            {
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposeTokenSource.Token);
+
+                CancellationToken token = cts.Token;
+
+                // Throws if the subscription has been disposed, or the caller's token cancelled.
+                token.ThrowIfCancellationRequested();
+
+                // Note that we defer subscription until an actual request is made in order to
+                // prevent redundant work/allocation for inactive project configurations.
+                // https://github.com/dotnet/project-system/issues/6327
+                //
+                // We don't pass the cancellation token here as initialization must be atomic.
+                EnsureInitialized();
+
+                token.ThrowIfCancellationRequested();
+
+                // Wait for the first state to be computed
+                await _dataReceived.Task.WithCancellation(token);
+
+                // Prevent overlapping requests
+                using AsyncSemaphore.Releaser _ = await _semaphore.EnterAsync(token);
+
+                bool result = await func(State, token);
+
+                lock (_dataReceived)
+                {
+                    State = State.WithLastCheckedAtUtc(DateTime.UtcNow);
+                }
+
+                return result;
+
+                void EnsureInitialized()
+                {
+                    if (_link != null)
+                    {
+                        // Already initialized (or disposed)
+                        return;
+                    }
+
+                    lock (_dataReceived)
+                    {
+                        // Double check within lock
+                        if (_link == null)
+                        {
+                            // Throw if either the subscription or up-to-date check operation were cancelled
+                            token.ThrowIfCancellationRequested();
+
+                            Assumes.Present(configuredProject.Services.ProjectSubscription);
+
+                            _link = ProjectDataSources.SyncLinkTo(
+                                configuredProject.Services.ProjectSubscription.JointRuleSource.SourceBlock.SyncLinkOptions(DataflowOption.WithRuleNames(ProjectPropertiesSchemas)),
+                                configuredProject.Services.ProjectSubscription.SourceItemsRuleSource.SourceBlock.SyncLinkOptions(),
+                                configuredProject.Services.ProjectSubscription.ProjectSource.SourceBlock.SyncLinkOptions(),
+                                projectItemSchemaService.SourceBlock.SyncLinkOptions(),
+                                configuredProject.Services.ProjectSubscription.ProjectCatalogSource.SourceBlock.SyncLinkOptions(),
+                                target: DataflowBlockFactory.CreateActionBlock<IProjectVersionedValue<ValueTuple<IProjectSubscriptionUpdate, IProjectSubscriptionUpdate, IProjectSnapshot, IProjectItemSchema, IProjectCatalogSnapshot>>>(OnChanged, configuredProject.UnconfiguredProject),
+                                linkOptions: DataflowOption.PropagateCompletion,
+                                CancellationToken.None);
+                        }
+                    }
+                }
+            }
+
+            internal void OnChanged(IProjectVersionedValue<ValueTuple<IProjectSubscriptionUpdate, IProjectSubscriptionUpdate, IProjectSnapshot, IProjectItemSchema, IProjectCatalogSnapshot>> e)
+            {
+                var snapshot = e.Value.Item3 as IProjectSnapshot2;
+                Assumes.NotNull(snapshot);
+
+                lock (_dataReceived)
+                {
+                    if (_disposeTokenSource.IsCancellationRequested)
+                    {
+                        // We've been disposed, so don't update State (which will be empty)
+                        return;
+                    }
+
+                    State = State.Update(
+                        jointRuleUpdate: e.Value.Item1,
+                        sourceItemsUpdate: e.Value.Item2,
+                        projectSnapshot: snapshot,
+                        projectItemSchema: e.Value.Item4,
+                        projectCatalogSnapshot: e.Value.Item5,
+                        configuredProjectVersion: e.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion]);
+                }
+
+                _dataReceived.TrySetResult(0);
+            }
+
+            /// <summary>
+            /// Tear down any Dataflow subscription and cancel any ongoing query.
+            /// </summary>
+            public void Dispose()
+            {
+                if (_disposeTokenSource.IsCancellationRequested)
+                {
+                    // Already disposed
+                    return;
+                }
+
+                lock (_dataReceived)
+                {
+                    _link?.Dispose();
+                    _link = null;
+
+                    State = State.Empty;
+
+                    _disposeTokenSource.Cancel();
+                    _disposeTokenSource.Dispose();
+                }
+
+                _dataReceived.TrySetCanceled();
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -13,7 +13,6 @@ using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Build;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Telemetry;
-using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 {
@@ -21,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
     [Export(typeof(IBuildUpToDateCheckProvider))]
     [Export(ExportContractNames.Scopes.ConfiguredProject, typeof(IProjectDynamicLoadComponent))]
     [ExportMetadata("BeforeDrainCriticalTasks", true)]
-    internal sealed partial class BuildUpToDateCheck : OnceInitializedOnceDisposedUnderLockAsync, IBuildUpToDateCheckProvider, IProjectDynamicLoadComponent
+    internal sealed partial class BuildUpToDateCheck : IBuildUpToDateCheckProvider, IProjectDynamicLoadComponent, IDisposable
     {
         private const string Link = "Link";
         private const string DefaultSetName = "";
@@ -48,11 +47,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private readonly ITelemetryService _telemetryService;
         private readonly IFileSystem _fileSystem;
 
-        private readonly object _stateLock = new();
+        private Subscription _subscription = new();
 
-        private State _state = State.Empty;
-
-        private IDisposable? _link;
+        private int _isDisposed;
 
         [ImportingConstructor]
         public BuildUpToDateCheck(
@@ -61,9 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             [Import(ExportContractNames.Scopes.ConfiguredProject)] IProjectAsynchronousTasksService tasksService,
             IProjectItemSchemaService projectItemSchemaService,
             ITelemetryService telemetryService,
-            IProjectThreadingService threadingService,
             IFileSystem fileSystem)
-            : base(threadingService.JoinableTaskContext)
         {
             _projectSystemOptions = projectSystemOptions;
             _configuredProject = configuredProject;
@@ -75,70 +70,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         public Task LoadAsync()
         {
-            return InitializeAsync();
+            return Task.CompletedTask;
         }
 
         public Task UnloadAsync()
         {
-            return ExecuteUnderLockAsync(_ =>
-            {
-                lock (_stateLock)
-                {
-                    _link?.Dispose();
-                    _link = null;
-
-                    _state = State.Empty;
-                }
-
-                return Task.CompletedTask;
-            });
-        }
-
-        protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
-        {
-            Assumes.Present(_configuredProject.Services.ProjectSubscription);
-
-            _link = ProjectDataSources.SyncLinkTo(
-                _configuredProject.Services.ProjectSubscription.JointRuleSource.SourceBlock.SyncLinkOptions(DataflowOption.WithRuleNames(ProjectPropertiesSchemas)),
-                _configuredProject.Services.ProjectSubscription.SourceItemsRuleSource.SourceBlock.SyncLinkOptions(),
-                _configuredProject.Services.ProjectSubscription.ProjectSource.SourceBlock.SyncLinkOptions(),
-                _projectItemSchemaService.SourceBlock.SyncLinkOptions(),
-                _configuredProject.Services.ProjectSubscription.ProjectCatalogSource.SourceBlock.SyncLinkOptions(),
-                target: DataflowBlockFactory.CreateActionBlock<IProjectVersionedValue<ValueTuple<IProjectSubscriptionUpdate, IProjectSubscriptionUpdate, IProjectSnapshot, IProjectItemSchema, IProjectCatalogSnapshot>>>(OnChanged, _configuredProject.UnconfiguredProject),
-                linkOptions: DataflowOption.PropagateCompletion,
-                cancellationToken: cancellationToken);
+            RecycleSubscription();
 
             return Task.CompletedTask;
         }
 
-        protected override Task DisposeCoreUnderLockAsync(bool initialized)
+        public void Dispose()
         {
-            _link?.Dispose();
-
-            return Task.CompletedTask;
-        }
-
-        internal void OnChanged(IProjectVersionedValue<ValueTuple<IProjectSubscriptionUpdate, IProjectSubscriptionUpdate, IProjectSnapshot, IProjectItemSchema, IProjectCatalogSnapshot>> e)
-        {
-            lock (_stateLock)
+            if (Interlocked.CompareExchange(ref _isDisposed, 1, 0) != 0)
             {
-                if (_link == null)
-                {
-                    // We've been unloaded, so don't update the state (which will be empty)
-                    return;
-                }
-
-                var snapshot = e.Value.Item3 as IProjectSnapshot2;
-                Assumes.NotNull(snapshot);
-
-                _state = _state.Update(
-                    jointRuleUpdate: e.Value.Item1,
-                    sourceItemsUpdate: e.Value.Item2,
-                    projectSnapshot: snapshot,
-                    projectItemSchema: e.Value.Item4,
-                    projectCatalogSnapshot: e.Value.Item5,
-                    configuredProjectVersion: e.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion]);
+                return;
             }
+
+            RecycleSubscription();
+        }
+
+        private void RecycleSubscription()
+        {
+            Subscription subscription = Interlocked.Exchange(ref _subscription, new Subscription());
+
+            subscription.Dispose();
         }
 
         private bool CheckGlobalConditions(Log log, State state)
@@ -595,11 +551,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             return true;
         }
 
-        public Task<bool> IsUpToDateAsync(BuildAction buildAction, TextWriter logWriter, CancellationToken cancellationToken = default)
+        public async Task<bool> IsUpToDateAsync(BuildAction buildAction, TextWriter logWriter, CancellationToken cancellationToken = default)
         {
+            if (Volatile.Read(ref _isDisposed) != 0)
+            {
+                throw new ObjectDisposedException(nameof(BuildUpToDateCheck));
+            }
+
             if (buildAction != BuildAction.Build)
             {
-                return TaskResult.False;
+                return false;
             }
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -607,24 +568,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             // Start the stopwatch now, so we include any lock acquisition in the timing
             var sw = Stopwatch.StartNew();
 
-            return ExecuteUnderLockAsync(IsUpToDateInternalAsync, cancellationToken);
+            Subscription subscription = Volatile.Read(ref _subscription);
 
-            async Task<bool> IsUpToDateInternalAsync(CancellationToken token)
+            return await subscription.RunAsync(IsUpToDateInternalAsync, _configuredProject, _projectItemSchemaService, cancellationToken);
+
+            async Task<bool> IsUpToDateInternalAsync(State state, CancellationToken token)
             {
                 token.ThrowIfCancellationRequested();
 
                 // Short-lived cache of timestamp by path
                 var timestampCache = new TimestampCache(_fileSystem);
 
-                await InitializeAsync(token);
-
                 LogLevel requestedLogLevel = await _projectSystemOptions.GetFastUpToDateLoggingLevelAsync(token);
                 var logger = new Log(logWriter, requestedLogLevel, sw, timestampCache, _configuredProject.UnconfiguredProject.FullPath ?? "", _telemetryService);
 
                 try
                 {
-                    State state = _state;
-
                     if (!CheckGlobalConditions(logger, state))
                     {
                         return false;
@@ -643,11 +602,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 }
                 finally
                 {
-                    lock (_stateLock)
-                    {
-                        _state = _state.WithLastCheckedAtUtc(DateTime.UtcNow);
-                    }
-
                     logger.Verbose("Up to date check completed in {0:N1} ms", sw.Elapsed.TotalMilliseconds);
                 }
             }
@@ -667,21 +621,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 _check = check;
             }
 
-            public State State => _check._state;
+            public State State => _check._subscription.State;
 
             public void SetLastCheckedAtUtc(DateTime lastCheckedAtUtc)
             {
-                _check._state = _check._state.WithLastCheckedAtUtc(lastCheckedAtUtc);
+                _check._subscription.State = _check._subscription.State.WithLastCheckedAtUtc(lastCheckedAtUtc);
             }
 
             public void SetLastItemsChangedAtUtc(DateTime lastItemsChangedAtUtc)
             {
-                _check._state = _check._state.WithLastItemsChangedAtUtc(lastItemsChangedAtUtc);
+                _check._subscription.State = _check._subscription.State.WithLastItemsChangedAtUtc(lastItemsChangedAtUtc);
             }
 
             public void SetLastAdditionalDependentFileTimesChangedAtUtc(DateTime lastAdditionalDependentFileTimesChangedAtUtc)
             {
-                _check._state = _check._state.WithLastAdditionalDependentFilesChangedAtUtc(lastAdditionalDependentFileTimesChangedAtUtc);
+                _check._subscription.State = _check._subscription.State.WithLastAdditionalDependentFilesChangedAtUtc(lastAdditionalDependentFileTimesChangedAtUtc);
+            }
+
+            public void OnChanged(IProjectVersionedValue<(IProjectSubscriptionUpdate, IProjectSubscriptionUpdate, IProjectSnapshot, IProjectItemSchema, IProjectCatalogSnapshot)> value)
+            {
+                _check._subscription.OnChanged(value);
             }
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -87,15 +87,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _fileSystem.AddFolder(_msBuildProjectDirectory);
             _fileSystem.AddFolder(_outputPath);
 
-            var threadingService = IProjectThreadingServiceFactory.Create();
-
             _buildUpToDateCheck = new BuildUpToDateCheck(
                 projectSystemOptions.Object,
                 configuredProject.Object,
                 projectAsynchronousTasksService.Object,
                 IProjectItemSchemaServiceFactory.Create(),
                 ITelemetryServiceFactory.Create(telemetryParameters => _telemetryEvents.Add(telemetryParameters)),
-                threadingService,
                 _fileSystem);
         }
 
@@ -157,7 +154,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 identity: ProjectDataSources.ConfiguredProjectVersion,
                 version: _projectVersion);
 
-            _buildUpToDateCheck.OnChanged(value);
+            _buildUpToDateCheck.TestAccess.OnChanged(value);
 
             return;
 


### PR DESCRIPTION
Fixes #6327.

The `BuildUpToDateCheck` component is constructed and initialised (via `IProjectDynamicLoadComponent`) for both active and inactive project configurations. Previously, this initialisation would trigger dataflow subscriptions for each project configuration, triggering CPS to construct a chain of dataflow blocks to service that subscription. For inactive configurations those chains linger in memory without actually being used.

This commit avoids this problem by deferring construction of the dataflow subscription until the first call to `IsUpToDateAsync`. This method is only called when the configuration is actually being used. In this way, the overhead associated with instances of `BuildUpToDateCheck` in inactive project configurations is minimised.

An `IProjectDynamicLoadComponent` may be loaded and unloaded multiple times, creating multiple lifetimes for the component. This change introduces a `Subscription` type into which all state associated with such a lifetime is moved: the state object and dataflow link. This makes the lifetime explicit and more clearly indicates lifetime events in the code.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6822)