### PR TITLE
Avoid calling expensive method in common case

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
@@ -57,9 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.CrossTarget
 
             foreach ((string tfm, ConfiguredProject configuredProject) in configuredProjectsMap)
             {
-                ProjectProperties projectProperties = configuredProject.Services.ExportProvider.GetExportedValue<ProjectProperties>();
-                ConfigurationGeneral configurationGeneralProperties = await projectProperties.GetConfigurationGeneralPropertiesAsync();
-                TargetFramework targetFramework = await GetTargetFrameworkAsync(tfm, configurationGeneralProperties);
+                TargetFramework targetFramework = await GetTargetFrameworkAsync(tfm, configuredProject);
 
                 targetFrameworks.Add(targetFramework);
 
@@ -82,10 +80,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.CrossTarget
 
         private async Task<TargetFramework> GetTargetFrameworkAsync(
             string shortOrFullName,
-            ConfigurationGeneral configurationGeneralProperties)
+            ConfiguredProject configuredProject)
         {
             if (string.IsNullOrEmpty(shortOrFullName))
             {
+                ProjectProperties projectProperties = configuredProject.Services.ExportProvider.GetExportedValue<ProjectProperties>();
+                ConfigurationGeneral configurationGeneralProperties = await projectProperties.GetConfigurationGeneralPropertiesAsync();
                 object? targetObject = await configurationGeneralProperties.TargetFramework.GetValueAsync();
 
                 if (targetObject == null)


### PR DESCRIPTION
Recently I've been working to make the dependencies tree populate faster on project load.

During testing, I found call to `GetConfigurationGeneralPropertiesAsync` seemed to be a source of some delay in the dependencies node code.

The result of that method is only used if `shortOrFullName` is null or empty, which rarely happens. I couldn't trigger this code path in my testing, so it might actually never happen.

This change avoids sourcing the `ProjectProperties` export and calling `GetConfigurationGeneralPropertiesAsync` on it unless it is absolutely necessary to do so.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6828)