### PR TITLE
Fix nullable field access

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
@@ -229,7 +229,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         private void PublishSnapshot(DesignTimeInputSnapshot snapshot)
         {
             _version++;
-            _broadcastBlock.Post(new ProjectVersionedValue<DesignTimeInputSnapshot>(
+            _broadcastBlock?.Post(new ProjectVersionedValue<DesignTimeInputSnapshot>(
                 snapshot,
                 Empty.ProjectValueVersions.Add(DataSourceKey, _version)));
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         private void PublishFiles(string[] files)
         {
             _version++;
-            _broadcastBlock.Post(new ProjectVersionedValue<string[]>(
+            _broadcastBlock?.Post(new ProjectVersionedValue<string[]>(
                 files,
                 Empty.ProjectValueVersions.Add(DataSourceKey, _version)));
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectTreeExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectTreeExtensions.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             IRule? properties = node.BrowseObjectProperties;
 
-            if (properties == null || properties.Schema == null || !project.Services.PropertyPagesCatalog.SourceBlock.TryReceive(null, out IProjectVersionedValue<IProjectCatalogSnapshot> catalogSnapshot))
+            if (properties?.Schema == null || !project.Services.PropertyPagesCatalog.SourceBlock.TryReceive(null, out IProjectVersionedValue<IProjectCatalogSnapshot>? catalogSnapshot))
                 return properties;
 
             // We let the snapshot be out of date with the "live" project

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectValueDataSource.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectValueDataSource.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             EnsureInitialized(true);
 
             _version++;
-            await _broadcastBlock.SendAsync(new ProjectVersionedValue<T>(
+            await _broadcastBlock!.SendAsync(new ProjectVersionedValue<T>(
                      value,
                      ImmutableDictionary<NamedIdentity, IComparable>.Empty.Add(DataSourceKey, _version)));
         }


### PR DESCRIPTION
1. Prevent NRE if used after dispose. Build started showing these warnings now, although the underlying problem existed for some time.
2. Fix nullable annotation warnings.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6982)