### PR TITLE
Fix dependency node when no TargetFramework(s) property exists in the project

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -311,7 +311,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
         private Task OnConfiguredProjectEvaluatedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
         {
             // If "TargetFrameworks" property has changed, we need to refresh the project context and subscriptions.
-            if (HasTargetFrameworksChanged())
+            // If no context exists yet, create one.
+            if (HasTargetFrameworksChanged() || _context.Current == null)
             {
                 return UpdateProjectContextAndSubscriptionsAsync();
             }


### PR DESCRIPTION
Fixes #6974

Currently, the logic is to construct these subscriptions _only_ when the `TargetFramework` or `TargetFrameworks` properties change.

For a regular .NET project this is fine as that property will be defined, and when it is first observed it will trigger the subscriptions that allow the Dependencies node to function correctly.

For a project type that does not define these properties (i.e. WAP projects) this logic is incorrect.

This fix ensures a `AggregateCrossTargetProjectContext` when the current instance is null.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6975)