### PR TITLE
Replace invalid use of the TargetFrameworkMoniker with target framework alias

### DIFF
--- a/src/Common/BannedSymbols.txt
+++ b/src/Common/BannedSymbols.txt
@@ -13,6 +13,8 @@ T:Microsoft.VisualStudio.ProjectSystem.IProjectLockService; Using IProjectAccess
 T:Microsoft.VisualStudio.ProjectSystem.VS.IProjectGuidService; Using ISafeProjectGuidService avoids reading the GUID before it is safe to do so during initialisation
 T:Microsoft.VisualStudio.ProjectSystem.VS.IProjectGuidService2; Using ISafeProjectGuidService avoids reading the GUID before it is safe to do so during initialisation
 
+T:NuGet.VisualStudio.IVsFrameworkParser; FrameworkName does not support the platform information added in .NET 5
+
 P:Microsoft.VisualStudio.ProjectSystem.VS.IProjectAsyncLoadDashboard.ProjectLoadedInHost; Using IUnconfiguredProjectTasksService.ProjectLoadedInHost prevents waiting indefinitely when the project is closed before it has finished loading
 
 M:Microsoft.VisualStudio.ProjectSystem.CommonProjectSystemTools.LoadedProject(Microsoft.VisualStudio.ProjectSystem.IProjectAsynchronousTasksService); Using IUnconfiguredProjectTasksService.LoadedProjectAsync is unit testable

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikerValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikerValueProvider.cs
@@ -3,11 +3,9 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell;
-using NuGet.VisualStudio;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
@@ -16,14 +14,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     {
         private readonly IUnconfiguredProjectVsServices _unconfiguredProjectVsServices;
         private readonly ProjectProperties _properties;
-        private readonly IVsFrameworkParser _frameworkParser;
 
         [ImportingConstructor]
-        public TargetFrameworkMonikerValueProvider(IUnconfiguredProjectVsServices unconfiguredProjectVsServices, ProjectProperties properties, IVsFrameworkParser frameworkParser)
+        public TargetFrameworkMonikerValueProvider(IUnconfiguredProjectVsServices unconfiguredProjectVsServices, ProjectProperties properties)
         {
             _unconfiguredProjectVsServices = unconfiguredProjectVsServices;
             _properties = properties;
-            _frameworkParser = frameworkParser;
         }
 
         public override async Task<string?> OnSetPropertyValueAsync(
@@ -41,8 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             }
             else if (!string.IsNullOrEmpty(currentTargetFramework))
             {
-                var frameworkName = new FrameworkName(unevaluatedPropertyValue);
-                await defaultProperties.SetPropertyValueAsync(ConfigurationGeneral.TargetFrameworkProperty, _frameworkParser.GetShortFrameworkName(frameworkName));
+                await defaultProperties.SetPropertyValueAsync(ConfigurationGeneral.TargetFrameworkProperty, unevaluatedPropertyValue);
             }
             else
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TargetFrameworkProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TargetFrameworkProvider.cs
@@ -3,81 +3,37 @@
 using System;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-using System.Runtime.Versioning;
-using NuGet.VisualStudio;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     [Export(typeof(ITargetFrameworkProvider))]
     internal sealed class TargetFrameworkProvider : ITargetFrameworkProvider
     {
-        private readonly IVsFrameworkParser _nuGetFrameworkParser;
-
         /// <summary>
-        /// Lookup for known <see cref="TargetFramework"/> objects, keyed by both
-        /// <see cref="TargetFramework.ShortName"/> and <see cref="TargetFramework.FullName"/>.
+        /// Lookup for <see cref="TargetFramework"/> objects keyed by
+        /// <see cref="TargetFramework.TargetFrameworkMoniker"/>.
         /// </summary>
         private ImmutableDictionary<string, TargetFramework> _targetFrameworkByName = ImmutableDictionary.Create<string, TargetFramework>(StringComparer.Ordinal);
 
-        [ImportingConstructor]
-        public TargetFrameworkProvider(IVsFrameworkParser nugetFrameworkParser)
+        public TargetFramework? GetTargetFramework(string? targetFrameworkMoniker)
         {
-            _nuGetFrameworkParser = nugetFrameworkParser;
-        }
-
-        public TargetFramework? GetTargetFramework(string? shortOrFullName)
-        {
-            if (Strings.IsNullOrEmpty(shortOrFullName))
+            if (Strings.IsNullOrEmpty(targetFrameworkMoniker))
             {
                 return null;
             }
 
             // Fast path for an exact name match
-            if (_targetFrameworkByName.TryGetValue(shortOrFullName, out TargetFramework? existing))
+            if (_targetFrameworkByName.TryGetValue(targetFrameworkMoniker, out TargetFramework? existing))
             {
                 return existing;
             }
 
-            try
-            {
-                // Try to parse a short or full framework name
-                FrameworkName? frameworkName = _nuGetFrameworkParser.ParseFrameworkName(shortOrFullName);
+            // This is a completely new target framework. Create, cache and return it.
+            var targetFramework = new TargetFramework(targetFrameworkMoniker);
 
-                if (frameworkName == null)
-                {
-                    return null;
-                }
+            ImmutableInterlocked.TryAdd(ref _targetFrameworkByName, targetFrameworkMoniker, targetFramework);
 
-                if (_targetFrameworkByName.TryGetValue(frameworkName.FullName, out TargetFramework? exitingByFullName))
-                {
-                    // The full name was known, so cache by the provided (unknown) name too for next time
-                    ImmutableInterlocked.TryAdd(ref _targetFrameworkByName, shortOrFullName, exitingByFullName);
-
-                    return exitingByFullName;
-                }
-
-                string? shortName = _nuGetFrameworkParser.GetShortFrameworkName(frameworkName);
-
-                if (shortName != null && _targetFrameworkByName.TryGetValue(shortName, out TargetFramework? exitingByShortName))
-                {
-                    // The short name was known, so cache by the provided (unknown) name too for next time
-                    ImmutableInterlocked.TryAdd(ref _targetFrameworkByName, shortOrFullName, exitingByShortName);
-
-                    return exitingByShortName;
-                }
-
-                // This is a completely new target framework. Create, cache and return it.
-                var targetFramework = new TargetFramework(frameworkName, shortName);
-
-                ImmutableInterlocked.TryAdd(ref _targetFrameworkByName, shortOrFullName, targetFramework);
-
-                return targetFramework;
-            }
-            catch
-            {
-                // Note: catching all exceptions and return a generic TargetFramework for given shortOrFullName
-                return new TargetFramework(shortOrFullName);
-            }
+            return targetFramework;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TargetFrameworkProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TargetFrameworkProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     {
         /// <summary>
         /// Lookup for <see cref="TargetFramework"/> objects keyed by
-        /// <see cref="TargetFramework.TargetFrameworkMoniker"/>.
+        /// <see cref="TargetFramework.TargetFrameworkAlias"/>.
         /// </summary>
         private ImmutableDictionary<string, TargetFramework> _targetFrameworkByName = ImmutableDictionary.Create<string, TargetFramework>(StringComparer.Ordinal);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/ITargetFrameworkProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/ITargetFrameworkProvider.cs
@@ -8,9 +8,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
     internal interface ITargetFrameworkProvider
     {
         /// <summary>
-        /// Parses full tfm or short framework name and returns a corresponding <see cref="TargetFramework"/>
-        /// instance, or <see langword="null" /> if the framework name has an invalid format.
+        /// Returns a <see cref="TargetFramework"/> instance for the target framework moniker
+        /// or <see langword="null" /> if the framework moniker is null or empty.
         /// </summary>
-        TargetFramework? GetTargetFramework(string? shortOrFullName);
+        TargetFramework? GetTargetFramework(string? targetFrameworkMoniker);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.Runtime.Versioning;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
@@ -19,36 +18,17 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// </summary>
         public static readonly TargetFramework Any = new("any");
 
-        public TargetFramework(FrameworkName frameworkName, string? shortName)
-        {
-            Requires.NotNull(frameworkName, nameof(frameworkName));
-
-            FullName = frameworkName.FullName;
-            ShortName = shortName ?? string.Empty;
-        }
-
-        /// <summary>
-        /// Should be never used directly, this is for special cases or for some unknown framework,
-        /// that Nuget is not aware of - highly unlikely to happen.
-        /// </summary>
-        /// <param name="moniker"></param>
         public TargetFramework(string moniker)
         {
             Requires.NotNull(moniker, nameof(moniker));
 
-            FullName = moniker;
-            ShortName = moniker;
+            TargetFrameworkMoniker = moniker;
         }
 
         /// <summary>
-        /// Gets the full moniker (TFM).
+        /// Gets the Target Framework Moniker.
         /// </summary>
-        public string FullName { get; }
-
-        /// <summary>
-        /// Gets the short name.
-        /// </summary>
-        public string ShortName { get; }
+        public string TargetFrameworkMoniker { get; }
 
         /// <summary>
         /// Override Equals to handle equivalency correctly. They are equal if the
@@ -61,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public bool Equals(TargetFramework? obj)
         {
-            return obj != null && FullName.Equals(obj.FullName, StringComparisons.FrameworkIdentifiers);
+            return obj != null && TargetFrameworkMoniker.Equals(obj.TargetFrameworkMoniker, StringComparisons.FrameworkIdentifiers);
         }
 
         public static bool operator ==(TargetFramework? left, TargetFramework? right)
@@ -76,12 +56,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public override int GetHashCode()
         {
-            return StringComparers.FrameworkIdentifiers.GetHashCode(FullName);
+            return StringComparers.FrameworkIdentifiers.GetHashCode(TargetFrameworkMoniker);
         }
 
         public override string ToString()
         {
-            return FullName;
+            return TargetFrameworkMoniker;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
@@ -22,13 +22,16 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             Requires.NotNull(moniker, nameof(moniker));
 
-            TargetFrameworkMoniker = moniker;
+            TargetFrameworkAlias = moniker;
         }
 
         /// <summary>
-        /// Gets the Target Framework Moniker.
+        /// Gets the Target Framework alias. This is a string that can be one of the well known
+        /// values set by the SDK (for example, "netcoreapp2.1") or a custom string set in the project file
+        /// such that evaluation generates a custom mapping of values of the well known properties like
+        /// "TargetFrameworkMoniker", "TargetFrameworkIdentifier", etc.
         /// </summary>
-        public string TargetFrameworkMoniker { get; }
+        public string TargetFrameworkAlias { get; }
 
         /// <summary>
         /// Override Equals to handle equivalency correctly. They are equal if the
@@ -41,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public bool Equals(TargetFramework? obj)
         {
-            return obj != null && TargetFrameworkMoniker.Equals(obj.TargetFrameworkMoniker, StringComparisons.FrameworkIdentifiers);
+            return obj != null && TargetFrameworkAlias.Equals(obj.TargetFrameworkAlias, StringComparisons.FrameworkIdentifiers);
         }
 
         public static bool operator ==(TargetFramework? left, TargetFramework? right)
@@ -56,12 +59,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public override int GetHashCode()
         {
-            return StringComparers.FrameworkIdentifiers.GetHashCode(TargetFrameworkMoniker);
+            return StringComparers.FrameworkIdentifiers.GetHashCode(TargetFrameworkAlias);
         }
 
         public override string ToString()
         {
-            return TargetFrameworkMoniker;
+            return TargetFrameworkAlias;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                     }
                     else
                     {
-                        IProjectTree? node = dependenciesTree.FindChildWithCaption(targetFramework.ShortName);
+                        IProjectTree? node = dependenciesTree.FindChildWithCaption(targetFramework.TargetFrameworkMoniker);
                         bool shouldAddTargetNode = node == null;
                         IDependencyViewModel targetViewModel = _viewModelFactory.CreateTargetViewModel(targetedSnapshot.TargetFramework, targetedSnapshot.MaximumVisibleDiagnosticLevel);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                     }
                     else
                     {
-                        IProjectTree? node = dependenciesTree.FindChildWithCaption(targetFramework.TargetFrameworkMoniker);
+                        IProjectTree? node = dependenciesTree.FindChildWithCaption(targetFramework.TargetFrameworkAlias);
                         bool shouldAddTargetNode = node == null;
                         IDependencyViewModel targetViewModel = _viewModelFactory.CreateTargetViewModel(targetedSnapshot.TargetFramework, targetedSnapshot.MaximumVisibleDiagnosticLevel);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -178,7 +178,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 // Scan the snapshot and tally dependencies
                 foreach ((TargetFramework targetFramework, TargetedDependenciesSnapshot targetedSnapshot) in _dependenciesSnapshot.DependenciesByTargetFramework)
                 {
-                    var targetData = new TargetData(targetFramework.ShortName);
+                    var targetData = new TargetData(targetFramework.TargetFrameworkMoniker);
 
                     data.Add(targetData);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -178,7 +178,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 // Scan the snapshot and tally dependencies
                 foreach ((TargetFramework targetFramework, TargetedDependenciesSnapshot targetedSnapshot) in _dependenciesSnapshot.DependenciesByTargetFramework)
                 {
-                    var targetData = new TargetData(targetFramework.TargetFrameworkMoniker);
+                    var targetData = new TargetData(targetFramework.TargetFrameworkAlias);
 
                     data.Add(targetData);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/TargetDependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/TargetDependencyViewModel.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 
         public TargetDependencyViewModel(TargetFramework targetFramework, DiagnosticLevel diagnosticLevel)
         {
-            Caption = targetFramework.ShortName;
+            Caption = targetFramework.TargetFrameworkMoniker;
             Flags = GetCachedFlags(targetFramework);
             _diagnosticLevel = diagnosticLevel;
 
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             {
                 return ImmutableInterlocked.GetOrAdd(
                     ref s_configurationFlags,
-                    targetFramework.FullName,
+                    targetFramework.TargetFrameworkMoniker,
                     fullName => DependencyTreeFlags.TargetNode
                         .Add($"$TFM:{fullName}")
                         .Add(ProjectTreeFlags.Common.VirtualFolder));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/TargetDependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/TargetDependencyViewModel.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 
         public TargetDependencyViewModel(TargetFramework targetFramework, DiagnosticLevel diagnosticLevel)
         {
-            Caption = targetFramework.TargetFrameworkMoniker;
+            Caption = targetFramework.TargetFrameworkAlias;
             Flags = GetCachedFlags(targetFramework);
             _diagnosticLevel = diagnosticLevel;
 
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             {
                 return ImmutableInterlocked.GetOrAdd(
                     ref s_configurationFlags,
-                    targetFramework.TargetFrameworkMoniker,
+                    targetFramework.TargetFrameworkAlias,
                     fullName => DependencyTreeFlags.TargetNode
                         .Add($"$TFM:{fullName}")
                         .Add(ProjectTreeFlags.Common.VirtualFolder));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -178,12 +178,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             {
                 string keyNames = dependenciesByTargetFramework.Count == 0
                     ? "no items"
-                    : string.Join(", ", dependenciesByTargetFramework.Keys.Select(t => $"\"{t.FullName}\""));
+                    : string.Join(", ", dependenciesByTargetFramework.Keys.Select(t => $"\"{t.TargetFrameworkMoniker}\""));
 
                 Requires.Argument(
                     false,
                     nameof(activeTargetFramework),
-                    $"Value \"{activeTargetFramework.FullName}\" is unexpected. Must be a key in {nameof(dependenciesByTargetFramework)}, which contains {keyNames}.");
+                    $"Value \"{activeTargetFramework.TargetFrameworkMoniker}\" is unexpected. Must be a key in {nameof(dependenciesByTargetFramework)}, which contains {keyNames}.");
             }
 #endif
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -202,6 +202,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             return max;
         }
 
-        public override string ToString() => $"{TargetFramework.ShortName} - {Dependencies.Length} dependencies";
+        public override string ToString() => $"{TargetFramework.TargetFrameworkMoniker} - {Dependencies.Length} dependencies";
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -202,6 +202,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             return max;
         }
 
-        public override string ToString() => $"{TargetFramework.TargetFrameworkMoniker} - {Dependencies.Length} dependencies";
+        public override string ToString() => $"{TargetFramework.TargetFrameworkAlias} - {Dependencies.Length} dependencies";
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.ContextTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.ContextTracker.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
 
                     if (!previousContext.IsCrossTargeting)
                     {
-                        string? newTargetFrameworkName = (string?)await projectProperties.TargetFramework.GetValueAsync();
+                        string? newTargetFrameworkName = (string?)await projectProperties.TargetFrameworkMoniker.GetValueAsync();
 
                         if (string.IsNullOrEmpty(newTargetFrameworkName) && TargetFramework.Empty.Equals(previousContext.ActiveTargetFramework))
                         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.ContextTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.ContextTracker.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
 
                     if (!previousContext.IsCrossTargeting)
                     {
-                        string? newTargetFrameworkName = (string?)await projectProperties.TargetFrameworkMoniker.GetValueAsync();
+                        string? newTargetFrameworkName = (string?)await projectProperties.TargetFramework.GetValueAsync();
 
                         if (string.IsNullOrEmpty(newTargetFrameworkName) && TargetFramework.Empty.Equals(previousContext.ActiveTargetFramework))
                         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/DependencyNodeIntegrationTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/DependencyNodeIntegrationTests.cs
@@ -29,11 +29,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             CreateProject(new Project("netcoreapp2.1;net45"));
 
             VerifyDependenciesNode(
-                new Node(".NETCoreApp 2.1", KnownMonikers.Library)
+                new Node("netcoreapp2.1", KnownMonikers.Library)
                 {
                     new Node("SDK", KnownMonikers.SDK)
                 },
-                new Node(".NETFramework 4.5", KnownMonikers.Library)
+                new Node("net45", KnownMonikers.Library)
                 {
                     new Node("Assemblies", KnownMonikers.Reference)
                 });
@@ -45,11 +45,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             CreateProject(new Project("netstandard2.0;net461"));
 
             VerifyDependenciesNode(
-                new Node(".NETFramework 4.6.1", KnownMonikers.Library)
+                new Node("net461", KnownMonikers.Library)
                 {
                     new Node("Assemblies", KnownMonikers.Reference)
                 },
-                new Node(".NETStandard 2.0", KnownMonikers.Library)
+                new Node("netstandard2.0", KnownMonikers.Library)
                 {
                     new Node("SDK", KnownMonikers.SDK)
                 });
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             CreateProject(project);
 
             VerifyDependenciesNode(
-                new Node(".NETFramework 4.6.1", KnownMonikers.Library)
+                new Node("net461", KnownMonikers.Library)
                 {
                     new Node("Assemblies", KnownMonikers.Reference),
                     new Node("Packages", KnownMonikers.NuGetNoColor)
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                         new Node("MetadataExtractor (2.1.0)", KnownMonikers.NuGetNoColor)
                     }
                 },
-                new Node(".NETStandard 2.0", KnownMonikers.Library)
+                new Node("netstandard2.0", KnownMonikers.Library)
                 {
                     new Node("Packages", KnownMonikers.NuGetNoColor)
                     {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
@@ -48,15 +48,15 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 foreach (var d in createTargetViewModel)
                 {
                     mock.Setup(x => x.CreateTargetViewModel(
-                            It.Is<TargetFramework>(t => string.Equals(t.FullName, d.Caption, StringComparison.OrdinalIgnoreCase)),
+                            It.Is<TargetFramework>(t => string.Equals(t.TargetFrameworkMoniker, d.Caption, StringComparison.OrdinalIgnoreCase)),
                             DiagnosticLevel.None))
                         .Returns(d.ToViewModel(DiagnosticLevel.None));
                     mock.Setup(x => x.CreateTargetViewModel(
-                            It.Is<TargetFramework>(t => string.Equals(t.FullName, d.Caption, StringComparison.OrdinalIgnoreCase)),
+                            It.Is<TargetFramework>(t => string.Equals(t.TargetFrameworkMoniker, d.Caption, StringComparison.OrdinalIgnoreCase)),
                             DiagnosticLevel.Warning))
                         .Returns(d.ToViewModel(DiagnosticLevel.Warning));
                     mock.Setup(x => x.CreateTargetViewModel(
-                            It.Is<TargetFramework>(t => string.Equals(t.FullName, d.Caption, StringComparison.OrdinalIgnoreCase)),
+                            It.Is<TargetFramework>(t => string.Equals(t.TargetFrameworkMoniker, d.Caption, StringComparison.OrdinalIgnoreCase)),
                             DiagnosticLevel.Error))
                         .Returns(d.ToViewModel(DiagnosticLevel.Error));
                 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
@@ -48,15 +48,15 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 foreach (var d in createTargetViewModel)
                 {
                     mock.Setup(x => x.CreateTargetViewModel(
-                            It.Is<TargetFramework>(t => string.Equals(t.TargetFrameworkMoniker, d.Caption, StringComparison.OrdinalIgnoreCase)),
+                            It.Is<TargetFramework>(t => string.Equals(t.TargetFrameworkAlias, d.Caption, StringComparison.OrdinalIgnoreCase)),
                             DiagnosticLevel.None))
                         .Returns(d.ToViewModel(DiagnosticLevel.None));
                     mock.Setup(x => x.CreateTargetViewModel(
-                            It.Is<TargetFramework>(t => string.Equals(t.TargetFrameworkMoniker, d.Caption, StringComparison.OrdinalIgnoreCase)),
+                            It.Is<TargetFramework>(t => string.Equals(t.TargetFrameworkAlias, d.Caption, StringComparison.OrdinalIgnoreCase)),
                             DiagnosticLevel.Warning))
                         .Returns(d.ToViewModel(DiagnosticLevel.Warning));
                     mock.Setup(x => x.CreateTargetViewModel(
-                            It.Is<TargetFramework>(t => string.Equals(t.TargetFrameworkMoniker, d.Caption, StringComparison.OrdinalIgnoreCase)),
+                            It.Is<TargetFramework>(t => string.Equals(t.TargetFrameworkAlias, d.Caption, StringComparison.OrdinalIgnoreCase)),
                             DiagnosticLevel.Error))
                         .Returns(d.ToViewModel(DiagnosticLevel.Error));
                 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             var result = factory.CreateTargetViewModel(targetFramework, maximumDiagnosticLevel: DiagnosticLevel.None);
 
             Assert.NotNull(result);
-            Assert.Equal(targetFramework.FullName, result.Caption);
+            Assert.Equal(targetFramework.TargetFrameworkMoniker, result.Caption);
             Assert.Equal(KnownMonikers.Library, result.Icon);
             Assert.Equal(KnownMonikers.Library, result.ExpandedIcon);
             Assert.True(result.Flags.Contains(DependencyTreeFlags.TargetNode));
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             var result = factory.CreateTargetViewModel(targetFramework, maximumDiagnosticLevel: DiagnosticLevel.Warning);
 
             Assert.NotNull(result);
-            Assert.Equal(targetFramework.FullName, result.Caption);
+            Assert.Equal(targetFramework.TargetFrameworkMoniker, result.Caption);
             Assert.Equal(KnownMonikers.LibraryWarning, result.Icon);
             Assert.Equal(KnownMonikers.LibraryWarning, result.ExpandedIcon);
             Assert.True(result.Flags.Contains(DependencyTreeFlags.TargetNode));

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             var result = factory.CreateTargetViewModel(targetFramework, maximumDiagnosticLevel: DiagnosticLevel.None);
 
             Assert.NotNull(result);
-            Assert.Equal(targetFramework.TargetFrameworkMoniker, result.Caption);
+            Assert.Equal(targetFramework.TargetFrameworkAlias, result.Caption);
             Assert.Equal(KnownMonikers.Library, result.Icon);
             Assert.Equal(KnownMonikers.Library, result.ExpandedIcon);
             Assert.True(result.Flags.Contains(DependencyTreeFlags.TargetNode));
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             var result = factory.CreateTargetViewModel(targetFramework, maximumDiagnosticLevel: DiagnosticLevel.Warning);
 
             Assert.NotNull(result);
-            Assert.Equal(targetFramework.TargetFrameworkMoniker, result.Caption);
+            Assert.Equal(targetFramework.TargetFrameworkAlias, result.Caption);
             Assert.Equal(KnownMonikers.LibraryWarning, result.Icon);
             Assert.Equal(KnownMonikers.LibraryWarning, result.ExpandedIcon);
             Assert.True(result.Flags.Contains(DependencyTreeFlags.TargetNode));


### PR DESCRIPTION
This PR reverts #6859 in order to restore #6712 with an additional fix.

The DependenciesSnapshotProvider keeps track of an AggregateCrossTargetProjectContextProvider (in its ContextTracker) to enable it to detect changes to a project's target framework. More specifically, it calls the context.TryUpdateCurrentAggregateProjectContextAsync expecting a non-null AggregateCrossTargetProjectContext if and only if the existing AggregateCrossTargetProjectContext is for a target framework that does not match the one in its current project context. This is the case:

1. Before any AggregateCrossTargetProjectContext has been created.
2. When the TargetFramework in the project file is changed.

When a new AggregateCrossTargetProjectContext needs to be created for the first time,  AggregateCrossTargetProjectContextProvider.CreateProjectContextAsync uses the ConfigurationGeneral.TargetFramework property to create a TargetFramework instance (saving this string as the target framework alias). In order to detect changes to project target frameworks, these TargetFramework instances are compared in the TryUpdateCurrentAggregateProjectContextAsync method. Therefore, the logic that picks up the target framework from the new/incoming project properties needs to also read this exact same ConfigurationGeneral.TargetFramework property. The change in PR #6712 missed this, causing a mismatch between the logic that creates new TargetFramework instances and the logic that detects changes to the project target framework. This mismatch resulted in the dependency node falsely reacting to target framework changes (and consequently repeatedly creating new AggregateCrossTargetProjectContexts then adding subscriptions to configured project evaluation) resulting in a significant increase in allocations.

This change fixes the logic to correctly detect the target framework and also renames the TargetFramework.TargetFrameworkMoniker property to TargetFramework.TargetFrameworkAlias to reduce some confusion about exactly what it contains.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6873)