### PR TITLE
Use C# 9 lambda discards

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextProviderTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var snapshot = IProjectRuleSnapshotFactory.FromJson(json);
 
             int callCount = 0;
-            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, __, ___, ____, ______, _______) => { callCount++; return null; });
+            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, _, _, _, _, _) => { callCount++; return null; });
             var provider = CreateInstance(workspaceProjectContextFactory: workspaceProjectContextFactory, projectRuleSnapshot: snapshot);
 
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration("Debug|AnyCPU");
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var projectGuidService = ISafeProjectGuidServiceFactory.ImplementGetProjectGuidAsync(new Guid(guid));
 
             string? result = null;
-            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, id, ___, ____, ______, _______) => { result = id; return null; });
+            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, id, _, _, _, _) => { result = id; return null; });
             var provider = CreateInstance(workspaceProjectContextFactory: workspaceProjectContextFactory, projectGuidService: projectGuidService);
 
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration(configuration);
@@ -154,7 +154,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         public async Task CreateProjectContextAsync_ReturnsContextWithLastDesignTimeBuildSucceededSetToFalse()
         {
             var context = IWorkspaceProjectContextMockFactory.Create();
-            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, __, ___, ____, ______, _______) => context);
+            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, _, _, _, _, _) => context);
             var provider = CreateInstance(workspaceProjectContextFactory: workspaceProjectContextFactory);
 
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration("Debug|AnyCPU");
@@ -168,7 +168,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         [Fact]
         public async Task CreateProjectContextAsync_WhenCreateProjectContextThrows_ReturnsNull()
         {
-            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, __, ___, ____, ______, _______) => { throw new Exception(); });
+            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, _, _, _, _, _) => { throw new Exception(); });
             var provider = CreateInstance(workspaceProjectContextFactory: workspaceProjectContextFactory);
 
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration("Debug|AnyCPU");

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/OnceInitializedOnceDisposedUnderLockAsyncTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/OnceInitializedOnceDisposedUnderLockAsyncTests.cs
@@ -232,9 +232,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             int callCount = 0;
             await instance.ExecuteUnderLockAsync(async (_) =>
             {
-                await instance.ExecuteUnderLockAsync(async (__) =>
+                await instance.ExecuteUnderLockAsync(async (_) =>
                 {
-                    await instance.ExecuteUnderLockAsync((___) =>
+                    await instance.ExecuteUnderLockAsync((_) =>
                     {
                         callCount++;
                         return Task.CompletedTask;
@@ -253,9 +253,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             int callCount = 0;
             await instance.ExecuteUnderLockAsync(async (_) =>
             {
-                await instance.ExecuteUnderLockAsync(async (__) =>
+                await instance.ExecuteUnderLockAsync(async (_) =>
                 {
-                    await instance.ExecuteUnderLockAsync((___) =>
+                    await instance.ExecuteUnderLockAsync((_) =>
                     {
                         callCount++;
                         return TaskResult.Null<string>();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProviderTests.cs
@@ -227,7 +227,7 @@ Project
         {
             var defaultEditorFactory = Guid.NewGuid();
 
-            var options = IProjectSystemOptionsFactory.ImplementGetUseDesignerByDefaultAsync((_, defaultValue, __) => defaultValue);
+            var options = IProjectSystemOptionsFactory.ImplementGetUseDesignerByDefaultAsync((_, defaultValue, _) => defaultValue);
             var provider = CreateInstanceWithDefaultEditorProvider(tree, options, defaultEditorFactory);
 
             var result = await provider.GetSpecificEditorAsync(@"C:\Foo.cs");
@@ -260,7 +260,7 @@ Project
         {
             string? categoryResult = null;
             bool? valueResult = null;
-            var options = IProjectSystemOptionsFactory.ImplementSetUseDesignerByDefaultAsync((category, value, __) => { categoryResult = category; valueResult = value; return Task.CompletedTask; });
+            var options = IProjectSystemOptionsFactory.ImplementSetUseDesignerByDefaultAsync((category, value, _) => { categoryResult = category; valueResult = value; return Task.CompletedTask; });
             var provider = CreateInstanceWithDefaultEditorProvider(tree, options);
 
             var result = await provider.SetUseGlobalEditorAsync(@"C:\Foo.cs", useGlobalEditor: true);


### PR DESCRIPTION
The `_` character is no longer treated as a parameter identifier, so can be repeated in a parameter list, or where another discard otherwise exists in the same scope.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6894)