### PR TITLE
Added accessible name to AnalysisLevelComboBox.

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.Designer.vb
@@ -96,10 +96,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             '
             'AnalysisLevelComboBox
             '
+            resources.ApplyResources(Me.AnalysisLevelComboBox, "AnalysisLevelComboBox")
             Me.AnalysisLevelComboBox.AutoCompleteCustomSource.AddRange(New String() {resources.GetString("AnalysisLevelComboBox.AutoCompleteCustomSource"), resources.GetString("AnalysisLevelComboBox.AutoCompleteCustomSource1"), resources.GetString("AnalysisLevelComboBox.AutoCompleteCustomSource2"), resources.GetString("AnalysisLevelComboBox.AutoCompleteCustomSource3")})
             Me.AnalysisLevelComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
             Me.AnalysisLevelComboBox.FormattingEnabled = True
-            resources.ApplyResources(Me.AnalysisLevelComboBox, "AnalysisLevelComboBox")
             Me.AnalysisLevelComboBox.Name = "AnalysisLevelComboBox"
             '
             'RunAnalyzersDuringLiveAnalysis

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.resx
@@ -291,6 +291,9 @@
   <data name="&gt;&gt;AnalysisLevelLabel.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="AnalysisLevelComboBox.AccessibleName" xml:space="preserve">
+    <value>Analysis level value</value>
+  </data>
   <data name="AnalysisLevelComboBox.AutoCompleteCustomSource" xml:space="preserve">
     <value>preview</value>
   </data>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AccessibleName">
+        <source>Analysis level value</source>
+        <target state="new">Analysis level value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
         <source>preview</source>
         <target state="translated">náhled</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AccessibleName">
+        <source>Analysis level value</source>
+        <target state="new">Analysis level value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
         <source>preview</source>
         <target state="translated">Vorschau</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AccessibleName">
+        <source>Analysis level value</source>
+        <target state="new">Analysis level value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
         <source>preview</source>
         <target state="translated">versión preliminar</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AccessibleName">
+        <source>Analysis level value</source>
+        <target state="new">Analysis level value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
         <source>preview</source>
         <target state="translated">préversion</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AccessibleName">
+        <source>Analysis level value</source>
+        <target state="new">Analysis level value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
         <source>preview</source>
         <target state="translated">anteprima</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AccessibleName">
+        <source>Analysis level value</source>
+        <target state="new">Analysis level value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
         <source>preview</source>
         <target state="translated">プレビュー</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AccessibleName">
+        <source>Analysis level value</source>
+        <target state="new">Analysis level value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
         <source>preview</source>
         <target state="translated">미리 보기</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AccessibleName">
+        <source>Analysis level value</source>
+        <target state="new">Analysis level value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
         <source>preview</source>
         <target state="translated">wersja zapoznawcza</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AccessibleName">
+        <source>Analysis level value</source>
+        <target state="new">Analysis level value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
         <source>preview</source>
         <target state="translated">versão prévia</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AccessibleName">
+        <source>Analysis level value</source>
+        <target state="new">Analysis level value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
         <source>preview</source>
         <target state="translated">предварительная версия</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AccessibleName">
+        <source>Analysis level value</source>
+        <target state="new">Analysis level value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
         <source>preview</source>
         <target state="translated">önizleme</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AccessibleName">
+        <source>Analysis level value</source>
+        <target state="new">Analysis level value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
         <source>preview</source>
         <target state="translated">预览</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../CodeAnalysisPropPage.resx">
     <body>
+      <trans-unit id="AnalysisLevelComboBox.AccessibleName">
+        <source>Analysis level value</source>
+        <target state="new">Analysis level value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalysisLevelComboBox.AutoCompleteCustomSource">
         <source>preview</source>
         <target state="translated">預覽</target>


### PR DESCRIPTION
For some reason, adding it via the designer saved us other accessibility bugs around that combo box (if I added it directly into the resource file, I got this error twice in the Accessibility Insights tool: An onscreen element must not have a null BoundingRectangle property).

Accessibility pass
On whole pane:
![image](https://user-images.githubusercontent.com/8518253/108115614-393da280-704f-11eb-96a5-74cf1b6f2379.png)

On Analysis level combo box:
![image](https://user-images.githubusercontent.com/8518253/108115655-48245500-704f-11eb-8439-8584c06e06d9.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6957)