### PR TITLE
Ban IVsFrameworkParser

### DIFF
--- a/src/Common/BannedSymbols.txt
+++ b/src/Common/BannedSymbols.txt
@@ -13,6 +13,8 @@ T:Microsoft.VisualStudio.ProjectSystem.IProjectLockService; Using IProjectAccess
 T:Microsoft.VisualStudio.ProjectSystem.VS.IProjectGuidService; Using ISafeProjectGuidService avoids reading the GUID before it is safe to do so during initialisation
 T:Microsoft.VisualStudio.ProjectSystem.VS.IProjectGuidService2; Using ISafeProjectGuidService avoids reading the GUID before it is safe to do so during initialisation
 
+T:NuGet.VisualStudio.IVsFrameworkParser; FrameworkName does not support the platform information added in .NET 5
+
 P:Microsoft.VisualStudio.ProjectSystem.VS.IProjectAsyncLoadDashboard.ProjectLoadedInHost; Using IUnconfiguredProjectTasksService.ProjectLoadedInHost prevents waiting indefinitely when the project is closed before it has finished loading
 
 M:Microsoft.VisualStudio.ProjectSystem.CommonProjectSystemTools.LoadedProject(Microsoft.VisualStudio.ProjectSystem.IProjectAsynchronousTasksService); Using IUnconfiguredProjectTasksService.LoadedProjectAsync is unit testable


### PR DESCRIPTION
As described in #6369 and #6370, `IVsFrameworkParser` uses the `FrameworkName` type which does not support the platform information added to target frameworks in .NET 5.

We have already done the work to remove usages of this interface. This change prevents us from attempting to use the type again in future.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6840)