### PR TITLE
Make git ignore WPF temporary projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ $RECYCLE.BIN/
 .DS_Store
 TRXUnit.zip
 RoslynTools.VSIXExpInstaller.zip
+*_wpftmp.csproj


### PR DESCRIPTION
During a build, WPF creates `_wpftmp.csproj` files in the source tree (not under `obj`). If you query the git repo's status during a build, it can show these as untracked files.

We should never have these in version control. This commit causes them to be ignored.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6981)