### PR TITLE
Fix the command Edit Project File on nexus client to open the file.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.Client/SolutionExplorer/ProjectNodeCommandHandler.cs
@@ -98,8 +98,9 @@ namespace Microsoft.VisualStudio.SolutionExplorer
 
                 try
                 {
-                    if (openDocumentService != null)
-                        await openDocumentService.OpenDocumentAsync(node.NodeMoniker, cancellationToken: default);
+                    if (openDocumentService != null &&
+                        node is IFileSystemNode fileSystemNode)
+                        await openDocumentService.OpenDocumentAsync(fileSystemNode.FullPath, cancellationToken: default);
                     //else
                         // TODO: figure out what to tell the user if we can't get the service
                         // https://github.com/dotnet/project-system/issues/6306


### PR DESCRIPTION
[AB#1245680](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1245680)

The issue:
Neither the NodeMoniker nor the NodeFullMoniker contain the required path
to find the project file on the server to use it with OpenDocumentAsync()

The change:
This small change replaces NodeMoniker with the local uri full path that is required
for OpenVisualStudioRemoteFile on the client.

How this change fixes the issue:
OpenVisualStudioRemoteFile will use the local full path to allow the command Edit Project File to find the corresponding project file
on the server.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6919)