### PR TITLE
Suppress validation of active target framework

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -161,6 +161,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             Requires.NotNull(activeTargetFramework, nameof(activeTargetFramework));
             Requires.NotNull(dependenciesByTargetFramework, nameof(dependenciesByTargetFramework));
 
+#if false
+            // The validation in this #if/#endif block is sound in theory, however is causing quite a few NFEs.
+            // For example https://github.com/dotnet/project-system/issues/6656.
+            //
+            // We have disabled it for now. The consequence of this test failing is that dependencies added to
+            // the tree are not exposed via extensibility APIs such as DTE/VSLangProj.
+            //
+            // At some point we should revisit how the dependencies tree models its target frameworks, likely
+            // as part of https://github.com/dotnet/project-system/issues/6183.
+
             // We have seen NFEs where the active target framework is unsupported. Skipping validation in such cases is better than faulting the dataflow.
             if (!activeTargetFramework.Equals(TargetFramework.Empty) &&
                 !activeTargetFramework.Equals(TargetFramework.Unsupported) &&
@@ -175,6 +185,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                     nameof(activeTargetFramework),
                     $"Value \"{activeTargetFramework.FullName}\" is unexpected. Must be a key in {nameof(dependenciesByTargetFramework)}, which contains {keyNames}.");
             }
+#endif
 
             ActiveTargetFramework = activeTargetFramework;
             DependenciesByTargetFramework = dependenciesByTargetFramework;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
@@ -26,18 +26,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
         [Fact]
         public void Constructor_ThrowsIfActiveTargetFrameworkNotEmptyAndNotInDependenciesByTargetFramework_NoTargets()
         {
-            var targetFramework = new TargetFramework("tfm1");
-
+#if false
             var ex = Assert.Throws<ArgumentException>(() => new DependenciesSnapshot(
-                activeTargetFramework: targetFramework,
+                activeTargetFramework: new TargetFramework("tfm1"),
                 dependenciesByTargetFramework: ImmutableDictionary<TargetFramework, TargetedDependenciesSnapshot>.Empty));
 
             Assert.StartsWith("Value \"tfm1\" is unexpected. Must be a key in dependenciesByTargetFramework, which contains no items.", ex.Message);
+#else
+            _ = new DependenciesSnapshot(
+                activeTargetFramework: new TargetFramework("tfm1"),
+                dependenciesByTargetFramework: ImmutableDictionary<TargetFramework, TargetedDependenciesSnapshot>.Empty);
+#endif
         }
 
         [Fact]
         public void Constructor_ThrowsIfActiveTargetFrameworkNotEmptyAndNotInDependenciesByTargetFramework_WithTargets()
         {
+#if false
             var tfm1 = new TargetFramework("tfm1");
             var tfm2 = new TargetFramework("tfm2");
             var tfm3 = new TargetFramework("tfm3");
@@ -49,6 +54,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                     .Add(tfm3, TargetedDependenciesSnapshot.CreateEmpty(tfm1, null))));
 
             Assert.StartsWith("Value \"tfm1\" is unexpected. Must be a key in dependenciesByTargetFramework, which contains \"tfm2\", \"tfm3\".", ex.Message);
+#else
+            var tfm1 = new TargetFramework("tfm1");
+            var tfm2 = new TargetFramework("tfm2");
+            var tfm3 = new TargetFramework("tfm3");
+
+            _ = new DependenciesSnapshot(
+                activeTargetFramework: tfm1,
+                dependenciesByTargetFramework: ImmutableDictionary<TargetFramework, TargetedDependenciesSnapshot>.Empty
+                    .Add(tfm2, TargetedDependenciesSnapshot.CreateEmpty(tfm1, null))
+                    .Add(tfm3, TargetedDependenciesSnapshot.CreateEmpty(tfm1, null)));
+#endif
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #6656.

The validation in is sound in theory, however is causing quite a few NFEs. For example https://github.com/dotnet/project-system/issues/6656.

This commit disables it for now. The consequence of this test failing is that dependencies added to the tree are not exposed via extensibility APIs such as DTE/VSLangProj.

At some point we should revisit how the dependencies tree models its target frameworks, likely as part of https://github.com/dotnet/project-system/issues/6183.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6824)