### PR TITLE
Replace project path hashes with project GUIDs

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/ConfiguredProjectPackageRestoreTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/ConfiguredProjectPackageRestoreTelemetryService.cs
@@ -1,7 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.VS;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.Telemetry
 {
@@ -10,23 +13,28 @@ namespace Microsoft.VisualStudio.Telemetry
     {
         private readonly ConfiguredProject _project;
         private readonly ITelemetryService _telemetryService;
-        private string? _projectTelemetryId;
+        private readonly AsyncLazy<Guid> _projectGuidLazy;
 
         [ImportingConstructor]
-        public ConfiguredProjectPackageRestoreTelemetryService(ConfiguredProject project, ITelemetryService telemetryService)
+        public ConfiguredProjectPackageRestoreTelemetryService(ConfiguredProject project, ITelemetryService telemetryService, IProjectThreadingService projectThreadingService)
         {
             _project = project;
             _telemetryService = telemetryService;
+
+            _projectGuidLazy = new AsyncLazy<Guid>(async () =>
+            {
+                return await _project.UnconfiguredProject.GetProjectGuidAsync();
+            }, projectThreadingService.JoinableTaskFactory);
         }
 
-        private string ProjectTelemetryId => _projectTelemetryId ??= _telemetryService.GetProjectId(_project.UnconfiguredProject);
+        private Guid ProjectGuid => _projectGuidLazy.GetValue();
 
         public void PostPackageRestoreEvent(string packageRestoreOperationName)
         {
             _telemetryService.PostProperties(TelemetryEventName.ProcessPackageRestore, new (string propertyName, object propertyValue)[]
                 {
                     (TelemetryPropertyName.PackageRestoreOperation, packageRestoreOperationName),
-                    (TelemetryPropertyName.PackageRestoreProjectId, ProjectTelemetryId),
+                    (TelemetryPropertyName.PackageRestoreProjectId, ProjectGuid),
                 });
         }
 
@@ -35,7 +43,7 @@ namespace Microsoft.VisualStudio.Telemetry
             _telemetryService.PostProperties(TelemetryEventName.ProcessPackageRestore, new (string propertyName, object propertyValue)[]
                 {
                     (TelemetryPropertyName.PackageRestoreOperation, packageRestoreOperationName),
-                    (TelemetryPropertyName.PackageRestoreProjectId, ProjectTelemetryId),
+                    (TelemetryPropertyName.PackageRestoreProjectId, ProjectGuid),
                     (TelemetryPropertyName.PackageRestoreProgressTrackerId, packageRestoreProgressTrackerId),
                 });
         }
@@ -46,7 +54,7 @@ namespace Microsoft.VisualStudio.Telemetry
                 {
                     (TelemetryPropertyName.PackageRestoreIsUpToDate, isRestoreUpToDate),
                     (TelemetryPropertyName.PackageRestoreOperation, PackageRestoreOperationNames.PackageRestoreProgressTrackerRestoreCompleted),
-                    (TelemetryPropertyName.PackageRestoreProjectId, ProjectTelemetryId),
+                    (TelemetryPropertyName.PackageRestoreProjectId, ProjectGuid),
                     (TelemetryPropertyName.PackageRestoreProgressTrackerId, packageRestoreProgressTrackerId),
                 });
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/UnconfiguredProjectLanguageServiceTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/UnconfiguredProjectLanguageServiceTelemetryService.cs
@@ -1,7 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.VS;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.Telemetry
 {
@@ -10,16 +13,21 @@ namespace Microsoft.VisualStudio.Telemetry
     {
         private readonly UnconfiguredProject _project;
         private readonly ITelemetryService _telemetryService;
-        private string? _projectTelemetryId;
+        private readonly AsyncLazy<Guid> _projectGuidLazy;
 
         [ImportingConstructor]
-        public UnconfiguredProjectLanguageServiceTelemetryService(UnconfiguredProject project, ITelemetryService telemetryService)
+        public UnconfiguredProjectLanguageServiceTelemetryService(UnconfiguredProject project, ITelemetryService telemetryService, IProjectThreadingService projectThreadingService)
         {
             _project = project;
             _telemetryService = telemetryService;
+
+            _projectGuidLazy = new AsyncLazy<Guid>(async () =>
+            {
+                return await _project.GetProjectGuidAsync();
+            }, projectThreadingService.JoinableTaskFactory);
         }
 
-        private string ProjectTelemetryId => _projectTelemetryId ??= _telemetryService.GetProjectId(_project);
+        private Guid ProjectGuid => _projectGuidLazy.GetValue();
 
         public void PostActiveWorkspaceProjectContextHostPublishingEvent()
         {
@@ -35,7 +43,7 @@ namespace Microsoft.VisualStudio.Telemetry
         {
             _telemetryService.PostProperties(TelemetryEventName.LanguageServiceOperation, new (string propertyName, object propertyValue)[]
                 {
-                    (TelemetryPropertyName.WorkspaceContextProjectId, ProjectTelemetryId),
+                    (TelemetryPropertyName.WorkspaceContextProjectId, ProjectGuid),
                     (TelemetryPropertyName.LanguageServiceOperationName, languageServiceOperationName),
                 });
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/UnconfiguredProjectPackageRestoreTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/UnconfiguredProjectPackageRestoreTelemetryService.cs
@@ -1,7 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.VS;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.Telemetry
 {
@@ -10,23 +13,28 @@ namespace Microsoft.VisualStudio.Telemetry
     {
         private readonly UnconfiguredProject _project;
         private readonly ITelemetryService _telemetryService;
-        private string? _projectTelemetryId;
+        private readonly AsyncLazy<Guid> _projectGuidLazy;
 
         [ImportingConstructor]
-        public UnconfiguredProjectPackageRestoreTelemetryService(UnconfiguredProject project, ITelemetryService telemetryService)
+        public UnconfiguredProjectPackageRestoreTelemetryService(UnconfiguredProject project, ITelemetryService telemetryService, IProjectThreadingService projectThreadingService)
         {
             _project = project;
             _telemetryService = telemetryService;
+
+            _projectGuidLazy = new AsyncLazy<Guid>(async () =>
+            {
+                return await _project.GetProjectGuidAsync();
+            }, projectThreadingService.JoinableTaskFactory);
         }
 
-        private string ProjectTelemetryId => _projectTelemetryId ??= _telemetryService.GetProjectId(_project);
+        private Guid ProjectGuid => _projectGuidLazy.GetValue();
 
         public void PostPackageRestoreEvent(string packageRestoreOperationName)
         {
             _telemetryService.PostProperties(TelemetryEventName.ProcessPackageRestore, new (string propertyName, object propertyValue)[]
                 {
                     (TelemetryPropertyName.PackageRestoreOperation, packageRestoreOperationName),
-                    (TelemetryPropertyName.PackageRestoreProjectId, ProjectTelemetryId),
+                    (TelemetryPropertyName.PackageRestoreProjectId, ProjectGuid),
                 });
         }
 
@@ -36,7 +44,7 @@ namespace Microsoft.VisualStudio.Telemetry
                 {
                     (TelemetryPropertyName.PackageRestoreIsUpToDate, isRestoreUpToDate),
                     (TelemetryPropertyName.PackageRestoreOperation, packageRestoreOperationName),
-                    (TelemetryPropertyName.PackageRestoreProjectId, ProjectTelemetryId),
+                    (TelemetryPropertyName.PackageRestoreProjectId, ProjectGuid),
                 });
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Security.Cryptography;
 using System.Text;
-using Microsoft.VisualStudio.ProjectSystem;
 
 namespace Microsoft.VisualStudio.Telemetry
 {
@@ -82,12 +81,6 @@ namespace Microsoft.VisualStudio.Telemetry
             byte[] inputBytes = Encoding.UTF8.GetBytes(value);
             using var cryptoServiceProvider = new SHA256CryptoServiceProvider();
             return BitConverter.ToString(cryptoServiceProvider.ComputeHash(inputBytes));
-        }
-
-        public string GetProjectId(UnconfiguredProject project)
-        {
-            string? fullPath = project?.FullPath;
-            return Strings.IsNullOrEmpty(fullPath) ? string.Empty : HashValue(fullPath);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ITelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ITelemetryService.cs
@@ -89,13 +89,5 @@ namespace Microsoft.VisualStudio.Telemetry
         /// <param name="value">Value to hashed.</param>
         /// <returns>Hashed value.</returns>
         string HashValue(string value);
-
-        /// <summary>
-        /// Computes a hash value that can be used to differentiate the
-        /// projects in telemetry events.
-        /// </summary>
-        /// <param name="project">The project whose identifying hash is required.</param>
-        /// <returns>A unique identifier for the project.</returns>
-        string GetProjectId(UnconfiguredProject project);
     }
 }


### PR DESCRIPTION
As of 16.10, CPS now exposes the UnconfiguredProjectExtensions.GetProjectGuidAsync method, which can be used to get project GUIDs even when the language service and package restore components are being initialized. This PR replaces path hashes with the GUIDs from this newly exposed API.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/6997)