### PR TITLE
Set TargetFramework on IWorkspaceProjectContext

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.ProjectContextInitData.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.ProjectContextInitData.cs
@@ -18,6 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             public string ProjectFilePath;
             public Guid ProjectGuid;
             public string WorkspaceProjectContextId;
+            public string TargetFramework;
 
             public bool IsInvalid()
             {
@@ -38,6 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 snapshot.Properties.TryGetValue(ConfigurationGeneral.LanguageServiceNameProperty, out data.LanguageName);
                 snapshot.Properties.TryGetValue(ConfigurationGeneral.TargetPathProperty, out data.BinOutputPath);
                 snapshot.Properties.TryGetValue(ConfigurationGeneral.MSBuildProjectFullPathProperty, out data.ProjectFilePath);
+                snapshot.Properties.TryGetValue(ConfigurationGeneral.TargetFrameworkProperty, out data.TargetFramework);
 
                 data.ProjectGuid = projectGuid;
                 data.WorkspaceProjectContextId = GetWorkspaceProjectContextId(data.ProjectFilePath, projectGuid, configuration);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.cs
@@ -86,6 +86,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                                                                     hostObject,
                                                                                     data.BinOutputPath);
 
+                context.SetProperty(ConfigurationGeneral.TargetFrameworkProperty, data.TargetFramework ?? "");
+
                 context.LastDesignTimeBuildSucceeded = false;  // By default, turn off diagnostics until the first design time build succeeds for this project.
 
                 return context;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.cs
@@ -86,6 +86,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                                                                     hostObject,
                                                                                     data.BinOutputPath);
 
+                // Roslyn needs a way to identify which workspace project context a given dependencies tree node relates to.
+                // Ideally we would store the project context ID on the node itself for Roslyn to query, however we are late
+                // in the 16.9 cycle and the magnitude of that change would likely make it too risky. For now, we pass the
+                // TargetFramework property value to the language service, so it can match the value against the
+                // "$TFM:net5.0"-style value found in the nodes capabilities property value.
                 context.SetProperty(ConfigurationGeneral.TargetFrameworkProperty, data.TargetFramework ?? "");
 
                 context.LastDesignTimeBuildSucceeded = false;  // By default, turn off diagnostics until the first design time build succeeds for this project.

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextProviderTests.cs
@@ -166,6 +166,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
+        public async Task CreateProjectContextAsync_ReturnsContextWithTargetFrameworkSet()
+        {
+            var context = new Mock<IWorkspaceProjectContext>();
+
+            context.Setup(c => c.SetProperty("TargetFramework", "net5.0"));
+
+            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, _, _, _, _, _) => context.Object);
+            var provider = CreateInstance(workspaceProjectContextFactory: workspaceProjectContextFactory);
+
+            var project = ConfiguredProjectFactory.ImplementProjectConfiguration("Debug|AnyCPU");
+
+            var result = await provider.CreateProjectContextAsync(project);
+
+            Assert.NotNull(result);
+
+            context.VerifyAll();
+        }
+
+        [Fact]
         public async Task CreateProjectContextAsync_WhenCreateProjectContextThrows_ReturnsNull()
         {
             var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, __, ___, ____, ______, _______) => { throw new Exception(); });
@@ -210,7 +229,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     ""Properties"": {
         ""MSBuildProjectFullPath"": ""C:\\Project\\Project.csproj"",
         ""LanguageServiceName"": ""CSharp"",
-        ""TargetPath"": ""C:\\Target.dll""
+        ""TargetPath"": ""C:\\Target.dll"",
+        ""TargetFramework"": ""net5.0""
     }
 }");
 


### PR DESCRIPTION
Relates to #6820

Roslyn needs a way to identify which workspace project context a given dependencies tree node relates to. Ideally we would store the project context ID on the node itself for Roslyn to query, however we are late in the 16.9 cycle and the magnitude of that change would likely make it too risky. For now, we pass the `TargetFramework` property value to the language service, so it can match the value against the `$TFM:net5.0`-style value found in the nodes capabilities property value.

---

@jasonmalinowski would this change be useful for you in the 16.9 at this point? In 16.10 we could revert this and make the context ID available on the browse object.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6893)