### PR TITLE
Launch Profiles project item provider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectItemProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectItemProvider.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         private readonly UnconfiguredProject _project;
         private readonly ILaunchSettingsProvider _launchSettingsProvider;
 
-#pragma warning disable CS0067
+#pragma warning disable CS0067 // Unused event
 
         /// <remarks>
         /// This would fire when an item is about to be renamed, but this provider does not

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectItemProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectItemProvider.cs
@@ -172,7 +172,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             if (snapshot.Profiles.Count == 0)
             {
-                return ImmutableArray<IProjectItem>.Empty;
+                return Enumerable.Empty<IProjectItem>();
             }
 
             return snapshot.Profiles.Select(p => new ProjectItem(p.Name ?? string.Empty, _project.FullPath, this));
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 return GetItemsAsync();
             }
 
-            return Task.FromResult<IEnumerable<IProjectItem>>(ImmutableArray<ProjectItem>.Empty);
+            return Task.FromResult(Enumerable.Empty<ProjectItem>());
         }
 
         public async Task<IEnumerable<IProjectItem>> GetItemsAsync(string itemType, string evaluatedInclude)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectItemProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectItemProvider.cs
@@ -107,9 +107,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             List<IProjectItem> projectItems = new();
 
-            foreach (Tuple<string, string, IEnumerable<KeyValuePair<string, string>>?> item in items)
+            foreach ((string itemType, string include, IEnumerable<KeyValuePair<string, string>>? metadata) in items)
             {
-                (string itemType, string include, IEnumerable<KeyValuePair<string, string>>? metadata) = item;
                 IProjectItem? projectItem = await AddAsync(itemType, include, metadata);
                 if (projectItem is not null)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectItemProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectItemProvider.cs
@@ -146,7 +146,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         public async Task<IImmutableSet<string>> GetExistingItemTypesAsync()
         {
-            var snapshot = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            ILaunchSettings? snapshot = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            Assumes.NotNull(snapshot);
+
             return snapshot.Profiles.Count > 0
                 ? s_itemTypes
                 : ImmutableSortedSet<string>.Empty;
@@ -166,7 +168,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         public async Task<IEnumerable<IProjectItem>> GetItemsAsync()
         {
-            var snapshot = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            ILaunchSettings? snapshot = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            Assumes.NotNull(snapshot);
+
             if (snapshot.Profiles.Count == 0)
             {
                 return ImmutableArray<IProjectItem>.Empty;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectItemProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectItemProvider.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </remarks>
         public static string ItemType = "LaunchProfile";
 
-        private static readonly ImmutableSortedSet<string> s_itemTypes = ImmutableSortedSet.Create(ItemType);
+        private static readonly ImmutableSortedSet<string> s_itemTypes = ImmutableSortedSet.Create(StringComparers.ItemTypes, ItemType);
         private readonly UnconfiguredProject _project;
         private readonly ILaunchSettingsProvider _launchSettingsProvider;
 
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 return GetItemsAsync();
             }
 
-            return Task.FromResult(Enumerable.Empty<ProjectItem>());
+            return Task.FromResult(Enumerable.Empty<IProjectItem>());
         }
 
         public async Task<IEnumerable<IProjectItem>> GetItemsAsync(string itemType, string evaluatedInclude)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectItemProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectItemProvider.cs
@@ -1,0 +1,354 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    /// <summary>
+    /// Exposes launch profiles (from launchSettings.json files) as CPS <see cref="IProjectItem"/>s,
+    /// where each launch profile becomes its own <see cref="IProjectItem"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This type mostly delegates to the <see cref="ILaunchSettingsProvider"/>, and serves to translate
+    /// its abilities to the <see cref="IProjectItemProvider"/> model.
+    /// </para>
+    /// <para>
+    /// <see cref="IProjectItem"/> support, like many things in CPS, is designed with MSBuild concepts
+    /// in mind (e.g., evaluated vs. unevaluated data, items/properties possibly being defined in
+    /// imported files rather than the project itself, etc.) and many of these do not translate
+    /// directly to launch profiles. Additional details can be found in the remarks on the individual
+    /// type members.
+    /// </para>
+    /// </remarks>
+    [Export(typeof(IProjectItemProvider))]
+    [ExportMetadata("Name", "LaunchProfiles")]
+    [AppliesTo(ProjectCapability.LaunchProfiles)]
+    internal class LaunchProfilesProjectItemProvider : IProjectItemProvider
+    {
+        /// <remarks>
+        /// <para>
+        /// Launch profiles will be exposed with this item type.
+        /// </para>
+        /// <para>
+        /// As an alternative, we could use the debug command associated with
+        /// a launch profile as the basis for the item type. That is, rather than
+        /// all launch profiles having the same item type, all launch profiles
+        /// with the same debug command have the same item type. In that design,
+        /// the set of item types returned by <see cref="GetItemTypesAsync"/>
+        /// would be based on the set of debug command handlers. This approach
+        /// might make it easier to bind an item presenting a launch profile to
+        /// related Rules, but at this time it it not clear that it is necessary.
+        /// </para>
+        /// </remarks>
+        public static string ItemType = "LaunchProfile";
+
+        private static readonly ImmutableSortedSet<string> s_itemTypes = ImmutableSortedSet.Create(ItemType);
+        private readonly UnconfiguredProject _project;
+        private readonly ILaunchSettingsProvider _launchSettingsProvider;
+
+#pragma warning disable CS0067
+
+        /// <remarks>
+        /// This would fire when an item is about to be renamed, but this provider does not
+        /// support renaming a launch profile. As such, this event will never be invoked.
+        /// </remarks>
+        public event AsyncEventHandler<ItemIdentityChangedEventArgs>? ItemIdentityChanging;
+
+        /// <remarks>
+        /// This would fire after an item is has been renamed, but this provider does not
+        /// support renaming a launch profile. As such, this event will never be invoked.
+        /// </remarks>
+        public event AsyncEventHandler<ItemIdentityChangedEventArgs>? ItemIdentityChangedOnWriter;
+
+        /// <remarks>
+        /// This would fire after an item is has been renamed, but this provider does not
+        /// support renaming a launch profile. As such, this event will never be invoked.
+        /// </remarks>
+        public event AsyncEventHandler<ItemIdentityChangedEventArgs>? ItemIdentityChanged;
+
+#pragma warning restore CS0067
+
+        [ImportingConstructor]
+        public LaunchProfilesProjectItemProvider(UnconfiguredProject project, ILaunchSettingsProvider launchSettingsProvider)
+        {
+            _project = project;
+            _launchSettingsProvider = launchSettingsProvider;
+        }
+
+        public async Task<IProjectItem?> AddAsync(string itemType, string include, IEnumerable<KeyValuePair<string, string>>? metadata = null)
+        {
+            if (!StringComparers.ItemTypes.Equals(itemType, ItemType))
+            {
+                throw new ArgumentException($"The {nameof(LaunchProfilesProjectItemProvider)} does not handle the '{itemType}' item type.");
+            }
+
+            WritableLaunchProfile newLaunchProfile = new() { Name = include };
+            await _launchSettingsProvider.AddOrUpdateProfileAsync(newLaunchProfile.ToLaunchProfile(), addToFront: false);
+
+            // TODO: set the metadata on the launch profile.
+
+            return await FindItemByNameAsync(include);
+        }
+
+        /// <remarks>
+        /// As this adds multiple items we should consider adding them all as an atomic operation.
+        /// However, <see cref="ILaunchSettingsProvider"/> currently provides no way of doing that.
+        /// </remarks>
+        public async Task<IEnumerable<IProjectItem>> AddAsync(IEnumerable<Tuple<string, string, IEnumerable<KeyValuePair<string, string>>?>> items)
+        {
+            List<IProjectItem> projectItems = new();
+
+            foreach (Tuple<string, string, IEnumerable<KeyValuePair<string, string>>?> item in items)
+            {
+                (string itemType, string include, IEnumerable<KeyValuePair<string, string>>? metadata) = item;
+                IProjectItem? projectItem = await AddAsync(itemType, include, metadata);
+                if (projectItem is not null)
+                {
+                    projectItems.Add(projectItem);
+                }
+            }
+
+            return projectItems;
+        }
+
+        /// <remarks>
+        /// Launch profiles do not represent a file on disk, so adding one via a path is
+        /// a meaningless operation.
+        /// </remarks>
+        public Task<IProjectItem> AddAsync(string path)
+        {
+            throw new InvalidOperationException($"The {nameof(LaunchProfilesProjectItemProvider)} does not support adding items as paths.");
+        }
+
+        /// <remarks>
+        /// Launch profiles do not represent a file on disk, so adding one via a path is
+        /// a meaningless operation.
+        /// </remarks>
+        public Task<IReadOnlyList<IProjectItem>> AddAsync(IEnumerable<string> paths)
+        {
+            throw new InvalidOperationException($"The {nameof(LaunchProfilesProjectItemProvider)} does not support adding items as paths.");
+        }
+
+        public async Task<IProjectItem?> FindItemByNameAsync(string evaluatedInclude)
+        {
+            IEnumerable<IProjectItem> items = await GetItemsAsync();
+            return items.FirstOrDefault(item => StringComparers.ItemNames.Equals(item.EvaluatedInclude, evaluatedInclude));
+        }
+
+        public async Task<IImmutableSet<string>> GetExistingItemTypesAsync()
+        {
+            var snapshot = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            return snapshot.Profiles.Count > 0
+                ? s_itemTypes
+                : ImmutableSortedSet<string>.Empty;
+        }
+
+        public async Task<IProjectItem?> GetItemAsync(IProjectPropertiesContext context)
+        {
+            if (context.ItemType is not null
+                && !StringComparers.ItemTypes.Equals(ItemType, context.ItemType))
+            {
+                return null;
+            }
+
+            IEnumerable<IProjectItem> items = await GetItemsAsync();
+            return items.FirstOrDefault(item => StringComparers.ItemNames.Equals(item.EvaluatedInclude, context.ItemName));
+        }
+
+        public async Task<IEnumerable<IProjectItem>> GetItemsAsync()
+        {
+            var snapshot = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            if (snapshot.Profiles.Count == 0)
+            {
+                return ImmutableArray<IProjectItem>.Empty;
+            }
+
+            return snapshot.Profiles.Select(p => new ProjectItem(p.Name ?? string.Empty, _project.FullPath, this));
+        }
+
+        public Task<IEnumerable<IProjectItem>> GetItemsAsync(string itemType)
+        {
+            if (StringComparers.ItemTypes.Equals(itemType, ItemType))
+            {
+                return GetItemsAsync();
+            }
+
+            return Task.FromResult<IEnumerable<IProjectItem>>(ImmutableArray<ProjectItem>.Empty);
+        }
+
+        public async Task<IEnumerable<IProjectItem>> GetItemsAsync(string itemType, string evaluatedInclude)
+        {
+            IEnumerable<IProjectItem> items = await GetItemsAsync(itemType);
+
+            return items.Where(item => StringComparers.ItemNames.Equals(item.EvaluatedInclude, evaluatedInclude));
+        }
+
+        public async Task<IReadOnlyCollection<IProjectItem?>> GetItemsAsync(IReadOnlyCollection<IProjectPropertiesContext> contexts)
+        {
+            ImmutableArray<IProjectItem?>.Builder builder = ImmutableArray.CreateBuilder<IProjectItem?>(initialCapacity: contexts.Count);
+
+            foreach (IProjectPropertiesContext context in contexts)
+            {
+                builder.Add(await GetItemAsync(context));
+            }
+
+            return builder.MoveToImmutable();
+        }
+
+        public Task<IImmutableSet<string>> GetItemTypesAsync()
+        {
+            return Task.FromResult<IImmutableSet<string>>(s_itemTypes);
+        }
+
+        public async Task RemoveAsync(string itemType, string include, DeleteOptions deleteOptions = DeleteOptions.None)
+        {
+            if (!StringComparers.ItemTypes.Equals(itemType, ItemType))
+            {
+                return;
+            }
+
+            await _launchSettingsProvider.RemoveProfileAsync(include);
+        }
+
+        public Task RemoveAsync(IProjectItem item, DeleteOptions deleteOptions = DeleteOptions.None)
+        {
+            return RemoveAsync(item.ItemType, item.UnevaluatedInclude, deleteOptions);
+        }
+
+        /// <remarks>
+        /// As this removes multiple items we should consider adding them all as an atomic operation.
+        /// However, <see cref="ILaunchSettingsProvider"/> currently provides no way of doing that.
+        /// </remarks>
+        public async Task RemoveAsync(IEnumerable<IProjectItem> items, DeleteOptions deleteOptions = DeleteOptions.None)
+        {
+            foreach (IProjectItem item in items)
+            {
+                await RemoveAsync(item, deleteOptions);
+            }
+        }
+
+        /// <remarks>
+        /// Effectively, setting the Include on an item renames that item. <see cref="ILaunchSettingsProvider"/> does
+        /// not natively support renaming a profile; we should consider adding that functionality or "faking" it via
+        /// a remove and add. In the latter case we would want this to be an atomic operation.
+        /// </remarks>
+        public Task SetUnevaluatedIncludesAsync(IReadOnlyCollection<KeyValuePair<IProjectItem, string>> renames)
+        {
+            throw new InvalidOperationException($"The {nameof(LaunchProfilesProjectItemProvider)} does not support renaming items.");
+        }
+
+        /// <summary>
+        /// An implementation of <see cref="IProjectItem"/> that represents an individual launch profile.
+        /// </summary>
+        private class ProjectItem : IProjectItem
+        {
+            private readonly string _name;
+            private readonly string _projectFilePath;
+            private readonly LaunchProfilesProjectItemProvider _provider;
+
+            public ProjectItem(string name, string projectFilePath, LaunchProfilesProjectItemProvider provider)
+            {
+                _name = name;
+                _projectFilePath = projectFilePath;
+                _provider = provider;
+
+                PropertiesContext = new ProjectPropertiesContext(name, projectFilePath);
+            }
+
+            public string ItemType => LaunchProfilesProjectItemProvider.ItemType;
+
+            /// <remarks>
+            /// Launch profiles have no concept of evaluation, so the evaluated and unevaluated
+            /// names are the same.
+            /// </remarks>
+            public string UnevaluatedInclude => _name;
+
+            /// <remarks>
+            /// Launch profiles have no concept of evaluation, so the evaluated and unevaluated
+            /// names are the same.
+            /// </remarks>
+            public string EvaluatedInclude => _name;
+
+            /// <remarks>
+            /// Launch profiles represent an entry in the launchSettings.json file rather than a
+            /// file on disk; as such there is no meaningful value we can return here.
+            /// </remarks>
+            public string EvaluatedIncludeAsFullPath => string.Empty;
+
+            /// <remarks>
+            /// Launch profiles represent an entry in the launchSettings.json file rather than a
+            /// file on disk; as such there is no meaningful value we can return here.
+            /// </remarks>
+            public string EvaluatedIncludeAsRelativePath => string.Empty;
+
+            public IProjectPropertiesContext PropertiesContext { get; }
+
+            public IProjectProperties Metadata => throw new NotImplementedException();
+
+            public Task RemoveAsync(DeleteOptions deleteOptions = DeleteOptions.None)
+            {
+                return _provider.RemoveAsync(this, deleteOptions);
+            }
+
+            /// <remarks>
+            /// The <see cref="LaunchProfilesProjectItemProvider"/> only supports one item type and
+            /// there is no meaningful "conversion" to other item types, so we don't allow this
+            /// operation.
+            /// </remarks>
+            public Task SetItemTypeAsync(string value)
+            {
+                throw new InvalidOperationException($"The {nameof(LaunchProfilesProjectItemProvider)} does not support changing item types.");
+            }
+
+            /// <remarks>
+            /// We don't support renaming a launch profile.
+            /// </remarks>
+            public Task SetUnevaluatedIncludeAsync(string value)
+            {
+                throw new InvalidOperationException($"The {nameof(LaunchProfilesProjectItemProvider)} does not support renaming items.");
+            }
+
+            /// <summary>
+            /// Implementation of <see cref="IProjectPropertiesContext"/> that represents a specific launch
+            /// profile.
+            /// </summary>
+            private class ProjectPropertiesContext : IProjectPropertiesContext
+            {
+                private readonly string _name;
+                private readonly string _projectFilePath;
+
+                public ProjectPropertiesContext(string name, string projectFilePath)
+                {
+                    _name = name;
+                    _projectFilePath = projectFilePath;
+                }
+
+                /// <remarks>
+                /// Launch profiles can only appear in the launchSettings.json, and there can only be
+                /// one launchSettings.json per project. As such, all profiles are logically part of
+                /// the project file.
+                /// </remarks>
+                public bool IsProjectFile => true;
+
+                /// <remarks>
+                /// Logically, profiles belong to the project file and can only belong to the project
+                /// file, as opposed to an imported file.
+                /// </remarks>
+                public string File => _projectFilePath;
+
+                public string? ItemType => LaunchProfilesProjectItemProvider.ItemType;
+
+                public string? ItemName => _name;
+            }
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchSettingsProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchSettingsProviderFactory.cs
@@ -16,20 +16,36 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// Creates a mock <see cref="ILaunchSettingsProvider"/> for testing purposes.
         /// </summary>
         /// <param name="activeProfileName">The name of the active profile in the new object.</param>
-        /// <param name="launchProfiles">The set of launch profiles to expose through the provider.</param>
+        /// <param name="launchProfiles">The initial set of launch profiles to expose through the provider.</param>
         /// <param name="setActiveProfileCallback">An optional method to call when the active profile is set.</param>
-        /// <param name="updateLaunchSettingsCallback">An optional method to call when the when the set of launch settings is updated</param>
+        /// <param name="updateLaunchSettingsCallback">An optional method to call when the set of launch settings is updated</param>
+        /// <param name="getProfilesCallback">
+        /// A optional method to call when the set of profile is queried. Given the initial set of <paramref name="launchProfiles"/> as an argument.
+        /// </param>
+        /// <param name="addOrUpdateProfileCallback">An optional method to call when a profile is added or updated.</param>
+        /// <param name="removeProfileCallback">An optional methods to call when a profile is removed.</param>
         public static ILaunchSettingsProvider Create(
             string? activeProfileName = null,
             IEnumerable<ILaunchProfile>? launchProfiles = null,
             Action<string>? setActiveProfileCallback = null,
-            Action<ILaunchSettings>? updateLaunchSettingsCallback = null)
+            Action<ILaunchSettings>? updateLaunchSettingsCallback = null,
+            Func<ImmutableList<ILaunchProfile>, ImmutableList<ILaunchProfile>>? getProfilesCallback = null,
+            Action<ILaunchProfile, bool>? addOrUpdateProfileCallback = null,
+            Action<string>? removeProfileCallback = null)
         {
             var launchSettingsMock = new Mock<ILaunchSettings>();
 
-            if (launchProfiles != null)
+            var initialLaunchProfiles = launchProfiles is not null
+                ? launchProfiles.ToImmutableList()
+                : ImmutableList<ILaunchProfile>.Empty;
+
+            if (getProfilesCallback is not null)
             {
-                launchSettingsMock.Setup(t => t.Profiles).Returns(launchProfiles.ToImmutableList());
+                launchSettingsMock.Setup(t => t.Profiles).Returns(() => getProfilesCallback(initialLaunchProfiles));
+            }
+            else
+            {
+                launchSettingsMock.Setup(t => t.Profiles).Returns(initialLaunchProfiles);
             }
 
             if (activeProfileName != null)
@@ -60,6 +76,26 @@ namespace Microsoft.VisualStudio.ProjectSystem
                     .Returns<ILaunchSettings>(v =>
                     {
                         updateLaunchSettingsCallback(v);
+                        return Task.CompletedTask;
+                    });
+            }
+
+            if (addOrUpdateProfileCallback is not null)
+            {
+                settingsProviderMock.Setup(t => t.AddOrUpdateProfileAsync(It.IsAny<ILaunchProfile>(), It.IsAny<bool>()))
+                    .Returns<ILaunchProfile, bool>((profile, addToFront) =>
+                    {
+                        addOrUpdateProfileCallback(profile, addToFront);
+                        return Task.CompletedTask;
+                    });
+            }
+
+            if (removeProfileCallback is not null)
+            {
+                settingsProviderMock.Setup(t => t.RemoveProfileAsync(It.IsAny<string>()))
+                    .Returns<string>(name =>
+                    {
+                        removeProfileCallback(name);
                         return Task.CompletedTask;
                     });
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectItemProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectItemProviderTests.cs
@@ -1,0 +1,624 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    public class LaunchProfilesProjectItemProviderTests
+    {
+        [Fact]
+        public async Task GetItemTypesAsync_ReturnsLaunchProfile()
+        {
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                ILaunchSettingsProviderFactory.Create());
+
+            var itemTypes = await itemProvider.GetItemTypesAsync();
+
+            Assert.Single(itemTypes, LaunchProfilesProjectItemProvider.ItemType);
+        }
+
+        [Fact]
+        public async Task WhenThereAreNoLaunchProfiles_GetExistingItemTypesAsyncReturnsAnEmptySet()
+        {
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new LaunchProfile[0]);
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var existingItemTypes = await itemProvider.GetExistingItemTypesAsync();
+
+            Assert.Empty(existingItemTypes);
+        }
+
+        [Fact]
+        public async Task WhenThereAreLaunchProfiles_GetExistingItemTypesAsyncReturnsASingleItem()
+        {
+            var profile = new WritableLaunchProfile { Name = "Test" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile.ToLaunchProfile() });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var existingItemTypes = await itemProvider.GetExistingItemTypesAsync();
+
+            Assert.Single(existingItemTypes, LaunchProfilesProjectItemProvider.ItemType);
+        }
+
+        [Fact]
+        public async Task WhenThereAreNoLaunchProfiles_GetItemsAsyncReturnsAnEmptyEnumerable()
+        {
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new LaunchProfile[0]);
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var items = await itemProvider.GetItemsAsync();
+
+            Assert.Empty(items);
+        }
+
+        [Fact]
+        public async Task WhenThereAreLaunchProfiles_GetItemsAsyncReturnsAnItemForEachProfile()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var items = await itemProvider.GetItemsAsync();
+
+            Assert.Collection(items,
+                item => Assert.Equal("Profile1", item.EvaluatedInclude),
+                item => Assert.Equal("Profile2", item.EvaluatedInclude));
+        }
+
+        [Fact]
+        public async Task WhenAskedForLaunchProfileItemTypes_GetItemsAsyncReturnsAnItemForEachProfile()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var items = await itemProvider.GetItemsAsync(LaunchProfilesProjectItemProvider.ItemType);
+
+            Assert.Collection(items,
+                item => Assert.Equal("Profile1", item.EvaluatedInclude),
+                item => Assert.Equal("Profile2", item.EvaluatedInclude));
+
+            items = await itemProvider.GetItemsAsync(LaunchProfilesProjectItemProvider.ItemType, "Profile2");
+
+            Assert.Collection(items,
+                item => Assert.Equal("Profile2", item.EvaluatedInclude));
+        }
+
+        [Fact]
+        public async Task WhenAskedForOtherItemTypes_GetItemsAsyncReturnsAnEmptyEnumerable()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var items = await itemProvider.GetItemsAsync("RandomItemType");
+
+            Assert.Empty(items);
+
+            items = await itemProvider.GetItemsAsync("RandomItemType", "Profile2");
+
+            Assert.Empty(items);
+        }
+
+        [Fact]
+        public async Task WhenProjectPropertyContextHasNoItemType_GetItemsAsyncReturnsAnItemWithAMatchingName()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var context = new TestProjectPropertiesContext(
+                isProjectFile: true,
+                file: "Foo",
+                itemType: null,
+                itemName: "Profile2");
+
+            var item = await itemProvider.GetItemAsync(context);
+
+            Assert.NotNull(item);
+            Assert.Equal("Profile2", item!.EvaluatedInclude);
+        }
+
+        [Fact]
+        public async Task WhenProjectPropertyContextHasTheWrongItemType_GetItemsAsyncReturnsNull()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var context = new TestProjectPropertiesContext(
+                isProjectFile: true,
+                file: "Foo",
+                itemType: "RandomItemType",
+                itemName: "Profile2");
+
+            var item = await itemProvider.GetItemAsync(context);
+
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public async Task WhenProjectPropertyContextHasLaunchProfileItemType_GetItemsAsyncReturnsAnItemWithAMatchingName()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var context = new TestProjectPropertiesContext(
+                isProjectFile: true,
+                file: "Foo",
+                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                itemName: "Profile2");
+
+            var item = await itemProvider.GetItemAsync(context);
+
+            Assert.NotNull(item);
+            Assert.Equal("Profile2", item!.EvaluatedInclude);
+        }
+
+        [Fact]
+        public async Task WhenGivenMultipleProjectPropertyContexts_GetItemsAsyncReturnsNullOrAnItemForEach()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var profile3 = new WritableLaunchProfile { Name = "Profile3" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[]
+                {
+                    profile1.ToLaunchProfile(),
+                    profile2.ToLaunchProfile(),
+                    profile3.ToLaunchProfile()
+                });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            List<IProjectPropertiesContext> contexts = new()
+            {
+                new TestProjectPropertiesContext(true, "Foo", null, "Profile3"),
+                new TestProjectPropertiesContext(true, "Foo", "RandomItemType", "Profile2"),
+                new TestProjectPropertiesContext(true, "Foo", LaunchProfilesProjectItemProvider.ItemType, "Profile1")
+            };
+
+            var items = await itemProvider.GetItemsAsync(contexts);
+
+            Assert.Collection(items,
+                item => Assert.Equal("Profile3", item!.EvaluatedInclude),
+                item => Assert.Null(item),
+                item => Assert.Equal("Profile1", item!.EvaluatedInclude));
+        }
+
+        [Fact]
+        public async Task WhenFindingAnItemByName_TheMatchingItemIsReturnedIfItExists()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var item = await itemProvider.FindItemByNameAsync("Profile2");
+
+            Assert.NotNull(item);
+            Assert.Equal(expected: "Profile2", actual: item!.EvaluatedInclude);
+        }
+
+        [Fact]
+        public async Task WhenFindingAnItemByName_NullIsReturnedIfNoMatchingItemExists()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var item = await itemProvider.FindItemByNameAsync("Profile3");
+
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public async Task WhenAddingAnItem_AnExceptionIsThrownIfTheItemTypeIsWrong()
+        {
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create();
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                var item = await itemProvider.AddAsync(itemType: "RandomItemType", include: "Alpha Profile");
+            });
+        }
+
+        [Fact(Skip = "Item metadata has not yet been implemented.")]
+        public Task WhenAddingAnItem_TheReturnedItemHasAllTheExpectedMetadata()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Fact]
+        public async Task WhenAddingAnItem_TheReturnedItemHasTheCorrectName()
+        {
+            ILaunchProfile? newProfile = null;
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                addOrUpdateProfileCallback: (p, a) =>
+                {
+                    newProfile = p;
+                },
+                getProfilesCallback: initialProfiles =>
+                {
+                    Assert.NotNull(newProfile);
+                    return initialProfiles.Add(newProfile!);
+                });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var item = await itemProvider.AddAsync(itemType: LaunchProfilesProjectItemProvider.ItemType, include: "Alpha Profile");
+
+            Assert.Equal(expected: "Alpha Profile", actual: item!.EvaluatedInclude);
+            Assert.Equal(expected: "Alpha Profile", actual: item!.UnevaluatedInclude);
+        }
+
+        [Fact]
+        public async Task WhenAddingMultipleItems_TheReturnedItemsHaveTheCorrectNames()
+        {
+            ImmutableList<ILaunchProfile> newProfiles = ImmutableList<ILaunchProfile>.Empty; ;
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                addOrUpdateProfileCallback: (p, a) =>
+                {
+                    newProfiles = newProfiles.Add(p);
+                },
+                getProfilesCallback: initialProfiles =>
+                {
+                    return initialProfiles.AddRange(newProfiles);
+                });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var items = await itemProvider.AddAsync(
+                new Tuple<string, string, IEnumerable<KeyValuePair<string, string>>?>[]
+                {
+                    new(LaunchProfilesProjectItemProvider.ItemType, "Alpha Profile", null),
+                    new(LaunchProfilesProjectItemProvider.ItemType, "Beta Profile", null),
+                    new(LaunchProfilesProjectItemProvider.ItemType, "Gamma Profile", null),
+
+                });
+
+            Assert.Collection(items,
+                item => { Assert.Equal("Alpha Profile", item.EvaluatedInclude); Assert.Equal("Alpha Profile", item.UnevaluatedInclude); },
+                item => { Assert.Equal("Beta Profile", item.EvaluatedInclude); Assert.Equal("Beta Profile", item.UnevaluatedInclude); },
+                item => { Assert.Equal("Gamma Profile", item.EvaluatedInclude); Assert.Equal("Gamma Profile", item.UnevaluatedInclude); });
+        }
+
+        [Fact]
+        public async Task WhenAddingAnItemAsAPath_AnInvalidOperationExceptionIsThrown()
+        {
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create();
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await itemProvider.AddAsync(@"C:\alpha\beta\gamma\delta.fakeextension");
+            });
+        }
+
+        [Fact]
+        public async Task WhenAddingItemsAsPaths_AnInvalidOperationExceptionIsThrown()
+        {
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create();
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await itemProvider.AddAsync(new[]
+                {
+                    @"C:\alpha\beta\gamma\delta.fakeextension",
+                    @"C:\epsilon\phi\kappa\psi.fakeextension"
+                });
+            });
+        }
+
+        [Fact]
+        public async Task WhenRenamingAnItem_AnInvalidOperationExceptionIsThrown()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+            var itemToRename = await itemProvider.FindItemByNameAsync("Profile1");
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await itemProvider.SetUnevaluatedIncludesAsync(new KeyValuePair<IProjectItem, string>[]
+                {
+                    new(itemToRename!, "New Profile Name")
+                });
+            });
+        }
+
+        [Fact]
+        public async Task WhenRemovingAnItem_TheRemoveIsIgnoredIfTheItemTypeIsWrong()
+        {
+            string? removedProfileName = null;
+
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() },
+                removeProfileCallback: name => removedProfileName = name);
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+            
+            await itemProvider.RemoveAsync(itemType: "RandomItemType", include: "Profile1");
+
+            Assert.Null(removedProfileName);
+        }
+
+        [Fact]
+        public async Task WhenRemovingAnItem_TheProfileIsRemovedFromTheLaunchSettings()
+        {
+            string? removedProfileName = null;
+
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() },
+                removeProfileCallback: name => removedProfileName = name);
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            await itemProvider.RemoveAsync(itemType: LaunchProfilesProjectItemProvider.ItemType, include: "Profile1");
+
+            Assert.Equal(expected: "Profile1", actual: removedProfileName);
+        }
+
+        [Fact]
+        public async Task WhenRetrievingAProjectItem_TheEvaluatedIncludeIsTheProfileName()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var projectItem = await itemProvider.FindItemByNameAsync("Profile2");
+
+            Assert.NotNull(projectItem);
+
+            Assert.Equal(expected: "Profile2", actual: projectItem!.EvaluatedInclude);
+        }
+
+        [Fact]
+        public async Task WhenRetrievingAProjectItem_TheUnevaluatedIncludeIsTheProfileName()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var projectItem = await itemProvider.FindItemByNameAsync("Profile2");
+
+            Assert.NotNull(projectItem);
+
+            Assert.Equal(expected: "Profile2", actual: projectItem!.UnevaluatedInclude);
+        }
+
+        [Fact]
+        public async Task WhenRetrievingAProjectItem_TheItemTypeIsLaunchProfile()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var projectItem = await itemProvider.FindItemByNameAsync("Profile2");
+
+            Assert.NotNull(projectItem);
+
+            Assert.Equal(expected: LaunchProfilesProjectItemProvider.ItemType, actual: projectItem!.ItemType);
+        }
+
+        [Fact]
+        public async Task WhenRetrievingAProjectItem_TheIncludesAsPathsAreTheEmptyString()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var projectItem = await itemProvider.FindItemByNameAsync("Profile2");
+
+            Assert.NotNull(projectItem);
+
+            Assert.Equal(expected: string.Empty, actual: projectItem!.EvaluatedIncludeAsFullPath);
+            Assert.Equal(expected: string.Empty, actual: projectItem!.EvaluatedIncludeAsRelativePath);
+        }
+
+        [Fact]
+        public async Task WhenSettingTheUnevaluatedIncludeOnAProjectItem_AnInvalidOperationExceptionIsThrown()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var projectItem = await itemProvider.FindItemByNameAsync("Profile2");
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await projectItem!.SetUnevaluatedIncludeAsync("New Profile Name");
+            });
+        }
+
+        [Fact]
+        public async Task WhenSettingTheItemTypeOnAProjectItem_AnInvalidOperationExceptionIsThrown()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var projectItem = await itemProvider.FindItemByNameAsync("Profile2");
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await projectItem!.SetItemTypeAsync("RandomItemType");
+            });
+        }
+
+        [Fact]
+        public async Task WhenRetrievingAProjectItem_ThePropertiesContextHasTheExpectedValues()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.ImplementFullPath(@"C:\alpha\beta\gamma.csproj"),
+                launchSettingsProvider);
+
+            var projectItem = await itemProvider.FindItemByNameAsync("Profile2");
+            var propertiesContext = projectItem!.PropertiesContext;
+
+            Assert.Equal(expected: @"C:\alpha\beta\gamma.csproj", actual: propertiesContext.File);
+            Assert.True(propertiesContext.IsProjectFile);
+            Assert.Equal(expected: "Profile2", actual: propertiesContext.ItemName);
+            Assert.Equal(expected: LaunchProfilesProjectItemProvider.ItemType, actual: propertiesContext.ItemType);
+        }
+
+        [Fact]
+        public async Task WhenTellingAProjectItemToRemoveItself_TheLaunchProfileIsRemoved()
+        {
+            string? removedProfileName = null;
+
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() },
+                removeProfileCallback: name => removedProfileName = name);
+
+            var itemProvider = new LaunchProfilesProjectItemProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var projectItem = await itemProvider.FindItemByNameAsync("Profile2");
+
+            await projectItem!.RemoveAsync();
+
+            Assert.Equal(expected: "Profile2", actual: removedProfileName);
+        }
+
+        private class TestProjectPropertiesContext : IProjectPropertiesContext
+        {
+            public TestProjectPropertiesContext(bool isProjectFile, string file, string? itemType, string? itemName)
+            {
+                IsProjectFile = isProjectFile;
+                File = file;
+                ItemType = itemType;
+                ItemName = itemName;
+            }
+
+            public bool IsProjectFile { get; }
+            public string File { get; }
+            public string? ItemType { get; }
+            public string? ItemName { get; }
+        }
+    }
+}


### PR DESCRIPTION
This is the first (small) step in exposing individual launch profiles as CPS project items (i.e., instances of `IProjectItem`). CPS has a lot of built in support for managing project items: things like source files, resource files, references--really anything that is described in an MSBuild file as an item. This includes support for adding and removing items, renaming items, accessing item metadata, and binding Rules to items to expose and edit their properties in various ways.

Each "item type" (Compile, EmbeddedResource, etc.) needs to be handled by an implementation of `IProjectItemProvider`. In practice all MSBuild items that represent files on disk are handled by the same default `IProjectItemProvider` owned by CPS, and it has its own extensibility points for customizing the behavior in various ways. Launch profiles, however, do not represent files on disk; rather, they are ultimately just entries in the project's launchSettings.json file.

So here we define our own `IProjectItemProvider` to handle adding, removing, and querying the set of launch profiles. This is implemented on top of the `ILaunchSettingsProvider` and delegates to it for all the heavy lifting.

Note the implementation here is currently limited in many ways. For one thing it does not support renaming launch profiles. Partly this is because the `ILaunchSettingsProvider` has no built in support for renames, and partly it is because the events associated with renaming an item (`ItemIdentityChanging`, `ItemIdentityChangedOnWriter`, and `ItemIdentityChanged`) are conceptually tied to the project locks--and the `ILaunchSettingsProvider` currently doesn't use the locks to control access to the launchSettings.json file (though arguably it should). As such we can't fire the events in the contexts that event handlers would expect. Regardless, I'm choosing to ignore that functionality for the moment.

The missing functionality shouldn't matter, as I do not currently expect anything to make use of this `IProjectItemProvider`. Long term, I expect the back end support for the new Launch Profiles UI to use it to handle adding, removing, and querying the set of launch profiles, along with an (as yet unwritten) `IProjectPropertiesProvider` to provide access to the item properties. This will allow us to reuse concepts from the new Project Properties back end, and possibly some code as well. In its current form, this implementation serves mostly to expose potential problems with this approach.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6912)