### PR TITLE
Properly handle changes to synthetic properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationManifestKindValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationManifestKindValueProvider.cs
@@ -61,7 +61,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 return NoManifestValue;
             }
 
-            if (_temporaryPropertyStorage.GetPropertyValue(ApplicationManifestKindProperty) is string storedValue)
+            string? storedValue = _temporaryPropertyStorage.GetPropertyValue(ApplicationManifestKindProperty);
+            if (!Strings.IsNullOrEmpty(storedValue))
             {
                 return storedValue;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/PackageLicenseKindValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/PackageLicenseKindValueProvider.cs
@@ -83,7 +83,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 return FileValue;
             }
 
-            if (_temporaryPropertyStorage.GetPropertyValue(PackageLicenseKindProperty) is string storedValue)
+            string? storedValue = _temporaryPropertyStorage.GetPropertyValue(PackageLicenseKindProperty);
+            if (!Strings.IsNullOrEmpty(storedValue))
             {
                 return storedValue;
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationManifestKindValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationManifestKindValueProviderTests.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    public class ApplicationManifestKindValueProviderTests
+    {
+        [Theory]
+        //          ApplicationManifest              NoWin32Manifest Stored value       Expected value
+        [InlineData("",                              "",             null,              "DefaultManifest")]
+        [InlineData("",                              "",             "NoManifest",      "NoManifest")]
+        [InlineData("",                              "",             "CustomManifest",  "CustomManifest")]
+        [InlineData("",                              "true",         null,              "NoManifest")]
+        [InlineData("",                              "false",        null,              "DefaultManifest")]
+        [InlineData("",                              "false",        "CustomManifest",  "CustomManifest")]
+        [InlineData(@"C:\alpha\beta\gamma.manifest", "",             null,              "CustomManifest")]
+        [InlineData(@"C:\alpha\beta\gamma.manifest", "true",         null,              "CustomManifest")]
+        [InlineData(@"C:\alpha\beta\gamma.manifest", "true",         "DefaultManifest", "CustomManifest")]
+        public async Task GetApplicationManifestKind(string applicationManifestPropertyValue, string noManifestPropertyValue, string? storedValue, string expectedValue)
+        {
+            Dictionary<string, string>? storedValues = null;
+            if (storedValue is not null)
+            {
+                storedValues = new Dictionary<string, string>
+                {
+                    { "ApplicationManifestKind", storedValue }
+                };
+            }
+            var storage = ITemporaryPropertyStorageFactory.Create(storedValues);
+            var provider = new ApplicationManifestKindValueProvider(storage);
+            var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(new Dictionary<string, string?>
+            {
+                { "ApplicationManifest", applicationManifestPropertyValue },
+                { "NoWin32Manifest", noManifestPropertyValue }
+            });
+
+            var kindValue = await provider.OnGetEvaluatedPropertyValueAsync(string.Empty, string.Empty, defaultProperties);
+
+            Assert.Equal(expected: expectedValue, actual: kindValue);
+        }
+
+        [Theory]
+        //          New value           Current                           Current          Expected     Expected         Expected
+        //                              AppManifest                       NoWin32Manifest  AppManifest  NoWin32Manifest  stored value
+        [InlineData("DefaultManifest",  @"C:\alpha\beta\gamma.manifest",  null,            null,        null,            "DefaultManifest")]
+        [InlineData("DefaultManifest",  @"C:\alpha\beta\gamma.manifest",  "false",         null,        null,            "DefaultManifest")]
+        [InlineData("DefaultManifest",  null,                             "true",          null,        null,            "DefaultManifest")]
+        [InlineData("CustomManifest",   null,                             "true",          null,        null,            "CustomManifest")]
+        [InlineData("NoManifest",       @"C:\alpha\beta\gamma.manifest",  null,            null,        "true",          "NoManifest")]
+        [InlineData("NoManifest",       @"C:\alpha\beta\gamma.manifest",  "false",         null,        "true",          "NoManifest")]
+        public async Task SetApplicationManifestKind(string newValue, string? currentApplicationManifestPropertyValue, string? currentNoManifestPropertyValue, string? expectedAppManifestPropertyValue, string? expectedNoManifestPropertyValue, string? expectedStoredValue)
+        {
+            Dictionary<string, string> storageDictionary = new();
+            var storage = ITemporaryPropertyStorageFactory.Create(storageDictionary);
+
+            Dictionary<string, string?> defaultPropertiesDictionary = new();
+            defaultPropertiesDictionary["ApplicationManifest"] = currentApplicationManifestPropertyValue;
+            defaultPropertiesDictionary["NoWin32Manifest"] = currentNoManifestPropertyValue;
+            var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(defaultPropertiesDictionary);
+
+            var provider = new ApplicationManifestKindValueProvider(storage);
+            await provider.OnSetPropertyValueAsync("", newValue, defaultProperties);
+
+            defaultPropertiesDictionary.TryGetValue("ApplicationManifest", out string? finalAppManifestPropertyValue);
+            defaultPropertiesDictionary.TryGetValue("NoWin32Manifest", out string? finalNoManifestPropertyValue);
+            storageDictionary.TryGetValue("ApplicationManifestKind", out string? finalStoredValue);
+
+            Assert.Equal(expectedAppManifestPropertyValue, finalAppManifestPropertyValue);
+            Assert.Equal(expectedNoManifestPropertyValue, finalNoManifestPropertyValue);
+            Assert.Equal(expectedStoredValue, finalStoredValue);
+        }
+    }
+
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/PackageLicenseKindValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/PackageLicenseKindValueProviderTests.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    public class PackageLicenseKindValueProviderTests
+    {
+        [Theory]
+        //          Expression  File                Stored value   Expected value
+        [InlineData(null,       null,               null,         "None")]
+        [InlineData(null,       null,               "File",       "File")]
+        [InlineData(null,       @"C:\license.txt",  null,         "File")]
+        [InlineData(null,       @"C:\license.txt",  "Expression", "File")]
+        [InlineData("alpha",    null,               null,         "Expression")]
+        [InlineData("alpha",    @"C:\license.txt",  null,         "Expression")]
+        [InlineData("alpha",    @"C:\license.txt",  "None",       "Expression")]
+        public async Task GetPackageLicenseKind(string? expressionPropertyValue, string? filePropertyValue, string? storedValue, string expectedValue)
+        {
+            Dictionary<string, string>? storedValues = null;
+            if (storedValue is not null)
+            {
+                storedValues = new Dictionary<string, string>
+                {
+                    { "PackageLicenseKind", storedValue }
+                };
+            }
+            var storage = ITemporaryPropertyStorageFactory.Create(storedValues);
+            var provider = new PackageLicenseKindValueProvider(storage);
+            var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(new Dictionary<string, string?>
+            {
+                { "PackageLicenseExpression", expressionPropertyValue },
+                { "PackageLicenseFile", filePropertyValue }
+            });
+
+            var kindValue = await provider.OnGetEvaluatedPropertyValueAsync(string.Empty, string.Empty, defaultProperties);
+
+            Assert.Equal(expected: expectedValue, actual: kindValue);
+        }
+
+        [Theory]
+
+        //          New value      Current     Current             Expected    Expected            Expected
+        //                         Expression  File                Expression  File                stored value
+        [InlineData("Expression",  null,       null,               null,       null,               "Expression")]
+        [InlineData("Expression",  "alpha",    null,               "alpha",    null,               "Expression")]
+        [InlineData("Expression",  null,       @"C:\license.txt",  null,       null,               "Expression")]
+        [InlineData("File",        null,       null,               null,       null,               "File")]
+        [InlineData("File",        "alpha",    @"C:\license.txt",  null,       @"C:\license.txt",  "File")]
+        [InlineData("File",        "alpha",    null,               null,       null,               "File")]
+        [InlineData("None",        "alpha",    null,               null,       null,               "None")]
+        [InlineData("None",        null,       @"C:\license.txt",  null,       null,               "None")]
+        public async Task SetPackageLicenseKind(string newValue, string? currentExpressionPropertyValue, string? currentFilePropertyValue, string? expectedExpressionPropertyValue, string? expectedFilePropertyValue, string? expectedStoredValue)
+        {
+            Dictionary<string, string> storageDictionary = new();
+            var storage = ITemporaryPropertyStorageFactory.Create(storageDictionary);
+
+            Dictionary<string, string?> defaultPropertiesDictionary = new();
+            defaultPropertiesDictionary["PackageLicenseExpression"] = currentExpressionPropertyValue;
+            defaultPropertiesDictionary["PackageLicenseFile"] = currentFilePropertyValue;
+            var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(defaultPropertiesDictionary);
+
+            var provider = new PackageLicenseKindValueProvider(storage);
+            await provider.OnSetPropertyValueAsync("", newValue, defaultProperties);
+
+            defaultPropertiesDictionary.TryGetValue("PackageLicenseExpression", out string? finalExpressionPropertyValue);
+            defaultPropertiesDictionary.TryGetValue("PackageLicenseFile", out string? finalFilePropertyValue);
+            storageDictionary.TryGetValue("PackageLicenseKind", out string? finalStoredValue);
+
+            Assert.Equal(expectedExpressionPropertyValue, finalExpressionPropertyValue);
+            Assert.Equal(expectedFilePropertyValue, finalFilePropertyValue);
+            Assert.Equal(expectedStoredValue, finalStoredValue);
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes #7001.
 
Currently, the drop downs to choose the kind of application manifest (custom, none, or default) and the kind of package license expression (none, expression, or file) are not working properly: when the user chooses picks a different option, the UI resets to the default value almost immediately.

The issue is that these are synthetic properties--they don't have any direct representation in the project, and instead compute their values based on the values of _other_ properties. If those properties don't yet have values, then the next time we retrieve the value of the synthetic property we will get its default. That's what's happening here: the user changes the property, the UI sends that property change and requests an update, it gets the default value back, and resets the UI.

The fix here is to store the synthetic property value in the `ITemporaryPropertyStorage` when setting it. The next time the property is retrieved we first try to compute it from other values. If that fails we try to get it from the `ITemporaryPropertyStorage`. If it hasn't been stored we return the default.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7011)