### PR TITLE
Add telemetry when we call CreateEditorInstance.

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
@@ -7,7 +7,6 @@ Imports Microsoft.VisualStudio.Designer.Interfaces
 Imports Microsoft.VisualStudio.Editors.AppDesInterop
 Imports Microsoft.VisualStudio.Shell
 Imports Microsoft.VisualStudio.Shell.Interop
-Imports Microsoft.VisualStudio.Telemetry
 
 Imports Common = Microsoft.VisualStudio.Editors.AppDesCommon
 
@@ -182,14 +181,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             ' If we're using the new project properties editor, delegate to its editor factory
             Dim shouldUseNewEditor As Boolean = UseNewEditor(Hierarchy)
 
-            Dim TelemetryEventRootPath As String = "vs/projectsystem/propertiespages/"
-            Dim TelemetryPropertyPrefix As String = "vs.projectsystem.propertiespages."
-
-            Dim telemetryEvent As TelemetryEvent = New TelemetryEvent(TelemetryEventRootPath + "CreateLegacyEditor")
-            telemetryEvent.Properties(TelemetryPropertyPrefix + "CreateLegacyEditor.UseNewEditor") = shouldUseNewEditor
-            telemetryEvent.Properties(TelemetryPropertyPrefix + "CreateLegacyEditor.FileName") = New TelemetryPiiProperty(FileName)
-            telemetryEvent.Properties(TelemetryPropertyPrefix + "CreateLegacyEditor.PhysicalView") = PhysicalView
-            TelemetryService.DefaultSession.PostEvent(telemetryEvent)
+            Common.TelemetryLogger.LogEditorCreation(shouldUseNewEditor, FileName, PhysicalView)
 
             If shouldUseNewEditor Then
                 Return GetNewEditorFactory().CreateEditorInstance(

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
@@ -7,6 +7,7 @@ Imports Microsoft.VisualStudio.Designer.Interfaces
 Imports Microsoft.VisualStudio.Editors.AppDesInterop
 Imports Microsoft.VisualStudio.Shell
 Imports Microsoft.VisualStudio.Shell.Interop
+Imports Microsoft.VisualStudio.Telemetry
 
 Imports Common = Microsoft.VisualStudio.Editors.AppDesCommon
 
@@ -179,7 +180,18 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Implements IVsEditorFactory.CreateEditorInstance
 
             ' If we're using the new project properties editor, delegate to its editor factory
-            If UseNewEditor(Hierarchy) Then
+            Dim shouldUseNewEditor As Boolean = UseNewEditor(Hierarchy)
+
+            Dim TelemetryEventRootPath As String = "vs/projectsystem/propertiespages/"
+            Dim TelemetryPropertyPrefix As String = "vs.projectsystem.propertiespages."
+
+            Dim telemetryEvent As TelemetryEvent = New TelemetryEvent(TelemetryEventRootPath + "CreateLegacyEditor")
+            telemetryEvent.Properties(TelemetryPropertyPrefix + "CreateLegacyEditor.UseNewEditor") = shouldUseNewEditor
+            telemetryEvent.Properties(TelemetryPropertyPrefix + "CreateLegacyEditor.FileName") = New TelemetryPiiProperty(FileName)
+            telemetryEvent.Properties(TelemetryPropertyPrefix + "CreateLegacyEditor.PhysicalView") = PhysicalView
+            TelemetryService.DefaultSession.PostEvent(telemetryEvent)
+
+            If shouldUseNewEditor Then
                 Return GetNewEditorFactory().CreateEditorInstance(
                     vscreateeditorflags,
                     FileName,

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
@@ -664,6 +664,17 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
 
                 TelemetryService.DefaultSession.PostEvent(userTask)
             End Sub
+
+            Public Shared Sub LogEditorCreation(useNewEditor As Boolean, fileName As String, physicalView As String)
+                Dim telemetryEventRootPath As String = "vs/projectsystem/propertiespages/"
+                Dim telemetryPropertyPrefix As String = "vs.projectsystem.propertiespages."
+
+                Dim telemetryEvent As TelemetryEvent = New TelemetryEvent(telemetryEventRootPath + "createEditor")
+                telemetryEvent.Properties(telemetryPropertyPrefix + "createEditor.UseNewEditor") = useNewEditor
+                telemetryEvent.Properties(telemetryPropertyPrefix + "createEditor.FileName") = New TelemetryPiiProperty(fileName)
+                telemetryEvent.Properties(telemetryPropertyPrefix + "createEditor.PhysicalView") = physicalView
+                TelemetryService.DefaultSession.PostEvent(telemetryEvent)
+            End Sub
         End Class
 #End Region
 


### PR DESCRIPTION
This will fire an event every time we call to create an editor instance. The flag `shouldUseNewEditor` will help us identify when it's being asked to delegate to the new editor.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6972)