### PR TITLE
Don't switch to UI thread to dispose workspace project context

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.cs
@@ -57,9 +57,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             Requires.NotNull(accessor, nameof(accessor));
 
-            // TODO: https://github.com/dotnet/project-system/issues/353.
-            await _threadingService.SwitchToUIThread();
-
             try
             {
                 accessor.Context.Dispose();


### PR DESCRIPTION
In https://github.com/dotnet/roslyn/issues/51016 @jasonmalinowski explains that disposal of `IWorkspaceProjectContext` is free threaded.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6953)