### PR TITLE
Update null annotations

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             // Get the active debug profile (timeout of 5s, though in reality is should never take this long as even in error conditions
             // a snapshot is produced).
-            ILaunchSettings currentProfiles = await _launchSettingsProvider.WaitForFirstSnapshot(5000);
+            ILaunchSettings? currentProfiles = await _launchSettingsProvider.WaitForFirstSnapshot(5000);
             ILaunchProfile? activeProfile = currentProfiles?.ActiveProfile;
 
             // Should have a profile

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     {
         IReceivableSourceBlock<ILaunchSettings> SourceBlock { get; }
 
-        ILaunchSettings CurrentSnapshot { get; }
+        ILaunchSettings? CurrentSnapshot { get; }
 
         [Obsolete("Use ILaunchSettingsProvider2.GetLaunchSettingsFilePathAsync instead.")]
         string LaunchSettingsFile { get; }
@@ -34,7 +34,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// Blocks until at least one snapshot has been generated.
         /// </summary>
         /// <param name="timeout">The timeout in milliseconds.</param>
-        Task<ILaunchSettings> WaitForFirstSnapshot(int timeout);
+        /// <returns>
+        /// The current <see cref="ILaunchSettings"/> snapshot, or <see langword="null"/> if the
+        /// timeout expires before the snapshot become available.
+        /// </returns>
+        Task<ILaunchSettings?> WaitForFirstSnapshot(int timeout);
 
         /// <summary>
         /// Adds the given profile to the list and saves to disk. If a profile with the same

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -730,7 +730,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 return CurrentSnapshot;
             }
 
-            await _firstSnapshotCompletionSource.Task.TryWaitForCompleteOrTimeout(timeout);
+            if (await _firstSnapshotCompletionSource.Task.TryWaitForCompleteOrTimeout(timeout))
+            {
+                Assumes.NotNull(CurrentSnapshot);
+            }
 
             return CurrentSnapshot;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -723,7 +723,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// This function blocks until a snapshot is available. It will return null if the timeout occurs
         /// prior to the snapshot is available
         /// </summary>
-        public async Task<ILaunchSettings> WaitForFirstSnapshot(int timeout)
+        public async Task<ILaunchSettings?> WaitForFirstSnapshot(int timeout)
         {
             if (CurrentSnapshot != null)
             {
@@ -732,7 +732,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             await _firstSnapshotCompletionSource.Task.TryWaitForCompleteOrTimeout(timeout);
 
-            Assumes.NotNull(CurrentSnapshot);
             return CurrentSnapshot;
         }
 
@@ -865,7 +864,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         public async Task<ILaunchSettings> GetSnapshotThrowIfErrors()
         {
-            ILaunchSettings currentSettings = await WaitForFirstSnapshot(WaitForFirstSnapshotDelayMillis);
+            ILaunchSettings? currentSettings = await WaitForFirstSnapshot(WaitForFirstSnapshotDelayMillis);
             if (currentSettings == null || (currentSettings.Profiles.Count == 1 && string.Equals(currentSettings.Profiles[0].CommandName, ErrorProfileCommandName, StringComparisons.LaunchProfileCommandNames)))
             {
                 string fileName = await GetLaunchSettingsFilePathAsync();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileNameValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileNameValueProvider.cs
@@ -50,9 +50,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// </remarks>
         private async Task<string> GetPropertyValueAsync()
         {
-            ILaunchSettings launchSettings = await _launchSettings.WaitForFirstSnapshot(Timeout.Infinite);
+            ILaunchSettings? launchSettings = await _launchSettings.WaitForFirstSnapshot(Timeout.Infinite);
 
-            return launchSettings.ActiveProfile?.Name ?? string.Empty;
+            return launchSettings!.ActiveProfile?.Name ?? string.Empty;
         }
 
         public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileNameValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileNameValueProvider.cs
@@ -50,9 +50,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// </remarks>
         private async Task<string> GetPropertyValueAsync()
         {
+            // Infinite timeout means this will not actually be null.
             ILaunchSettings? launchSettings = await _launchSettings.WaitForFirstSnapshot(Timeout.Infinite);
+            Assumes.NotNull(launchSettings);
 
-            return launchSettings!.ActiveProfile?.Name ?? string.Empty;
+            return launchSettings.ActiveProfile?.Name ?? string.Empty;
         }
 
         public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/LaunchSettingsValueProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/LaunchSettingsValueProviderBase.cs
@@ -45,9 +45,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
-            ILaunchSettings launchSettings = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            ILaunchSettings? launchSettings = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
 
-            var writableLaunchSettings = launchSettings.ToWritableLaunchSettings();
+            IWritableLaunchSettings writableLaunchSettings = launchSettings!.ToWritableLaunchSettings();
             if (SetPropertyValue(propertyName, unevaluatedPropertyValue, writableLaunchSettings))
             {
                 await _launchSettingsProvider.UpdateAndSaveSettingsAsync(writableLaunchSettings.ToLaunchSettings());
@@ -61,9 +61,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         private async Task<string> GetPropertyValueAsync(string propertyName)
         {
-            ILaunchSettings launchSettings = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            ILaunchSettings? launchSettings = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
 
-            return GetPropertyValue(propertyName, launchSettings) ?? string.Empty;
+            return GetPropertyValue(propertyName, launchSettings!) ?? string.Empty;
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/LaunchSettingsValueProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/LaunchSettingsValueProviderBase.cs
@@ -45,9 +45,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
+            // Infinite timeout means this will not actually be null.
             ILaunchSettings? launchSettings = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            Assumes.NotNull(launchSettings);
 
-            IWritableLaunchSettings writableLaunchSettings = launchSettings!.ToWritableLaunchSettings();
+            IWritableLaunchSettings writableLaunchSettings = launchSettings.ToWritableLaunchSettings();
             if (SetPropertyValue(propertyName, unevaluatedPropertyValue, writableLaunchSettings))
             {
                 await _launchSettingsProvider.UpdateAndSaveSettingsAsync(writableLaunchSettings.ToLaunchSettings());
@@ -61,9 +63,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         private async Task<string> GetPropertyValueAsync(string propertyName)
         {
+            // Infinite timeout means this will not actually be null.
             ILaunchSettings? launchSettings = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            Assumes.NotNull(launchSettings);
 
-            return GetPropertyValue(propertyName, launchSettings!) ?? string.Empty;
+            return GetPropertyValue(propertyName, launchSettings) ?? string.Empty;
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/LaunchTargetPropertyPageValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/LaunchTargetPropertyPageValueProvider.cs
@@ -61,9 +61,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             {
                 _projectThreadingService.RunAndForget(async () =>
                 {
+                    // Infinite timeout means this will not actually be null.
                     ILaunchSettings? launchSettings = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+                    Assumes.NotNull(launchSettings);
 
-                    IWritableLaunchSettings writableLaunchSettings = launchSettings!.ToWritableLaunchSettings();
+                    IWritableLaunchSettings writableLaunchSettings = launchSettings.ToWritableLaunchSettings();
                     IWritableLaunchProfile? activeProfile = writableLaunchSettings.ActiveProfile;
                     if (activeProfile != null)
                     {
@@ -81,8 +83,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         private async Task<string> GetPropertyValueAsync()
         {
+            // Infinite timeout means this will not actually be null.
             ILaunchSettings? launchSettings = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
-            string? commandName = launchSettings!.ActiveProfile?.CommandName;
+            Assumes.NotNull(launchSettings);
+
+            string? commandName = launchSettings.ActiveProfile?.CommandName;
             if (commandName == null)
             {
                 return string.Empty;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/LaunchTargetPropertyPageValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/LaunchTargetPropertyPageValueProvider.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
@@ -41,15 +42,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
-            var configuredProject = await _project.GetSuggestedConfiguredProjectAsync();
-            var catalogProvider = configuredProject?.Services.PropertyPagesCatalog;
+            ConfiguredProject? configuredProject = await _project.GetSuggestedConfiguredProjectAsync();
+            IPropertyPagesCatalogProvider? catalogProvider = configuredProject?.Services.PropertyPagesCatalog;
             if (catalogProvider == null)
             {
                 return null;
             }
 
             IPropertyPagesCatalog catalog = await catalogProvider.GetCatalogAsync(PropertyPageContexts.Project);
-            var rule = catalog.GetSchema(unevaluatedPropertyValue);
+            Rule? rule = catalog.GetSchema(unevaluatedPropertyValue);
             if (rule == null)
             {
                 return null;
@@ -87,8 +88,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 return string.Empty;
             }
 
-            var configuredProject = await _project.GetSuggestedConfiguredProjectAsync();
-            var catalogProvider = configuredProject?.Services.PropertyPagesCatalog;
+            ConfiguredProject? configuredProject = await _project.GetSuggestedConfiguredProjectAsync();
+            IPropertyPagesCatalogProvider? catalogProvider = configuredProject?.Services.PropertyPagesCatalog;
 
             if (catalogProvider == null)
             {
@@ -96,9 +97,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             }
 
             IPropertyPagesCatalog catalog = await catalogProvider.GetCatalogAsync(PropertyPageContexts.Project);
-            foreach (var schemaName in catalog.GetPropertyPagesSchemas())
+            foreach (string schemaName in catalog.GetPropertyPagesSchemas())
             {
-                var rule = catalog.GetSchema(schemaName);
+                Rule? rule = catalog.GetSchema(schemaName);
                 if (rule != null
                     && string.Equals(rule.PageTemplate, "CommandNameBasedDebugger", StringComparison.OrdinalIgnoreCase)
                     && rule.Metadata.TryGetValue("CommandName", out object pageCommandNameObj)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/LaunchTargetPropertyPageValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/LaunchTargetPropertyPageValueProvider.cs
@@ -60,10 +60,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             {
                 _projectThreadingService.RunAndForget(async () =>
                 {
-                    ILaunchSettings launchSettings = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+                    ILaunchSettings? launchSettings = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
 
-                    var writableLaunchSettings = launchSettings.ToWritableLaunchSettings();
-                    var activeProfile = writableLaunchSettings.ActiveProfile;
+                    IWritableLaunchSettings writableLaunchSettings = launchSettings!.ToWritableLaunchSettings();
+                    IWritableLaunchProfile? activeProfile = writableLaunchSettings.ActiveProfile;
                     if (activeProfile != null)
                     {
                         activeProfile.CommandName = pageCommandName;
@@ -80,8 +80,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         private async Task<string> GetPropertyValueAsync()
         {
-            ILaunchSettings launchSettings = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
-            var commandName = launchSettings.ActiveProfile?.CommandName;
+            ILaunchSettings? launchSettings = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            string? commandName = launchSettings!.ActiveProfile?.CommandName;
             if (commandName == null)
             {
                 return string.Empty;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Shipped.txt
@@ -37,14 +37,14 @@ Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider.ActiveProfile.get -> Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile?
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider.AddOrUpdateGlobalSettingAsync(string! settingName, object! settingContent) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider.AddOrUpdateProfileAsync(Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile! profile, bool addToFront) -> System.Threading.Tasks.Task!
-Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider.CurrentSnapshot.get -> Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettings!
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider.CurrentSnapshot.get -> Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettings?
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider.LaunchSettingsFile.get -> string!
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider.RemoveGlobalSettingAsync(string! settingName) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider.RemoveProfileAsync(string! profileName) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider.SetActiveProfileAsync(string! profileName) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider.SourceBlock.get -> System.Threading.Tasks.Dataflow.IReceivableSourceBlock<Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettings!>!
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider.UpdateAndSaveSettingsAsync(Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettings! profiles) -> System.Threading.Tasks.Task!
-Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider.WaitForFirstSnapshot(int timeout) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettings!>!
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider.WaitForFirstSnapshot(int timeout) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettings?>!
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider2
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider2.GetLaunchSettingsFilePathAsync() -> System.Threading.Tasks.Task<string!>!
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsSerializationProvider

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchSettingsProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchSettingsProviderFactory.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var launchSettings = launchSettingsMock.Object;
 
             var settingsProviderMock = new Mock<ILaunchSettingsProvider>();
-            settingsProviderMock.Setup(t => t.WaitForFirstSnapshot(It.IsAny<int>())).Returns(Task.FromResult(launchSettings));
+            settingsProviderMock.Setup(t => t.WaitForFirstSnapshot(It.IsAny<int>())).Returns(Task.FromResult<ILaunchSettings?>(launchSettings));
 
             if (setActiveProfileCallback != null)
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProviderTests.cs
@@ -43,8 +43,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             _launchSettingsProviderMoq.Setup(x => x.ActiveProfile).Returns(() => _activeProfile);
             _launchSettingsProviderMoq.Setup(x => x.WaitForFirstSnapshot(It.IsAny<int>())).Returns(() =>
                 _activeProfile != null ?
-                    Task.FromResult((ILaunchSettings)new LaunchSettings(new List<ILaunchProfile> { _activeProfile }, null, _activeProfile.Name)) :
-                    Task.FromResult((ILaunchSettings)new LaunchSettings()));
+                    Task.FromResult((ILaunchSettings?)new LaunchSettings(new List<ILaunchProfile> { _activeProfile }, null, _activeProfile.Name)) :
+                    Task.FromResult((ILaunchSettings?)new LaunchSettings()));
         }
 
         [Fact]


### PR DESCRIPTION
This is a follow up to #6872.

Currently, the `ILaunchSettingsProvider` interface claims that the `CurrentSnapshot` property and `WaitForFirstSnapshot` method will always return a non-null `ILaunchSettings`. Unfortunately, neither is true.

In practice, creating an `ILaunchSettings` snapshot requires knowing the active profile name, and this is stored in a property in the .user file (if it exists). Retrieving the property requires an evaluation; as such we can't produce an `ILaunchSettings` until at least one evaluation has occurred and we have a chance to process it.

It is possible for a consumer of `ILaunchSettingsProvider` to request the `CurrentSnapshot` before this has occurred, in which case they will receive `null`. Note that the implementation of this property (in the `LaunchSettingsProvider` class) calls `EnsureInitalized()`; this may give the appearance of guaranteeing that the snapshot is available, but all it does is ensure that we are signed up to receive, eventually, the data we need to produce that snapshot.

`WaitForFirstSnapshot` _could_ guarantee that a non-null `ILaunchSettings`--except that the caller may pass a time out, and if the time out expires before a snapshot is available, the call will return `null`.

This change updates the interface to reflect reality, and updates all callers in our code to respond accordingly. In most cases we were already handling the possibility of `null`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6876)