### PR TITLE
Fix two usability issues with the package restore telemetry:

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
@@ -179,16 +179,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             _packageReferenceTelemetryService.PostPackageRestoreEvent(PackageRestoreOperationNames.BeginNominateRestore);
             RestoreLogger.BeginNominateRestore(_logger, _project.FullPath, restoreInfo);
 
+            bool nominationSucceeded = false;
             try
             {
-                return await _solutionRestoreService.NominateProjectAsync(_project.FullPath, restoreInfo, cancellationToken);
+                nominationSucceeded = await _solutionRestoreService.NominateProjectAsync(_project.FullPath, restoreInfo, cancellationToken);
+                return nominationSucceeded;
             }
             finally
             {
                 CodeMarkers.Instance.CodeMarker(CodeMarkerTimerId.PerfPackageRestoreEnd);
 
                 RestoreLogger.EndNominateRestore(_logger, _project.FullPath);
-                _packageReferenceTelemetryService.PostPackageRestoreEvent(PackageRestoreOperationNames.EndNominateRestore);
+                _packageReferenceTelemetryService.PostNominationCompleteEvent(nominationSucceeded);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreProgressTracker.PackageRestoreProgressTrackerInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreProgressTracker.PackageRestoreProgressTrackerInstance.cs
@@ -101,13 +101,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 
             internal void OnRestoreCompleted(IProjectVersionedValue<ValueTuple<IProjectSnapshot, RestoreData>> value)
             {
-                bool isRestoreUpToDate = IsRestoreUpToDate(value.Value.Item1, value.Value.Item2);
-
-                _packageReferenceTelemetryService.PostPackageRestoreCompletedEvent(isRestoreUpToDate, _packageRestoreProgressTrackerId);
+                RestoreData restoreData = value.Value.Item2;
+                bool isRestoreUpToDate = IsRestoreUpToDate(value.Value.Item1, restoreData);
 
                 if (isRestoreUpToDate)
                 {
                     _progressRegistration!.NotifyOutputDataCalculated(value.DataSourceVersions);
+                    _packageReferenceTelemetryService.PostPackageRestoreCompletedEvent(restoreData.Succeeded, _packageRestoreProgressTrackerId);
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/ConfiguredProjectPackageRestoreTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/ConfiguredProjectPackageRestoreTelemetryService.cs
@@ -40,11 +40,11 @@ namespace Microsoft.VisualStudio.Telemetry
                 });
         }
 
-        public void PostPackageRestoreCompletedEvent(bool isRestoreUpToDate, long packageRestoreProgressTrackerId)
+        public void PostPackageRestoreCompletedEvent(bool restoreSucceeded, long packageRestoreProgressTrackerId)
         {
             _telemetryService.PostProperties(TelemetryEventName.ProcessPackageRestore, new (string propertyName, object propertyValue)[]
                 {
-                    (TelemetryPropertyName.PackageRestoreIsUpToDate, isRestoreUpToDate),
+                    (TelemetryPropertyName.PackageRestoreSucceeded, restoreSucceeded),
                     (TelemetryPropertyName.PackageRestoreOperation, PackageRestoreOperationNames.PackageRestoreProgressTrackerRestoreCompleted),
                     (TelemetryPropertyName.PackageRestoreProjectId, ProjectTelemetryId),
                     (TelemetryPropertyName.PackageRestoreProgressTrackerId, packageRestoreProgressTrackerId),

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/UnconfiguredProjectPackageRestoreTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/UnconfiguredProjectPackageRestoreTelemetryService.cs
@@ -30,12 +30,12 @@ namespace Microsoft.VisualStudio.Telemetry
                 });
         }
 
-        public void PostPackageRestoreEvent(string packageRestoreOperationName, bool isRestoreUpToDate)
+        public void PostNominationCompleteEvent(bool nominationSucceeded)
         {
             _telemetryService.PostProperties(TelemetryEventName.ProcessPackageRestore, new (string propertyName, object propertyValue)[]
                 {
-                    (TelemetryPropertyName.PackageRestoreIsUpToDate, isRestoreUpToDate),
-                    (TelemetryPropertyName.PackageRestoreOperation, packageRestoreOperationName),
+                    (TelemetryPropertyName.PackageRestoreOperation, PackageRestoreOperationNames.EndNominateRestore),
+                    (TelemetryPropertyName.PackageRestoreNominationSucceeded, nominationSucceeded),
                     (TelemetryPropertyName.PackageRestoreProjectId, ProjectTelemetryId),
                 });
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/IConfiguredProjectPackageRestoreTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/IConfiguredProjectPackageRestoreTelemetryService.cs
@@ -13,12 +13,13 @@ namespace Microsoft.VisualStudio.Telemetry
     /// restore has completed. This interface provides methods to enable this notification by posting
     /// this event:
     /// 
-    ///  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    /// | Event Name                                             | Property Name                                                | Property Value                                                                           |
-    /// |------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-    /// | <see cref="TelemetryEventName.ProcessPackageRestore"/> | <see cref="TelemetryPropertyName.PackageRestoreOperation"/>  | PackageRestoreOperationNames.PackageRestoreProgressTrackerRestoreCompleted               |
-    /// |                                                        | <see cref="TelemetryPropertyName.PackageRestoreIsUpToDate"/> | True when operation progress is notified                                                 |
-    ///  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    ///  -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    /// | Event Name                                             | Property Name                                                | Property Value                                                                |
+    /// |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+    /// | <see cref="TelemetryEventName.ProcessPackageRestore"/> | <see cref="TelemetryPropertyName.PackageRestoreOperation"/>  | PackageRestoreOperationNames.PackageRestoreProgressTrackerRestoreCompleted    |
+    /// |                                                        | <see cref="TelemetryPropertyName.PackageRestoreSucceeded"/>  | Restore success/failure flag posted when operation progress has been notified |
+    /// |                                                        |                                                              | that package restore is up to date                                            |
+    ///  -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     ///
     /// It also enables the package restore components to post telemetry events indicating
     /// whether the initialization of the package restore components (for the ConfiguredProject) suceeded.
@@ -41,11 +42,11 @@ namespace Microsoft.VisualStudio.Telemetry
 
         /// <summary>
         /// Posts a <see cref="TelemetryEventName.ProcessPackageRestore"/> event with a
-        /// <see cref="TelemetryPropertyName.PackageRestoreIsUpToDate"/> property whose value will be set to
-        /// indicate whether package restore is up to date.
+        /// <see cref="TelemetryPropertyName.PackageRestoreSucceeded"/> property whose value will be set to
+        /// indicate whether package restore succeeded.
         /// </summary>
-        /// <param name="isRestoreUpToDate">Flag indicating whether the restore is up to date.</param>
+        /// <param name="restoreSucceeded">Flag indicating if the restore was successful.</param>
         /// <param name="packageRestoreProgressTrackerId">An identifier to enable correlation of events.</param>
-        void PostPackageRestoreCompletedEvent(bool isRestoreUpToDate, long packageRestoreProgressTrackerId);
+        void PostPackageRestoreCompletedEvent(bool restoreSucceeded, long packageRestoreProgressTrackerId);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/IUnconfiguredProjectPackageRestoreTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/IUnconfiguredProjectPackageRestoreTelemetryService.cs
@@ -30,5 +30,13 @@ namespace Microsoft.VisualStudio.Telemetry
         /// </summary>
         /// <param name="packageRestoreOperationName">The name of the specific package restore operation.</param>
         void PostPackageRestoreEvent(string packageRestoreOperationName);
+
+        /// <summary>
+        /// Posts a <see cref="TelemetryEventName.ProcessPackageRestore"/> event with a
+        /// <see cref="TelemetryPropertyName.PackageRestoreNominationSucceeded"/> property whose value will be set to
+        /// indicate whether or not nomination of a project for restore succeeded.
+        /// </summary>
+        /// <param name="nominationSucceeded">Flag indicating whether the project nomination completed successfully.</param>
+        void PostNominationCompleteEvent(bool nominationSucceeded);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
@@ -179,9 +179,14 @@ namespace Microsoft.VisualStudio.Telemetry
         public static readonly string PackageRestoreOperation = BuildPropertyName(TelemetryEventName.ProcessPackageRestore, "OperationName");
 
         /// <summary>
-        ///     Indicates whether package restore is up to date
+        ///     Indicates whether package restore succeeded
         /// </summary>
-        public static readonly string PackageRestoreIsUpToDate = BuildPropertyName(TelemetryEventName.ProcessPackageRestore, "RestoreIsUpToDate");
+        public static readonly string PackageRestoreSucceeded = BuildPropertyName(TelemetryEventName.ProcessPackageRestore, "RestoreSucceeded");
+
+        /// <summary>
+        ///     Indicates whether project nomination for package restore succeeded
+        /// </summary>
+        public static readonly string PackageRestoreNominationSucceeded = BuildPropertyName(TelemetryEventName.ProcessPackageRestore, "NominationSucceeded");
 
         /// <summary>
         ///     Indicates which specific language service operation triggered a telemetry event


### PR DESCRIPTION
1. The implementation assumes that the package restore being up to date is sufficient to determine whether operations completed successfully. However, the more important data point is whether or not the restore failed or succeeded. This PR updates IConfiguredProjectPackageRestoreTelemetryService to reflect this and its implementation to report this success/failure status when restore is up to date.

2. The PackageRestoreDataSource posts an event with the PackageRestoreOperationNames.EndNominateRestore operation regardless of whether the nomination of a project completes successfully. However, the actual success/failure status is required to determine whether the operation ran into any issues. This PR adds the status flag to the nomination telemetry event.