### PR TITLE
Updated build.cmd to use version minimum from Version.props

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -57,9 +57,6 @@ if "%OptDiagnostic%" == "true" (
 
 call "%Root%\build\script\SetVSEnvironment.cmd" || exit /b 1
 
-REM WORKAROUND: See https://github.com/dotnet/project-system/issues/5177
-SET LIB=
-
 msbuild %Root%build\proj\Build.proj /m /warnaserror /nologo /clp:Summary /nodeReuse:%OptNodeReuse% /p:Configuration=%BuildConfiguration% /p:Build=%OptBuild% /p:Rebuild=%OptRebuild% /p:Deploy=%OptDeploy% /p:Test=%OptTest% /p:IntegrationTest=%OptIntegrationTest% /p:Sign=%OptSign% /p:CIBuild=%OptCI% /p:EnableIbc=%OptIbc% /p:ClearNuGetCache=%OptClearNuGetCache% %LogCmdLine% %RootSuffixCmdLine%
 set MSBuildErrorLevel=%ERRORLEVEL%
 

--- a/build/script/SetVSEnvironment.cmd
+++ b/build/script/SetVSEnvironment.cmd
@@ -4,7 +4,7 @@ REM Configures the build environment to be able to build the tree
 REM
 REM Downloads VSWhere, uses it to find a compatible Visual Studio and call a developer prompt to set the environment.
 
-set RequiredVSVersion=16.0
+FOR /F "USEBACKQ delims=" %%i IN (`powershell -NonInteractive -NoLogo -NoProfile -Command "([xml](Get-Content %~dp0\..\import\Versions.props)).Project.PropertyGroup.ProjectSystemVersion"`) DO SET RequiredVSVersion=%%i
 
 REM Are we already in Developer Command Prompt?
 if defined VSINSTALLDIR (
@@ -13,7 +13,7 @@ if defined VSINSTALLDIR (
 
 if not exist "%TEMP%\vswhere.exe" (
   echo Downloading VSWhere so that we can find Visual Studio...
-  powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest https://github.com/microsoft/vswhere/releases/download/2.6.7/vswhere.exe -OutFile $env:TEMP\vswhere.exe" || (
+  powershell -NonInteractive -NoLogo -NoProfile -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $pp = $ProgressPreference; $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest https://github.com/microsoft/vswhere/releases/download/2.8.4/vswhere.exe -OutFile $env:TEMP\vswhere.exe; $ProgressPreference = $pp" || (
     echo Failed to download, check your internet connection.
     exit /b 1
   )


### PR DESCRIPTION
Related: https://github.com/dotnet/project-system/issues/6744

- Removed temporary workaround that has been fixed
- Updated RequiredVSVersion to pull the version number from Versions.props which sets the ProjectSystemVersion
  - The current version in that file is `16.8.1`.
- Added arguments for calling `powershell` to reduce potential failures and removed progress bar for downloading VSWhere
  - Progress bars (traditionally) have overhead in Windows PowerShell.
  - We are using Windows PowerShell since we call `powershell`. PowerShell Core uses `pwsh`.
- Updated version of VSWhere used to latest release

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6839)