### PR TITLE
Search for a Source property instead of field in DebuggerTraceListener

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/DebuggerTraceListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/DebuggerTraceListener.cs
@@ -21,14 +21,22 @@ namespace Microsoft.VisualStudio.Packaging
             // There's no public API registering a trace listener for a 
             // non-public trace source, so we need to use reflection
             string assemblyName = typeof(AppliesToAttribute).Assembly.FullName;
+            string typeName = $"Microsoft.VisualStudio.ProjectSystem.TraceUtilities, {assemblyName}";
 
-            var type = Type.GetType($"Microsoft.VisualStudio.ProjectSystem.TraceUtilities, {assemblyName}");
-            Assumes.NotNull(type);
+            var type = Type.GetType(typeName);
+            if (type is null)
+            {
+                Assumes.Fail($"Could not find type '{typeName}'");
+            }
 
-            FieldInfo field = type.GetField("Source", BindingFlags.NonPublic | BindingFlags.Static);
-            Assumes.NotNull(field);
+            const string sourcePropertyName = "Source";
+            PropertyInfo property = type.GetProperty(sourcePropertyName, BindingFlags.NonPublic | BindingFlags.Static);
+            if (property is null)
+            {
+                Assumes.Fail($"Could not find property '{sourcePropertyName}' in type '{typeName}'");
+            }
 
-            var source = (TraceSource)field.GetValue(null);
+            var source = (TraceSource)property.GetValue(null);
 
             source.Switch.Level = SourceLevels.Warning;
             source.Listeners.Add(this);


### PR DESCRIPTION
[CPS PR 291660](https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/291660) converted the TraceUtilities.Source field into a property. The managed project system code now needs to detect this property. This PR also replaces the Assumes.NotNull calls with Assumes.Fail so that a helpful error message is written to the activity log detailing exactly why the managed project system package failed to load successfully. This can be improved once https://github.com/microsoft/vs-validation/issues/78 has been addressed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7012)