### PR TITLE
Add description to SQL Debugging property

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
@@ -50,9 +50,10 @@
 
   <BoolProperty Name="NativeDebugging"
                 DisplayName="Enable native code debugging"
-                Description="Enables debugging for managed and native code together, also known as mixed-mode debugging." />
+                Description="Enable debugging for managed and native code together, also known as mixed-mode debugging." />
 
   <BoolProperty Name="SqlDebugging"
-                DisplayName="Enable SQL Server debugging" />
+                DisplayName="Enable SQL Server debugging"
+                Description="Enable debugging of SQL scripts and stored procedures." />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
@@ -45,8 +45,9 @@
 
   <BoolProperty Name="NativeDebugging"
                 DisplayName="Enable native code debugging"
-                Description="Enables debugging for managed and native code together, also known as mixed-mode debugging. "/>
+                Description="Enable debugging for managed and native code together, also known as mixed-mode debugging." />
 
   <BoolProperty Name="SqlDebugging"
-                DisplayName="Enable SQL Server debugging" />
+                DisplayName="Enable SQL Server debugging"
+                Description="Enable debugging of SQL scripts and stored procedures." />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.cs.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../ExecutableDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging.</source>
-        <target state="translated">Povolí společné ladění spravovaného a nativního kódu, což se označuje také jako ladění v kombinovaném režimu.</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Povolí společné ladění spravovaného a nativního kódu, což se označuje také jako ladění v kombinovaném režimu.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Použít vzdálený počítač</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.de.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="de" original="../ExecutableDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging.</source>
-        <target state="translated">Hiermit wird das gemeinsame Debugging für verwalteten und nativen Code aktiviert. Dies wird auch als Debuggen im gemischten Modus bezeichnet.</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Hiermit wird das gemeinsame Debugging für verwalteten und nativen Code aktiviert. Dies wird auch als Debuggen im gemischten Modus bezeichnet.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Remotecomputer verwenden</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.es.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="es" original="../ExecutableDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging.</source>
-        <target state="translated">Habilita la depuración de código administrado y nativo a la vez, lo que también se conoce como depuración en modo mixto.</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Habilita la depuración de código administrado y nativo a la vez, lo que también se conoce como depuración en modo mixto.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Usar máquina remota</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.fr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../ExecutableDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging.</source>
-        <target state="translated">Active le débogage pour le code managé et le code natif, également appelé débogage en mode mixte.</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Active le débogage pour le code managé et le code natif, également appelé débogage en mode mixte.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Utiliser une machine distante</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.it.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="it" original="../ExecutableDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging.</source>
-        <target state="translated">Abilita il debug congiunto per codice gestito e nativo, noto anche come debug in modalità mista.</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Abilita il debug congiunto per codice gestito e nativo, noto anche come debug in modalità mista.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Usa computer remoto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ja.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../ExecutableDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging.</source>
-        <target state="translated">マネージドおよびネイティブ コードのデバッグを同時に有効にします。これは、混合モード デバッグとも呼ばれます。</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">マネージドおよびネイティブ コードのデバッグを同時に有効にします。これは、混合モード デバッグとも呼ばれます。</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">リモート マシンを使用する</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ko.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../ExecutableDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging.</source>
-        <target state="translated">관리형 코드와 네이티브 코드를 함께 디버깅(혼합 모드 디버깅)할 수 있도록 설정합니다.</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">관리형 코드와 네이티브 코드를 함께 디버깅(혼합 모드 디버깅)할 수 있도록 설정합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">원격 머신 사용</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pl.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../ExecutableDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging.</source>
-        <target state="translated">Umożliwia wspólne debugowanie kodu zarządzanego i natywnego. Jest to również znane jako debugowanie w trybie mieszanym.</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Umożliwia wspólne debugowanie kodu zarządzanego i natywnego. Jest to również znane jako debugowanie w trybie mieszanym.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Użyj maszyny zdalnej</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pt-BR.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ExecutableDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging.</source>
-        <target state="translated">Permite a depuração de código gerenciado e nativo em conjunto, também conhecida como depuração de modo misto.</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Permite a depuração de código gerenciado e nativo em conjunto, também conhecida como depuração de modo misto.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Usar computador remoto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ru.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../ExecutableDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging.</source>
-        <target state="translated">Включает совместную отладку управляемого и машинного кода (смешанный режим отладки).</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Включает совместную отладку управляемого и машинного кода (смешанный режим отладки).</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Использование удаленного компьютера</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.tr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../ExecutableDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging.</source>
-        <target state="translated">Yönetilen ve yerel kod için birlikte hata ayıklamayı (karma mod hata ayıklama olarak da bilinir) etkinleştirir.</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Yönetilen ve yerel kod için birlikte hata ayıklamayı (karma mod hata ayıklama olarak da bilinir) etkinleştirir.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Uzak makine kullan</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hans.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ExecutableDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging.</source>
-        <target state="translated">启用托管代码和本机代码的调试，这也被称为混合模式调试。</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">启用托管代码和本机代码的调试，这也被称为混合模式调试。</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">使用远程计算机</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hant.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ExecutableDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging.</source>
-        <target state="translated">同時為受控碼和機器碼啟用偵錯，也稱為混合模式偵錯。</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">同時為受控碼和機器碼啟用偵錯，也稱為混合模式偵錯。</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">使用遠端電腦</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.cs.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../ProjectDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging. </source>
-        <target state="translated">Povolí společné ladění spravovaného a nativního kódu, což se označuje také jako ladění v kombinovaném režimu. </target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Povolí společné ladění spravovaného a nativního kódu, což se označuje také jako ladění v kombinovaném režimu. </target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Použít vzdálený počítač</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.de.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="de" original="../ProjectDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging. </source>
-        <target state="translated">Hiermit wird das gemeinsame Debuggen für verwalteten und nativen Code aktiviert. Dies wird auch als Debuggen im gemischten Modus bezeichnet.</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Hiermit wird das gemeinsame Debuggen für verwalteten und nativen Code aktiviert. Dies wird auch als Debuggen im gemischten Modus bezeichnet.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Remotecomputer verwenden</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.es.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="es" original="../ProjectDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging. </source>
-        <target state="translated">Habilita la depuración de código administrado y nativo a la vez, lo que también se conoce como depuración en modo mixto. </target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Habilita la depuración de código administrado y nativo a la vez, lo que también se conoce como depuración en modo mixto. </target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Usar máquina remota</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.fr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../ProjectDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging. </source>
-        <target state="translated">Active le débogage pour le code managé et le code natif, également appelé débogage en mode mixte. </target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Active le débogage pour le code managé et le code natif, également appelé débogage en mode mixte. </target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Utiliser une machine distante</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.it.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="it" original="../ProjectDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging. </source>
-        <target state="translated">Abilita il debug congiunto per codice gestito e nativo, noto anche come debug in modalità mista. </target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Abilita il debug congiunto per codice gestito e nativo, noto anche come debug in modalità mista. </target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Usa computer remoto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ja.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../ProjectDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging. </source>
-        <target state="translated">マネージドおよびネイティブ コードのデバッグを同時に有効にします。これは、混合モード デバッグとも呼ばれます。</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">マネージドおよびネイティブ コードのデバッグを同時に有効にします。これは、混合モード デバッグとも呼ばれます。</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">リモート マシンを使用する</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ko.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../ProjectDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging. </source>
-        <target state="translated">관리형 코드와 네이티브 코드를 함께 디버깅(혼합 모드 디버깅)할 수 있도록 설정합니다. </target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">관리형 코드와 네이티브 코드를 함께 디버깅(혼합 모드 디버깅)할 수 있도록 설정합니다. </target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">원격 머신 사용</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pl.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../ProjectDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging. </source>
-        <target state="translated">Umożliwia wspólne debugowanie kodu zarządzanego i natywnego (debugowanie mieszane). </target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Umożliwia wspólne debugowanie kodu zarządzanego i natywnego (debugowanie mieszane). </target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Użyj maszyny zdalnej</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pt-BR.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ProjectDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging. </source>
-        <target state="translated">Permite a depuração de código nativo e gerenciado em conjunto, também conhecida como depuração de modo misto. </target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Permite a depuração de código nativo e gerenciado em conjunto, também conhecida como depuração de modo misto. </target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Usar computador remoto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ru.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../ProjectDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging. </source>
-        <target state="translated">Включает совместную отладку управляемого и машинного кода, известную также как отладка в смешанном режиме.</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Включает совместную отладку управляемого и машинного кода, известную также как отладка в смешанном режиме.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Использование удаленного компьютера</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.tr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../ProjectDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging. </source>
-        <target state="translated">Yönetilen ve yerel kod için birlikte hata ayıklamayı (karma mod hata ayıklama olarak da bilinir) etkinleştirir. </target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">Yönetilen ve yerel kod için birlikte hata ayıklamayı (karma mod hata ayıklama olarak da bilinir) etkinleştirir. </target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">Uzak makine kullan</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hans.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ProjectDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging. </source>
-        <target state="translated">启用托管代码和本机代码的调试，这也被称为混合模式调试。</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">启用托管代码和本机代码的调试，这也被称为混合模式调试。</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">使用远程计算机</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hant.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ProjectDebugPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|NativeDebugging|Description">
-        <source>Enables debugging for managed and native code together, also known as mixed-mode debugging. </source>
-        <target state="translated">同時為受控碼及機器碼啟用偵錯，也稱為混合模式偵錯。</target>
+        <source>Enable debugging for managed and native code together, also known as mixed-mode debugging.</source>
+        <target state="needs-review-translation">同時為受控碼及機器碼啟用偵錯，也稱為混合模式偵錯。</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|NativeDebugging|DisplayName">
@@ -20,6 +20,11 @@
       <trans-unit id="BoolProperty|RemoteDebugEnabled|DisplayName">
         <source>Use remote machine</source>
         <target state="translated">使用遠端電腦</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|SqlDebugging|Description">
+        <source>Enable debugging of SQL scripts and stored procedures.</source>
+        <target state="new">Enable debugging of SQL scripts and stored procedures.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SqlDebugging|DisplayName">


### PR DESCRIPTION
Fixes [AB#1278242](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1278242)

Without a `Description`, the new Project Properties UI shows a checkbox with no label, which results in an accessibility failure:

> An onscreen element must not have a null BoundingRectangle property.

### Before

![image](https://user-images.githubusercontent.com/350947/108180387-d0435100-715a-11eb-9f78-551f6c0d09c6.png)

### After

![image](https://user-images.githubusercontent.com/350947/108180836-5069b680-715b-11eb-93d2-0f63cfa3abc3.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6967)