### PR TITLE
Implement WarningsNotAsErrors in the new property pages

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/TreatWarningsAsErrorsValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/TreatWarningsAsErrorsValueProvider.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    [ExportInterceptingPropertyValueProvider("TreatWarningsAsErrors", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    internal sealed class TreatWarningsAsErrorsValueProvider : InterceptingPropertyValueProviderBase
+    {
+        private const string WarningsAsErrorsProperty = "WarningsAsErrors";
+        private const string WarningsNotAsErrorsProperty = "WarningsNotAsErrors";
+        private readonly ITemporaryPropertyStorage _temporaryPropertyStorage;
+
+        [ImportingConstructor]
+        public TreatWarningsAsErrorsValueProvider(ITemporaryPropertyStorage temporaryPropertyStorage)
+        {
+            _temporaryPropertyStorage = temporaryPropertyStorage;
+        }
+
+        public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+        {
+            if (StringComparers.PropertyLiteralValues.Equals(unevaluatedPropertyValue, "true"))
+            {
+                // When setting this to "true", remove WarningsAsErrors
+                await defaultProperties.SaveValueIfCurrentlySetAsync(WarningsAsErrorsProperty, _temporaryPropertyStorage);
+                await defaultProperties.DeletePropertyAsync(WarningsAsErrorsProperty, dimensionalConditions);
+                await defaultProperties.RestoreValueIfNotCurrentlySetAsync(WarningsNotAsErrorsProperty, _temporaryPropertyStorage);
+            }
+            else
+            {
+                // When settings this to "false", remove WarningsNotAsErrors
+                await defaultProperties.SaveValueIfCurrentlySetAsync(WarningsNotAsErrorsProperty, _temporaryPropertyStorage);
+                await defaultProperties.DeletePropertyAsync(WarningsNotAsErrorsProperty, dimensionalConditions);
+                await defaultProperties.RestoreValueIfNotCurrentlySetAsync(WarningsAsErrorsProperty, _temporaryPropertyStorage);
+            }
+
+            return await base.OnSetPropertyValueAsync(propertyName, unevaluatedPropertyValue, defaultProperties, dimensionalConditions);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -186,6 +186,11 @@
                 DisplayName="Treat warnings as errors"
                 Description="Used to specify which warnings are treated as errors."
                 Category="ErrorsAndWarnings" >
+    
+    <EnumProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception" />
+    </EnumProperty.DataSource>
+    
     <EnumValue Name="false"
                DisplayName="None" />
     <EnumValue Name="true"
@@ -196,7 +201,27 @@
                   DisplayName="Treat specific warnings as errors"
                   HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147301"
                   Description="Treats the specified warnings as errors. Separate multiple warning numbers with a comma (',') or semicolon (';')."
-                  Category="ErrorsAndWarnings" />
+                  Category="ErrorsAndWarnings">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DependsOn" Value="Build::TreatWarningsAsErrors" />
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-evaluated-value "Build" "TreatWarningsAsErrors" "false")</NameValuePair.Value>
+      </NameValuePair>
+    </StringProperty.Metadata>
+  </StringProperty>
+
+  <StringProperty Name="WarningsNotAsErrors"
+                  DisplayName="Exempt specific warnings from being treated as errors"
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147301"
+                  Description="Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';')."
+                  Category="ErrorsAndWarnings">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DependsOn" Value="Build::TreatWarningsAsErrors" />
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-evaluated-value "Build" "TreatWarningsAsErrors" "true")</NameValuePair.Value>
+      </NameValuePair>
+    </StringProperty.Metadata>
+  </StringProperty>
 
   <StringProperty Name="BaseOutputPath"
                   DisplayName="Base output path"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.cs.xlf
@@ -352,6 +352,16 @@
         <target state="translated">Považovat konkrétní upozornění za chyby</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
+        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
+        <source>Exempt specific warnings from being treated as errors</source>
+        <target state="new">Exempt specific warnings from being treated as errors</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.de.xlf
@@ -352,6 +352,16 @@
         <target state="translated">Spezifische Warnungen als Fehler behandeln</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
+        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
+        <source>Exempt specific warnings from being treated as errors</source>
+        <target state="new">Exempt specific warnings from being treated as errors</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.es.xlf
@@ -352,6 +352,16 @@
         <target state="translated">Tratar advertencias específicas como errores</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
+        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
+        <source>Exempt specific warnings from being treated as errors</source>
+        <target state="new">Exempt specific warnings from being treated as errors</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.fr.xlf
@@ -352,6 +352,16 @@
         <target state="translated">Traiter les avertissements spécifiques comme des erreurs</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
+        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
+        <source>Exempt specific warnings from being treated as errors</source>
+        <target state="new">Exempt specific warnings from being treated as errors</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.it.xlf
@@ -352,6 +352,16 @@
         <target state="translated">Considera avvisi specifici come errori</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
+        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
+        <source>Exempt specific warnings from being treated as errors</source>
+        <target state="new">Exempt specific warnings from being treated as errors</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ja.xlf
@@ -352,6 +352,16 @@
         <target state="translated">特定の警告をエラーとして扱う</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
+        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
+        <source>Exempt specific warnings from being treated as errors</source>
+        <target state="new">Exempt specific warnings from being treated as errors</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ko.xlf
@@ -352,6 +352,16 @@
         <target state="translated">특정 경고를 오류로 처리</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
+        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
+        <source>Exempt specific warnings from being treated as errors</source>
+        <target state="new">Exempt specific warnings from being treated as errors</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pl.xlf
@@ -352,6 +352,16 @@
         <target state="translated">Traktuj konkretne ostrzeżenia jako błędy</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
+        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
+        <source>Exempt specific warnings from being treated as errors</source>
+        <target state="new">Exempt specific warnings from being treated as errors</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pt-BR.xlf
@@ -352,6 +352,16 @@
         <target state="translated">Tratar avisos específicos como erros</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
+        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
+        <source>Exempt specific warnings from being treated as errors</source>
+        <target state="new">Exempt specific warnings from being treated as errors</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ru.xlf
@@ -352,6 +352,16 @@
         <target state="translated">Интерпретировать указанные предупреждения как ошибки</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
+        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
+        <source>Exempt specific warnings from being treated as errors</source>
+        <target state="new">Exempt specific warnings from being treated as errors</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.tr.xlf
@@ -352,6 +352,16 @@
         <target state="translated">Belirli uyarıları hata olarak değerlendir</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
+        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
+        <source>Exempt specific warnings from being treated as errors</source>
+        <target state="new">Exempt specific warnings from being treated as errors</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hans.xlf
@@ -352,6 +352,16 @@
         <target state="translated">将特定警告视为错误</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
+        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
+        <source>Exempt specific warnings from being treated as errors</source>
+        <target state="new">Exempt specific warnings from being treated as errors</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hant.xlf
@@ -352,6 +352,16 @@
         <target state="translated">將特定警告視為錯誤</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
+        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
+        <source>Exempt specific warnings from being treated as errors</source>
+        <target state="new">Exempt specific warnings from being treated as errors</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Related to #6720.

### Background

The C# compiler provides a switch allowing the user to specify whether or not warnings _in general_ should be treated as errors. In addition to that, specific warnings can be treated as errors, or _blocked_ from being treated as errors. In the project file, these settings are stored in the `TreatWarningsAsErrors`, `WarningsAsErrors`, and `WarningsNotAsErrors` properties, respectively.

Currently, the project property pages only expose the first two of these. This change adds support for the third, `WarningsNotAsErrors`.

### Explanation

The first thing to note is that all we have to do to get the new control to show up in the UI *and* to get the property persisted to the right place in the project file is to add a new `StringProperty` element to BuildPropertyPage.xaml. The `Name` attribute uniquely identifies the property within the Build page, _and_ specifies the property name that is read and written in the project file.

Second, note the `VisibilityCondition` metadata on the new `WarningsNotAsErrors` and existing `WarningsAsErrors` property. We only want to show one or the other of these properties in the UI, not both. If warnings _in general_ are being treated as errors it makes sense to only show `WarningsNotAsErrors`; but if warnings are not being treated as errors then we should only show `WarningsAsErrors`. The `VisibilityCondition` contains an expression that controls whether or not the control should be displayed.

Before I get into specifics of the expressions implemented here, it is important to note that `TreatWarningsAsErrors`, `WarningsAsErrors`, and `WarningsNotAsErrors` are all configuration dependent properties. That is, their values could vary from one configuration to another, and so the property effectively has multiple values--one per configuration. There are also many configuration independent properties; these have at most one value.

We want the `WarningsAsErrors` control to show up if `TreatWarningsAsErrors` is false in _any_ configuration, and this is achieved with the following expression:

```
(has-evaluated-value "Build" "TreatWarningsAsErrors" "false")
```

This looks at all of the evaluated values of the `TreatWarningsAsErrors` property on the `Build` page and checks if any of them is "false"; if so, the overall expression evaluates to "true" and the control is displayed.

If the properties were configuration independent we could have gone with

```
(eq (evaluated "Build" "TreatWarningsAsErrors") "true")
```

to check if the evaluated value of TreatWarningsAsErrors is "true", or even just

```
(evaluated "Build" "TreatWarningsAsErrors")
```

Third, let's leave the .xaml file for the moment and look and the one piece of code, TreatWarningsAsErrorsValueProvider.cs. When the user toggles the value of `TreatWarningsAsErrors` we don't just want to hide or show `WarningsAsErrors` and/or `WarningsNotAsErrors`, we want to clear out the property values that no longer make sense. E.g., if we're setting `TreatWarningsAsErrors` to false, we can delete `WarningsNotAsErrors` entirely as it has no effect.

We accomplish this by implementing an `IInterceptingPropertyValueProvider` for `TreatWarningsAsErrors`. An intercepting value provider gets a chance to handle a property set before it is passed on for default handling; this allows it to manipulate the value or even other properties. It also has a chance to manipulate the values _read_ from the default handler before they are passed on to the property pages, but we don't need this ability here.

However, if the user toggles `TreatWarningsAsErrors` back and forth we don't want to permanently delete whatever values they had for the other two properties. Rather, we squirrel them away in `ITemporaryPropertyStorage` before deleting them, and restore the value from there when switching back.

Fourth, go back to the .xaml file and take a look at the `Rule.DataSource` entry at the top of the page. The `Persistence` attribute indicates that the property values will read from and written to the "ProjectFile" handler which, of course, reads and writes to the project file itself (as opposed to the .user file or some other .props or .targets file). However, as we want to intercept the `TreatWarningsAsErrors` property we update its `DataSource` entry to instead specify the "ProjectFileWithInterception" persistence handler. This handler runs the property through an applicable interceptors before handing it off to the "ProjectFile" handler. Without this, the TreatWarningsAsErrorsValueProvider would never be called.

Fifth and finally, note that the values of `WarningsAsErrors` and `WarningsNotAsErrors` now depend on the value of `TreatWarningsAsErrors`. We need to tell the UI that when `TreatWarningsAsErrors` is updated, it should re-query the values of the other two. This is done via the `DependsOn` metadata added to both of those properties' entries. Without this, the UI may become out of sync with the actual values in the project as the user makes changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6971)