### PR TITLE
Re-enable IDE0100

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -218,8 +218,6 @@ csharp_preferred_modifier_order = public,private,protected,internal,static,exter
 
 # Dotnet code analysis settings:
 [*.{cs,vb}]
-# Bugs
-dotnet_diagnostic.IDE0100.severity = none # https://github.com/dotnet/roslyn/issues/48236
 
 # Microsoft.Analyzers.ManagedCodeAnalysis
 dotnet_diagnostic.CA1801.severity = none


### PR DESCRIPTION
It was disabled due to a crash. The crash is supposed to be fixed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6833)