### PR TITLE
Define a launch profiles editor service

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -27,7 +27,7 @@
     <PackageReference Update="RoslynDependencies.ProjectSystem.OptimizationData"                      Version="$(RoslynDependenciesProjectSystemOptimizationDataVersion)" />
     <PackageReference Update="Microsoft.DotNet.IBCMerge"                                              Version="[$(MicrosoftDotNetIBCMergeVersion)]" />
     <PackageReference Update="Microsoft.DiaSymReader.Pdb2Pdb"                                         Version="$(MicrosoftDiaSymReaderPdb2PdbVersion)" />
-    <PackageReference Update="Microsoft.Net.Compilers.Toolset"                                        Version="3.8.0-5.final" />
+    <PackageReference Update="Microsoft.Net.Compilers.Toolset"                                        Version="3.9.0-5.final" />
     <PackageReference Update="OpenCover"                                                              Version="4.6.519" />
     <PackageReference Update="Codecov"                                                                Version="$(CodecovVersion)" />
     <PackageReference Update="MicroBuild.Core"                                                        Version="0.2.0" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/Designer/LaunchProfileEditorServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/Designer/LaunchProfileEditorServiceFactory.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.ServiceHub.Framework.Services;
+using Microsoft.VisualStudio.ProjectSystem.Debug.Designer;
+using Microsoft.VisualStudio.RpcContracts;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug.Designer
+{
+    [Export(typeof(IPackageService))]
+    internal sealed class LaunchProfileEditorServiceFactory : IPackageService, IDisposable
+    {
+        private const string LaunchProfileEditorServiceName = "Microsoft.VisualStudio.ProjectSystem.Managed.LaunchProfileEditorService";
+        private const string ProjectGuidActivationArgumentName = "ProjectGuid";
+
+        internal static readonly ServiceJsonRpcDescriptor LaunchProfileEditorServiceDescriptorV1 = new(
+            new ServiceMoniker(LaunchProfileEditorServiceName, new Version(0, 1)),
+            ServiceJsonRpcDescriptor.Formatters.UTF8,
+            ServiceJsonRpcDescriptor.MessageDelimiters.HttpLikeHeaders);
+
+        private readonly IProjectServiceAccessor _projectServiceAccessor;
+        private IDisposable? _profferDisposable;
+        private ILaunchProfileEditorService? _launchProfileEditorService;
+
+        [ImportingConstructor]
+        public LaunchProfileEditorServiceFactory(IProjectServiceAccessor projectServiceAccessor)
+        {
+            _projectServiceAccessor = projectServiceAccessor;
+        }
+
+        public async Task InitializeAsync(IAsyncServiceProvider asyncServiceProvider)
+        {
+            IBrokeredServiceContainer brokeredServiceContainer = await asyncServiceProvider.GetServiceAsync<SVsBrokeredServiceContainer, IBrokeredServiceContainer>();
+
+            _profferDisposable = brokeredServiceContainer.Proffer(LaunchProfileEditorServiceDescriptorV1, CreateInstanceAsync);
+
+            async ValueTask<object?> CreateInstanceAsync(
+                ServiceMoniker moniker,
+                ServiceActivationOptions options,
+                IServiceBroker serviceBroker,
+                AuthorizationServiceClient authorizationServiceClient,
+                CancellationToken cancellationToken)
+            {
+                await authorizationServiceClient.AuthorizeOrThrowAsync(WellKnownProtectedOperations.CreateClientIsOwner(), cancellationToken);
+
+                if (options.ActivationArguments is null
+                    || !options.ActivationArguments.TryGetValue("ProjectGuid", out string projectGuidString))
+                {
+                    throw new InvalidOperationException($"Missing required activation argument \"{ProjectGuidActivationArgumentName}\".");
+                }
+
+                if (!Guid.TryParse(projectGuidString, out Guid projectGuid))
+                {
+                    throw new InvalidOperationException($"Unable to parse activation argument \"{ProjectGuidActivationArgumentName}\": \"{projectGuidString}\".");
+                }
+
+                if (options.ClientRpcTarget is not ILaunchProfileEditorClientSession clientSession)
+                {
+                    throw new InvalidOperationException($"Missing client RPC target \"{nameof(ILaunchProfileEditorClientSession)}\".");
+                }
+
+                if (_launchProfileEditorService is null)
+                {
+                    _launchProfileEditorService = _projectServiceAccessor
+                        .GetProjectService()
+                        .Services
+                        .ExportProvider
+                        .GetExport<ILaunchProfileEditorService>()
+                        .Value;
+                }
+
+                if (await _launchProfileEditorService.CreateConnectionAsync(projectGuid, clientSession) is not ILaunchProfileEditorConnection connection)
+                {
+                    throw new InvalidOperationException($"Unable to connect to project with GUID \"{projectGuid}\".");
+                }
+
+                return connection;
+            }
+        }
+
+        public void Dispose()
+        {
+            _profferDisposable?.Dispose();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/Designer/LaunchProfileEditorServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/Designer/LaunchProfileEditorServiceFactory.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug.Designer
                 // When the client requests the service we expect it to pass the target project's
                 // GUID, which is how we figure out which list of launch profiles to provide.
                 if (options.ActivationArguments is null
-                    || !options.ActivationArguments.TryGetValue("ProjectGuid", out string projectGuidString))
+                    || !options.ActivationArguments.TryGetValue(ProjectGuidActivationArgumentName, out string projectGuidString))
                 {
                     throw new InvalidOperationException($"Missing required activation argument \"{ProjectGuidActivationArgumentName}\".");
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsHierarchyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsHierarchyExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS;
@@ -28,8 +27,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
         /// <summary>
         ///     Gets the value of the specified property if the hierarchy supports it, or throws an exception if there was an error.
         /// </summary>
-        [return: MaybeNull]
-        public static T GetProperty<T>(this IVsHierarchy hierarchy, VsHierarchyPropID property, T defaultValue = default)
+        public static T? GetProperty<T>(this IVsHierarchy hierarchy, VsHierarchyPropID property, T? defaultValue = default)
         {
             return GetProperty(hierarchy, HierarchyId.Root, property, defaultValue);
         }
@@ -37,12 +35,9 @@ namespace Microsoft.VisualStudio.Shell.Interop
         /// <summary>
         ///     Gets the value of the specified property of the specified item if the hierarchy supports it, or throws an exception if there was an error.
         /// </summary>
-        [return: MaybeNull]
-        public static T GetProperty<T>(this IVsHierarchy hierarchy, HierarchyId item, VsHierarchyPropID property, T defaultValue = default)
+        public static T? GetProperty<T>(this IVsHierarchy hierarchy, HierarchyId item, VsHierarchyPropID property, T? defaultValue)
         {
-#pragma warning disable CS8717 // Needs https://github.com/dotnet/roslyn/issues/38638
-            Verify.HResult(GetProperty(hierarchy, item, property, defaultValue, out T result));
-#pragma warning restore CS8717
+            Verify.HResult(GetProperty(hierarchy, item, property, defaultValue, out T? result));
 
             return result;
         }
@@ -50,17 +45,15 @@ namespace Microsoft.VisualStudio.Shell.Interop
         /// <summary>
         ///     Gets the value of the specified property if the hierarchy supports it, or returns a HRESULT if there was an error.
         /// </summary>
-        public static int GetProperty<T>(this IVsHierarchy hierarchy, VsHierarchyPropID property, T defaultValue, [MaybeNull]out T result)
+        public static int GetProperty<T>(this IVsHierarchy hierarchy, VsHierarchyPropID property, T? defaultValue, out T? result)
         {
-#pragma warning disable CS8717 // Needs https://github.com/dotnet/roslyn/issues/38638
             return GetProperty(hierarchy, HierarchyId.Root, property, defaultValue, out result);
-#pragma warning restore CS8717 
         }
 
         /// <summary>
         ///     Gets the value of the specified property of the specified item if the hierarchy supports it, or returns a HRESULT if there was an error.
         /// </summary>
-        public static int GetProperty<T>(this IVsHierarchy hierarchy, HierarchyId item, VsHierarchyPropID property, T defaultValue, [MaybeNull] out T result)
+        public static int GetProperty<T>(this IVsHierarchy hierarchy, HierarchyId item, VsHierarchyPropID property, T? defaultValue, out T? result)
         {
             Requires.NotNull(hierarchy, nameof(hierarchy));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/Designer/DataTransferTypes.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/Designer/DataTransferTypes.cs
@@ -1,24 +1,58 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Immutable;
+using Microsoft.VisualStudio.Imaging.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug.Designer
 {
     internal sealed record PropertyValueChangeRequest(
-        string ProfileName,
         string PropertyName,
         object Value);
 
-    internal sealed record Profile(string Name, string DisplayName);
+    internal sealed record ProfileType(
+        string CommandName,
+        string DisplayName,
+        string? HelpUrl,
+        ImageMoniker Icon);
 
-    internal sealed record Category(string Name, string DisplayName);
+    /// <summary>
+    /// Represents a launch profile and all associated properties and values.
+    /// </summary>
+    /// <remarks>
+    /// The design of this type (as well as ILaunchProfileEditorClientSession"
+    /// assumes that the debugger command name associated with a Profile never changes.
+    /// The set of properties associated with a profile depends on the debugger command;
+    /// if the command can change than the set of properties on a profile can change,
+    /// not just their values as in the current design. If we adopt an alternative
+    /// design that allows changing the command we will also need to update ILaunchProfileClientEditorSession"
+    /// to support adding/removing properties.
+    /// </remarks>
+    /// <param name="Name">
+    /// The unique name of the profile.
+    /// </param>
+    /// <param name="CommandName">
+    /// The debugger command associated with this profile. Corresponds to ProfileType.CommandName.
+    /// </param>
+    /// <param name="Properties">
+    /// The properties and values for this launch profile.
+    /// </param>
+    internal sealed record Profile(
+        string Name,
+        string CommandName,
+        ImmutableArray<Property> Properties);
 
-    internal sealed record PropertyEditor(string Name, ImmutableDictionary<string, string> Metadata);
+    internal sealed record Category(
+        string Name,
+        string DisplayName,
+        int Priority);
+
+    internal sealed record PropertyEditor(
+        string Name,
+        ImmutableDictionary<string, string> Metadata);
 
     internal sealed record PropertyMetadata(
         string Name,
         string DisplayName,
-        Profile Profile,
         Category Category,
         string? DependsOn,
         string? Description,
@@ -38,7 +72,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug.Designer
         ImmutableArray<SupportedValue> SupportedValues);
 
     internal sealed record PropertyUpdate(
-        string ProfileName,
         string PropertyName,
         object? Value);
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/Designer/DataTransferTypes.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/Designer/DataTransferTypes.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug.Designer
+{
+    internal sealed record PropertyValueChangeRequest(
+        string ProfileName,
+        string PropertyName,
+        object Value);
+
+    internal sealed record Profile(string Name, string DisplayName);
+
+    internal sealed record Category(string Name, string DisplayName);
+
+    internal sealed record PropertyEditor(string Name, ImmutableDictionary<string, string> Metadata);
+
+    internal sealed record PropertyMetadata(
+        string Name,
+        string DisplayName,
+        Profile Profile,
+        Category Category,
+        string? DependsOn,
+        string? Description,
+        int Priority,
+        PropertyEditor? Editor,
+        string? SearchTerms,
+        string? HelpUrl,
+        string? VisibilityCondition);
+
+    internal sealed record SupportedValue(
+        string DisplayName,
+        object Value);
+
+    internal sealed record Property(
+        PropertyMetadata Metadata,
+        object? Value,
+        ImmutableArray<SupportedValue> SupportedValues);
+
+    internal sealed record PropertyUpdate(
+        string ProfileName,
+        string PropertyName,
+        object? Value);
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/Designer/ILaunchProfileEditorClientSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/Designer/ILaunchProfileEditorClientSession.cs
@@ -12,19 +12,71 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug.Designer
     internal interface ILaunchProfileEditorClientSession
     {
         /// <summary>
-        /// Provides an editor client with the initial snapshot of properties, including all metadata and values.
+        /// <para>
+        /// Informs the client editor that a profile has been added, including all metadata and values.
+        /// </para>
+        /// <para>
+        /// When the client first connects to the server this method will be called multiple times to inform the client of all existing profiles.
+        /// </para>
         /// </summary>
-        Task ReceivePropertiesAsync(
-            ImmutableArray<Property> properties);
+        /// <param name="correlationId">
+        /// The correlation ID provided by the client, if this profile is being added as a result of calling <see cref="ILaunchProfileEditorConnection.AddAsync(Guid, string, string)"/>.
+        /// </param>
+        /// <param name="profile">The newly-added <see cref="Profile"/> along with all metadata and properties.</param>
+        /// <returns>
+        /// A Task that completes when the client has received and scheduled the profile addition.
+        /// </returns>
+        Task LaunchProfileAddedAsync(Guid? correlationId, Profile profile);
 
         /// <summary>
-        /// Notifies an editor client of a change to the values of one or more properties.
+        /// Informs the client editor that a profile has been removed.
         /// </summary>
+        /// <param name="correlationId">
+        /// The correlation ID provided by the client, if the profile is being removed as a result of calling <see cref="ILaunchProfileEditorConnection.RemoveAsync(Guid, string)"/>.
+        /// </param>
+        /// <param name="profileName">
+        /// The name of the removed profile.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the client has received and scheduled the profile removal.
+        /// </returns>
+        Task LaunchProfileRemovedAsync(Guid? correlationId, string profileName);
+
+        /// <summary>
+        /// Informs the client editor that a profile has been renamed.
+        /// </summary>
+        /// <param name="correlationId">
+        /// The correlation ID provided by the client, if the profile is being renamed as a result of calling <see cref="ILaunchProfileEditorConnection.RenameAsync(Guid, string, string)"/>.
+        /// </param>
+        /// <param name="oldProfileName">
+        /// The old profile name.
+        /// </param>
+        /// <param name="newProfileName">
+        /// The new profile name.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the client has received and scheduled the profile rename.
+        /// </returns>
+        Task LaunchProfileRenamedAsync(Guid? correlationId, string oldProfileName, string newProfileName);
+
+        /// <summary>
+        /// Notifies an editor client of a change to the values of one or more properties in a profile.
+        /// </summary>
+        /// <param name="correlationId">
+        /// The correlation ID provided by the client, if the properties are being updated as a result of calling <see cref="ILaunchProfileEditorConnection.SetValuesAsync(Guid, string, ImmutableArray{PropertyValueChangeRequest})"/>.
+        /// </param>
+        /// <param name="profileName">
+        /// The name of the updated profile.
+        /// </param>
+        /// <param name="propertyUpdates">
+        /// The set of updated properties and their new values.
+        /// </param>
         /// <returns>
         /// A Task that completes when the client has received and scheduled the property update.
         /// </returns>
         Task ReceivePropertyUpdatesAsync(
             Guid? correlationId,
+            string profileName,
             ImmutableArray<PropertyUpdate> propertyUpdates);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/Designer/ILaunchProfileEditorClientSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/Designer/ILaunchProfileEditorClientSession.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug.Designer
+{
+    /// <summary>
+    /// Proffered by the client, for notifications from the server.
+    /// </summary>
+    internal interface ILaunchProfileEditorClientSession
+    {
+        /// <summary>
+        /// Provides an editor client with the initial snapshot of properties, including all metadata and values.
+        /// </summary>
+        Task ReceivePropertiesAsync(
+            ImmutableArray<Property> properties);
+
+        /// <summary>
+        /// Notifies an editor client of a change to the values of one or more properties.
+        /// </summary>
+        /// <returns>
+        /// A Task that completes when the client has received and scheduled the property update.
+        /// </returns>
+        Task ReceivePropertyUpdatesAsync(
+            Guid? correlationId,
+            ImmutableArray<PropertyUpdate> propertyUpdates);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/Designer/ILaunchProfileEditorConnection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/Designer/ILaunchProfileEditorConnection.cs
@@ -15,12 +15,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug.Designer
     /// </remarks>
     internal interface ILaunchProfileEditorConnection : IAsyncDisposable
     {
-        Task SetValuesAsync(Guid correlationId, ImmutableArray<PropertyValueChangeRequest> changes);
+        Task SetValuesAsync(Guid correlationId, string profileName, ImmutableArray<PropertyValueChangeRequest> changes);
 
         /// <summary>
-        /// Returns the set of available debug command names.
+        /// Returns the set of available profile types.
         /// </summary>
-        Task<ImmutableArray<string>> GetDebugCommandNamesAsync();
+        Task<ImmutableArray<ProfileType>> GetProfileTypesAsync();
 
         /// <summary>
         /// Adds a profile with the given name and debug command name.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/Designer/ILaunchProfileEditorConnection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/Designer/ILaunchProfileEditorConnection.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug.Designer
+{
+    /// <summary>
+    /// Connection object provided to a launch profile editor client, via which a client
+    /// may add, remove, and update profiles.
+    /// </summary>
+    /// <remarks>
+    /// Must be disposed when the connection is no longer required.
+    /// </remarks>
+    internal interface ILaunchProfileEditorConnection : IAsyncDisposable
+    {
+        Task SetValuesAsync(Guid correlationId, ImmutableArray<PropertyValueChangeRequest> changes);
+
+        /// <summary>
+        /// Returns the set of available debug command names.
+        /// </summary>
+        Task<ImmutableArray<string>> GetDebugCommandNamesAsync();
+
+        /// <summary>
+        /// Adds a profile with the given name and debug command name.
+        /// </summary>
+        Task AddAsync(Guid correlationId, string profileName, string debugCommandName);
+
+        /// <summary>
+        /// Removes the profile with the given name.
+        /// </summary>
+        Task RemoveAsync(Guid correlationId, string profileName);
+
+        /// <summary>
+        /// Renames the profile with the given name.
+        /// </summary>
+        Task RenameAsync(Guid correlationId, string currentProfileName, string newProfileName);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/Designer/ILaunchProfileEditorService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/Designer/ILaunchProfileEditorService.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug.Designer
+{
+    /// <summary>
+    /// Creates <see cref="ILaunchProfileEditorConnection"/>s for CPS-based .NET projects.
+    /// </summary>
+    /// <remarks>
+    /// When CPS proffers a brokered service that returns <see cref="ILaunchProfileEditorConnection"/>s
+    /// it will delegate to the implementation of <see cref="ILaunchProfileEditorService"/>
+    /// to satisfy the request.
+    /// Some other component could presumably implement their own brokered service to return
+    /// <see cref="ILaunchProfileEditorConnection"/>s and proffer it via a different service
+    /// descriptor.
+    /// </remarks>
+    internal interface ILaunchProfileEditorService
+    {
+        /// <summary>
+        /// Creates a connection to the launch profiles for the project specified by
+        /// <paramref name="projectGuid"/>.
+        /// </summary>
+        /// <param name="projectGuid">The <see cref="Guid"/> uniquely identifying the desired project.</param>
+        /// <param name="clientSession">
+        /// The client object that will receive notifications from the server.
+        /// Note that the server may invoke methods on this object before the call to
+        /// <see cref="CreateConnectionAsync(Guid, ILaunchProfileEditorClientSession)" /> is complete.
+        /// </param>
+        /// <returns>
+        /// An <see cref="ILaunchProfileEditorConnection"/> the client can use to update property
+        /// values as well as signal when it is done (via calls to Dispose).
+        /// </returns>
+        Task<ILaunchProfileEditorConnection?> CreateConnectionAsync(Guid projectGuid, ILaunchProfileEditorClientSession clientSession);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Utilities/IsExternalInit.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Utilities/IsExternalInit.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Used by C# 9 for property <see langword="init" /> accessors.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    {
+    }
+}


### PR DESCRIPTION
Define a launch profiles editor service and expose it through the `IBrokeredService`. This contains very little of the actual implementation--just the data transfer objects and interfaces needed to communicate across the brokered service boundary.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6986)