### PR TITLE
Fix race condition in LaunchSettingsProvider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -143,12 +143,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             }
             protected set
             {
+                ILaunchSettings? prior = _currentSnapshot;
+                _currentSnapshot = value;
+
                 // If this is the first snapshot, complete the taskCompletionSource
-                if (_currentSnapshot == null)
+                if (prior is null)
                 {
                     _firstSnapshotCompletionSource.TrySetResult();
                 }
-                _currentSnapshot = value;
             }
         }
 


### PR DESCRIPTION
A `TaskCompletionSource` is used within `LaunchSettingsProvider` to signal when the first data snapshot is available to callers of `WaitForFirstSnapshot`.

The previous code would signal completion _before_ setting the field. This might seem to create an impossibly narrow window for a race condition to occur, however by default `TaskCompletionSource` schedules its continuations to run synchronously. This means that code waiting for the snapshot to arrive would be executed before the field was set. That code is likely to immediately query the snapshot, which will be null. Such code might expect the value to be non-null*, resulting in exceptions.

---

*There are issues with the null annotations in this type which should be addressed separately. Specifically:

```diff
diff --git a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
index 76fd68b14..e7c07d103 100644
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
@@ -15,7 +15,7 @@ public interface ILaunchSettingsProvider
     {
         IReceivableSourceBlock<ILaunchSettings> SourceBlock { get; }
 
-        ILaunchSettings CurrentSnapshot { get; }
+        ILaunchSettings? CurrentSnapshot { get; }
 
         [Obsolete("Use ILaunchSettingsProvider2.GetLaunchSettingsFilePathAsync instead.")]
         string LaunchSettingsFile { get; }
@@ -34,7 +34,7 @@ public interface ILaunchSettingsProvider
         /// Blocks until at least one snapshot has been generated.
         /// </summary>
         /// <param name="timeout">The timeout in milliseconds.</param>
-        Task<ILaunchSettings> WaitForFirstSnapshot(int timeout);
+        Task<ILaunchSettings?> WaitForFirstSnapshot(int timeout);
 
         /// <summary>
         /// Adds the given profile to the list and saves to disk. If a profile with the same
```

...and all knock-on consequences of those annotation changes throughout the solution.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6872)