### PR TITLE
Update Project Query API data providers to understand the binding context

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/IPropertyPageQueryCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/IPropertyPageQueryCache.cs
@@ -39,7 +39,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </remarks>
     internal interface IPropertyPageQueryCache
     {
-        Task<IRule?> BindToRule(ProjectConfiguration projectConfiguration, string schemaName);
+        /// <summary>
+        /// Binds the specified schema to a particular context within the given project configuration.
+        /// </summary>
+        Task<IRule?> BindToRule(ProjectConfiguration projectConfiguration, string schemaName, QueryProjectPropertiesContext context);
         Task<IImmutableSet<ProjectConfiguration>?> GetKnownConfigurationsAsync();
         Task<ProjectConfiguration?> GetSuggestedConfigurationAsync();
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUIPropertyValueActionCore.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUIPropertyValueActionCore.cs
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                             foreach (ProjectConfiguration knownConfiguration in knownConfigurations)
                             {
                                 if (knownConfiguration.MatchesDimensions(_dimensions)
-                                    && await propertyPageCache.BindToRule(knownConfiguration, _pageName) is IRule boundRule)
+                                    && await propertyPageCache.BindToRule(knownConfiguration, _pageName, QueryProjectPropertiesContext.ProjectFile) is IRule boundRule)
                                 {
                                     projectRules.Add(boundRule);
                                 }
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                         // The property is configuration-independent; we only need the bound rule for a single
                         // configuration.
                         if (await propertyPageCache.GetSuggestedConfigurationAsync() is ProjectConfiguration suggestedConfiguration
-                            && await propertyPageCache.BindToRule(suggestedConfiguration, _pageName) is IRule boundRule)
+                            && await propertyPageCache.BindToRule(suggestedConfiguration, _pageName, QueryProjectPropertiesContext.ProjectFile) is IRule boundRule)
                         {
                             projectRules.Add(boundRule);
                         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageByIdDataProducer.cs
@@ -29,8 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id)
         {
-            if (id.KeysCount == 2
-                && id.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string projectPath)
+            if (QueryProjectPropertiesContext.TryCreateFromEntityId(id, out QueryProjectPropertiesContext? context)
                 && id.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName))
             {
                 return PropertyPageDataProducer.CreatePropertyPageValueAsync(
@@ -38,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     id,
                     _projectService,
                     _queryCacheProvider,
-                    projectPath,
+                    context,
                     propertyPageName,
                     _properties);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageProviderState.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageProviderState.cs
@@ -12,19 +12,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal sealed class PropertyPageProviderState
     {
-        public PropertyPageProviderState(IPropertyPageQueryCache cache, Rule rule)
-            : this(cache, rule, new List<Rule>(capacity: 0))
+        public PropertyPageProviderState(IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, Rule rule)
+            : this(cache, context, rule, new List<Rule>(capacity: 0))
         {
         }
 
-        public PropertyPageProviderState(IPropertyPageQueryCache cache, Rule rule, List<Rule> debugChildRules)
+        public PropertyPageProviderState(IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, Rule rule, List<Rule> debugChildRules)
         {
             Cache = cache;
+            Context = context;
             Rule = rule;
             DebugChildRules = debugChildRules;
         }
 
         public IPropertyPageQueryCache Cache { get; }
+        public QueryProjectPropertiesContext Context { get; }
         public Rule Rule { get; }
         public List<Rule> DebugChildRules { get; }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyProviderState.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyProviderState.cs
@@ -11,15 +11,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal sealed class PropertyProviderState
     {
-        public PropertyProviderState(IPropertyPageQueryCache cache, Rule containingRule, string propertyName)
+        public PropertyProviderState(IPropertyPageQueryCache cache, Rule containingRule, QueryProjectPropertiesContext context, string propertyName)
         {
             Cache = cache;
             ContainingRule = containingRule;
+            Context = context;
             PropertyName = propertyName;
         }
 
         public IPropertyPageQueryCache Cache { get; }
         public Rule ContainingRule { get; }
+        public QueryProjectPropertiesContext Context { get; }
         public string PropertyName { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryProjectPropertiesContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryProjectPropertiesContext.cs
@@ -1,7 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {
@@ -64,6 +67,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             }
 
             return hashCode;
+        }
+
+        public static bool TryCreateFromEntityId(EntityIdentity id, [NotNullWhen(true)] out QueryProjectPropertiesContext? context)
+        {
+            if (id.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string projectPath))
+            {
+                id.TryGetValue(ProjectModelIdentityKeys.SourceItemType, out string? itemType);
+                id.TryGetValue(ProjectModelIdentityKeys.SourceItemType, out string? itemName);
+                context = new QueryProjectPropertiesContext(isProjectFile: true, projectPath, itemType, itemName);
+                return true;
+            }
+
+            context = null;
+            return false;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryProjectPropertiesContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryProjectPropertiesContext.cs
@@ -19,6 +19,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </remarks>
     internal sealed class QueryProjectPropertiesContext : IProjectPropertiesContext, IEquatable<QueryProjectPropertiesContext>
     {
+        /// <summary>
+        /// A well-known context representing the project file as a whole.
+        /// </summary>
+        /// <remarks>
+        /// Note that if an <see cref="IProjectPropertiesContext"/> has the <see cref="IProjectPropertiesContext.IsProjectFile"/>
+        /// property is set to <c>true</c> and the <see cref="IProjectPropertiesContext.ItemType"/>
+        /// and <see cref="IProjectPropertiesContext.ItemName"/> properties are <c>null</c>
+        /// then the properties system treats it as referring to the project file as a whole
+        /// regardless of the <see cref="IProjectPropertiesContext.File"/> property. This
+        /// lets us get away with setting it to the empty string and re-using the same
+        /// instance across projects.
+        /// </remarks>
         public static readonly QueryProjectPropertiesContext ProjectFile = new(isProjectFile: true, file: string.Empty, itemType: null, itemName: null);
 
         public QueryProjectPropertiesContext(bool isProjectFile, string file, string? itemType, string? itemName)
@@ -69,6 +81,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             return hashCode;
         }
 
+        /// <summary>
+        /// Creates a <see cref="QueryProjectPropertiesContext"/> from a Project Query API
+        /// <see cref="EntityIdentity"/>.
+        /// </summary>
         public static bool TryCreateFromEntityId(EntityIdentity id, [NotNullWhen(true)] out QueryProjectPropertiesContext? context)
         {
             if (id.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string projectPath))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryProjectPropertiesContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryProjectPropertiesContext.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// An implementation of <see cref="IProjectPropertiesContext"/> for use in the
+    /// Project Query API implementation.
+    /// </summary>
+    /// <remarks>
+    /// The point here is to capture the context for a part of a query execution in a
+    /// manner that can be passed from one provider to another and is also suitable as a
+    /// key into a cache (such as the <see cref="IPropertyPageQueryCache"/>).
+    /// </remarks>
+    internal sealed class QueryProjectPropertiesContext : IProjectPropertiesContext, IEquatable<QueryProjectPropertiesContext>
+    {
+        public static readonly QueryProjectPropertiesContext ProjectFile = new(isProjectFile: true, file: string.Empty, itemType: null, itemName: null);
+
+        public QueryProjectPropertiesContext(bool isProjectFile, string file, string? itemType, string? itemName)
+        {
+            IsProjectFile = isProjectFile;
+            File = file;
+            ItemType = itemType;
+            ItemName = itemName;
+        }
+
+        public bool IsProjectFile { get; }
+
+        public string File { get; }
+
+        public string? ItemType { get; }
+
+        public string? ItemName { get; }
+
+        public bool Equals(QueryProjectPropertiesContext? other)
+        {
+            return other is not null
+                && IsProjectFile == other.IsProjectFile
+                && StringComparers.Paths.Equals(File, other.File)
+                && StringComparers.ItemTypes.Equals(ItemType, other.ItemType)
+                && StringComparers.ItemNames.Equals(ItemName, other.ItemName);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as QueryProjectPropertiesContext);
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = IsProjectFile.GetHashCode();
+            hashCode = (hashCode * -1521134295) + StringComparers.Paths.GetHashCode(File);
+            
+            if (ItemType is not null)
+            {
+                hashCode = (hashCode * -1521134295) + StringComparers.ItemTypes.GetHashCode(ItemType);
+            }
+            
+            if (ItemName is not null)
+            {
+                hashCode = (hashCode * -1521134295) + StringComparers.ItemNames.GetHashCode(ItemName);
+            }
+
+            return hashCode;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyByIdProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyByIdProducer.cs
@@ -27,8 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id)
         {
-            if (id.KeysCount == 3
-                && id.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string projectPath)
+            if (QueryProjectPropertiesContext.TryCreateFromEntityId(id, out QueryProjectPropertiesContext? context)
                 && id.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName)
                 && id.TryGetValue(ProjectModelIdentityKeys.UIPropertyName, out string propertyName))
             {
@@ -37,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     id,
                     _projectService,
                     _queryCacheProvider,
-                    projectPath,
+                    context,
                     propertyPageName,
                     propertyName,
                     _properties);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromPropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromPropertyPageDataProducer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IEntityValue parent, PropertyPageProviderState providerState)
         {
-            return Task.FromResult(UIPropertyDataProducer.CreateUIPropertyValues(parent, providerState.Cache, providerState.Rule, providerState.DebugChildRules, _properties));
+            return Task.FromResult(UIPropertyDataProducer.CreateUIPropertyValues(parent, providerState.Cache, providerState.Context, providerState.Rule, providerState.DebugChildRules, _properties));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -71,6 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             IEntityValue parent,
             IPropertyPageQueryCache cache,
             Rule schema,
+            QueryProjectPropertiesContext context,
             string propertyName,
             IUIPropertyValuePropertiesAvailableStatus requestedProperties)
         {
@@ -103,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             foreach (ProjectConfiguration configuration in configurations)
             {
-                if (await cache.BindToRule(configuration, schema.Name, QueryProjectPropertiesContext.ProjectFile) is IRule rule
+                if (await cache.BindToRule(configuration, schema.Name, context) is IRule rule
                     && rule.GetProperty(propertyName) is ProjectSystem.Properties.IProperty property)
                 {
                     IEntityValue propertyValue = await CreateUIPropertyValueValueAsync(parent, configuration, property, requestedProperties);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             foreach (ProjectConfiguration configuration in configurations)
             {
-                if (await cache.BindToRule(configuration, schema.Name) is IRule rule
+                if (await cache.BindToRule(configuration, schema.Name, QueryProjectPropertiesContext.ProjectFile) is IRule rule
                     && rule.GetProperty(propertyName) is ProjectSystem.Properties.IProperty property)
                 {
                     IEntityValue propertyValue = await CreateUIPropertyValueValueAsync(parent, configuration, property, requestedProperties);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueFromUIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueFromUIPropertyDataProducer.cs
@@ -25,6 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 parent,
                 providerState.Cache,
                 providerState.ContainingRule,
+                providerState.Context,
                 providerState.PropertyName,
                 _properties);
         }

--- a/test.csx
+++ b/test.csx
@@ -1,1 +1,0 @@
-System.Console.WriteLine(5+5);

--- a/test.csx
+++ b/test.csx
@@ -1,0 +1,1 @@
+System.Console.WriteLine(5+5);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IPropertyPageQueryCacheFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IPropertyPageQueryCacheFactory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         internal static IPropertyPageQueryCache Create(
             IImmutableSet<ProjectConfiguration>? projectConfigurations = null,
             ProjectConfiguration? defaultConfiguration = null,
-            Func<ProjectConfiguration, string, IRule>? bindToRule = null)
+            Func<ProjectConfiguration, string, QueryProjectPropertiesContext, IRule>? bindToRule = null)
         {
             var mock = new Mock<IPropertyPageQueryCache>();
 
@@ -31,8 +31,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             if (bindToRule is not null)
             {
                 mock.Setup(cache => cache
-                    .BindToRule(It.IsAny<ProjectConfiguration>(), It.IsAny<string>()))
-                    .Returns((ProjectConfiguration config, string schema) => Task.FromResult<IRule?>(bindToRule(config, schema)));
+                    .BindToRule(It.IsAny<ProjectConfiguration>(), It.IsAny<string>(), It.IsAny<QueryProjectPropertiesContext>()))
+                    .Returns((ProjectConfiguration config, string schema, QueryProjectPropertiesContext context) => Task.FromResult<IRule?>(bindToRule(config, schema, context)));
             }
 
             return mock.Object;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/ProjectActionProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/ProjectActionProviderTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
             var queryCacheProvider = IPropertyPageQueryCacheProviderFactory.Create(
                 IPropertyPageQueryCacheFactory.Create(
                     projectConfigurations,
-                    bindToRule: (config, schemaName) => IRuleFactory.Create(
+                    bindToRule: (config, schemaName, context) => IRuleFactory.Create(
                         name: "MyPage",
                         properties: new[]
                         {
@@ -115,7 +115,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
             var queryCacheProvider = IPropertyPageQueryCacheProviderFactory.Create(
                 IPropertyPageQueryCacheFactory.Create(
                     projectConfigurations,
-                    bindToRule: (config, schemaName) => IRuleFactory.Create(
+                    bindToRule: (config, schemaName, context) => IRuleFactory.Create(
                         name: "MyPage",
                         properties: new[]
                         {
@@ -156,7 +156,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
             var queryCacheProvider = IPropertyPageQueryCacheProviderFactory.Create(
                 IPropertyPageQueryCacheFactory.Create(
                     projectConfigurations,
-                    bindToRule: (config, schemaName) => IRuleFactory.Create(
+                    bindToRule: (config, schemaName, context) => IRuleFactory.Create(
                         name: "MyPage",
                         properties: new[]
                         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducerTests.cs
@@ -18,9 +18,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             var propertyPage = (PropertyPageValue)PropertyPageDataProducer.CreatePropertyPageValue(
                 IEntityWithIdFactory.Create(key: "A", value: "B"),
                 IPropertyPageQueryCacheFactory.Create(),
+                QueryProjectPropertiesContext.ProjectFile,
                 new Rule { Name = "MyRule", DisplayName = "My Rule Display Name", Order = 42, PageTemplate = "generic" },
                 debugChildRules: new List<Rule>(),
-                properties);
+                requestedProperties: properties);
 
             Assert.Equal(expected: "MyRule", actual: propertyPage.Name);
             Assert.Equal(expected: "My Rule Display Name", actual: propertyPage.DisplayName);
@@ -36,9 +37,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             var propertyPage = (IEntityValueFromProvider)PropertyPageDataProducer.CreatePropertyPageValue(
                 IEntityWithIdFactory.Create(key: "A", value: "B"),
                 IPropertyPageQueryCacheFactory.Create(),
+                QueryProjectPropertiesContext.ProjectFile,
                 new Rule { Name = "MyRule", DisplayName = "My Rule Display Name", Order = 42, PageTemplate = "generic" },
                 debugChildRules: new List<Rule>(),
-                properties) ;
+                requestedProperties: properties);
 
             Assert.IsType<PropertyPageProviderState>(propertyPage.ProviderState);
         }
@@ -51,9 +53,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             var propertyPage = (PropertyPageValue)PropertyPageDataProducer.CreatePropertyPageValue(
                 IEntityWithIdFactory.Create(key: "ParentKey", value: "ParentValue"),
                 IPropertyPageQueryCacheFactory.Create(),
+                QueryProjectPropertiesContext.ProjectFile,
                 new Rule { Name = "MyRule", DisplayName = "My Rule Display Name", Order = 42, PageTemplate = "generic" },
                 debugChildRules: new List<Rule>(),
-                properties);
+                requestedProperties: properties);
 
             Assert.Equal(expected: "MyRule", actual: propertyPage.Id[ProjectModelIdentityKeys.PropertyPageName]);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             var order = 42;
             InitializeFakeRuleForProperty(property);
 
-            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(parentEntity, cache, property, order, properties);
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(parentEntity, cache, QueryProjectPropertiesContext.ProjectFile, property, order, properties);
 
             Assert.Equal(expected: "MyProperty", actual: result.Id[ProjectModelIdentityKeys.UIPropertyName]);
         }
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             };
             InitializeFakeRuleForProperty(property);
 
-            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, QueryProjectPropertiesContext.ProjectFile, property, order: 42, requestedProperties: properties);
 
             Assert.Equal(expected: "A", actual: result.Name);
             Assert.Equal(expected: "Page A", actual: result.DisplayName);
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             rule.Properties.Add(property);
             rule.EndInit();
 
-            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, QueryProjectPropertiesContext.ProjectFile, property, order: 42, requestedProperties: properties);
 
             Assert.IsType<PropertyProviderState>(((IEntityValueFromProvider)result).ProviderState);
         }
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             rule.EndInit();
             var debugChildRules = new List<Rule>();
 
-            var result = UIPropertyDataProducer.CreateUIPropertyValues(parentEntity, cache, rule, debugChildRules, properties);
+            var result = UIPropertyDataProducer.CreateUIPropertyValues(parentEntity, cache, QueryProjectPropertiesContext.ProjectFile, rule, debugChildRules, properties);
 
             Assert.Collection(result, new Action<IEntityValue>[]
             {
@@ -127,7 +127,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 Metadata = new List<NameValuePair>()
             };
 
-            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, QueryProjectPropertiesContext.ProjectFile, property, order: 42, requestedProperties: properties);
 
             Assert.Equal(expected: "", actual: result.SearchTerms);
         }
@@ -148,7 +148,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 }
             };
 
-            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, QueryProjectPropertiesContext.ProjectFile, property, order: 42, requestedProperties: properties);
 
             Assert.Equal(expected: "", actual: result.SearchTerms);
         }
@@ -169,7 +169,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 }
             };
 
-            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, QueryProjectPropertiesContext.ProjectFile, property, order: 42, requestedProperties: properties);
 
             Assert.Equal(expected: "Alpha;Beta;Gamma", actual: result.SearchTerms);
         }
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             };
             InitializeFakeRuleForProperty(property);
 
-            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, QueryProjectPropertiesContext.ProjectFile, property, order: 42, requestedProperties: properties);
 
             Assert.Equal(expected: "", actual: result.DependsOn);
         }
@@ -210,7 +210,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             };
             InitializeFakeRuleForProperty(property);
 
-            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, QueryProjectPropertiesContext.ProjectFile, property, order: 42, requestedProperties: properties);
 
             Assert.Equal(expected: "", actual: result.DependsOn);
         }
@@ -232,7 +232,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             };
             InitializeFakeRuleForProperty(property);
 
-            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, QueryProjectPropertiesContext.ProjectFile, property, order: 42, requestedProperties: properties);
 
             Assert.Equal(expected: "Alpha;Beta;Gamma", actual: result.DependsOn);
         }
@@ -252,7 +252,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             };
             InitializeFakeRuleForProperty(property);
 
-            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, QueryProjectPropertiesContext.ProjectFile, property, order: 42, requestedProperties: properties);
 
             Assert.Equal(expected: string.Empty, actual: result.VisibilityCondition);
         }
@@ -276,7 +276,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             };
             InitializeFakeRuleForProperty(property);
 
-            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, property, order: 42, properties);
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(runtimeModel, id, cache, QueryProjectPropertiesContext.ProjectFile, property, order: 42, requestedProperties: properties);
 
             Assert.Equal(expected: "true or false", actual: result.VisibilityCondition);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducerTests.cs
@@ -158,6 +158,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 parent,
                 cache,
                 schema,
+                context: QueryProjectPropertiesContext.ProjectFile,
                 propertyName,
                 requestedProperties);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducerTests.cs
@@ -141,7 +141,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             var cache = IPropertyPageQueryCacheFactory.Create(
                 projectConfigurations: ImmutableHashSet<ProjectConfiguration>.Empty.Add(defaultConfiguration).Add(otherConfiguration),
                 defaultConfiguration: defaultConfiguration,
-                bindToRule: (config, schemaName) => IRuleFactory.Create(
+                bindToRule: (config, schemaName, context) => IRuleFactory.Create(
                     name: "ParentName",
                     properties: new[] { IPropertyFactory.Create("MyProperty") }));
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/QueryProjectPropertiesContextTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/QueryProjectPropertiesContextTests.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    public class QueryProjectPropertiesContextTests
+    {
+        [Theory]
+        [MemberData(nameof(ContextsThatAreEqual))]
+        public void Equal(IProjectPropertiesContext a, IProjectPropertiesContext b)
+        {
+            Assert.True(a.Equals(b));
+            Assert.True(a.GetHashCode() == b.GetHashCode());
+        }
+
+        [Theory]
+        [MemberData(nameof(ContextsThatAreNotEqual))]
+        public void NotEqual(IProjectPropertiesContext a, IProjectPropertiesContext b)
+        {
+            Assert.False(a.Equals(b));
+            Assert.False(a.GetHashCode() == b.GetHashCode());
+        }
+
+        public static IEnumerable<IProjectPropertiesContext[]> ContextsThatAreEqual()
+        {
+            return new QueryProjectPropertiesContext[][]
+            {
+                new QueryProjectPropertiesContext[] { QueryProjectPropertiesContext.ProjectFile, QueryProjectPropertiesContext.ProjectFile },
+                new QueryProjectPropertiesContext[] { new(true, string.Empty, null, null), QueryProjectPropertiesContext.ProjectFile },
+                new QueryProjectPropertiesContext[] { new(true, @"C:\alpha\beta", null, null), new(true, @"c:\ALPHA\Beta", null, null) },
+                new QueryProjectPropertiesContext[] { new(true, @"C:\alpha\beta", "myItemType", null), new(true, @"C:\alpha\beta", "MyItemType", null) },
+                new QueryProjectPropertiesContext[] { new(true, @"C:\alpha\beta", null, "MyItemName"), new(true, @"C:\alpha\beta", null, "MYITEMNAME") }
+            };
+        }
+
+        public static IEnumerable<object[]> ContextsThatAreNotEqual()
+        {
+            return new QueryProjectPropertiesContext[][]
+            {
+                new QueryProjectPropertiesContext[] { new QueryProjectPropertiesContext(false, string.Empty, null, null), QueryProjectPropertiesContext.ProjectFile },
+                new QueryProjectPropertiesContext[] { new(true, @"C:\alpha\beta", null, null), new(true, @"C:\alpha\gamma", null, null) },
+                new QueryProjectPropertiesContext[] { new(true, @"C:\alpha\beta", "myItemType", null), new(true, @"C:\alpha\beta", "MyOtherItemType", null) },
+                new QueryProjectPropertiesContext[] { new(true, @"C:\alpha\beta", null, "MyItemName"), new(true, @"C:\alpha\beta", null, "MyOtherItemName") }
+            };
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/QueryProjectPropertiesContextTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/QueryProjectPropertiesContextTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         public void Equal(IProjectPropertiesContext a, IProjectPropertiesContext b)
         {
             Assert.True(a.Equals(b));
+            Assert.True(b.Equals(a));
             Assert.True(a.GetHashCode() == b.GetHashCode());
         }
 
@@ -40,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         {
             return new QueryProjectPropertiesContext[][]
             {
-                new QueryProjectPropertiesContext[] { new QueryProjectPropertiesContext(false, string.Empty, null, null), QueryProjectPropertiesContext.ProjectFile },
+                new QueryProjectPropertiesContext[] { new(false, string.Empty, null, null), QueryProjectPropertiesContext.ProjectFile },
                 new QueryProjectPropertiesContext[] { new(true, @"C:\alpha\beta", null, null), new(true, @"C:\alpha\gamma", null, null) },
                 new QueryProjectPropertiesContext[] { new(true, @"C:\alpha\beta", "myItemType", null), new(true, @"C:\alpha\beta", "MyOtherItemType", null) },
                 new QueryProjectPropertiesContext[] { new(true, @"C:\alpha\beta", null, "MyItemName"), new(true, @"C:\alpha\beta", null, "MyOtherItemName") }


### PR DESCRIPTION
When retrieving properties through the CPS properties system three pieces of data are needed:

- A configured project (represented by a `ConfiguredProject`) which represents the "world" in which the property retrieval occurs
- A `Rule` describing _which_ properties to retrieve, including metadata about how to retrieve them and how the consumer should interpret them
- A binding context that both identifies the entity that you want to investigate, and the context in which to investigate it. This is represented by an `IProjectPropertiesContext` (which is a somewhat misleading name for reasons I will get to in a moment).

The binding context requires further explanation. Some examples may help. An `IProjectPropertiesContext` may refer to:

- The project as a whole, in which case the properties retrieved are _project properties_.
- An imported .props or .targets file, in which case the properties are _project properties as defined in that import_.
- An item of a particular item type, in which case the properties are the _item properties for that specific definition of the item_.
- An item without a particular item type, in which case the properties are the _item properties for **some** definition of that item_.
- An item type, in which case the properties are the _default properties supplied to all that items of that type_.
- Various other combinations.

If you didn't follow all of that, that's OK. The important point is that the `Rule`s describing a set a properties can be largely independent of the source of those properties. The same `Rule` could be used, for example, to query/update the properties on a specific `<Reference>` item _or_ the default properties of **all** `<Reference>` items and the consuming code doesn't need to be concerned about which it is--the properties system will do the right thing depending on the context.

Of course, not all combinations of `Rule`s and `IProjectPropertiesContext`s are meaningful. There isn't much point in binding the `Rule` for the "Application" property page to a specific item, and it is ultimately up to the `IProjectPropertiesProvider` (representing the underlying storage for properties) to determine what a particular `IProjectPropertiesContext` represents.

With that background out of the way, we can move on to the specifics of this change. Currently, when the providers that implement the Project Query API for the new project property pages bind the `Rule`s representing the individual pages they implicitly use the "project file" context. Outside of that implicit context, however, nothing about the providers is specific to _project_ properties--all the logic could apply equally well to item properties.

Now we're planning to expose individual launch profiles through their own UI. By creating an `IProjectPropertiesProvider` that can read and write launch profile properties from the launchSettings.json file (in a separate PR) and replacing the implicit context with an explicit context (done here) we can re-use a great deal of code we've already created for the project properties pages:

- We can use mostly the same Project Query API model types for both project property pages and launch profiles...
- ...which means the UI layer can reuse many of its controls with minimal changes
- On the back end, the same Project Query API data providers can handle both project property pages and launch profiles
- Developers can use the same .xaml format for `Rule` files to describe both the property pages and the properties to expose for a launch profile

The bulk of this change is to define an implementation of `IProjectPropertiesContext` we can use while processing a query, and pass instances of that context between the different providers.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7006)