### PR TITLE
Remove ProjectNotRunnableDirectlyException

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
@@ -23,6 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     internal class LaunchProfilesDebugLaunchProvider : DebugLaunchProviderBase, IDeployedProjectItemMappingProvider, IStartupProjectProvider
     {
         private readonly IVsService<IVsDebuggerLaunchAsync> _vsDebuggerService;
+        // Launch providers to enforce requirements for debuggable projects
         private readonly ILaunchSettingsProvider _launchSettingsProvider;
         private IDebugProfileLaunchTargetsProvider? _lastLaunchProvider;
 
@@ -58,24 +59,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// </summary>
         public async Task<bool> CanBeStartupProjectAsync(DebugLaunchOptions launchOptions)
         {
-            try
-            {
-                ILaunchProfile activeProfile = await GetActiveProfileAsync();
+            ILaunchProfile activeProfile = await GetActiveProfileAsync();
 
-                // Now find the DebugTargets provider for this profile
-                IDebugProfileLaunchTargetsProvider? launchProvider = GetLaunchTargetsProvider(activeProfile);
-                if (launchProvider is null)
-                {
-                    return true;
-                }
+            // Now find the DebugTargets provider for this profile
+            IDebugProfileLaunchTargetsProvider? launchProvider = GetLaunchTargetsProvider(activeProfile);
 
-                if (launchProvider is IDebugProfileLaunchTargetsProvider3 provider3)
-                {
-                    return await provider3.CanBeStartupProjectAsync(launchOptions, activeProfile);
-                }
-            }
-            catch (Exception)
+            if (launchProvider is IDebugProfileLaunchTargetsProvider3 provider3)
             {
+                return await provider3.CanBeStartupProjectAsync(launchOptions, activeProfile);
             }
 
             // Maintain backwards compat
@@ -84,7 +75,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
         private async Task<ILaunchProfile> GetActiveProfileAsync()
         {
-            // Launch providers to enforce requirements for debuggable projects
             // Get the active debug profile (timeout of 5s, though in reality is should never take this long as even in error conditions
             // a snapshot is produced).
             ILaunchSettings currentProfiles = await _launchSettingsProvider.WaitForFirstSnapshot(5000);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
@@ -49,10 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// <summary>
         /// Called by CPS to determine whether we can launch
         /// </summary>
-        public override Task<bool> CanLaunchAsync(DebugLaunchOptions launchOptions)
-        {
-            return TplExtensions.TrueTask;
-        }
+        public override Task<bool> CanLaunchAsync(DebugLaunchOptions launchOptions) => TplExtensions.TrueTask;
 
         /// <summary>
         /// Called by StartupProjectRegistrar to determine whether this project should appear in the Startup list.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -66,44 +66,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             _remoteDebuggerAuthenticationService = remoteDebuggerAuthenticationService;
         }
 
-        private Task<ConfiguredProject?> GetConfiguredProjectForDebugAsync()
-        {
-            return _activeDebugFramework.GetConfiguredProjectForActiveFrameworkAsync();
-        }
+        private Task<ConfiguredProject?> GetConfiguredProjectForDebugAsync() =>
+            _activeDebugFramework.GetConfiguredProjectForActiveFrameworkAsync();
 
         /// <summary>
         /// This provider handles running the Project and empty commandName (this generally just runs the executable)
         /// </summary>
-        public bool SupportsProfile(ILaunchProfile profile)
-        {
-            return string.IsNullOrWhiteSpace(profile.CommandName) || IsRunProjectCommand(profile) || IsRunExecutableCommand(profile);
-        }
+        public bool SupportsProfile(ILaunchProfile profile) =>
+            string.IsNullOrWhiteSpace(profile.CommandName) || IsRunProjectCommand(profile) || IsRunExecutableCommand(profile);
 
         /// <summary>
         /// Called just prior to launch to do additional work (put up ui, do special configuration etc).
         /// </summary>
-        public Task OnBeforeLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile)
-        {
-            return Task.CompletedTask;
-        }
+        public Task OnBeforeLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile) => Task.CompletedTask;
 
         /// <summary>
         /// Called just after the launch to do additional work (put up ui, do special configuration etc).
         /// </summary>
-        public Task OnAfterLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile)
-        {
-            return Task.CompletedTask;
-        }
+        public Task OnAfterLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile) => Task.CompletedTask;
 
-        private Task<bool> IsClassLibraryAsync()
-        {
-            return IsOutputTypeAsync(ConfigurationGeneral.OutputTypeValues.Library);
-        }
+        private Task<bool> IsClassLibraryAsync() => IsOutputTypeAsync(ConfigurationGeneral.OutputTypeValues.Library);
 
-        private Task<bool> IsConsoleAppAsync()
-        {
-            return IsOutputTypeAsync(ConfigurationGeneral.OutputTypeValues.Exe);
-        }
+        private Task<bool> IsConsoleAppAsync() => IsOutputTypeAsync(ConfigurationGeneral.OutputTypeValues.Exe);
 
         private async Task<bool> IsOutputTypeAsync(string outputType)
         {
@@ -124,19 +108,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             return launchSettings != null;
         }
 
-        public async Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsForDebugLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile activeProfile)
-        {
-            return (await QueryDebugTargetsAsync(launchOptions, activeProfile, validateSettings: true)) ?? Array.Empty<IDebugLaunchSettings>();
-        }
+        public async Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsForDebugLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile activeProfile) =>
+            await QueryDebugTargetsAsync(launchOptions, activeProfile, validateSettings: true) ?? throw new Exception(VSResources.ProjectNotRunnableDirectly);
 
         /// <summary>
         /// This is called on F5/Ctrl-F5 to return the list of debug targets. What we return depends on the type
         /// of project.
         /// </summary>
-        public async Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsAsync(DebugLaunchOptions launchOptions, ILaunchProfile activeProfile)
-        {
-            return (await QueryDebugTargetsAsync(launchOptions, activeProfile, validateSettings: false)) ?? Array.Empty<IDebugLaunchSettings>();
-        }
+        public async Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsAsync(DebugLaunchOptions launchOptions, ILaunchProfile activeProfile) =>
+            await QueryDebugTargetsAsync(launchOptions, activeProfile, validateSettings: false) ?? throw new Exception(VSResources.ProjectNotRunnableDirectly);
 
         /// <summary>
         /// Returns <c>null</c> if the debug launch settings are <c>null</c>. Otherwise, the list of debug launch settings.
@@ -159,11 +139,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             {
                 throw new ProjectLaunchSettingValidationException(string.Format(VSResources.NoDebugExecutableSpecified, profileName));
             }
-            else if (executable.IndexOf(Path.DirectorySeparatorChar) != -1 && !_fileSystem.FileExists(executable))
+
+            if (executable.IndexOf(Path.DirectorySeparatorChar) != -1 && !_fileSystem.FileExists(executable))
             {
                 throw new ProjectLaunchSettingValidationException(string.Format(VSResources.DebugExecutableNotFound, executable, profileName));
             }
-            else if (!string.IsNullOrEmpty(workingDir) && !_fileSystem.DirectoryExists(workingDir))
+
+            if (!string.IsNullOrEmpty(workingDir) && !_fileSystem.DirectoryExists(workingDir))
             {
                 throw new ProjectLaunchSettingValidationException(string.Format(VSResources.WorkingDirecotryInvalid, workingDir, profileName));
             }
@@ -196,15 +178,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             }
         }
 
-        private static bool IsRunExecutableCommand(ILaunchProfile profile)
-        {
-            return string.Equals(profile.CommandName, LaunchSettingsProvider.RunExecutableCommandName, StringComparisons.LaunchProfileCommandNames);
-        }
+        private static bool IsRunExecutableCommand(ILaunchProfile profile) =>
+            string.Equals(profile.CommandName, LaunchSettingsProvider.RunExecutableCommandName, StringComparisons.LaunchProfileCommandNames);
 
-        private static bool IsRunProjectCommand(ILaunchProfile profile)
-        {
-            return string.Equals(profile.CommandName, LaunchSettingsProvider.RunProjectCommandName, StringComparisons.LaunchProfileCommandNames);
-        }
+        private static bool IsRunProjectCommand(ILaunchProfile profile) =>
+            string.Equals(profile.CommandName, LaunchSettingsProvider.RunProjectCommandName, StringComparisons.LaunchProfileCommandNames);
 
         private async Task<bool> IsIntegratedConsoleEnabledAsync()
         {
@@ -659,13 +637,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// <summary>
         /// Helper returns the correct debugger engine based on the targeted framework
         /// </summary>
-        internal static Guid GetManagedDebugEngineForFramework(string targetFramework)
-        {
+        internal static Guid GetManagedDebugEngineForFramework(string targetFramework) =>
             // The engine depends on the framework
-            return IsDotNetCoreFramework(targetFramework) ?
+            IsDotNetCoreFramework(targetFramework) ?
                 DebuggerEngines.ManagedCoreEngine :
                 DebuggerEngines.ManagedOnlyEngine;
-        }
 
         /// <summary>
         /// TODO: This is a placeholder until issue https://github.com/dotnet/project-system/issues/423 is addressed.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -101,16 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         protected const int WaitForFirstSnapshotDelayMillis = 5000;
 
         [Obsolete("Use GetLaunchSettingsFilePathAsync instead.")]
-        public string LaunchSettingsFile
-        {
-            get
-            {
-                return _commonProjectServices.ThreadingService.ExecuteSynchronously(() =>
-                {
-                    return GetLaunchSettingsFilePathAsync();
-                });
-            }
-        }
+        public string LaunchSettingsFile => _commonProjectServices.ThreadingService.ExecuteSynchronously(GetLaunchSettingsFilePathAsync);
 
         /// <summary>
         /// Returns the active profile. Looks up the value of the ActiveProfile property. If the value doesn't match the

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderFactory.cs
@@ -10,16 +10,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     {
         public static IDebugLaunchProvider ImplementIsProjectDebuggableAsync(Func<bool> action)
         {
-            var mock = new Mock<IDebugLaunchProviderMock>();
+            var mock = new Mock<IDebugLaunchProvider>();
 
-            mock.Setup(d => d.CanBeStartupProjectAsync(It.IsAny<DebugLaunchOptions>()))
-                                .ReturnsAsync(action);
+            mock.As<IStartupProjectProvider>()
+                .Setup(d => d.CanBeStartupProjectAsync(It.IsAny<DebugLaunchOptions>()))
+                .ReturnsAsync(action);
 
             return mock.Object;
         }
-    }
-
-    internal interface IDebugLaunchProviderMock : IDebugLaunchProvider, IStartupProjectProvider
-    {
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProviderTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             new(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst);
 
         private readonly Mock<ConfiguredProject> _configuredProjectMoq = new();
-        private readonly Mock<ILaunchSettingsProvider> _LaunchSettingsProviderMoq = new();
+        private readonly Mock<ILaunchSettingsProvider> _launchSettingsProviderMoq = new();
         private readonly List<IDebugLaunchSettings> _webProviderSettings = new();
         private readonly List<IDebugLaunchSettings> _dockerProviderSettings = new();
         private readonly List<IDebugLaunchSettings> _exeProviderSettings = new();
@@ -40,16 +40,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             _launchProviders.Add(new Lazy<IDebugProfileLaunchTargetsProvider, IOrderPrecedenceMetadataView>(() => _mockDockerProvider.Object, mockMetadata.Object));
             _launchProviders.Add(new Lazy<IDebugProfileLaunchTargetsProvider, IOrderPrecedenceMetadataView>(() => _mockExeProvider.Object, mockMetadata.Object));
 
-            _LaunchSettingsProviderMoq.Setup(x => x.ActiveProfile).Returns(() => _activeProfile);
-            _LaunchSettingsProviderMoq.Setup(x => x.WaitForFirstSnapshot(It.IsAny<int>())).Returns(() =>
-            {
-                if (_activeProfile != null)
-                {
-                    return Task.FromResult((ILaunchSettings)new LaunchSettings(new List<ILaunchProfile>() { _activeProfile }, null, _activeProfile.Name));
-                }
-
-                return Task.FromResult((ILaunchSettings)new LaunchSettings());
-            });
+            _launchSettingsProviderMoq.Setup(x => x.ActiveProfile).Returns(() => _activeProfile);
+            _launchSettingsProviderMoq.Setup(x => x.WaitForFirstSnapshot(It.IsAny<int>())).Returns(() =>
+                _activeProfile != null ?
+                    Task.FromResult((ILaunchSettings)new LaunchSettings(new List<ILaunchProfile> { _activeProfile }, null, _activeProfile.Name)) :
+                    Task.FromResult((ILaunchSettings)new LaunchSettings()));
         }
 
         [Fact]
@@ -67,10 +62,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public void GetLaunchTargetsProviderForProfileTestsAsync()
         {
             var provider = CreateInstance();
-            Assert.Equal(_mockWebProvider.Object,  provider.GetLaunchTargetsProvider(new LaunchProfile() { Name = "test", CommandName = "IISExpress" }));
-            Assert.Equal(_mockDockerProvider.Object,  provider.GetLaunchTargetsProvider(new LaunchProfile() { Name = "test", CommandName = "Docker" }));
-            Assert.Equal(_mockExeProvider.Object,  provider.GetLaunchTargetsProvider(new LaunchProfile() { Name = "test", CommandName = "Project" }));
-            Assert.Null(provider.GetLaunchTargetsProvider(new LaunchProfile() { Name = "test", CommandName = "IIS" }));
+            Assert.Equal(_mockWebProvider.Object, provider.GetLaunchTargetsProvider(new LaunchProfile { Name = "test", CommandName = "IISExpress" }));
+            Assert.Equal(_mockDockerProvider.Object, provider.GetLaunchTargetsProvider(new LaunchProfile { Name = "test", CommandName = "Docker" }));
+            Assert.Equal(_mockExeProvider.Object, provider.GetLaunchTargetsProvider(new LaunchProfile { Name = "test", CommandName = "Project" }));
+            Assert.Null(provider.GetLaunchTargetsProvider(new LaunchProfile { Name = "test", CommandName = "IIS" }));
         }
 
         [Fact]
@@ -78,15 +73,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             var provider = CreateInstance();
 
-            _activeProfile = new LaunchProfile() { Name = "test", CommandName = "IISExpress" };
+            _activeProfile = new LaunchProfile { Name = "test", CommandName = "IISExpress" };
             var result = await provider.QueryDebugTargetsAsync(0);
             Assert.Equal(_webProviderSettings, result);
 
-            _activeProfile = new LaunchProfile() { Name = "test", CommandName = "Docker" };
+            _activeProfile = new LaunchProfile { Name = "test", CommandName = "Docker" };
             result = await provider.QueryDebugTargetsAsync(0);
             Assert.Equal(_dockerProviderSettings, result);
 
-            _activeProfile = new LaunchProfile() { Name = "test", CommandName = "Project" };
+            _activeProfile = new LaunchProfile { Name = "test", CommandName = "Project" };
             result = await provider.QueryDebugTargetsAsync(0);
             Assert.Equal(_exeProviderSettings, result);
         }
@@ -97,27 +92,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             var provider = CreateInstance();
             _activeProfile = null;
 
-            await Assert.ThrowsAsync<Exception>(() =>
-            {
-                return provider.QueryDebugTargetsAsync(0);
-            });
+            await Assert.ThrowsAsync<Exception>(() => provider.QueryDebugTargetsAsync(0));
         }
 
         [Fact]
         public async Task QueryDebugTargetsAsync_WhenNoInstalledProvider_Throws()
         {
             var provider = CreateInstance();
-            _activeProfile = new LaunchProfile() { Name = "NoActionProfile", CommandName = "SomeOtherExtension" };
+            _activeProfile = new LaunchProfile { Name = "NoActionProfile", CommandName = "SomeOtherExtension" };
 
-            await Assert.ThrowsAsync<Exception>(() =>
-            {
-                return provider.QueryDebugTargetsAsync(0);
-            });
+            await Assert.ThrowsAsync<Exception>(() => provider.QueryDebugTargetsAsync(0));
         }
 
         private LaunchProfilesDebugLaunchProvider CreateInstance()
         {
-            var provider = new LaunchProfilesDebugLaunchProvider(_configuredProjectMoq.Object, _LaunchSettingsProviderMoq.Object, vsDebuggerService: null!);
+            var provider = new LaunchProfilesDebugLaunchProvider(_configuredProjectMoq.Object, _launchSettingsProviderMoq.Object, vsDebuggerService: null!);
 
             provider.LaunchTargetsProviders.Add(_mockWebProvider.Object);
             provider.LaunchTargetsProviders.Add(_mockDockerProvider.Object);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             _mockFS.WriteAllText(@"c:\program files\dotnet\dotnet.exe", "");
             _mockFS.CreateDirectory(@"c:\test\project");
 
-            var activeProfile = new LaunchProfile() { Name = "MyApplication", CommandName = "Project", CommandLineArgs = "--someArgs" };
+            var activeProfile = new LaunchProfile { Name = "MyApplication", CommandName = "Project", CommandLineArgs = "--someArgs" };
             var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
             Assert.Single(targets);
             Assert.Equal(@"c:\program files\dotnet\dotnet.exe", targets[0].Executable);
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             _mockFS.WriteAllText(@"c:\program files\dotnet\dotnet.exe", "");
             _mockFS.CreateDirectory(@"c:\test\project");
 
-            var activeProfile = new LaunchProfile()
+            var activeProfile = new LaunchProfile
             {
                 Name = "MyApplication",
                 CommandName = "Project",
@@ -126,10 +126,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             var debugger = GetDebugTargetsProvider();
 
-            var activeProfile = new LaunchProfile() { Name = "MyApplication", CommandName = "Project", CommandLineArgs = "--someArgs" };
+            var activeProfile = new LaunchProfile { Name = "MyApplication", CommandName = "Project", CommandLineArgs = "--someArgs" };
 
             // Now control-F5, add env
-            activeProfile.EnvironmentVariables = new Dictionary<string, string>() { { "var1", "Value1" } }.ToImmutableDictionary();
+            activeProfile.EnvironmentVariables = new Dictionary<string, string> { { "var1", "Value1" } }.ToImmutableDictionary();
             var targets = await debugger.QueryDebugTargetsAsync(DebugLaunchOptions.NoDebug, activeProfile);
             Assert.Single(targets);
             Assert.EndsWith(@"\cmd.exe", targets[0].Executable, StringComparison.OrdinalIgnoreCase);
@@ -145,7 +145,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             var debugger = GetDebugTargetsProvider();
 
-            var activeProfile = new LaunchProfile() { Name = "MyApplication", CommandName = "Project", CommandLineArgs = "--someArgs" };
+            var activeProfile = new LaunchProfile { Name = "MyApplication", CommandName = "Project", CommandLineArgs = "--someArgs" };
 
             // Validate that when the DLO_Profiling is set we don't run the cmd.exe
             var targets = await debugger.QueryDebugTargetsAsync(DebugLaunchOptions.NoDebug | DebugLaunchOptions.Profiling, activeProfile);
@@ -159,7 +159,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             var debugger = GetDebugTargetsProvider();
 
-            var activeProfile = new LaunchProfile() { Name = "MyApplication", CommandLineArgs = "--someArgs", ExecutablePath = @"c:\test\Project\someapp.exe" };
+            var activeProfile = new LaunchProfile { Name = "MyApplication", CommandLineArgs = "--someArgs", ExecutablePath = @"c:\test\Project\someapp.exe" };
             var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
             Assert.Single(targets);
             Assert.Equal(activeProfile.ExecutablePath, targets[0].Executable);
@@ -173,10 +173,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             var debugger = GetDebugTargetsProvider();
 
-            var activeProfile = new LaunchProfile() { Name = "MyApplication", CommandLineArgs = "--someArgs", ExecutablePath = @"c:\test\Project\someapp.exe" };
+            var activeProfile = new LaunchProfile { Name = "MyApplication", CommandLineArgs = "--someArgs", ExecutablePath = @"c:\test\Project\someapp.exe" };
 
             // Now control-F5, add env vars
-            activeProfile.EnvironmentVariables = new Dictionary<string, string>() { { "var1", "Value1" } }.ToImmutableDictionary();
+            activeProfile.EnvironmentVariables = new Dictionary<string, string> { { "var1", "Value1" } }.ToImmutableDictionary();
             var targets = await debugger.QueryDebugTargetsAsync(DebugLaunchOptions.NoDebug, activeProfile);
             Assert.Single(targets);
             Assert.Equal(activeProfile.ExecutablePath, targets[0].Executable);
@@ -193,12 +193,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         [InlineData(null)]
         public async Task QueryDebugTargetsAsync_ExeProfileAsyncExeRelativeNoWorkingDir(string outdir)
         {
-            var properties = new Dictionary<string, string?>() {
+            var properties = new Dictionary<string, string?>
+            {
                     {"RunCommand", @"dotnet"},
                     {"RunArguments", "exec " + "\"" + @"c:\test\project\bin\project.dll"+ "\""},
                     {"RunWorkingDirectory",  @"bin\"},
-                    { "TargetFrameworkIdentifier", @".NetCoreApp" },
-                    { "OutDir", outdir }
+                    {"TargetFrameworkIdentifier", @".NetCoreApp"},
+                    {"OutDir", outdir}
                 };
 
             var debugger = GetDebugTargetsProvider("exe", properties);
@@ -206,7 +207,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             // Exe relative, no working dir
             _mockFS.WriteAllText(@"c:\test\project\bin\test.exe", string.Empty);
             _mockFS.WriteAllText(@"c:\test\project\test.exe", string.Empty);
-            var activeProfile = new LaunchProfile() { Name = "run", ExecutablePath = ".\\test.exe" };
+            var activeProfile = new LaunchProfile { Name = "run", ExecutablePath = ".\\test.exe" };
             var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
             Assert.Single(targets);
             if (outdir == null || outdir == @"doesntExist\")
@@ -232,7 +233,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             _mockFS.WriteAllText(@"c:\WorkingDir\mytest.exe", string.Empty);
             _mockFS.SetCurrentDirectory(@"c:\Test");
             _mockFS.CreateDirectory(@"c:\WorkingDir");
-            var activeProfile = new LaunchProfile() { Name = "run", ExecutablePath = ".\\mytest.exe", WorkingDirectory = workingDir };
+            var activeProfile = new LaunchProfile { Name = "run", ExecutablePath = ".\\mytest.exe", WorkingDirectory = workingDir };
             var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
             Assert.Single(targets);
             Assert.Equal(@"c:\WorkingDir\mytest.exe", targets[0].Executable);
@@ -247,7 +248,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             // Exe relative to full working dir
             _mockFS.WriteAllText(@"c:\WorkingDir\mytest.exe", string.Empty);
             _mockFS.CreateDirectory(@"c:\WorkingDir");
-            var activeProfile = new LaunchProfile() { Name = "run", ExecutablePath = "./mytest.exe", WorkingDirectory = @"c:/WorkingDir" };
+            var activeProfile = new LaunchProfile { Name = "run", ExecutablePath = "./mytest.exe", WorkingDirectory = @"c:/WorkingDir" };
             var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
             Assert.Single(targets);
             Assert.Equal(@"c:\WorkingDir\mytest.exe", targets[0].Executable);
@@ -257,7 +258,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         [Fact]
         public async Task QueryDebugTargetsAsync_SetsProject()
         {
-            var project = new LaunchProfile() { Name = "run", ExecutablePath = "dotnet.exe" };
+            var project = new LaunchProfile { Name = "run", ExecutablePath = "dotnet.exe" };
 
             var debugger = GetDebugTargetsProvider();
             var targets = await debugger.QueryDebugTargetsAsync(0, project);
@@ -274,7 +275,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             var debugger = GetDebugTargetsProvider();
 
             // Exe relative to path
-            var activeProfile = new LaunchProfile() { Name = "run", ExecutablePath = exeName };
+            var activeProfile = new LaunchProfile { Name = "run", ExecutablePath = exeName };
             var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
             Assert.Single(targets);
             Assert.Equal(@"c:\program files\dotnet\dotnet.exe", targets[0].Executable);
@@ -290,7 +291,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             _mockFS.SetCurrentDirectory(@"c:\CurrentDirectory");
 
             // Exe relative to path
-            var activeProfile = new LaunchProfile() { Name = "run", ExecutablePath = exeName };
+            var activeProfile = new LaunchProfile { Name = "run", ExecutablePath = exeName };
             var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
             Assert.Single(targets);
             Assert.Equal(@"c:\CurrentDirectory\myexe.exe", targets[0].Executable);
@@ -304,7 +305,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             _mockFS.SetCurrentDirectory(@"e:\CurrentDirectory");
 
             // Exe relative to path
-            var activeProfile = new LaunchProfile() { Name = "run", ExecutablePath = @"\myexe.exe" };
+            var activeProfile = new LaunchProfile { Name = "run", ExecutablePath = @"\myexe.exe" };
             var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
             Assert.Single(targets);
             Assert.Equal(@"e:\myexe.exe", targets[0].Executable);
@@ -313,14 +314,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         [Fact]
         public async Task QueryDebugTargetsAsync_WhenLibraryWithRunCommand_ReturnsRunCommand()
         {
-            var properties = new Dictionary<string, string?>() {
+            var properties = new Dictionary<string, string?>
+            {
                 {"RunCommand", @"C:\dotnet.exe"},
-                {"TargetFrameworkIdentifier", @".NETFramework" }
-                };
+                {"TargetFrameworkIdentifier", @".NETFramework"}
+            };
 
             var debugger = GetDebugTargetsProvider("Library", properties);
 
-            var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
+            var activeProfile = new LaunchProfile { Name = "Name", CommandName = "Project" };
 
             var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
 
@@ -331,14 +333,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         [Fact]
         public async Task QueryDebugTargetsAsync_WhenLibraryWithoutRunCommand_ReturnsTargetPath()
         {
-            var properties = new Dictionary<string, string?>() {
+            var properties = new Dictionary<string, string?>
+            {
                 {"TargetPath", @"C:\library.dll"},
-                {"TargetFrameworkIdentifier", @".NETFramework" }
-                };
+                {"TargetFrameworkIdentifier", @".NETFramework"}
+            };
 
             var debugger = GetDebugTargetsProvider("Library", properties);
 
-            var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
+            var activeProfile = new LaunchProfile { Name = "Name", CommandName = "Project" };
 
             var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
 
@@ -349,14 +352,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         [Fact]
         public async Task QueryDebugTargetsAsync_WhenLibraryWithoutRunCommand_DoesNotManipulateTargetPath()
         {
-            var properties = new Dictionary<string, string?>() {
+            var properties = new Dictionary<string, string?>
+            {
                 {"TargetPath", @"library.dll"},
-                {"TargetFrameworkIdentifier", @".NETFramework" }
-                };
+                {"TargetFrameworkIdentifier", @".NETFramework"}
+            };
 
             var debugger = GetDebugTargetsProvider("Library", properties);
 
-            var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
+            var activeProfile = new LaunchProfile { Name = "Name", CommandName = "Project" };
 
             var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
 
@@ -367,36 +371,35 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         [Fact]
         public async Task QueryDebugTargetsForDebugLaunchAsync_WhenLibraryAndNoRunCommandSpecified_Throws()
         {
-            var properties = new Dictionary<string, string?>() {
+            var properties = new Dictionary<string, string?>
+            {
                 {"TargetPath", @"C:\library.dll"},
-                {"TargetFrameworkIdentifier", @".NETFramework" }
-                };
+                {"TargetFrameworkIdentifier", @".NETFramework"}
+            };
 
             _mockFS.WriteAllText(@"C:\library.dll", string.Empty);
 
             var debugger = GetDebugTargetsProvider("Library", properties);
 
-            var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
+            var activeProfile = new LaunchProfile { Name = "Name", CommandName = "Project" };
 
-            await Assert.ThrowsAsync<ProjectNotRunnableDirectlyException>(() =>
-            {
-                return debugger.QueryDebugTargetsForDebugLaunchAsync(0, activeProfile);
-            });
+            Assert.Empty(await debugger.QueryDebugTargetsForDebugLaunchAsync(0, activeProfile));
         }
 
         [Fact]
         public async Task QueryDebugTargetsForDebugLaunchAsync_WhenLibraryAndRunCommandSpecified_ReturnsRunCommand()
         {
-            var properties = new Dictionary<string, string?>() {
+            var properties = new Dictionary<string, string?>
+            {
                 {"RunCommand", @"C:\dotnet.exe"},
-                {"TargetFrameworkIdentifier", @".NETFramework" }
-                };
+                {"TargetFrameworkIdentifier", @".NETFramework"}
+            };
 
             _mockFS.WriteAllText(@"C:\library.dll", string.Empty);
 
             var debugger = GetDebugTargetsProvider("Library", properties);
 
-            var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
+            var activeProfile = new LaunchProfile { Name = "Name", CommandName = "Project" };
 
             var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
 
@@ -407,14 +410,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         [Fact]
         public async Task QueryDebugTargetsAsync_ConsoleAppLaunchWithNoDebugger_WrapsInCmd()
         {
-            var properties = new Dictionary<string, string?>() {
+            var properties = new Dictionary<string, string?>
+            {
                 {"TargetPath", @"C:\ConsoleApp.exe"},
-                {"TargetFrameworkIdentifier", @".NETFramework" }
-                };
+                {"TargetFrameworkIdentifier", @".NETFramework"}
+            };
 
             var debugger = GetDebugTargetsProvider("exe", properties);
 
-            var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
+            var activeProfile = new LaunchProfile { Name = "Name", CommandName = "Project" };
 
             var result = await debugger.QueryDebugTargetsAsync(DebugLaunchOptions.NoDebug, activeProfile);
 
@@ -426,16 +430,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public async Task QueryDebugTargetsAsync_ConsoleAppLaunchWithNoDebuggerWithIntegratedConsoleEnabled_DoesNotWrapInCmd()
         {
             var debugger = IVsDebugger10Factory.ImplementIsIntegratedConsoleEnabled(enabled: true);
-            var properties = new Dictionary<string, string?>() {
+            var properties = new Dictionary<string, string?>
+            {
                 {"TargetPath", @"C:\ConsoleApp.exe"},
-                {"TargetFrameworkIdentifier", @".NETFramework" }
-                };
+                {"TargetFrameworkIdentifier", @".NETFramework"}
+            };
 
             var scope = IProjectCapabilitiesScopeFactory.Create(capabilities: new string[] { ProjectCapabilities.IntegratedConsoleDebugging });
 
             var provider = GetDebugTargetsProvider("exe", properties, debugger, scope);
 
-            var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
+            var activeProfile = new LaunchProfile { Name = "Name", CommandName = "Project" };
 
             var result = await provider.QueryDebugTargetsAsync(DebugLaunchOptions.NoDebug, activeProfile);
 
@@ -449,16 +454,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public async Task QueryDebugTargetsAsync_ConsoleAppLaunch_IncludesIntegratedConsoleInLaunchOptions(DebugLaunchOptions launchOptions)
         {
             var debugger = IVsDebugger10Factory.ImplementIsIntegratedConsoleEnabled(enabled: true);
-            var properties = new Dictionary<string, string?>() {
+            var properties = new Dictionary<string, string?>
+            {
                 {"TargetPath", @"C:\ConsoleApp.exe"},
-                {"TargetFrameworkIdentifier", @".NETFramework" }
-                };
+                {"TargetFrameworkIdentifier", @".NETFramework"}
+            };
 
             var scope = IProjectCapabilitiesScopeFactory.Create(capabilities: new string[] { ProjectCapabilities.IntegratedConsoleDebugging });
 
             var provider = GetDebugTargetsProvider("exe", properties, debugger, scope);
 
-            var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
+            var activeProfile = new LaunchProfile { Name = "Name", CommandName = "Project" };
 
             var result = await provider.QueryDebugTargetsAsync(launchOptions, activeProfile);
 
@@ -472,14 +478,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public async Task QueryDebugTargetsAsync_NonIntegratedConsoleCapability_DoesNotIncludeIntegrationConsoleInLaunchOptions(DebugLaunchOptions launchOptions)
         {
             var debugger = IVsDebugger10Factory.ImplementIsIntegratedConsoleEnabled(enabled: true);
-            var properties = new Dictionary<string, string?>() {
+            var properties = new Dictionary<string, string?>
+            {
                 {"TargetPath", @"C:\ConsoleApp.exe"},
-                {"TargetFrameworkIdentifier", @".NETFramework" }
-                };
+                {"TargetFrameworkIdentifier", @".NETFramework"}
+            };
 
             var provider = GetDebugTargetsProvider("exe", properties, debugger);
 
-            var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
+            var activeProfile = new LaunchProfile { Name = "Name", CommandName = "Project" };
 
             var result = await provider.QueryDebugTargetsAsync(launchOptions, activeProfile);
 
@@ -495,14 +502,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public async Task QueryDebugTargetsAsync_NonConsoleAppLaunch_DoesNotIncludeIntegrationConsoleInLaunchOptions(string outputType)
         {
             var debugger = IVsDebugger10Factory.ImplementIsIntegratedConsoleEnabled(enabled: true);
-            var properties = new Dictionary<string, string?>() {
+            var properties = new Dictionary<string, string?>
+            {
                 {"TargetPath", @"C:\ConsoleApp.exe"},
-                {"TargetFrameworkIdentifier", @".NETFramework" }
-                };
+                {"TargetFrameworkIdentifier", @".NETFramework"}
+            };
 
             var provider = GetDebugTargetsProvider(outputType, properties, debugger);
 
-            var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
+            var activeProfile = new LaunchProfile { Name = "Name", CommandName = "Project" };
 
             var result = await provider.QueryDebugTargetsAsync(0, activeProfile);
 
@@ -517,14 +525,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         [InlineData("WinMDObj")]
         public async Task QueryDebugTargetsAsync_NonConsoleAppLaunchWithNoDebugger_DoesNotWrapInCmd(string outputType)
         {
-            var properties = new Dictionary<string, string?>() {
+            var properties = new Dictionary<string, string?>
+            {
                 {"TargetPath", @"C:\ConsoleApp.exe"},
-                {"TargetFrameworkIdentifier", @".NETFramework" }
-                };
+                {"TargetFrameworkIdentifier", @".NETFramework"}
+            };
 
             var debugger = GetDebugTargetsProvider(outputType, properties);
 
-            var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
+            var activeProfile = new LaunchProfile { Name = "Name", CommandName = "Project" };
 
             var result = await debugger.QueryDebugTargetsAsync(DebugLaunchOptions.NoDebug, activeProfile);
 
@@ -628,11 +637,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             var project = UnconfiguredProjectFactory.Create(fullPath: _ProjectFile);
 
-            var outputTypeEnum = new PageEnumValue(new EnumValue() { Name = outputType });
+            var outputTypeEnum = new PageEnumValue(new EnumValue { Name = outputType });
             var data = new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputTypeProperty, outputTypeEnum);
             var projectProperties = ProjectPropertiesFactory.Create(project, data);
 
-            properties ??= new Dictionary<string, string?>()
+            properties ??= new Dictionary<string, string?>
             {
                 {"RunCommand", @"dotnet"},
                 {"RunArguments", "exec " + "\"" + @"c:\test\project\bin\project.dll" + "\""},

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -383,7 +383,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             var activeProfile = new LaunchProfile { Name = "Name", CommandName = "Project" };
 
-            Assert.Empty(await debugger.QueryDebugTargetsForDebugLaunchAsync(0, activeProfile));
+            await Assert.ThrowsAsync<Exception>(() => debugger.QueryDebugTargetsForDebugLaunchAsync(0, activeProfile));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes: [AB#1245470](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1245470)
Related: https://github.com/dotnet/project-system/pull/6443#pullrequestreview-458792319

Currently, `ProjectNotRunnableDirectlyException` is thrown when the project cannot be debugged, such as a class library. Then, this exception is explicitly caught in `CanBeStartupProjectAsync`. If caught, it cannot be a startup projects (returns false). Otherwise, the method returns true.

This exception is thrown in `GetTargetCommandAsync`. Working up the call stack, this is used in the 2 public methods, `QueryDebugTargetsForDebugLaunchAsync` and `QueryDebugTargetsAsync`. These implement a couple of provider interfaces for the `ProjectLaunchTargetsProvider`. So, anything that calls these methods has the potential of throwing a `ProjectNotRunnableDirectlyException`.

In the attached issue, the exception the user saw was correctly being thrown from `CanBeStartupProjectAsync` according to the provided call stack. However, it is not a good practice to use exceptions as the 'happy path' for logic, even if they are being caught and handled. Instead, I've used a sentinel value `null` to represent the 'bad path' for this call stack. It isn't the best design, but it is the simplest solution without redesign of the calling structure. In the PR, the changes mainly relate to passing `null` up the call stack until it reaches `CanBeStartupProjectAsync`. If `null` is given to that method, it returns false. Otherwise, it returns true. If `null` reaches the 2 public methods, they will return an empty array to adhere to the interface the methods implement.

Other changes in this PR are addressing @drewnoakes comments on the [PR that added this exception](https://github.com/dotnet/project-system/pull/6443#pullrequestreview-458792319). Plus, minor cleanup in files that I touched, such as tab alignment and extra whitespace being removed.