### PR TITLE
Suppress exceptions in CanBeStartupProjectAsync

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -104,7 +104,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
         public async Task<bool> CanBeStartupProjectAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile)
         {
-            IReadOnlyList<IDebugLaunchSettings>? launchSettings = await QueryDebugTargetsAsync(launchOptions, profile, validateSettings: true);
+            IReadOnlyList<IDebugLaunchSettings>? launchSettings = null;
+
+            try
+            {
+                launchSettings = await QueryDebugTargetsAsync(launchOptions, profile, validateSettings: true);
+            }
+            catch
+            {
+                // This is catching all exceptions since we are unaware currently what exceptions potentially happen as part of QueryDebugTargetsAsync
+            }
+
             return launchSettings != null;
         }
 


### PR DESCRIPTION
Adds a catch for CanBeStartupProjectAsync to suppress all exceptions. This is the 16.9 fix of https://github.com/dotnet/project-system/pull/6890, which is the 16.10 fix. We're doing 2 different fixes since we don't know what other potential exceptions might be thrown. The 16.10 fix works specifically for the issues filed in that PR. The PR here is to simply add the catch that was previously there as to suppress any potential exceptions for the 16.9 release.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6891)