### PR TITLE
Add accessible name to AnalysisLevelComboBox

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.Designer.vb
@@ -101,6 +101,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.AnalysisLevelComboBox.FormattingEnabled = True
             resources.ApplyResources(Me.AnalysisLevelComboBox, "AnalysisLevelComboBox")
             Me.AnalysisLevelComboBox.Name = "AnalysisLevelComboBox"
+            Me.AnalysisLevelComboBox.AccessibleName = Me.AnalysisLevelLabel.Text
             '
             'RunAnalyzersDuringLiveAnalysis
             '


### PR DESCRIPTION
This change would fix the accessibility bug "The Name property of a focusable element must not be null" in [AzDO#1247585](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1247585), and will not require a localization pass.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6976)