### PR TITLE
Fix IWorkspaceProjectContextHost annotations

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectContextCodeModelProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectContextCodeModelProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             _projectContextHost = projectContextHost;
         }
 
-        public CodeModel GetCodeModel(Project project)
+        public CodeModel? GetCodeModel(Project project)
         {
             Requires.NotNull(project, nameof(project));
 
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             });
         }
 
-        private async Task<CodeModel> GetCodeModelAsync(Project project)
+        private async Task<CodeModel?> GetCodeModelAsync(Project project)
         {
             await _threadingService.SwitchToUIThread();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectFileOrAssemblyInfoPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectFileOrAssemblyInfoPropertiesProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         {
         }
 
-        private static ProjectId GetProjectId(IProjectThreadingService threadingService, IActiveWorkspaceProjectContextHost projectContextHost)
+        private static ProjectId? GetProjectId(IProjectThreadingService threadingService, IActiveWorkspaceProjectContextHost projectContextHost)
         {
             return threadingService.ExecuteSynchronously(() =>
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ActiveWorkspaceProjectContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ActiveWorkspaceProjectContextHost.cs
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             }
         }
 
-        public async Task<T> OpenContextForWriteAsync<T>(Func<IWorkspaceProjectContextAccessor, Task<T>> action)
+        public async Task<T?> OpenContextForWriteAsync<T>(Func<IWorkspaceProjectContextAccessor, Task<T>> action)
         {
             while (true)
             {
@@ -92,7 +92,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                         return await host.OpenContextForWriteAsync(action);
                     }
 
-                    return default!;
+                    return default;
                 }
                 catch (ActiveProjectConfigurationChangedException)
                 {   // Host was unloaded because configuration changed, retry on new config

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IWorkspaceProjectContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IWorkspaceProjectContextHost.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     The <see cref="Func{T, TResult}"/> to run while holding the lock.
         /// </param>
         /// <returns>
-        ///     The result of <paramref name="action"/>.
+        ///     The result of <paramref name="action"/>, or <see langword="null"/> if no host is active.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///     <paramref name="action"/> is <see langword="null"/>.
@@ -68,6 +68,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     The <see cref="IWorkspaceProjectContextHost"/> represents the active one, and
         ///     the configuration changed.
         /// </exception>
-        Task<T> OpenContextForWriteAsync<T>(Func<IWorkspaceProjectContextAccessor, Task<T>> action);
+        Task<T?> OpenContextForWriteAsync<T>(Func<IWorkspaceProjectContextAccessor, Task<T>> action);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.cs
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             await instance.OpenContextForWriteAsync(action);
         }
 
-        public async Task<T> OpenContextForWriteAsync<T>(Func<IWorkspaceProjectContextAccessor, Task<T>> action)
+        public async Task<T?> OpenContextForWriteAsync<T>(Func<IWorkspaceProjectContextAccessor, Task<T>> action)
         {
             Requires.NotNull(action, nameof(action));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AbstractProjectFileOrAssemblyInfoPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AbstractProjectFileOrAssemblyInfoPropertiesProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     internal abstract class AbstractProjectFileOrAssemblyInfoPropertiesProvider : DelegatedProjectPropertiesProviderBase
     {
         private readonly ImmutableArray<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> _interceptingValueProviders;
-        private readonly Func<ProjectId> _getActiveProjectId;
+        private readonly Func<ProjectId?> _getActiveProjectId;
         private readonly Workspace _workspace;
         private readonly IProjectThreadingService _threadingService;
 
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             IProjectInstancePropertiesProvider instanceProvider,
             IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> interceptingValueProviders,
             UnconfiguredProject project,
-            Func<ProjectId> getActiveProjectId,
+            Func<ProjectId?> getActiveProjectId,
             Workspace workspace,
             IProjectThreadingService threadingService)
             : base(delegatedProvider, instanceProvider, project)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AssemblyInfoProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AssemblyInfoProperties.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public AssemblyInfoProperties(
             IProjectProperties delegatedProjectProperties,
-            Func<ProjectId> getActiveProjectId,
+            Func<ProjectId?> getActiveProjectId,
             Workspace workspace,
             IProjectThreadingService threadingService)
             : base(delegatedProjectProperties)
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         private static ImmutableDictionary<string, SourceAssemblyAttributePropertyValueProvider> CreateAttributeValueProviderMap(
-            Func<ProjectId> getActiveProjectId,
+            Func<ProjectId?> getActiveProjectId,
             Workspace workspace,
             IProjectThreadingService threadingService)
         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveWorkspaceProjectContextHostFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveWorkspaceProjectContextHostFactory.cs
@@ -52,9 +52,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 return action(_accessor);
             }
 
-            public Task<T> OpenContextForWriteAsync<T>(Func<IWorkspaceProjectContextAccessor, Task<T>> action)
+            public Task<T?> OpenContextForWriteAsync<T>(Func<IWorkspaceProjectContextAccessor, Task<T>> action)
             {
-                return action(_accessor);
+                return action(_accessor)!;
             }
         }
     }


### PR DESCRIPTION
`IWorkspaceProjectContextHost.OpenContextForWriteAsync` can return null.

This means that several other methods can return null too. Looking at usages of those methods, they seem to expect null values, as they handle them.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6908)