### PR TITLE
Remove triggers referencing master

### DIFF
--- a/build/ci/richnav.yml
+++ b/build/ci/richnav.yml
@@ -1,7 +1,7 @@
 # Name: DotNet-Project-System Rich Code Navigation
 # URL: https://dev.azure.com/devdiv/DevDiv/_build?definitionId=9675
 #
-# Creates the Rich Navigation index for navigation throughout the master branch
+# Creates the Rich Navigation index for navigation throughout the main branch
 # of dotnet/project-system
 #
 
@@ -9,7 +9,6 @@
 trigger:
   branches:
     include:
-    - master
     - main
     - dev*
     - feature/*
@@ -18,7 +17,6 @@ trigger:
 pr:
   branches:
     include:
-    - master
     - main
     - dev*
     - feature/*

--- a/build/ci/unit-tests.yml
+++ b/build/ci/unit-tests.yml
@@ -7,7 +7,6 @@
 trigger:
   branches:
     include:
-    - master
     - main
     - dev*
     - feature/*
@@ -16,7 +15,6 @@ trigger:
 pr:
   branches:
     include:
-    - master
     - main
     - dev*
     - feature/*


### PR DESCRIPTION
Part of #6857

pipelines no longer need to know about `master` branch

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/project-system/pull/6864)