### PR TITLE
Change the default value for Symbols Rename in a fresh VS installation.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
@@ -230,7 +230,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
         {
             ISettingsManager settings = await _settingsManagerService.GetValueAsync();
 
-            bool enableSymbolicRename = settings.GetValueOrDefault("SolutionNavigator.EnableSymbolicRename", false);
+            bool enableSymbolicRename = settings.GetValueOrDefault("SolutionNavigator.EnableSymbolicRename", true);
 
             await _projectVsServices.ThreadingService.SwitchToUIThread();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
@@ -230,6 +230,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
         {
             ISettingsManager settings = await _settingsManagerService.GetValueAsync();
 
+            // Default value needs to match the default value in the checkbox Tools|Options|Project and Solutions|Enable symbolic renaming.
             bool enableSymbolicRename = settings.GetValueOrDefault("SolutionNavigator.EnableSymbolicRename", true);
 
             await _projectVsServices.ThreadingService.SwitchToUIThread();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/RenamerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/RenamerTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
         {
             var settingsManagerMock = new Mock<ISettingsManager>();
 
-            settingsManagerMock.Setup(f => f.GetValueOrDefault("SolutionNavigator.EnableSymbolicRename", false))
+            settingsManagerMock.Setup(f => f.GetValueOrDefault("SolutionNavigator.EnableSymbolicRename", true))
                 .Returns(enableSymbolicRename);
 
             return IVsServiceFactory.Create<SVsSettingsPersistenceManager, ISettingsManager>(settingsManagerMock.Object);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasic/RenamerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasic/RenamerTests.cs
@@ -195,7 +195,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.VisualBasic
         {
             var settingsManagerMock = new Mock<ISettingsManager>();
 
-            settingsManagerMock.Setup(f => f.GetValueOrDefault("SolutionNavigator.EnableSymbolicRename", false))
+            settingsManagerMock.Setup(f => f.GetValueOrDefault("SolutionNavigator.EnableSymbolicRename", true))
                 .Returns(enableSymbolicRename);
 
             return IVsServiceFactory.Create<SVsSettingsPersistenceManager, ISettingsManager>(settingsManagerMock.Object);


### PR DESCRIPTION
fixes [AB#1237959](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1237959)

In a fresh VS installation or repair, Dotnet ProjectSystem cannot get the value in the checkbox Tools | Options | Project and Solutions | Enable Symbol Rename. At this point VS has no knowledge of this value and that is how the system works. The user has to turn the checkbox off and then on to make it work and have a persisted value for future usages.

This small change sets the default value of EnableSymbolRename to true to match the value on a fresh VS Installation.

This change will enable Symbols Rename by default on a fresh installation.