### PR TITLE
Prevent NullReferenceException in StartupProjectRegistrar

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     {
         private readonly UnconfiguredProject _project;
         private readonly IUnconfiguredProjectTasksService _projectTasksService;
-        private readonly IVsService<IVsStartupProjectsListService> _startupProjectsListService;
+        private readonly IVsService<IVsStartupProjectsListService?> _startupProjectsListService;
         private readonly IProjectThreadingService _threadingService;
         private readonly ISafeProjectGuidService _projectGuidService;
         private readonly IActiveConfiguredProjectSubscriptionService _projectSubscriptionService;
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public StartupProjectRegistrar(
             UnconfiguredProject project,
             IUnconfiguredProjectTasksService projectTasksService,
-            IVsService<SVsStartupProjectsListService, IVsStartupProjectsListService> startupProjectsListService,
+            IVsService<SVsStartupProjectsListService, IVsStartupProjectsListService?> startupProjectsListService,
             IProjectThreadingService threadingService,
             ISafeProjectGuidService projectGuidService,
             IActiveConfiguredProjectSubscriptionService projectSubscriptionService,
@@ -87,7 +87,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             {
                 bool isDebuggable = await IsDebuggableAsync();
 
-                IVsStartupProjectsListService startupProjectsListService = await _startupProjectsListService.GetValueAsync();
+                IVsStartupProjectsListService? startupProjectsListService = await _startupProjectsListService.GetValueAsync();
+
+                if (startupProjectsListService == null)
+                {
+                    return;
+                }
 
                 if (isDebuggable)
                 {


### PR DESCRIPTION
Fixes [AB#1229073](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1229073).

Follows #6722.

This NRE is currently the number 4 NFE for CPS-based projects. Those reports show that there may be no `IVsStartupProjectsListService` service registered, in which case the return value will be `null`.

The fix is to return early when the service does not exist.