### PR TITLE
Implement basic launch profile support in the Project Query API

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -93,9 +93,9 @@
     <PackageReference Include="VSSDK.TemplateWizardInterface"                                         Version="12.0.4"                          ExcludeAssets="All" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.10.117-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.10.117-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="16.10.117-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.10.127-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.10.127-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="16.10.127-pre" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="3.10.0-2.21121.14" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducer.cs
@@ -22,13 +22,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             Requires.NotNull(parent, nameof(parent));
             Requires.NotNull(category, nameof(category));
 
-            string categoryName = DebugUtilities.GetDebugCategoryNameOrNull(rule, category) ?? category.Name;
-
             var identity = new EntityIdentity(
                 ((IEntityWithId)parent).Id,
                 new KeyValuePair<string, string>[]
                 {
-                    new(ProjectModelIdentityKeys.CategoryName, categoryName)
+                    new(ProjectModelIdentityKeys.CategoryName, category.Name)
                 });
 
             return CreateCategoryValue(parent.EntityRuntime, identity, rule, category, order, requestedProperties);
@@ -46,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             if (requestedProperties.Name)
             {
-                newCategory.Name = DebugUtilities.GetDebugCategoryNameOrNull(rule, category) ?? category.Name;
+                newCategory.Name = category.Name;
             }
 
             if (requestedProperties.Order)
@@ -59,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             return newCategory;
         }
 
-        public static IEnumerable<IEntityValue> CreateCategoryValues(IEntityValue parent, Rule rule, List<Rule> debugChildRules, ICategoryPropertiesAvailableStatus requestedProperties)
+        public static IEnumerable<IEntityValue> CreateCategoryValues(IEntityValue parent, Rule rule, ICategoryPropertiesAvailableStatus requestedProperties)
         {
             int index = 0;
             foreach (Category category in rule.EvaluatedCategories)
@@ -67,16 +65,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 IEntityValue categoryValue = CreateCategoryValue(parent, rule, category, index, requestedProperties);
                 yield return categoryValue;
                 index++;
-            }
-
-            foreach (Rule childRule in debugChildRules)
-            {
-                foreach (Category category in childRule.EvaluatedCategories)
-                {
-                    IEntityValue categoryValue = CreateCategoryValue(parent, childRule, category, index, requestedProperties);
-                    yield return categoryValue;
-                    index++;
-                }
             }
         }
 
@@ -89,8 +77,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             string categoryName,
             ICategoryPropertiesAvailableStatus requestedProperties)
         {
-            (propertyPageName, categoryName) = DebugUtilities.ConvertDebugPageAndCategoryToRealPageAndCategory(propertyPageName, categoryName);
-
             if (projectService.GetLoadedProject(projectPath) is UnconfiguredProject project
                 && await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
                 && projectCatalog.GetSchema(propertyPageName) is Rule rule)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryFromPropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryFromPropertyPageDataProducer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IEntityValue parent, PropertyPageProviderState providerState)
         {
-            return Task.FromResult(CategoryDataProducer.CreateCategoryValues(parent, providerState.Rule, providerState.DebugChildRules, _properties));
+            return Task.FromResult(CategoryDataProducer.CreateCategoryValues(parent, providerState.Rule, _properties));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/DebugUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/DebugUtilities.cs
@@ -14,69 +14,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     internal static class DebugUtilities
     {
         private const string CommandNameBasedDebuggerPageTemplate = "commandNameBasedDebugger";
-        private const string DebuggerParentPrefix = "#debuggerParent#";
-        private const string DebuggerChildPrefix = "#debuggerChild#";
-
-        public static string ConvertDebugPageNameToRealPageName(string pageName)
-        {
-            if (pageName.StartsWith(DebuggerParentPrefix))
-            {
-                return pageName.Substring(DebuggerParentPrefix.Length);
-            }
-            else
-            {
-                return pageName;
-            }
-        }
-
-        public static string ConvertRealPageNameToDebugPageName(string pageName)
-        {
-            return DebuggerParentPrefix + pageName;
-        }
-
-        public static (string pageName, string categoryName) ConvertDebugPageAndCategoryToRealPageAndCategory(string pageName, string categoryName)
-        {
-            if (categoryName.StartsWith(DebuggerChildPrefix))
-            {
-                categoryName = categoryName.Substring(DebuggerChildPrefix.Length);
-
-                int index = categoryName.IndexOf("#");
-                if (index >= 0)
-                {
-                    pageName = categoryName.Substring(0, index);
-                    categoryName = categoryName.Substring(index + 1);
-                }
-            }
-
-            return (pageName, categoryName);
-        }
-
-        public static string ConvertRealPageAndCategoryToDebugCategory(string pageName, string categoryName)
-        {
-            return DebuggerChildPrefix + pageName + "#" + categoryName;
-        }
-
-        public static (string pageName, string propertyName) ConvertDebugPageAndPropertyToRealPageAndProperty(string pageName, string propertyName)
-        {
-            if (propertyName.StartsWith(DebuggerChildPrefix))
-            {
-                propertyName = propertyName.Substring(DebuggerChildPrefix.Length);
-
-                int index = propertyName.IndexOf("#");
-                if (index >= 0)
-                {
-                    pageName = propertyName.Substring(0, index);
-                    propertyName = propertyName.Substring(index + 1);
-                }
-            }
-
-            return (pageName, propertyName);
-        }
-
-        public static string ConvertRealPageAndPropertyToDebugProperty(string pageName, string propertyName)
-        {
-            return DebuggerChildPrefix + pageName + "#" + propertyName;
-        }
 
         public static IEnumerable<Rule> GetDebugChildRules(IPropertyPagesCatalog projectCatalog)
         {
@@ -89,58 +26,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     yield return possibleChildRule;
                 }
             }
-        }
-
-        public static string? GetDebugCategoryNameOrNull(Rule rule, Category category)
-        {
-            return GetDebugCategoryNameOrNull(rule, category.Name);
-        }
-
-        public static string? GetDebugCategoryNameOrNull(Rule rule, string categoryName)
-        {
-            if (rule.PageTemplate == CommandNameBasedDebuggerPageTemplate)
-            {
-                return ConvertRealPageAndCategoryToDebugCategory(rule.Name, categoryName);
-            }
-
-            return null;
-        }
-
-        public static string? GetDebugPropertyNameOrNull(BaseProperty property)
-        {
-            if (property.ContainingRule.PageTemplate == CommandNameBasedDebuggerPageTemplate)
-            {
-                return ConvertRealPageAndPropertyToDebugProperty(property.ContainingRule.Name, property.Name);
-            }
-
-            return null;
-        }
-
-        public static string? UpdateDebuggerDependsOnMetadata(Rule containingRule, string? dependsOnString)
-        {
-            if (containingRule.PageTemplate == CommandNameBasedDebuggerPageTemplate)
-            {
-                dependsOnString = dependsOnString is not null
-                    ? dependsOnString + ";"
-                    : string.Empty;
-
-                dependsOnString = dependsOnString + "ParentDebugPropertyPage::ActiveLaunchProfile;ParentDebugPropertyPage::LaunchTarget";
-            }
-
-            return dependsOnString;
-        }
-
-        public static string? UpdateDebuggerVisibilityConditionMetadata(string? visibilityCondition, Rule rule)
-        {
-            if (rule.PageTemplate == CommandNameBasedDebuggerPageTemplate)
-            {
-                var commandNameCondition = $"(eq (evaluated \"ParentDebugPropertyPage\" \"LaunchTarget\") \"{rule.Name}\")";
-                visibilityCondition = visibilityCondition is not null
-                    ? $"(and {visibilityCondition} {commandNameCondition})"
-                    : commandNameCondition;
-            }
-
-            return visibilityCondition;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileCategoryDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileCategoryDataProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
@@ -16,28 +15,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// cref="ICategory"/>).
     /// </summary>
     /// <remarks>
-    /// Responsible for populating <see cref="IPropertyPage.Categories"/>. Can also retrieve a <see cref="ICategory"/>
-    /// based on its ID.
-    /// Note this is almost identical to the <see cref="LaunchProfileCategoryDataProvider"/>; the only reason we have
-    /// both is that <see cref="RelationshipQueryDataProviderAttribute"/> cannot be applied multiple times to the same
-    /// type, so we can't have one type that handles multiple relationships.
+    /// Responsible for populating <see cref="ILaunchProfile.Categories"/>.
+    /// Note this is almost identical to the <see cref="CategoryDataProvider"/>; the only reason we have both is that
+    /// <see cref="RelationshipQueryDataProviderAttribute"/> cannot be applied multiple times to the same type, so we
+    /// can't have one type that handles multiple relationships.
     /// </remarks>
     [QueryDataProvider(CategoryType.TypeName, ProjectModel.ModelName)]
-    [RelationshipQueryDataProvider(PropertyPageType.TypeName, PropertyPageType.CategoriesPropertyName)]
+    [RelationshipQueryDataProvider(LaunchProfileType.TypeName, LaunchProfileType.CategoriesPropertyName)]
     [QueryDataProviderZone(ProjectModelZones.Cps)]
-    [Export(typeof(IQueryByIdDataProvider))]
     [Export(typeof(IQueryByRelationshipDataProvider))]
-    internal class CategoryDataProvider : QueryDataProviderBase, IQueryByIdDataProvider, IQueryByRelationshipDataProvider
+    internal class LaunchProfileCategoryDataProvider : QueryDataProviderBase, IQueryByRelationshipDataProvider
     {
         [ImportingConstructor]
-        public CategoryDataProvider(IProjectServiceAccessor projectServiceAccessor)
+        public LaunchProfileCategoryDataProvider(IProjectServiceAccessor projectServiceAccessor)
             : base(projectServiceAccessor)
         {
-        }
-
-        public IQueryDataProducer<IReadOnlyCollection<EntityIdentity>, IEntityValue> CreateQueryDataSource(IPropertiesAvailableStatus properties)
-        {
-            return new CategoryByIdDataProducer((ICategoryPropertiesAvailableStatus)properties, ProjectService);
         }
 
         IQueryDataProducer<IEntityValue, IEntityValue> IQueryByRelationshipDataProvider.CreateQueryDataSource(IPropertiesAvailableStatus properties)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileDataProvider.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Metadata;
+using Microsoft.VisualStudio.ProjectSystem.Query.Providers;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
+{
+    /// <summary>
+    /// Creates <see cref="IQueryDataProducer{TRequest, TResult}"/> instances that retrieve launch profile information
+    /// (see <see cref="ILaunchProfile"/>) for a project.
+    /// </summary>
+    /// <remarks>
+    /// Responsible for populating <see cref="IProject.LaunchProfiles"/>.
+    /// </remarks>
+    [QueryDataProvider(LaunchProfileType.TypeName, ProjectModel.ModelName)]
+    [RelationshipQueryDataProvider(ProjectSystem.Query.ProjectModel.Metadata.ProjectType.TypeName, ProjectSystem.Query.ProjectModel.Metadata.ProjectType.LaunchProfilesPropertyName)]
+    [QueryDataProviderZone(ProjectModelZones.Cps)]
+    [Export(typeof(IQueryByRelationshipDataProvider))]
+    internal class LaunchProfileDataProvider : QueryDataProviderBase, IQueryByRelationshipDataProvider
+    {
+        private readonly IPropertyPageQueryCacheProvider _queryCacheProvider;
+
+        [ImportingConstructor]
+        public LaunchProfileDataProvider(
+            IProjectServiceAccessor projectServiceAccessor,
+            IPropertyPageQueryCacheProvider queryCacheProvider)
+            : base(projectServiceAccessor)
+        {
+            _queryCacheProvider = queryCacheProvider;
+        }
+
+        IQueryDataProducer<IEntityValue, IEntityValue> IQueryByRelationshipDataProvider.CreateQueryDataSource(IPropertiesAvailableStatus properties)
+        {
+            return new LaunchProfileFromProjectDataProducer((ILaunchProfilePropertiesAvailableStatus)properties, _queryCacheProvider);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileFromProjectDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileFromProjectDataProducer.cs
@@ -1,0 +1,119 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
+{
+    internal class LaunchProfileFromProjectDataProducer : QueryDataFromProviderStateProducerBase<UnconfiguredProject>
+    {
+        private readonly ILaunchProfilePropertiesAvailableStatus _properties;
+        private readonly IPropertyPageQueryCacheProvider _queryCacheProvider;
+
+        public LaunchProfileFromProjectDataProducer(ILaunchProfilePropertiesAvailableStatus properties, IPropertyPageQueryCacheProvider queryCacheProvider)
+        {
+            _properties = properties;
+            _queryCacheProvider = queryCacheProvider;
+        }
+
+        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IEntityValue parent, UnconfiguredProject providerState)
+        {
+            return CreateLaunchProfileValuesAsync(parent, providerState);
+        }
+
+        private async Task<IEnumerable<IEntityValue>> CreateLaunchProfileValuesAsync(IEntityValue parent, UnconfiguredProject project)
+        {
+            if (project.Services.ExportProvider.GetExportedValueOrDefault<ILaunchSettingsProvider>() is ILaunchSettingsProvider launchSettingsProvider
+                && await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
+                && await launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite) is ILaunchSettings launchSettings)
+            {
+                return createLaunchProfileValues();
+            }
+
+            return Enumerable.Empty<IEntityValue>();
+
+            IEnumerable<IEntityValue> createLaunchProfileValues()
+            {
+                IPropertyPageQueryCache propertyPageQueryCache = _queryCacheProvider.CreateCache(project);
+
+                Dictionary<string, Rule> debugRules = new();
+                foreach (Rule rule in DebugUtilities.GetDebugChildRules(projectCatalog))
+                {
+                    if (rule.Metadata.TryGetValue("CommandName", out object? commandNameObj)
+                        && commandNameObj is string commandName)
+                    {
+                        debugRules[commandName] = rule;
+                    }
+                }
+
+                foreach ((int index, ProjectSystem.Debug.ILaunchProfile profile) in launchSettings.Profiles.WithIndices())
+                {
+                    if (!Strings.IsNullOrEmpty(profile.Name)
+                        && !Strings.IsNullOrEmpty(profile.CommandName)
+                        && debugRules.TryGetValue(profile.CommandName, out Rule rule))
+                    {
+                        QueryProjectPropertiesContext context = new(
+                            isProjectFile: true,
+                            file: project.FullPath,
+                            itemType: LaunchProfilesProjectItemProvider.ItemType,
+                            itemName: profile.Name);
+
+                        IEntityValue launchProfileValue = CreateLaunchProfileValue(parent, context, rule, index, propertyPageQueryCache);
+                        yield return launchProfileValue;
+                    }
+                }
+            }
+        }
+
+        private IEntityValue CreateLaunchProfileValue(IEntityValue parent, QueryProjectPropertiesContext context, Rule rule, int order, IPropertyPageQueryCache propertyPageQueryCache)
+        {
+            EntityIdentity identity = new(
+                ((IEntityWithId)parent).Id,
+                new Dictionary<string, string>
+                {
+                    { ProjectModelIdentityKeys.SourceItemType, context.ItemType! },
+                    { ProjectModelIdentityKeys.SourceItemName, context.ItemName! }
+                });
+
+            return CreateLaunchProfileValue(parent.EntityRuntime, identity, context, rule, order, propertyPageQueryCache);
+        }
+
+        private IEntityValue CreateLaunchProfileValue(IEntityRuntimeModel runtimeModel, EntityIdentity id, QueryProjectPropertiesContext context, Rule rule, int order, IPropertyPageQueryCache cache)
+        {
+            LaunchProfileValue newLaunchProfile = new(runtimeModel, id, new LaunchProfilePropertiesAvailableStatus());
+
+            if (_properties.Name)
+            {
+                newLaunchProfile.Name = context.ItemType;
+            }
+
+            if (_properties.CommandName)
+            {
+                if (rule.Metadata.TryGetValue("CommandName", out object? commandNameObj)
+                    && commandNameObj is string commandName)
+                {
+                    newLaunchProfile.CommandName = commandName;
+                }
+            }
+
+            if (_properties.Order)
+            {
+                newLaunchProfile.Order = order;
+            }
+
+            ((IEntityValueFromProvider)newLaunchProfile).ProviderState = new PropertyPageProviderState(cache, context, rule);
+
+            return newLaunchProfile;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileFromProjectDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileFromProjectDataProducer.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
                         QueryProjectPropertiesContext context = new(
                             isProjectFile: true,
                             file: project.FullPath,
-                            itemType: LaunchProfilesProjectItemProvider.ItemType,
+                            itemType: LaunchProfileProjectItemProvider.ItemType,
                             itemName: profile.Name);
 
                         IEntityValue launchProfileValue = CreateLaunchProfileValue(parent, context, rule, index, propertyPageQueryCache);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileTypeDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileTypeDataProvider.cs
@@ -1,0 +1,141 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Metadata;
+using Microsoft.VisualStudio.ProjectSystem.Query.Providers;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
+{
+    /// <summary>
+    /// Creates <see cref="IQueryDataProducer{TRequest, TResult}"/> instances that retrieve launch profile type information
+    /// (see <see cref="ILaunchProfileType"/>) for a project.
+    /// </summary>
+    /// <remarks>
+    /// Responsible for populating <see cref="IProject.LaunchProfiles"/>.
+    /// </remarks>
+    [QueryDataProvider(LaunchProfileTypeType.TypeName, ProjectModel.ModelName)]
+    [RelationshipQueryDataProvider(ProjectSystem.Query.ProjectModel.Metadata.ProjectType.TypeName, ProjectSystem.Query.ProjectModel.Metadata.ProjectType.LaunchProfileTypesPropertyName)]
+    [QueryDataProviderZone(ProjectModelZones.Cps)]
+    [Export(typeof(IQueryByRelationshipDataProvider))]
+    internal class LaunchProfileTypeDataProvider : QueryDataProviderBase, IQueryByRelationshipDataProvider
+    {
+        [ImportingConstructor]
+        public LaunchProfileTypeDataProvider(
+            IProjectServiceAccessor projectServiceAccessor)
+            : base(projectServiceAccessor)
+        {
+        }
+
+        IQueryDataProducer<IEntityValue, IEntityValue> IQueryByRelationshipDataProvider.CreateQueryDataSource(IPropertiesAvailableStatus properties)
+        {
+            return new LaunchProfileTypeFromProjectDataProducer((ILaunchProfileTypePropertiesAvailableStatus)properties);
+        }
+    }
+
+    internal class LaunchProfileTypeFromProjectDataProducer : QueryDataFromProviderStateProducerBase<UnconfiguredProject>
+    {
+        private readonly ILaunchProfileTypePropertiesAvailableStatus _properties;
+
+        public LaunchProfileTypeFromProjectDataProducer(ILaunchProfileTypePropertiesAvailableStatus properties)
+        {
+            _properties = properties;
+        }
+
+        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IEntityValue parent, UnconfiguredProject providerState)
+        {
+            return CreateLaunchProfileTypeValuesAsync(parent, providerState);
+        }
+
+        private async Task<IEnumerable<IEntityValue>> CreateLaunchProfileTypeValuesAsync(IEntityValue parent, UnconfiguredProject project)
+        {
+            if (await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog)
+            {
+                return createLaunchProfileTypeValues();
+            }
+
+            return Enumerable.Empty<IEntityValue>();
+
+            IEnumerable<IEntityValue> createLaunchProfileTypeValues()
+            {
+                foreach (Rule rule in DebugUtilities.GetDebugChildRules(projectCatalog))
+                {
+                    if (rule.Metadata.TryGetValue("CommandName", out object? commandNameObj)
+                        && commandNameObj is string commandName)
+                    {
+                        IEntityValue launchProfileTypeValue = CreateLaunchProfileTypeValue(parent, commandName, rule);
+                        yield return launchProfileTypeValue;
+                    }
+                }
+            }
+        }
+
+        private IEntityValue CreateLaunchProfileTypeValue(IEntityValue parent, string commandName, Rule rule)
+        {
+            EntityIdentity identity = new(
+                ((IEntityWithId)parent).Id,
+                new Dictionary<string, string>
+                {
+                    { ProjectModelIdentityKeys.LaunchProfileTypeName, commandName }
+                });
+
+            return CreateLaunchProfileTypeValue(parent.EntityRuntime, identity, commandName, rule);
+        }
+
+        private IEntityValue CreateLaunchProfileTypeValue(IEntityRuntimeModel entityRuntime, EntityIdentity identity, string commandName, Rule rule)
+        {
+            LaunchProfileTypeValue newLaunchProfileType = new(entityRuntime, identity, new LaunchProfileTypePropertiesAvailableStatus());
+
+            if (_properties.CommandName)
+            {
+                newLaunchProfileType.CommandName = commandName;
+            }
+
+            if (_properties.DisplayName)
+            {
+                newLaunchProfileType.DisplayName = rule.DisplayName ?? commandName;
+            }
+
+            if (_properties.HelpUrl)
+            {
+                if (rule.Metadata.TryGetValue("HelpUrl", out object? helpUrlObj)
+                            && helpUrlObj is string helpUrlString)
+                {
+                    newLaunchProfileType.HelpUrl = helpUrlString;
+                }
+                else
+                {
+                    newLaunchProfileType.HelpUrl = string.Empty;
+                }
+            }
+
+            if (_properties.ImageMoniker)
+            {
+                if (rule.Metadata.TryGetValue("ImageMonikerGuid", out object? imageMonikerGuidObj)
+                            && imageMonikerGuidObj is Guid imageMonikerGuid
+                            && rule.Metadata.TryGetValue("ImageMonikerId", out object? imageMonikerIdObj)
+                            && imageMonikerIdObj is int imageMonikerId)
+                {
+                    newLaunchProfileType.ImageMoniker = new ImageMoniker { Guid = imageMonikerGuid, Id = imageMonikerId };
+                }
+                else
+                {
+                    newLaunchProfileType.ImageMoniker = KnownMonikers.SettingsGroup;
+                }
+            }
+
+            return newLaunchProfileType;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileUIPropertyDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileUIPropertyDataProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
@@ -16,31 +15,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// <see cref="IUIProperty"/>).
     /// </summary>
     /// <remarks>
-    /// Responsible for populating <see cref="IPropertyPage.Properties"/>. Can also retrieve a <see cref="IUIProperty"/>
-    /// based on its ID.
-    /// Note this is almost identical to the <see cref="LaunchProfileUIPropertyDataProvider"/>; the only reason we have
-    /// both is that <see cref="RelationshipQueryDataProviderAttribute"/> cannot be applied multiple times to the same
-    /// type, so we can't have one type that handles multiple relationships.
+    /// Responsible for populating <see cref="ILaunchProfile.Properties"/>.
+    /// Note this is almost identical to the <see cref="UIPropertyDataProvider"/>; the only reason we have both is that
+    /// <see cref="RelationshipQueryDataProviderAttribute"/> cannot be applied multiple times to the same type, so we
+    /// can't have one type that handles multiple relationships.
     /// </remarks>
     [QueryDataProvider(UIPropertyType.TypeName, ProjectModel.ModelName)]
-    [RelationshipQueryDataProvider(PropertyPageType.TypeName, PropertyPageType.PropertiesPropertyName)]
+    [RelationshipQueryDataProvider(LaunchProfileType.TypeName, LaunchProfileType.PropertiesPropertyName)]
     [QueryDataProviderZone(ProjectModelZones.Cps)]
-    [Export(typeof(IQueryByIdDataProvider))]
     [Export(typeof(IQueryByRelationshipDataProvider))]
-    internal class UIPropertyDataProvider : QueryDataProviderBase, IQueryByIdDataProvider, IQueryByRelationshipDataProvider
+    internal class LaunchProfileUIPropertyDataProvider : QueryDataProviderBase, IQueryByRelationshipDataProvider
     {
-        private readonly IPropertyPageQueryCacheProvider _queryCacheProvider;
-
         [ImportingConstructor]
-        public UIPropertyDataProvider(IProjectServiceAccessor projectServiceAccessor, IPropertyPageQueryCacheProvider queryCacheProvider)
+        public LaunchProfileUIPropertyDataProvider(IProjectServiceAccessor projectServiceAccessor)
             : base(projectServiceAccessor)
         {
-            _queryCacheProvider = queryCacheProvider;
-        }
-
-        public IQueryDataProducer<IReadOnlyCollection<EntityIdentity>, IEntityValue> CreateQueryDataSource(IPropertiesAvailableStatus properties)
-        {
-            return new UIPropertyByIdProducer((IUIPropertyPropertiesAvailableStatus)properties, ProjectService, _queryCacheProvider);
         }
 
         IQueryDataProducer<IEntityValue, IEntityValue> IQueryByRelationshipDataProvider.CreateQueryDataSource(IPropertiesAvailableStatus properties)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUIPropertyValueActionCore.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUIPropertyValueActionCore.cs
@@ -43,8 +43,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             IEnumerable<(string dimension, string value)> dimensions,
             Func<IProperty, Task> setValueAsync)
         {
-            (pageName, propertyName) = DebugUtilities.ConvertDebugPageAndPropertyToRealPageAndProperty(pageName, propertyName);
-
             _queryCacheProvider = queryCacheProvider;
             _pageName = pageName;
             _propertyName = propertyName;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageProviderState.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageProviderState.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System.Collections.Generic;
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
 
@@ -13,21 +12,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     internal sealed class PropertyPageProviderState
     {
         public PropertyPageProviderState(IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, Rule rule)
-            : this(cache, context, rule, new List<Rule>(capacity: 0))
-        {
-        }
-
-        public PropertyPageProviderState(IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, Rule rule, List<Rule> debugChildRules)
         {
             Cache = cache;
             Context = context;
             Rule = rule;
-            DebugChildRules = debugChildRules;
         }
 
         public IPropertyPageQueryCache Cache { get; }
         public QueryProjectPropertiesContext Context { get; }
         public Rule Rule { get; }
-        public List<Rule> DebugChildRules { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromPropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromPropertyPageDataProducer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IEntityValue parent, PropertyPageProviderState providerState)
         {
-            return Task.FromResult(UIPropertyDataProducer.CreateUIPropertyValues(parent, providerState.Cache, providerState.Context, providerState.Rule, providerState.DebugChildRules, _properties));
+            return Task.FromResult(UIPropertyDataProducer.CreateUIPropertyValues(parent, providerState.Cache, providerState.Context, providerState.Rule, _properties));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProjectItemProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProjectItemProvider.cs
@@ -30,9 +30,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     /// </para>
     /// </remarks>
     [Export(typeof(IProjectItemProvider))]
-    [ExportMetadata("Name", "LaunchProfiles")]
+    [ExportMetadata("Name", "LaunchProfile")]
     [AppliesTo(ProjectCapability.LaunchProfiles)]
-    internal class LaunchProfilesProjectItemProvider : IProjectItemProvider
+    internal class LaunchProfileProjectItemProvider : IProjectItemProvider
     {
         /// <remarks>
         /// <para>
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 #pragma warning restore CS0067
 
         [ImportingConstructor]
-        public LaunchProfilesProjectItemProvider(UnconfiguredProject project, ILaunchSettingsProvider launchSettingsProvider)
+        public LaunchProfileProjectItemProvider(UnconfiguredProject project, ILaunchSettingsProvider launchSettingsProvider)
         {
             _project = project;
             _launchSettingsProvider = launchSettingsProvider;
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             if (!StringComparers.ItemTypes.Equals(itemType, ItemType))
             {
-                throw new ArgumentException($"The {nameof(LaunchProfilesProjectItemProvider)} does not handle the '{itemType}' item type.");
+                throw new ArgumentException($"The {nameof(LaunchProfileProjectItemProvider)} does not handle the '{itemType}' item type.");
             }
 
             WritableLaunchProfile newLaunchProfile = new() { Name = include };
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </remarks>
         public Task<IProjectItem> AddAsync(string path)
         {
-            throw new InvalidOperationException($"The {nameof(LaunchProfilesProjectItemProvider)} does not support adding items as paths.");
+            throw new InvalidOperationException($"The {nameof(LaunchProfileProjectItemProvider)} does not support adding items as paths.");
         }
 
         /// <remarks>
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </remarks>
         public Task<IReadOnlyList<IProjectItem>> AddAsync(IEnumerable<string> paths)
         {
-            throw new InvalidOperationException($"The {nameof(LaunchProfilesProjectItemProvider)} does not support adding items as paths.");
+            throw new InvalidOperationException($"The {nameof(LaunchProfileProjectItemProvider)} does not support adding items as paths.");
         }
 
         public async Task<IProjectItem?> FindItemByNameAsync(string evaluatedInclude)
@@ -246,7 +246,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </remarks>
         public Task SetUnevaluatedIncludesAsync(IReadOnlyCollection<KeyValuePair<IProjectItem, string>> renames)
         {
-            throw new InvalidOperationException($"The {nameof(LaunchProfilesProjectItemProvider)} does not support renaming items.");
+            throw new InvalidOperationException($"The {nameof(LaunchProfileProjectItemProvider)} does not support renaming items.");
         }
 
         /// <summary>
@@ -256,9 +256,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             private readonly string _name;
             private readonly string _projectFilePath;
-            private readonly LaunchProfilesProjectItemProvider _provider;
+            private readonly LaunchProfileProjectItemProvider _provider;
 
-            public ProjectItem(string name, string projectFilePath, LaunchProfilesProjectItemProvider provider)
+            public ProjectItem(string name, string projectFilePath, LaunchProfileProjectItemProvider provider)
             {
                 _name = name;
                 _projectFilePath = projectFilePath;
@@ -267,7 +267,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 PropertiesContext = new ProjectPropertiesContext(name, projectFilePath);
             }
 
-            public string ItemType => LaunchProfilesProjectItemProvider.ItemType;
+            public string ItemType => LaunchProfileProjectItemProvider.ItemType;
 
             /// <remarks>
             /// Launch profiles have no concept of evaluation, so the evaluated and unevaluated
@@ -303,13 +303,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             }
 
             /// <remarks>
-            /// The <see cref="LaunchProfilesProjectItemProvider"/> only supports one item type and
+            /// The <see cref="LaunchProfileProjectItemProvider"/> only supports one item type and
             /// there is no meaningful "conversion" to other item types, so we don't allow this
             /// operation.
             /// </remarks>
             public Task SetItemTypeAsync(string value)
             {
-                throw new InvalidOperationException($"The {nameof(LaunchProfilesProjectItemProvider)} does not support changing item types.");
+                throw new InvalidOperationException($"The {nameof(LaunchProfileProjectItemProvider)} does not support changing item types.");
             }
 
             /// <remarks>
@@ -317,7 +317,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             /// </remarks>
             public Task SetUnevaluatedIncludeAsync(string value)
             {
-                throw new InvalidOperationException($"The {nameof(LaunchProfilesProjectItemProvider)} does not support renaming items.");
+                throw new InvalidOperationException($"The {nameof(LaunchProfileProjectItemProvider)} does not support renaming items.");
             }
 
             /// <summary>
@@ -348,7 +348,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 /// </remarks>
                 public string File => _projectFilePath;
 
-                public string? ItemType => LaunchProfilesProjectItemProvider.ItemType;
+                public string? ItemType => LaunchProfileProjectItemProvider.ItemType;
 
                 public string? ItemName => _name;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProjectPropertiesProvider.cs
@@ -12,11 +12,11 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
-    [Export("LaunchProfiles", typeof(IProjectPropertiesProvider))]
+    [Export("LaunchProfile", typeof(IProjectPropertiesProvider))]
     [Export(typeof(IProjectPropertiesProvider))]
-    [ExportMetadata("Name", "LaunchProfiles")]
+    [ExportMetadata("Name", "LaunchProfile")]
     [AppliesTo(ProjectCapability.LaunchProfiles)]
-    internal class LaunchProfilesProjectPropertiesProvider : IProjectPropertiesProvider
+    internal class LaunchProfileProjectPropertiesProvider : IProjectPropertiesProvider
     {
         private const string CommandNamePropertyName = "CommandName";
         private const string ExecutablePathPropertyName = "ExecutablePath";
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         private readonly ILaunchSettingsProvider _launchSettingsProvider;
 
         [ImportingConstructor]
-        public LaunchProfilesProjectPropertiesProvider(UnconfiguredProject project,
+        public LaunchProfileProjectPropertiesProvider(UnconfiguredProject project,
             ILaunchSettingsProvider launchSettingsProvider)
         {
             _project = project;
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             if (item is null
                 || (itemType is not null
-                    && itemType != LaunchProfilesProjectItemProvider.ItemType)
+                    && itemType != LaunchProfileProjectItemProvider.ItemType)
                 || !StringComparers.Paths.Equals(_project.FullPath, file))
             {
                 // The interface is CPS currently asserts that the Get*Properties methods return a
@@ -194,9 +194,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         private class LaunchProfileProperties : IProjectProperties
         {
             private readonly LaunchProfilePropertiesContext _context;
-            private readonly LaunchProfilesProjectPropertiesProvider _provider;
+            private readonly LaunchProfileProjectPropertiesProvider _provider;
 
-            public LaunchProfileProperties(string filePath, string profileName, LaunchProfilesProjectPropertiesProvider provider)
+            public LaunchProfileProperties(string filePath, string profileName, LaunchProfileProjectPropertiesProvider provider)
             {
                 _context = new LaunchProfilePropertiesContext(filePath, profileName);
                 _provider = provider;
@@ -260,7 +260,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
                 public string File { get; }
 
-                public string ItemType => LaunchProfilesProjectItemProvider.ItemType;
+                public string ItemType => LaunchProfileProjectItemProvider.ItemType;
 
                 public string ItemName { get; }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProvider.cs
@@ -1,7 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Threading;
 
@@ -13,12 +18,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     [AppliesTo(ProjectCapability.LaunchProfiles)]
     internal class LaunchProfilesProjectPropertiesProvider : IProjectPropertiesProvider
     {
+        /// <remarks>
+        /// These correspond to the properties explicitly declared on <see cref="ILaunchProfile"/>
+        /// and as such they are always considered to exist on the profile, though they may
+        /// not have a value.
+        /// </remarks>
+        private static readonly string[] s_standardPropertyNames = new[]
+        {
+            "CommandName",
+            "ExecutablePath",
+            "CommandLineArgs",
+            "WorkingDirectory",
+            "LaunchBrowser",
+            "LaunchUrl",
+            "EnvironmentVariables"
+        };
+
         private readonly UnconfiguredProject _project;
+        private readonly ILaunchSettingsProvider _launchSettingsProvider;
 
         [ImportingConstructor]
-        public LaunchProfilesProjectPropertiesProvider(UnconfiguredProject project)
+        public LaunchProfilesProjectPropertiesProvider(UnconfiguredProject project,
+            ILaunchSettingsProvider launchSettingsProvider)
         {
             _project = project;
+            _launchSettingsProvider = launchSettingsProvider;
         }
 
         /// <remarks>
@@ -76,7 +100,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             if (item is null
                 || (itemType is not null
-                    && itemType != LaunchProfilesProjectItemProvider.ItemType))
+                    && itemType != LaunchProfilesProjectItemProvider.ItemType)
+                || !StringComparers.Paths.Equals(_project.FullPath, file))
             {
                 // The interface is CPS currently asserts that the Get*Properties methods return a
                 // non-null value, but this is incorrect--in practice the implementations do return
@@ -84,7 +109,153 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 return null!;
             }
 
-            throw new NotImplementedException();
+            return new LaunchProfileProperties(file, item, this);
+        }
+
+        /// <remarks>
+        /// If the profile exists we return all the standard property names (as they are
+        /// always considered defined) plus all of the defined properties supported by
+        /// extenders.
+        /// </remarks>
+        private async Task<IEnumerable<string>> GetPropertyNamesAsync(string profileName)
+        {
+            ILaunchSettings? snapshot = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            Assumes.NotNull(snapshot);
+
+            ILaunchProfile? profile = snapshot.Profiles.FirstOrDefault(p => StringComparers.LaunchProfileNames.Equals(p.Name, profileName));
+            if (profile is null)
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            return s_standardPropertyNames;
+
+            // TODO: Handle property names supported by launch profile extenders.
+        }
+
+        private async Task<string> GetEvaluatedPropertyValueAsync(string itemName, string propertyName)
+        {
+            return await GetUnevaluatedPropertyValueAsync(itemName, propertyName) ?? string.Empty;
+        }
+
+        /// <returns>
+        /// If the profile does not exist, returns <c>null</c>. Otherwise, returns the value
+        /// of the property if the property is not defined, or <c>null</c> otherwise. The
+        /// standard properties are always considered to be defined.
+        /// </returns>
+        private async Task<string?> GetUnevaluatedPropertyValueAsync(string profileName, string propertyName)
+        {
+            ILaunchSettings? snapshot = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            Assumes.NotNull(snapshot);
+
+            ILaunchProfile? profile = snapshot.Profiles.FirstOrDefault(p => StringComparers.LaunchProfileNames.Equals(p.Name, profileName));
+            if (profile is null)
+            {
+                return null;
+            }
+
+            return propertyName switch
+            {
+                "CommandName" => profile.CommandName ?? string.Empty,
+                "ExecutablePath" => profile.ExecutablePath ?? string.Empty,
+                "CommandLineArgs" => profile.CommandLineArgs ?? string.Empty,
+                "WorkingDirectory" => profile.WorkingDirectory ?? string.Empty,
+                "LaunchBrowser" => profile.LaunchBrowser ? "true" : "false",
+                "LaunchUrl" => profile.LaunchUrl ?? string.Empty,
+                "EnvironmentVariables" => ConvertDictionaryToString(profile.EnvironmentVariables) ?? string.Empty,
+                _ => null
+                // TODO: Handle properties supported by launch profile extenders.
+            };
+        }
+
+        private static string? ConvertDictionaryToString(ImmutableDictionary<string, string>? value)
+        {
+            if (value is null)
+            {
+                return null;
+            }
+
+            return string.Join(",", value.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).Select(kvp => $"{encode(kvp.Key)}={encode(kvp.Value)}"));
+
+            static string encode(string value)
+            {
+                return value.Replace("/", "//").Replace(",", "/,").Replace("=", "/=");
+            }
+        }
+
+        private class LaunchProfileProperties : IProjectProperties
+        {
+            private readonly LaunchProfilePropertiesContext _context;
+            private readonly LaunchProfilesProjectPropertiesProvider _provider;
+
+            public LaunchProfileProperties(string filePath, string profileName, LaunchProfilesProjectPropertiesProvider provider)
+            {
+                _context = new LaunchProfilePropertiesContext(filePath, profileName);
+                _provider = provider;
+            }
+
+            public IProjectPropertiesContext Context => _context;
+
+            public string FileFullPath => _context.File;
+
+            public PropertyKind PropertyKind => PropertyKind.ItemGroup;
+
+            public Task DeleteDirectPropertiesAsync()
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task DeletePropertyAsync(string propertyName, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<IEnumerable<string>> GetDirectPropertyNamesAsync()
+            {
+                return GetPropertyNamesAsync();
+            }
+
+            public Task<string> GetEvaluatedPropertyValueAsync(string propertyName)
+            {
+                return _provider.GetEvaluatedPropertyValueAsync(_context.ItemName, propertyName);
+            }
+
+            public Task<IEnumerable<string>> GetPropertyNamesAsync()
+            {
+                return _provider.GetPropertyNamesAsync(_context.ItemName);
+            }
+
+            public Task<string?> GetUnevaluatedPropertyValueAsync(string propertyName)
+            {
+                return _provider.GetUnevaluatedPropertyValueAsync(_context.ItemName, propertyName);
+            }
+
+            public Task<bool> IsValueInheritedAsync(string propertyName)
+            {
+                return TaskResult.False;
+            }
+
+            public Task SetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+            {
+                throw new NotImplementedException();
+            }
+
+            private class LaunchProfilePropertiesContext : IProjectPropertiesContext
+            {
+                public LaunchProfilePropertiesContext(string file, string itemName)
+                {
+                    File = file;
+                    ItemName = itemName;
+                }
+
+                public bool IsProjectFile => true;
+
+                public string File { get; }
+
+                public string ItemType => LaunchProfilesProjectItemProvider.ItemType;
+
+                public string ItemName { get; }
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProvider.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    [Export("LaunchProfiles", typeof(IProjectPropertiesProvider))]
+    [Export(typeof(IProjectPropertiesProvider))]
+    [ExportMetadata("Name", "LaunchProfiles")]
+    [AppliesTo(ProjectCapability.LaunchProfiles)]
+    internal class LaunchProfilesProjectPropertiesProvider : IProjectPropertiesProvider
+    {
+        // Launch profiles are stored in the launchSettings.json file, but the logical
+        // context is the project file.
+        public string DefaultProjectPath => throw new NotImplementedException();
+
+#pragma warning disable CS0067 // Unused events
+        // Currently nothing consumes these, so we don't need to worry about firing them.
+        // This is great, because they are supposed to offer guarantees to the event
+        // handlers about what locks are held--but the launch profiles don't use such
+        // locks.
+        public event AsyncEventHandler<ProjectPropertyChangedEventArgs>? ProjectPropertyChanging;
+        public event AsyncEventHandler<ProjectPropertyChangedEventArgs>? ProjectPropertyChangedOnWriter;
+        public event AsyncEventHandler<ProjectPropertyChangedEventArgs>? ProjectPropertyChanged;
+#pragma warning restore CS0067
+
+        // This should return an empty IProjectProperties--we're going to treat the global
+        // properties in the launch settings as though they belonged to each individual
+        // profile.
+        public IProjectProperties GetCommonProperties()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IProjectProperties GetItemProperties(string? itemType, string? item)
+        {
+            throw new NotImplementedException();
+        }
+
+        // This should also return an empty IProjectProperties--there are no properties that
+        // are defined _to have the same value_ for all launch profiles. There are some properties
+        // that exist on each LaunchProfile, but each one will have different values.
+        public IProjectProperties GetItemTypeProperties(string? itemType)
+        {
+            throw new NotImplementedException();
+        }
+
+        // This should just end up deferring to the other Get*Properties methods.
+        public IProjectProperties GetProperties(string file, string? itemType, string? item)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProvider.cs
@@ -1,7 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Threading;
 
@@ -13,26 +16,53 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     [AppliesTo(ProjectCapability.LaunchProfiles)]
     internal class LaunchProfilesProjectPropertiesProvider : IProjectPropertiesProvider
     {
-        // Launch profiles are stored in the launchSettings.json file, but the logical
-        // context is the project file.
-        public string DefaultProjectPath => throw new NotImplementedException();
+        private readonly UnconfiguredProject _project;
+
+        [ImportingConstructor]
+        public LaunchProfilesProjectPropertiesProvider(UnconfiguredProject project)
+        {
+            _project = project;
+        }
+
+        /// <remarks>
+        /// There is a 1:1 mapping between launchSettings.json and the related project, and
+        /// launch profiles can't come from anywhere else (i.e., there's no equivalent of
+        /// imported .props and .targets files for launch settings). As such, launch profiles
+        /// are stored in the launchSettings.json file, but the logical context is the
+        /// project file.
+        /// </remarks>
+        public string DefaultProjectPath => _project.FullPath;
 
 #pragma warning disable CS0067 // Unused events
         // Currently nothing consumes these, so we don't need to worry about firing them.
-        // This is great, because they are supposed to offer guarantees to the event
+        // This is great because they are supposed to offer guarantees to the event
         // handlers about what locks are held--but the launch profiles don't use such
         // locks.
+        // If in the future we determine that we need to fire these we will either need to
+        // work through the implications on the project locks, or we will need to decide
+        // if we can only fire a subset of these events.
         public event AsyncEventHandler<ProjectPropertyChangedEventArgs>? ProjectPropertyChanging;
         public event AsyncEventHandler<ProjectPropertyChangedEventArgs>? ProjectPropertyChangedOnWriter;
         public event AsyncEventHandler<ProjectPropertyChangedEventArgs>? ProjectPropertyChanged;
 #pragma warning restore CS0067
 
-        // This should return an empty IProjectProperties--we're going to treat the global
-        // properties in the launch settings as though they belonged to each individual
-        // profile.
+        /// <remarks>
+        /// <para>
+        /// There are no "project-level" properties supported by the launch profiles. We
+        /// return an implementation of <see cref="IProjectProperties"/> for the sake of
+        /// completeness but there isn't much the consumer can do with it. We could also
+        /// consider just throwing a <see cref="NotSupportedException"/> for this method,
+        /// but the impact of that isn't clear.
+        /// </para>
+        /// <para>
+        /// Note that the launch settings do support the concept of global properties, but
+        /// we're choosing to expose those as if they were properties on the individual
+        /// launch profiles.
+        /// </para>
+        /// </remarks>
         public IProjectProperties GetCommonProperties()
         {
-            throw new NotImplementedException();
+            return new CommonProperties(_project.FullPath);
         }
 
         public IProjectProperties GetItemProperties(string? itemType, string? item)
@@ -51,7 +81,118 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         // This should just end up deferring to the other Get*Properties methods.
         public IProjectProperties GetProperties(string file, string? itemType, string? item)
         {
+            if (StringComparers.Paths.Equals(file, _project.FullPath)
+                && itemType is null
+                && item is null)
+            {
+                return GetCommonProperties();
+            }
+
             throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// A no-op implementation of <see cref="IProjectProperties"/> to represent the
+        /// (non-existent) project-level launch settings.
+        /// </summary>
+        private class CommonProperties : IProjectProperties
+        {
+            private static readonly Task<IEnumerable<string>> s_emptyNames = Task.FromResult(Enumerable.Empty<string>());
+            
+            public CommonProperties(string fileFullPath)
+            {
+                FileFullPath = fileFullPath;
+                Context = new Context(isProjectFile: true, FileFullPath, itemType: null, itemName: null);
+            }
+
+            public IProjectPropertiesContext Context { get; }
+
+            public string FileFullPath { get; }
+
+            public PropertyKind PropertyKind => PropertyKind.PropertyGroup;
+
+            /// <remarks>
+            /// Throws a <see cref="NotSupportedException"/> as there are no properties we can delete.
+            /// </remarks>
+            public Task DeleteDirectPropertiesAsync()
+            {
+                throw new NotSupportedException();
+            }
+
+            /// <remarks>
+            /// Throws a <see cref="NotSupportedException"/> as there are no properties we can delete.
+            /// </remarks>
+            public Task DeletePropertyAsync(string propertyName, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+            {
+                throw new NotSupportedException();
+            }
+
+            /// <remarks>
+            /// There are no common (that is, project-level) properties for a launch profile.
+            /// </remarks>
+            public Task<IEnumerable<string>> GetDirectPropertyNamesAsync()
+            {
+                return s_emptyNames;
+            }
+
+            /// <remarks>
+            /// Throws a <see cref="NotSupportedException"/> as there are no properties that can provide a value.
+            /// </remarks>
+            public Task<string> GetEvaluatedPropertyValueAsync(string propertyName)
+            {
+                throw new NotSupportedException();
+            }
+
+            /// <remarks>
+            /// There are no common (that is, project-level) properties for a launch profile.
+            /// </remarks>
+            public Task<IEnumerable<string>> GetPropertyNamesAsync()
+            {
+                return s_emptyNames;
+            }
+
+            /// <remarks>
+            /// Throws a <see cref="NotSupportedException"/> as there are no properties that can provide a value.
+            /// </remarks>
+            public Task<string?> GetUnevaluatedPropertyValueAsync(string propertyName)
+            {
+                throw new NotSupportedException();
+            }
+
+            /// <remarks>
+            /// Always returns <c>false</c> as there are no project-level properties for launch profiles.
+            /// </remarks> 
+            public Task<bool> IsValueInheritedAsync(string propertyName)
+            {
+                return TaskResult.False;
+            }
+
+            /// <remarks>
+            /// Throws a <see cref="NotSupportedException"/> as there are no properties for which you can provide a value;
+            /// </remarks>
+            public Task SetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        private class Context : IProjectPropertiesContext
+        {
+            public Context(bool isProjectFile, string file, string? itemType, string? itemName)
+            {
+                IsProjectFile = isProjectFile;
+                File = file;
+                ItemType = itemType;
+                ItemName = itemName;
+            }
+
+            public bool IsProjectFile { get; }
+
+            public string File { get; }
+
+            public string? ItemType { get; }
+
+            public string? ItemName { get; }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProvider.cs
@@ -18,6 +18,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     [AppliesTo(ProjectCapability.LaunchProfiles)]
     internal class LaunchProfilesProjectPropertiesProvider : IProjectPropertiesProvider
     {
+        private const string CommandNamePropertyName = "CommandName";
+        private const string ExecutablePathPropertyName = "ExecutablePath";
+        private const string CommandLineArgumentsPropertyName = "CommandLineArguments";
+        private const string WorkingDirectoryPropertyName = "WorkingDirectory";
+        private const string LaunchBrowserPropertyName = "LaunchBrowser";
+        private const string LaunchUrlPropertyName = "LaunchUrl";
+        private const string EnvironmentVariablesPropertyName = "EnvironmentVariables";
+
         /// <remarks>
         /// These correspond to the properties explicitly declared on <see cref="ILaunchProfile"/>
         /// and as such they are always considered to exist on the profile, though they may
@@ -25,13 +33,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </remarks>
         private static readonly string[] s_standardPropertyNames = new[]
         {
-            "CommandName",
-            "ExecutablePath",
-            "CommandLineArgs",
-            "WorkingDirectory",
-            "LaunchBrowser",
-            "LaunchUrl",
-            "EnvironmentVariables"
+            CommandNamePropertyName,
+            ExecutablePathPropertyName,
+            CommandLineArgumentsPropertyName,
+            WorkingDirectoryPropertyName,
+            LaunchBrowserPropertyName,
+            LaunchUrlPropertyName,
+            EnvironmentVariablesPropertyName
         };
 
         private readonly UnconfiguredProject _project;
@@ -156,13 +164,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             return propertyName switch
             {
-                "CommandName" => profile.CommandName ?? string.Empty,
-                "ExecutablePath" => profile.ExecutablePath ?? string.Empty,
-                "CommandLineArgs" => profile.CommandLineArgs ?? string.Empty,
-                "WorkingDirectory" => profile.WorkingDirectory ?? string.Empty,
-                "LaunchBrowser" => profile.LaunchBrowser ? "true" : "false",
-                "LaunchUrl" => profile.LaunchUrl ?? string.Empty,
-                "EnvironmentVariables" => ConvertDictionaryToString(profile.EnvironmentVariables) ?? string.Empty,
+                CommandNamePropertyName => profile.CommandName ?? string.Empty,
+                ExecutablePathPropertyName => profile.ExecutablePath ?? string.Empty,
+                CommandLineArgumentsPropertyName => profile.CommandLineArgs ?? string.Empty,
+                WorkingDirectoryPropertyName => profile.WorkingDirectory ?? string.Empty,
+                LaunchBrowserPropertyName => profile.LaunchBrowser ? "true" : "false",
+                LaunchUrlPropertyName => profile.LaunchUrl ?? string.Empty,
+                EnvironmentVariablesPropertyName => ConvertDictionaryToString(profile.EnvironmentVariables) ?? string.Empty,
                 _ => null
                 // TODO: Handle properties supported by launch profile extenders.
             };

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
@@ -10,6 +10,12 @@
 
   <Rule.Metadata>
     <sys:String x:Key="CommandName">Executable</sys:String>
+    
+    <!-- KnownImageIds.ImageCatalogGuid -->
+    <sys:Guid x:Key="ImageMonikerGuid">AE27A6B0-E345-4288-96DF-5EAF394EE369</sys:Guid>
+    
+    <!-- KnownImageIds.SettingsGroup-->
+    <sys:Int32 x:Key="ImageMonikerId">2770</sys:Int32> 
   </Rule.Metadata>
 
   <Rule.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
@@ -19,7 +19,7 @@
   </Rule.Metadata>
 
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFileWithInterception"
+    <DataSource Persistence="LaunchProfiles"
                 HasConfigurationCondition="False" />
   </Rule.DataSource>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
@@ -19,7 +19,7 @@
   </Rule.Metadata>
 
   <Rule.DataSource>
-    <DataSource Persistence="LaunchProfiles"
+    <DataSource Persistence="LaunchProfile"
                 HasConfigurationCondition="False" />
   </Rule.DataSource>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
@@ -10,6 +10,12 @@
 
   <Rule.Metadata>
     <sys:String x:Key="CommandName">Project</sys:String>
+
+    <!-- KnownImageIds.ImageCatalogGuid -->
+    <sys:Guid x:Key="ImageMonikerGuid">AE27A6B0-E345-4288-96DF-5EAF394EE369</sys:Guid>
+
+    <!-- KnownImageIds.SettingsGroup-->
+    <sys:Int32 x:Key="ImageMonikerId">2770</sys:Int32>
   </Rule.Metadata>
 
   <Rule.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
@@ -19,7 +19,7 @@
   </Rule.Metadata>
 
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFileWithInterception"
+    <DataSource Persistence="LaunchProfiles"
                 HasConfigurationCondition="False" />
   </Rule.DataSource>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
@@ -19,7 +19,7 @@
   </Rule.Metadata>
 
   <Rule.DataSource>
-    <DataSource Persistence="LaunchProfiles"
+    <DataSource Persistence="LaunchProfile"
                 HasConfigurationCondition="False" />
   </Rule.DataSource>
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectItemProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectItemProviderTests.cs
@@ -14,13 +14,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [Fact]
         public async Task GetItemTypesAsync_ReturnsLaunchProfile()
         {
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 ILaunchSettingsProviderFactory.Create());
 
             var itemTypes = await itemProvider.GetItemTypesAsync();
 
-            Assert.Single(itemTypes, LaunchProfilesProjectItemProvider.ItemType);
+            Assert.Single(itemTypes, LaunchProfileProjectItemProvider.ItemType);
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new LaunchProfile[0]);
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -45,13 +45,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile.ToLaunchProfile() });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
             var existingItemTypes = await itemProvider.GetExistingItemTypesAsync();
 
-            Assert.Single(existingItemTypes, LaunchProfilesProjectItemProvider.ItemType);
+            Assert.Single(existingItemTypes, LaunchProfileProjectItemProvider.ItemType);
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new LaunchProfile[0]);
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -96,17 +96,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
-            var items = await itemProvider.GetItemsAsync(LaunchProfilesProjectItemProvider.ItemType);
+            var items = await itemProvider.GetItemsAsync(LaunchProfileProjectItemProvider.ItemType);
 
             Assert.Collection(items,
                 item => Assert.Equal("Profile1", item.EvaluatedInclude),
                 item => Assert.Equal("Profile2", item.EvaluatedInclude));
 
-            items = await itemProvider.GetItemsAsync(LaunchProfilesProjectItemProvider.ItemType, "Profile2");
+            items = await itemProvider.GetItemsAsync(LaunchProfileProjectItemProvider.ItemType, "Profile2");
 
             Assert.Collection(items,
                 item => Assert.Equal("Profile2", item.EvaluatedInclude));
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -141,7 +141,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -165,7 +165,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -188,14 +188,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
             var context = new TestProjectPropertiesContext(
                 isProjectFile: true,
                 file: "Foo",
-                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                itemType: LaunchProfileProjectItemProvider.ItemType,
                 itemName: "Profile2");
 
             var item = await itemProvider.GetItemAsync(context);
@@ -218,7 +218,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                     profile3.ToLaunchProfile()
                 });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -226,7 +226,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             {
                 new TestProjectPropertiesContext(true, "Foo", null, "Profile3"),
                 new TestProjectPropertiesContext(true, "Foo", "RandomItemType", "Profile2"),
-                new TestProjectPropertiesContext(true, "Foo", LaunchProfilesProjectItemProvider.ItemType, "Profile1")
+                new TestProjectPropertiesContext(true, "Foo", LaunchProfileProjectItemProvider.ItemType, "Profile1")
             };
 
             var items = await itemProvider.GetItemsAsync(contexts);
@@ -245,7 +245,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -263,7 +263,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -277,7 +277,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create();
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -308,11 +308,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                     return initialProfiles.Add(newProfile!);
                 });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
-            var item = await itemProvider.AddAsync(itemType: LaunchProfilesProjectItemProvider.ItemType, include: "Alpha Profile");
+            var item = await itemProvider.AddAsync(itemType: LaunchProfileProjectItemProvider.ItemType, include: "Alpha Profile");
 
             Assert.Equal(expected: "Alpha Profile", actual: item!.EvaluatedInclude);
             Assert.Equal(expected: "Alpha Profile", actual: item!.UnevaluatedInclude);
@@ -332,16 +332,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                     return initialProfiles.AddRange(newProfiles);
                 });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
             var items = await itemProvider.AddAsync(
                 new Tuple<string, string, IEnumerable<KeyValuePair<string, string>>?>[]
                 {
-                    new(LaunchProfilesProjectItemProvider.ItemType, "Alpha Profile", null),
-                    new(LaunchProfilesProjectItemProvider.ItemType, "Beta Profile", null),
-                    new(LaunchProfilesProjectItemProvider.ItemType, "Gamma Profile", null),
+                    new(LaunchProfileProjectItemProvider.ItemType, "Alpha Profile", null),
+                    new(LaunchProfileProjectItemProvider.ItemType, "Beta Profile", null),
+                    new(LaunchProfileProjectItemProvider.ItemType, "Gamma Profile", null),
 
                 });
 
@@ -355,7 +355,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public async Task WhenAddingAnItemAsAPath_AnInvalidOperationExceptionIsThrown()
         {
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create();
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -369,7 +369,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public async Task WhenAddingItemsAsPaths_AnInvalidOperationExceptionIsThrown()
         {
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create();
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -391,7 +391,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
             var itemToRename = await itemProvider.FindItemByNameAsync("Profile1");
@@ -416,7 +416,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() },
                 removeProfileCallback: name => removedProfileName = name);
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
             
@@ -436,11 +436,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() },
                 removeProfileCallback: name => removedProfileName = name);
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
-            await itemProvider.RemoveAsync(itemType: LaunchProfilesProjectItemProvider.ItemType, include: "Profile1");
+            await itemProvider.RemoveAsync(itemType: LaunchProfileProjectItemProvider.ItemType, include: "Profile1");
 
             Assert.Equal(expected: "Profile1", actual: removedProfileName);
         }
@@ -453,7 +453,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -472,7 +472,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -491,7 +491,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -499,7 +499,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             Assert.NotNull(projectItem);
 
-            Assert.Equal(expected: LaunchProfilesProjectItemProvider.ItemType, actual: projectItem!.ItemType);
+            Assert.Equal(expected: LaunchProfileProjectItemProvider.ItemType, actual: projectItem!.ItemType);
         }
 
         [Fact]
@@ -510,7 +510,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -530,7 +530,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -550,7 +550,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -570,7 +570,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.ImplementFullPath(@"C:\alpha\beta\gamma.csproj"),
                 launchSettingsProvider);
 
@@ -580,7 +580,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.Equal(expected: @"C:\alpha\beta\gamma.csproj", actual: propertiesContext.File);
             Assert.True(propertiesContext.IsProjectFile);
             Assert.Equal(expected: "Profile2", actual: propertiesContext.ItemName);
-            Assert.Equal(expected: LaunchProfilesProjectItemProvider.ItemType, actual: propertiesContext.ItemType);
+            Assert.Equal(expected: LaunchProfileProjectItemProvider.ItemType, actual: propertiesContext.ItemType);
         }
 
         [Fact]
@@ -594,7 +594,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() },
                 removeProfileCallback: name => removedProfileName = name);
 
-            var itemProvider = new LaunchProfilesProjectItemProvider(
+            var itemProvider = new LaunchProfileProjectItemProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProviderTests.cs
@@ -1,0 +1,152 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    public class LaunchProfilesProjectPropertiesProviderTests
+    {
+        [Fact]
+        public void DefaultProjectPath_IsTheProjectPath()
+        {
+            string projectPath = @"C:\alpha\beta\gamma.csproj";
+            var project = UnconfiguredProjectFactory.ImplementFullPath(projectPath);
+
+            var provider = new LaunchProfilesProjectPropertiesProvider(project);
+
+            var defaultProjectPath = provider.DefaultProjectPath;
+            Assert.Equal(expected: projectPath, actual: defaultProjectPath);
+        }
+
+        [Fact]
+        public async Task WhenRetrievingCommonProperties_ThereAreNoPropertyNames()
+        {
+            var project = UnconfiguredProjectFactory.Create();
+            var provider = new LaunchProfilesProjectPropertiesProvider(project);
+
+            var commonProperties = provider.GetCommonProperties();
+
+            var directPropertyNames = await commonProperties.GetDirectPropertyNamesAsync();
+            Assert.Empty(directPropertyNames);
+
+            var propertyNames = await commonProperties.GetPropertyNamesAsync();
+            Assert.Empty(propertyNames);
+        }
+
+        [Fact]
+        public void WhenRetrievingCommonProperties_FileFullPathIsTheProjectPath()
+        {
+            string projectPath = @"C:\alpha\beta\gamma.csproj";
+            var project = UnconfiguredProjectFactory.ImplementFullPath(projectPath);
+
+            var provider = new LaunchProfilesProjectPropertiesProvider(project);
+            var commonProperties = provider.GetCommonProperties();
+
+            var fileFullPath = commonProperties.FileFullPath;
+            Assert.Equal(expected: projectPath, actual: fileFullPath);
+        }
+
+        [Fact]
+        public void WhenRetrievingCommonProperties_PropertyKindIsPropertyGroup()
+        {
+            var project = UnconfiguredProjectFactory.Create();
+
+            var provider = new LaunchProfilesProjectPropertiesProvider(project);
+            var commonProperties = provider.GetCommonProperties();
+
+            var propertyKind = commonProperties.PropertyKind;
+            Assert.Equal(expected: PropertyKind.PropertyGroup, actual: propertyKind);
+        }
+
+        [Fact]
+        public void WhenRetrievingCommonProperties_TheContextRefersToTheProject()
+        {
+            string projectPath = @"C:\alpha\beta\gamma.csproj";
+            var project = UnconfiguredProjectFactory.ImplementFullPath(projectPath);
+
+            var provider = new LaunchProfilesProjectPropertiesProvider(project);
+            var commonProperties = provider.GetCommonProperties();
+            var context = commonProperties.Context;
+
+            Assert.Equal(expected: projectPath, actual: context.File);
+            Assert.True(context.IsProjectFile);
+            Assert.Null(context.ItemName);
+            Assert.Null(context.ItemType);
+        }
+
+        [Fact]
+        public async Task WhenDeletingDirectPropertiesOfCommonProperties_ANotSupportedExceptionIsThrown()
+        {
+            var project = UnconfiguredProjectFactory.Create();
+
+            var provider = new LaunchProfilesProjectPropertiesProvider(project);
+            var commonProperties = provider.GetCommonProperties();
+
+            await Assert.ThrowsAsync<NotSupportedException>(() => commonProperties.DeleteDirectPropertiesAsync());
+        }
+
+        [Fact]
+        public async Task WhenDeletingAPropertyOfTheCommonProperties_ANotSupportedExceptionIsThrown()
+        {
+            var project = UnconfiguredProjectFactory.Create();
+
+            var provider = new LaunchProfilesProjectPropertiesProvider(project);
+            var commonProperties = provider.GetCommonProperties();
+
+            await Assert.ThrowsAsync<NotSupportedException>(() => commonProperties.DeletePropertyAsync("Alpha"));
+        }
+
+        [Fact]
+        public async Task WhenGettingTheValueOfACommonProperty_ANotSupportedExceptionIsThrown()
+        {
+            var project = UnconfiguredProjectFactory.Create();
+
+            var provider = new LaunchProfilesProjectPropertiesProvider(project);
+            var commonProperties = provider.GetCommonProperties();
+
+            await Assert.ThrowsAsync<NotSupportedException>(() => commonProperties.GetEvaluatedPropertyValueAsync("Alpha"));
+            await Assert.ThrowsAsync<NotSupportedException>(() => commonProperties.GetUnevaluatedPropertyValueAsync("Alpha"));
+        }
+
+        [Fact]
+        public async Task WhenCheckingIfACommonPropertyIsInherited_TheResultIsFalse()
+        {
+            var project = UnconfiguredProjectFactory.Create();
+
+            var provider = new LaunchProfilesProjectPropertiesProvider(project);
+            var commonProperties = provider.GetCommonProperties();
+
+            Assert.False(await commonProperties.IsValueInheritedAsync("Alpha"));
+        }
+
+        [Fact]
+        public async Task WhenSettingTheValueOfACommonProperty_ANotSupportedExceptionIsThrown()
+        {
+            var project = UnconfiguredProjectFactory.Create();
+
+            var provider = new LaunchProfilesProjectPropertiesProvider(project);
+            var commonProperties = provider.GetCommonProperties();
+
+            await Assert.ThrowsAsync<NotSupportedException>(() => commonProperties.SetPropertyValueAsync("Alpha", "Value"));
+        }
+
+        [Fact]
+        public void WhenRequestingPropertiesForTheProjectFile_TheCommonPropertiesAreReturned()
+        {
+            string projectPath = @"C:\alpha\beta\gamma.csproj";
+            var project = UnconfiguredProjectFactory.ImplementFullPath(projectPath);
+
+            var provider = new LaunchProfilesProjectPropertiesProvider(project);
+            var properties = provider.GetProperties(file: projectPath, itemType: null, item: null);
+            var context = properties.Context;
+
+            Assert.Equal(expected: projectPath, actual: context.File);
+            Assert.True(context.IsProjectFile);
+            Assert.Null(context.ItemName);
+            Assert.Null(context.ItemType);
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProviderTests.cs
@@ -1,8 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
-using System.Threading.Tasks;
-using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
@@ -22,131 +19,36 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task WhenRetrievingCommonProperties_ThereAreNoPropertyNames()
+        public void WhenRetrievingProjectLevelProperties_NullIsReturned()
         {
             var project = UnconfiguredProjectFactory.Create();
             var provider = new LaunchProfilesProjectPropertiesProvider(project);
 
             var commonProperties = provider.GetCommonProperties();
 
-            var directPropertyNames = await commonProperties.GetDirectPropertyNamesAsync();
-            Assert.Empty(directPropertyNames);
-
-            var propertyNames = await commonProperties.GetPropertyNamesAsync();
-            Assert.Empty(propertyNames);
+            Assert.Null(commonProperties);
         }
 
         [Fact]
-        public void WhenRetrievingCommonProperties_FileFullPathIsTheProjectPath()
-        {
-            string projectPath = @"C:\alpha\beta\gamma.csproj";
-            var project = UnconfiguredProjectFactory.ImplementFullPath(projectPath);
-
-            var provider = new LaunchProfilesProjectPropertiesProvider(project);
-            var commonProperties = provider.GetCommonProperties();
-
-            var fileFullPath = commonProperties.FileFullPath;
-            Assert.Equal(expected: projectPath, actual: fileFullPath);
-        }
-
-        [Fact]
-        public void WhenRetrievingCommonProperties_PropertyKindIsPropertyGroup()
+        public void WhenRetrievingItemTypeProperties_NullIsReturned()
         {
             var project = UnconfiguredProjectFactory.Create();
-
             var provider = new LaunchProfilesProjectPropertiesProvider(project);
-            var commonProperties = provider.GetCommonProperties();
 
-            var propertyKind = commonProperties.PropertyKind;
-            Assert.Equal(expected: PropertyKind.PropertyGroup, actual: propertyKind);
+            var itemTypeProperties = provider.GetItemTypeProperties(LaunchProfilesProjectItemProvider.ItemType);
+
+            Assert.Null(itemTypeProperties);
         }
 
         [Fact]
-        public void WhenRetrievingCommonProperties_TheContextRefersToTheProject()
-        {
-            string projectPath = @"C:\alpha\beta\gamma.csproj";
-            var project = UnconfiguredProjectFactory.ImplementFullPath(projectPath);
-
-            var provider = new LaunchProfilesProjectPropertiesProvider(project);
-            var commonProperties = provider.GetCommonProperties();
-            var context = commonProperties.Context;
-
-            Assert.Equal(expected: projectPath, actual: context.File);
-            Assert.True(context.IsProjectFile);
-            Assert.Null(context.ItemName);
-            Assert.Null(context.ItemType);
-        }
-
-        [Fact]
-        public async Task WhenDeletingDirectPropertiesOfCommonProperties_ANotSupportedExceptionIsThrown()
+        public void WhenRetrievingItemProperties_NullIsReturnedIfTheItemIsNull()
         {
             var project = UnconfiguredProjectFactory.Create();
-
             var provider = new LaunchProfilesProjectPropertiesProvider(project);
-            var commonProperties = provider.GetCommonProperties();
 
-            await Assert.ThrowsAsync<NotSupportedException>(() => commonProperties.DeleteDirectPropertiesAsync());
-        }
+            var itemProperties = provider.GetItemProperties(LaunchProfilesProjectItemProvider.ItemType, item: null);
 
-        [Fact]
-        public async Task WhenDeletingAPropertyOfTheCommonProperties_ANotSupportedExceptionIsThrown()
-        {
-            var project = UnconfiguredProjectFactory.Create();
-
-            var provider = new LaunchProfilesProjectPropertiesProvider(project);
-            var commonProperties = provider.GetCommonProperties();
-
-            await Assert.ThrowsAsync<NotSupportedException>(() => commonProperties.DeletePropertyAsync("Alpha"));
-        }
-
-        [Fact]
-        public async Task WhenGettingTheValueOfACommonProperty_ANotSupportedExceptionIsThrown()
-        {
-            var project = UnconfiguredProjectFactory.Create();
-
-            var provider = new LaunchProfilesProjectPropertiesProvider(project);
-            var commonProperties = provider.GetCommonProperties();
-
-            await Assert.ThrowsAsync<NotSupportedException>(() => commonProperties.GetEvaluatedPropertyValueAsync("Alpha"));
-            await Assert.ThrowsAsync<NotSupportedException>(() => commonProperties.GetUnevaluatedPropertyValueAsync("Alpha"));
-        }
-
-        [Fact]
-        public async Task WhenCheckingIfACommonPropertyIsInherited_TheResultIsFalse()
-        {
-            var project = UnconfiguredProjectFactory.Create();
-
-            var provider = new LaunchProfilesProjectPropertiesProvider(project);
-            var commonProperties = provider.GetCommonProperties();
-
-            Assert.False(await commonProperties.IsValueInheritedAsync("Alpha"));
-        }
-
-        [Fact]
-        public async Task WhenSettingTheValueOfACommonProperty_ANotSupportedExceptionIsThrown()
-        {
-            var project = UnconfiguredProjectFactory.Create();
-
-            var provider = new LaunchProfilesProjectPropertiesProvider(project);
-            var commonProperties = provider.GetCommonProperties();
-
-            await Assert.ThrowsAsync<NotSupportedException>(() => commonProperties.SetPropertyValueAsync("Alpha", "Value"));
-        }
-
-        [Fact]
-        public void WhenRequestingPropertiesForTheProjectFile_TheCommonPropertiesAreReturned()
-        {
-            string projectPath = @"C:\alpha\beta\gamma.csproj";
-            var project = UnconfiguredProjectFactory.ImplementFullPath(projectPath);
-
-            var provider = new LaunchProfilesProjectPropertiesProvider(project);
-            var properties = provider.GetProperties(file: projectPath, itemType: null, item: null);
-            var context = properties.Context;
-
-            Assert.Equal(expected: projectPath, actual: context.File);
-            Assert.True(context.IsProjectFile);
-            Assert.Null(context.ItemName);
-            Assert.Null(context.ItemType);
+            Assert.Null(itemProperties);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProviderTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [Fact]
         public void DefaultProjectPath_IsTheProjectPath()
         {
-            var provider = new LaunchProfilesProjectPropertiesProvider(
+            var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
                 ILaunchSettingsProviderFactory.Create());
 
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public void WhenRetrievingProjectLevelProperties_NullIsReturned()
         {
             var project = UnconfiguredProjectFactory.Create();
-            var provider = new LaunchProfilesProjectPropertiesProvider(
+            var provider = new LaunchProfileProjectPropertiesProvider(
                 project,
                 ILaunchSettingsProviderFactory.Create());
 
@@ -37,11 +37,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public void WhenRetrievingItemTypeProperties_NullIsReturned()
         {
             var project = UnconfiguredProjectFactory.Create();
-            var provider = new LaunchProfilesProjectPropertiesProvider(
+            var provider = new LaunchProfileProjectPropertiesProvider(
                 project,
                 ILaunchSettingsProviderFactory.Create());
 
-            var itemTypeProperties = provider.GetItemTypeProperties(LaunchProfilesProjectItemProvider.ItemType);
+            var itemTypeProperties = provider.GetItemTypeProperties(LaunchProfileProjectItemProvider.ItemType);
 
             Assert.Null(itemTypeProperties);
         }
@@ -50,11 +50,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public void WhenRetrievingItemProperties_NullIsReturnedIfTheItemIsNull()
         {
             var project = UnconfiguredProjectFactory.Create();
-            var provider = new LaunchProfilesProjectPropertiesProvider(
+            var provider = new LaunchProfileProjectPropertiesProvider(
                 project,
                 ILaunchSettingsProviderFactory.Create());
 
-            var itemProperties = provider.GetItemProperties(LaunchProfilesProjectItemProvider.ItemType, item: null);
+            var itemProperties = provider.GetItemProperties(LaunchProfileProjectItemProvider.ItemType, item: null);
 
             Assert.Null(itemProperties);
         }
@@ -62,12 +62,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [Fact]
         public void WhenRetrievingItemProperties_PropertiesAreReturnedIfTheItemTypeMatches()
         {
-            var provider = new LaunchProfilesProjectPropertiesProvider(
+            var provider = new LaunchProfileProjectPropertiesProvider(
                 UnconfiguredProjectFactory.Create(),
                 CreateDefaultTestLaunchSettings());
 
             var properties = provider.GetItemProperties(
-                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                itemType: LaunchProfileProjectItemProvider.ItemType,
                 item: "Profile1");
 
             Assert.NotNull(properties);
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [Fact]
         public void WhenRetrievingItemProperties_PropertiesAreReturnedIfTheItemTypeIsNull()
         {
-            var provider = new LaunchProfilesProjectPropertiesProvider(
+            var provider = new LaunchProfileProjectPropertiesProvider(
                 UnconfiguredProjectFactory.Create(),
                 CreateDefaultTestLaunchSettings());
 
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
 
-            var provider = new LaunchProfilesProjectPropertiesProvider(
+            var provider = new LaunchProfileProjectPropertiesProvider(
                 UnconfiguredProjectFactory.Create(),
                 launchSettingsProvider);
 
@@ -109,13 +109,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [Fact]
         public void WhenRetrievingItemProperties_NullIsReturnedWhenTheFilePathIsNotTheProjectPath()
         {
-            var provider = new LaunchProfilesProjectPropertiesProvider(
+            var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
                 CreateDefaultTestLaunchSettings());
 
             var properties = provider.GetProperties(
                 file: @"C:\sigma\lambda\other.csproj",
-                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                itemType: LaunchProfileProjectItemProvider.ItemType,
                 item: "Profile1");
 
             Assert.Null(properties);
@@ -124,30 +124,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [Fact]
         public void WhenRetrievingItemProperties_TheContextHasTheExpectedValues()
         {
-            var provider = new LaunchProfilesProjectPropertiesProvider(
+            var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
                 CreateDefaultTestLaunchSettings());
 
             var properties = provider.GetItemProperties(
-                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                itemType: LaunchProfileProjectItemProvider.ItemType,
                 item: "Profile1");
             var context = properties.Context;
 
             Assert.Equal(expected: DefaultTestProjectPath, actual: context.File);
             Assert.True(context.IsProjectFile);
             Assert.Equal(expected: "Profile1", actual: context.ItemName);
-            Assert.Equal(expected: LaunchProfilesProjectItemProvider.ItemType, actual: context.ItemType);
+            Assert.Equal(expected: LaunchProfileProjectItemProvider.ItemType, actual: context.ItemType);
         }
 
         [Fact]
         public void WhenRetrievingItemProperties_TheFilePathIsTheProjectPath()
         {
-            var provider = new LaunchProfilesProjectPropertiesProvider(
+            var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
                 CreateDefaultTestLaunchSettings());
 
             var properties = provider.GetItemProperties(
-                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                itemType: LaunchProfileProjectItemProvider.ItemType,
                 item: "Profile1");
 
             Assert.Equal(expected: DefaultTestProjectPath, actual: properties.FileFullPath);
@@ -156,12 +156,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [Fact]
         public void WhenRetrievingItemProperties_ThePropertyKindIsItemGroup()
         {
-            var provider = new LaunchProfilesProjectPropertiesProvider(
+            var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
                 CreateDefaultTestLaunchSettings());
 
             var properties = provider.GetItemProperties(
-                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                itemType: LaunchProfileProjectItemProvider.ItemType,
                 item: "Profile1");
 
             Assert.Equal(expected: PropertyKind.ItemGroup, actual: properties.PropertyKind);
@@ -174,17 +174,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile() });
 
-            var provider = new LaunchProfilesProjectPropertiesProvider(
+            var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
                 launchSettingsProvider);
             var properties = provider.GetItemProperties(
-                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                itemType: LaunchProfileProjectItemProvider.ItemType,
                 item: "Profile1");
             var propertyNames = await properties.GetPropertyNamesAsync();
 
             Assert.Contains("CommandName", propertyNames);
             Assert.Contains("ExecutablePath", propertyNames);
-            Assert.Contains("CommandLineArgs", propertyNames);
+            Assert.Contains("CommandLineArguments", propertyNames);
             Assert.Contains("WorkingDirectory", propertyNames);
             Assert.Contains("LaunchBrowser", propertyNames);
             Assert.Contains("LaunchUrl", propertyNames);
@@ -198,18 +198,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile() });
 
-            var provider = new LaunchProfilesProjectPropertiesProvider(
+            var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
                 launchSettingsProvider);
             var properties = provider.GetItemProperties(
-                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                itemType: LaunchProfileProjectItemProvider.ItemType,
                 item: "Profile1");
 
             var standardPropertyNames = new[]
             {
                 "CommandName",
                 "ExecutablePath",
-                "CommandLineArgs",
+                "CommandLineArguments",
                 "WorkingDirectory",
                 "LaunchUrl",
                 "EnvironmentVariables"
@@ -231,11 +231,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile() });
 
-            var provider = new LaunchProfilesProjectPropertiesProvider(
+            var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
                 launchSettingsProvider);
             var properties = provider.GetItemProperties(
-                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                itemType: LaunchProfileProjectItemProvider.ItemType,
                 item: "Profile1");
 
             var evaluatedValue = await properties.GetEvaluatedPropertyValueAsync("LaunchBrowser");
@@ -261,16 +261,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile() });
-            var provider = new LaunchProfilesProjectPropertiesProvider(
+            var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
                 launchSettingsProvider);
             var properties = provider.GetItemProperties(
-                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                itemType: LaunchProfileProjectItemProvider.ItemType,
                 item: "Profile1");
 
             var expectedValues = new Dictionary<string, string>
             {
-                ["CommandLineArgs"] = "alpha beta gamma",
+                ["CommandLineArguments"] = "alpha beta gamma",
                 ["CommandName"] = "epsilon",
                 ["EnvironmentVariables"] = "One=1,Two=2",
                 ["ExecutablePath"] = @"D:\five\six\seven\eight.exe",

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProviderTests.cs
@@ -1,5 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
@@ -9,20 +12,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [Fact]
         public void DefaultProjectPath_IsTheProjectPath()
         {
-            string projectPath = @"C:\alpha\beta\gamma.csproj";
-            var project = UnconfiguredProjectFactory.ImplementFullPath(projectPath);
-
-            var provider = new LaunchProfilesProjectPropertiesProvider(project);
+            var provider = new LaunchProfilesProjectPropertiesProvider(
+                CreateDefaultTestProject(),
+                ILaunchSettingsProviderFactory.Create());
 
             var defaultProjectPath = provider.DefaultProjectPath;
-            Assert.Equal(expected: projectPath, actual: defaultProjectPath);
+            Assert.Equal(expected: DefaultTestProjectPath, actual: defaultProjectPath);
         }
 
         [Fact]
         public void WhenRetrievingProjectLevelProperties_NullIsReturned()
         {
             var project = UnconfiguredProjectFactory.Create();
-            var provider = new LaunchProfilesProjectPropertiesProvider(project);
+            var provider = new LaunchProfilesProjectPropertiesProvider(
+                project,
+                ILaunchSettingsProviderFactory.Create());
 
             var commonProperties = provider.GetCommonProperties();
 
@@ -33,7 +37,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public void WhenRetrievingItemTypeProperties_NullIsReturned()
         {
             var project = UnconfiguredProjectFactory.Create();
-            var provider = new LaunchProfilesProjectPropertiesProvider(project);
+            var provider = new LaunchProfilesProjectPropertiesProvider(
+                project,
+                ILaunchSettingsProviderFactory.Create());
 
             var itemTypeProperties = provider.GetItemTypeProperties(LaunchProfilesProjectItemProvider.ItemType);
 
@@ -44,11 +50,266 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public void WhenRetrievingItemProperties_NullIsReturnedIfTheItemIsNull()
         {
             var project = UnconfiguredProjectFactory.Create();
-            var provider = new LaunchProfilesProjectPropertiesProvider(project);
+            var provider = new LaunchProfilesProjectPropertiesProvider(
+                project,
+                ILaunchSettingsProviderFactory.Create());
 
             var itemProperties = provider.GetItemProperties(LaunchProfilesProjectItemProvider.ItemType, item: null);
 
             Assert.Null(itemProperties);
         }
+
+        [Fact]
+        public void WhenRetrievingItemProperties_PropertiesAreReturnedIfTheItemTypeMatches()
+        {
+            var provider = new LaunchProfilesProjectPropertiesProvider(
+                UnconfiguredProjectFactory.Create(),
+                CreateDefaultTestLaunchSettings());
+
+            var properties = provider.GetItemProperties(
+                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                item: "Profile1");
+
+            Assert.NotNull(properties);
+        }
+
+        [Fact]
+        public void WhenRetrievingItemProperties_PropertiesAreReturnedIfTheItemTypeIsNull()
+        {
+            var provider = new LaunchProfilesProjectPropertiesProvider(
+                UnconfiguredProjectFactory.Create(),
+                CreateDefaultTestLaunchSettings());
+
+            var properties = provider.GetItemProperties(
+                itemType: null,
+                item: "Profile1");
+
+            Assert.NotNull(properties);
+        }
+
+        [Fact]
+        public void WhenRetrievingItemProperties_NullIsReturnedIfTheItemTypeDoesNotMatch()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+
+            var provider = new LaunchProfilesProjectPropertiesProvider(
+                UnconfiguredProjectFactory.Create(),
+                launchSettingsProvider);
+
+            var properties = provider.GetItemProperties(
+                itemType: "RandomItemType",
+                item: "Profile1");
+
+            Assert.Null(properties);
+        }
+
+        [Fact]
+        public void WhenRetrievingItemProperties_NullIsReturnedWhenTheFilePathIsNotTheProjectPath()
+        {
+            var provider = new LaunchProfilesProjectPropertiesProvider(
+                CreateDefaultTestProject(),
+                CreateDefaultTestLaunchSettings());
+
+            var properties = provider.GetProperties(
+                file: @"C:\sigma\lambda\other.csproj",
+                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                item: "Profile1");
+
+            Assert.Null(properties);
+        }
+
+        [Fact]
+        public void WhenRetrievingItemProperties_TheContextHasTheExpectedValues()
+        {
+            var provider = new LaunchProfilesProjectPropertiesProvider(
+                CreateDefaultTestProject(),
+                CreateDefaultTestLaunchSettings());
+
+            var properties = provider.GetItemProperties(
+                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                item: "Profile1");
+            var context = properties.Context;
+
+            Assert.Equal(expected: DefaultTestProjectPath, actual: context.File);
+            Assert.True(context.IsProjectFile);
+            Assert.Equal(expected: "Profile1", actual: context.ItemName);
+            Assert.Equal(expected: LaunchProfilesProjectItemProvider.ItemType, actual: context.ItemType);
+        }
+
+        [Fact]
+        public void WhenRetrievingItemProperties_TheFilePathIsTheProjectPath()
+        {
+            var provider = new LaunchProfilesProjectPropertiesProvider(
+                CreateDefaultTestProject(),
+                CreateDefaultTestLaunchSettings());
+
+            var properties = provider.GetItemProperties(
+                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                item: "Profile1");
+
+            Assert.Equal(expected: DefaultTestProjectPath, actual: properties.FileFullPath);
+        }
+
+        [Fact]
+        public void WhenRetrievingItemProperties_ThePropertyKindIsItemGroup()
+        {
+            var provider = new LaunchProfilesProjectPropertiesProvider(
+                CreateDefaultTestProject(),
+                CreateDefaultTestLaunchSettings());
+
+            var properties = provider.GetItemProperties(
+                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                item: "Profile1");
+
+            Assert.Equal(expected: PropertyKind.ItemGroup, actual: properties.PropertyKind);
+        }
+
+        [Fact]
+        public async Task WhenRetrievingItemPropertyNames_AllStandardProfilePropertyNamesAreReturnedEvenIfNotDefined()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile() });
+
+            var provider = new LaunchProfilesProjectPropertiesProvider(
+                CreateDefaultTestProject(),
+                launchSettingsProvider);
+            var properties = provider.GetItemProperties(
+                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                item: "Profile1");
+            var propertyNames = await properties.GetPropertyNamesAsync();
+
+            Assert.Contains("CommandName", propertyNames);
+            Assert.Contains("ExecutablePath", propertyNames);
+            Assert.Contains("CommandLineArgs", propertyNames);
+            Assert.Contains("WorkingDirectory", propertyNames);
+            Assert.Contains("LaunchBrowser", propertyNames);
+            Assert.Contains("LaunchUrl", propertyNames);
+            Assert.Contains("EnvironmentVariables", propertyNames);
+        }
+
+        [Fact]
+        public async Task WhenRetrievingStandardPropertyValues_TheEmptyStringIsReturnedForUndefinedProperties()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile() });
+
+            var provider = new LaunchProfilesProjectPropertiesProvider(
+                CreateDefaultTestProject(),
+                launchSettingsProvider);
+            var properties = provider.GetItemProperties(
+                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                item: "Profile1");
+
+            var standardPropertyNames = new[]
+            {
+                "CommandName",
+                "ExecutablePath",
+                "CommandLineArgs",
+                "WorkingDirectory",
+                "LaunchUrl",
+                "EnvironmentVariables"
+            };
+
+            foreach (var standardPropertyName in standardPropertyNames)
+            {
+                var evaluatedValue = await properties.GetEvaluatedPropertyValueAsync(standardPropertyName);
+                Assert.Equal(expected: string.Empty, actual: evaluatedValue);
+                var unevaluatedValue = await properties.GetUnevaluatedPropertyValueAsync(standardPropertyName);
+                Assert.Equal(expected: string.Empty, actual: unevaluatedValue);
+            }
+        }
+
+        [Fact]
+        public async Task WhenRetrievingTheLaunchBrowserValue_TheDefaultValueIsFalse()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile() });
+
+            var provider = new LaunchProfilesProjectPropertiesProvider(
+                CreateDefaultTestProject(),
+                launchSettingsProvider);
+            var properties = provider.GetItemProperties(
+                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                item: "Profile1");
+
+            var evaluatedValue = await properties.GetEvaluatedPropertyValueAsync("LaunchBrowser");
+            Assert.Equal(expected: "false", actual: evaluatedValue);
+            var unevaluatedValue = await properties.GetUnevaluatedPropertyValueAsync("LaunchBrowser");
+            Assert.Equal(expected: "false", actual: unevaluatedValue);
+        }
+
+        [Fact]
+        public async Task WhenRetrievingStandardPropertyValues_TheExpectedValuesAreReturned()
+        {
+            var profile1 = new WritableLaunchProfile
+            {
+                Name = "Profile1",
+                CommandLineArgs = "alpha beta gamma",
+                CommandName = "epsilon",
+                EnvironmentVariables = { ["One"] = "1", ["Two"] = "2" },
+                ExecutablePath = @"D:\five\six\seven\eight.exe",
+                LaunchBrowser = true,
+                LaunchUrl = "https://localhost/profile",
+                WorkingDirectory = @"C:\users\other\temp"
+            };
+
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile() });
+            var provider = new LaunchProfilesProjectPropertiesProvider(
+                CreateDefaultTestProject(),
+                launchSettingsProvider);
+            var properties = provider.GetItemProperties(
+                itemType: LaunchProfilesProjectItemProvider.ItemType,
+                item: "Profile1");
+
+            var expectedValues = new Dictionary<string, string>
+            {
+                ["CommandLineArgs"] = "alpha beta gamma",
+                ["CommandName"] = "epsilon",
+                ["EnvironmentVariables"] = "One=1,Two=2",
+                ["ExecutablePath"] = @"D:\five\six\seven\eight.exe",
+                ["LaunchBrowser"] = "true",
+                ["LaunchUrl"] = "https://localhost/profile",
+                ["WorkingDirectory"] = @"C:\users\other\temp",
+            };
+
+            foreach (var (propertyName, expectedPropertyValue) in expectedValues)
+            {
+                var actualUnevaluatedValue = await properties.GetUnevaluatedPropertyValueAsync(propertyName);
+                var actualEvaluatedValue = await properties.GetEvaluatedPropertyValueAsync(propertyName);
+                Assert.Equal(expectedPropertyValue, actualUnevaluatedValue);
+                Assert.Equal(expectedPropertyValue, actualEvaluatedValue);
+            }
+        }
+
+        /// <summary>
+        /// Creates an <see cref="UnconfiguredProject"/> where the <see cref="UnconfiguredProject.FullPath"/>
+        /// is set to <see cref="DefaultTestProjectPath"/>.
+        /// </summary>
+        private static UnconfiguredProject CreateDefaultTestProject()
+        {
+            return UnconfiguredProjectFactory.ImplementFullPath(DefaultTestProjectPath);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="ILaunchSettingsProvider"/> with two empty profiles named
+        /// "Profile1" and "Profile2".
+        /// </summary>
+        private static ILaunchSettingsProvider CreateDefaultTestLaunchSettings()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+            return launchSettingsProvider;
+        }
+
+        private const string DefaultTestProjectPath = @"C:\alpha\beta\gamma.csproj";
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
@@ -84,7 +83,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 }
             };
 
-            var result = CategoryDataProducer.CreateCategoryValues(parentEntity, rule, new List<Rule>(), properties);
+            var result = CategoryDataProducer.CreateCategoryValues(parentEntity, rule, properties);
 
             Assert.Collection(result, new Action<IEntityValue>[]
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducerTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System.Collections.Generic;
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
@@ -20,7 +19,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 IPropertyPageQueryCacheFactory.Create(),
                 QueryProjectPropertiesContext.ProjectFile,
                 new Rule { Name = "MyRule", DisplayName = "My Rule Display Name", Order = 42, PageTemplate = "generic" },
-                debugChildRules: new List<Rule>(),
                 requestedProperties: properties);
 
             Assert.Equal(expected: "MyRule", actual: propertyPage.Name);
@@ -39,7 +37,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 IPropertyPageQueryCacheFactory.Create(),
                 QueryProjectPropertiesContext.ProjectFile,
                 new Rule { Name = "MyRule", DisplayName = "My Rule Display Name", Order = 42, PageTemplate = "generic" },
-                debugChildRules: new List<Rule>(),
                 requestedProperties: properties);
 
             Assert.IsType<PropertyPageProviderState>(propertyPage.ProviderState);
@@ -55,7 +52,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 IPropertyPageQueryCacheFactory.Create(),
                 QueryProjectPropertiesContext.ProjectFile,
                 new Rule { Name = "MyRule", DisplayName = "My Rule Display Name", Order = 42, PageTemplate = "generic" },
-                debugChildRules: new List<Rule>(),
                 requestedProperties: properties);
 
             Assert.Equal(expected: "MyRule", actual: propertyPage.Id[ProjectModelIdentityKeys.PropertyPageName]);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
@@ -96,9 +96,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 new TestProperty { Name = "Gamma" },
             });
             rule.EndInit();
-            var debugChildRules = new List<Rule>();
 
-            var result = UIPropertyDataProducer.CreateUIPropertyValues(parentEntity, cache, QueryProjectPropertiesContext.ProjectFile, rule, debugChildRules, properties);
+            var result = UIPropertyDataProducer.CreateUIPropertyValues(parentEntity, cache, QueryProjectPropertiesContext.ProjectFile, rule, properties);
 
             Assert.Collection(result, new Action<IEntityValue>[]
             {


### PR DESCRIPTION
Now that the Project Query API has been updated to represent launch profiles, this change implements basic support for querying the launch profiles. This involves the following pieces:

1. Implementing Project Query API data providers that allow us to map from:
    1. A project to a set of "launch profile types"--that is, the different kinds of launch profiles (e.g., Project, Executable, IIS, IISExpress, etc.).
    2. A project to the actual set of launch profiles--that is, the individual profiles in the launchSettings.json file as exposed through the `ILaunchSettingsProvider` interface.
    3. A launch profile to a set of properties
    4. A launch profile to a set of categories (for organizing the properties)
2. Implementing an `IProjectPropertiesProvider` that can expose the launch settings to the properties system.
3. Removing the temporary support we had for exposing the _active_ launch profile as the Debug page of the new project property pages.

## Details

### Launch Profile Types

The most important property of a profile is the _command name_. This controls which component gets to take the active launch profile and turn it into debugger settings. As such, the command name effectively determines which properties in the profile are relevant to debugging, and which ones should be surfaced to the user in the UI and how.

For the Launch Profiles UI, each command name will need to have a corresponding `Rule` defined in a .xaml file. This specifies which properties to expose for a profile utilizing that command, just as we use `Rule`s to define the properties that appear on the project property pages. Metadata on the `Rule` specifies the command name, an `ImageMoniker` to use as an icon, and a URL for further help. Producing the launch profile types is a matter of enumerating these `Rules` and returning objects with this metadata.

### Launch Profiles

Producing Project Query API entities is largely a matter of looping over the set of launch profiles. For each one we verify that we can find the corresponding `Rule` (as described above) and if so we create a `QueryProjectPropertiesContext` representing that launch profile within the properties system. If we can't find the corresponding `Rule` we filter out that profile, as we won't be able to show any UI anyway.

### Properties and Categories

At this point we've reduced the profile to a combination of a `Rule` and a `QueryProjectPropertiesContext`. These are the same concepts used to produce categories and properties for the project property pages, so we can reuse those providers almost as-is. We do need a couple of extra types just to represent the launch-profile-to-category and launch-profile-to-property relationship.

### IProjectPropertiesProvider

The role of an `IProjectPropertiesProvider` is to take a context (such as a `QueryProjectPropertiesContext`) and provide read and write access to that context's properties in a standardized fashion that abstracts away the underlying storage mechanism. Here we implement a provider that wraps the `ILaunchSettingsProvider`, effectively exposing the data on launch profiles to the larger properties system.

When we want to create the properties to return through the Project Query API, the properties system will take the `Rule` we've provided and read the data in its `DataSource.Persistence` property to determine which `IProjectPropertiesProvider` should handle the property access. The _set_ of properties to produce comes from the `Rule`, while the `IProjectPropertiesProvider` is given the context (the `QueryProjectPropertiesContext`) and asked to produce the property _values_ for that context.

### Removing the Debug page

This is essentially a matter of backing out the changes in #6770, which was always meant to be temporary. The code involved mangled the names of properties and categories associated with debugging; this was a useful and necessary hack at the time but is no longer necessary or desirable. This *does* mean that until the new Launch Profiles UI is up and running the only way to edit the debug settings will be through the old property pages, or by editing the launchSettings.json directly.

### Limitations

The implementation here only supports reading properties from launch profiles, not setting them. Also, only the properties directly exposed by `ILaunchProfile` (`ExecutablePath`, `CommandLineArgs`, `WorkingDirectory`, etc.) are exposed. Other properties ultimately get stored in either `ILaunchSettings.GlobalSettings` or `ILaunchProfile.OtherSettings`; defining, reading, and writing these properties will need an extension mechanism of some sort.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7020)