### PR TITLE
Add telemetry to track when properties pages are already opened.

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
@@ -970,6 +970,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             Return True
         End Function
 
+        Public Sub AppDesignerAlreadyLoaded()
+            Dim ActivePanel As ApplicationDesignerPanel = _designerPanels(_activePanelIndex)
+            Common.TelemetryLogger.LogAppDesignerPageOpened(ActivePanel.ActualGuid, ActivePanel.TabTitle, True)
+        End Sub
+
         ''' <summary>
         ''' Show the requested tab
         ''' </summary>

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
@@ -970,7 +970,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             Return True
         End Function
 
-        Public Sub AppDesignerAlreadyLoaded()
+        Friend Sub AppDesignerAlreadyLoaded()
             Dim ActivePanel As ApplicationDesignerPanel = _designerPanels(_activePanelIndex)
             Common.TelemetryLogger.LogAppDesignerPageOpened(ActivePanel.ActualGuid, ActivePanel.TabTitle, True)
         End Sub

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerWindowPane.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerWindowPane.vb
@@ -245,6 +245,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 End If
             Else
                 'App designer already loaded - just navigate to the correct view
+                AppDesignerView.AppDesignerAlreadyLoaded()
                 If Not rguidLogicalView.Equals(Guid.Empty) And Not rguidLogicalView.Equals(GetActiveView()) Then
                     SetActiveView(rguidLogicalView)
                 End If

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
@@ -643,12 +643,12 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
                 LogAppDesignerPageOpened(DEFAULT_PAGE)
             End Sub
 
-            Public Shared Sub LogAppDesignerPageOpened(pageGuid As Guid, Optional tabTitle As String = Nothing)
+            Public Shared Sub LogAppDesignerPageOpened(pageGuid As Guid, Optional tabTitle As String = Nothing, Optional alreadyOpened As Boolean = False)
                 Dim pageId = PageGuidToId(pageGuid)
-                LogAppDesignerPageOpened(pageId, pageGuid, tabTitle)
+                LogAppDesignerPageOpened(pageId, pageGuid, tabTitle, alreadyOpened)
             End Sub
 
-            Private Shared Sub LogAppDesignerPageOpened(pageId As Byte, Optional pageGuid As Guid? = Nothing, Optional tabTitle As String = Nothing)
+            Private Shared Sub LogAppDesignerPageOpened(pageId As Byte, Optional pageGuid As Guid? = Nothing, Optional tabTitle As String = Nothing, Optional alreadyOpened As Boolean = False)
                 Dim userTask = New UserTaskEvent("vs/projectsystem/appdesigner/page-opened", TelemetryResult.Success)
                 userTask.Properties("vs.projectsystem.appdesigner.page-opened") = pageId
 
@@ -658,6 +658,10 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
 
                 If tabTitle IsNot Nothing Then
                     userTask.Properties("vs.projectsystem.appdesigner.page-opened.tabtitle") = tabTitle
+                End If
+
+                If alreadyOpened Then
+                    userTask.Properties("vs.projectsystem.appdesigner.page-opened.alreadyopened") = alreadyOpened
                 End If
 
                 TelemetryService.DefaultSession.PostEvent(userTask)

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
@@ -660,9 +660,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
                     userTask.Properties("vs.projectsystem.appdesigner.page-opened.tabtitle") = tabTitle
                 End If
 
-                If alreadyOpened Then
-                    userTask.Properties("vs.projectsystem.appdesigner.page-opened.alreadyopened") = alreadyOpened
-                End If
+                userTask.Properties("vs.projectsystem.appdesigner.page-opened.alreadyopened") = alreadyOpened
 
                 TelemetryService.DefaultSession.PostEvent(userTask)
             End Sub

--- a/src/Microsoft.VisualStudio.AppDesigner/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.AppDesigner/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
+Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerView.AppDesignerAlreadyLoaded() -> Void
 Microsoft.VisualStudio.Editors.PropertyPages.PropertyControlData.PropertyName(value As String) -> Void

--- a/src/Microsoft.VisualStudio.AppDesigner/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.AppDesigner/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
-Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerView.AppDesignerAlreadyLoaded() -> Void
 Microsoft.VisualStudio.Editors.PropertyPages.PropertyControlData.PropertyName(value As String) -> Void


### PR DESCRIPTION
The goal is to be able to measure the success of opening the properties pages. For that, we already track when they are closed and asked to be opened; but we missed an event to track when they are already opened (focused or not focused).

The general flow is as follows:
![IMG_8081](https://user-images.githubusercontent.com/8518253/105672927-1bd74780-5e9a-11eb-9e83-ca60220aa5de.jpg)


The diagram can be read like this:
- The user first right clicks the project. This is the context menu.
- The user then selects the "Properties" command.
- The ProjectFileDocumentManager calls the method `OpenWithSpecific`, which calls to the ApplicationDesignerWindowPane's `ActivateLogicalWindow`, `PopulateView`, which calls to create the AppDesignerView with the `InitView` method. This is where we get our first event out: we call `LogAppDesignerDefaultPageOpened` which sends vs/projectsystem/appdesigner/page-opened.
- We move on to adding the pages o tabs to the AppDesigner in `AddTabs`, where for each tab we send a vs/projectsystem/appdesigner/tabinfo event. This includes the tab title, tab guid, project extension and project guid.
- Additionally, we send information about "specialtabs", which they refer to the resource and settings page. This is captured in vs/projectsystem/appdesigner/tabinfo/specialtabs.
- Finally, we get to `OnInitializationComplete` where we call `ShowTab` to either show the default page if this is the first time opening the properties pages (i.e. after creating a project), or to show the last active page. This is reflected in the last event sent, vs/projectsystem/appdesigner/page-opened, by calling `LogAppDesignerPageOpened`.

As mentioned at the beginning, this flow only covers the scenarios of having the properties pages closed. When having the properties pages opened, the flow is shorter: 
- The ProjectFileDocumentManager calls `OpenWithSpecific`, which again calls the ApplicationDesignerWindowPane's `ActivateLogicalWindow`; but since the AppDesignerView already exists, jumps straight to showing it.

With these changes, after realizing that the AppDesignerView already exists, we call a new method `AppDesignerAlreadyLoaded` which calls the `LogAppDesignerPageOpened` with a flag to identify that the properties pages are opened. This would look something like this:

![IMG_8082](https://user-images.githubusercontent.com/8518253/105671889-4d4f1380-5e98-11eb-9267-7774f41645c5.jpg)

Note that the event is now called three times and we can tell them apart from the properties and values being sent:
1. At the `InitView` when we create our properties pages. `page-opened` = 0.
2. At the `ShowTabs` when we actually display a page from it. `page-opened` = 2, a `pageguid` and the `tabtitle` = Application.
3. When we detect the page is already opened. `page-opened` = 2, a `pageguid`, the `tabtitle` = Application and the flag `alreadyopened` = True.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6861)