### PR TITLE
Use correct project value when finding target node

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeProjectSearchContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeProjectSearchContext.cs
@@ -61,12 +61,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                 IProjectSubscriptionUpdate subscriptionUpdate = (await configuredProject.Services.ProjectSubscription.ProjectRuleSource.GetLatestVersionAsync(configuredProject, cancellationToken: cancellationToken)).Value;
 
                 if (!subscriptionUpdate.CurrentState.TryGetValue(ConfigurationGeneral.SchemaName, out IProjectRuleSnapshot configurationGeneralSnapshot) ||
-                    !configurationGeneralSnapshot.Properties.TryGetValue(ConfigurationGeneral.TargetFrameworkMonikerProperty, out string tfm))
+                    !configurationGeneralSnapshot.Properties.TryGetValue(ConfigurationGeneral.TargetFrameworkProperty, out string tf))
                 {
                     return null;
                 }
 
-                IProjectTree? targetNode = _dependenciesNode.FindChildWithFlags(ProjectTreeFlags.Create("$TFM:" + tfm));
+                IProjectTree? targetNode = _dependenciesNode.FindChildWithFlags(ProjectTreeFlags.Create("$TFM:" + tf));
 
                 if (targetNode == null)
                 {


### PR DESCRIPTION
In #6873 we changed the dependencies tree to no longer use the `TargetFrameworkMoniker` to identify per-target branches of the dependencies tree. This fixed an issue where `net5.0` and `net5.0-windows` would merge into one, because they have identical `TargetFrameworkMoniker` values.

Code in `DependenciesTreeProjectSearchContext` was missed during that change. This commit brings it up to date.

Missing this usage broke searching in the dependencies tree for multi-targeting projects, causing such searches to return no results within the dependencies tree.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6930)