### PR TITLE
Add a link to show the new Launch Profile UI

### DIFF
--- a/docs/repo/property-pages/property-specification.md
+++ b/docs/repo/property-pages/property-specification.md
@@ -226,7 +226,7 @@ The click handler is exported via:
 [ExportMetadata("CommandName", "MyCommandName")]
 internal sealed class MyCommandActionHandler : ILinkActionHandler
 {
-    public void Handle(IReadOnlyDictionary<string, string> editorMetadata)
+    public void Handle(ProjectContext projectContext, IReadOnlyDictionary<string, string> editorMetadata)
     {
         // Handle command invocation
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/OpenLaunchProfilesEditorValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/OpenLaunchProfilesEditorValueProvider.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    [ExportInterceptingPropertyValueProvider("OpenLaunchProfilesEditor", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    internal sealed class OpenLaunchProfilesEditorValueProvider : NoOpInterceptingPropertyValueProvider
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/DebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/DebugPropertyPage.xaml
@@ -17,7 +17,7 @@
 
   <StringProperty Name="DebugPagePlaceholderDescription"
                   DisplayName="Ignored"
-                  Description="The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.">
+                  Description="The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.">
     <StringProperty.ValueEditors>
       <ValueEditor EditorType="Description" />
     </StringProperty.ValueEditors>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/DebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/DebugPropertyPage.xaml
@@ -10,21 +10,28 @@
       xmlns="http://schemas.microsoft.com/build/2009/properties">
 
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile"
+    <DataSource Persistence="ProjectFileWithInterception"
                 SourceOfDefaultValue="AfterContext"
                 HasConfigurationCondition="False" />
   </Rule.DataSource>
 
   <StringProperty Name="DebugPagePlaceholderDescription"
                   DisplayName="Ignored"
-                  Description="The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.">
-    <StringProperty.DataSource>
-      <DataSource PersistedName="DebugPagePlaceholderDescription"
-                  Persistence="ProjectFileWithInterception"
-                  HasConfigurationCondition="False" />
-    </StringProperty.DataSource>
+                  Description="The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.">
     <StringProperty.ValueEditors>
       <ValueEditor EditorType="Description" />
+    </StringProperty.ValueEditors>
+  </StringProperty>
+
+  <StringProperty Name="OpenLaunchProfilesEditor"
+                  DisplayName="Open debug launch profiles UI">
+    <StringProperty.ValueEditors>
+      <ValueEditor EditorType="LinkAction">
+        <ValueEditor.Metadata>
+          <NameValuePair Name="Action" Value="Command" />
+          <NameValuePair Name="Command" Value="OpenLaunchProfilesEditor" />
+        </ValueEditor.Metadata>
+      </ValueEditor>
     </StringProperty.ValueEditors>
   </StringProperty>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.cs.xlf
@@ -13,13 +13,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</source>
-        <target state="new">The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">
         <source>Ignored</source>
         <target state="new">Ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
+        <source>Open debug launch profiles UI</source>
+        <target state="new">Open debug launch profiles UI</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.cs.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
-        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.de.xlf
@@ -13,13 +13,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</source>
-        <target state="new">The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">
         <source>Ignored</source>
         <target state="new">Ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
+        <source>Open debug launch profiles UI</source>
+        <target state="new">Open debug launch profiles UI</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.de.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
-        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.es.xlf
@@ -13,13 +13,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</source>
-        <target state="new">The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">
         <source>Ignored</source>
         <target state="new">Ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
+        <source>Open debug launch profiles UI</source>
+        <target state="new">Open debug launch profiles UI</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.es.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
-        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.fr.xlf
@@ -13,13 +13,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</source>
-        <target state="new">The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">
         <source>Ignored</source>
         <target state="new">Ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
+        <source>Open debug launch profiles UI</source>
+        <target state="new">Open debug launch profiles UI</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.fr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
-        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.it.xlf
@@ -13,13 +13,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</source>
-        <target state="new">The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">
         <source>Ignored</source>
         <target state="new">Ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
+        <source>Open debug launch profiles UI</source>
+        <target state="new">Open debug launch profiles UI</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.it.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
-        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ja.xlf
@@ -13,13 +13,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</source>
-        <target state="new">The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">
         <source>Ignored</source>
         <target state="new">Ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
+        <source>Open debug launch profiles UI</source>
+        <target state="new">Open debug launch profiles UI</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ja.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
-        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ko.xlf
@@ -13,13 +13,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</source>
-        <target state="new">The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">
         <source>Ignored</source>
         <target state="new">Ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
+        <source>Open debug launch profiles UI</source>
+        <target state="new">Open debug launch profiles UI</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ko.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
-        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.pl.xlf
@@ -13,13 +13,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</source>
-        <target state="new">The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">
         <source>Ignored</source>
         <target state="new">Ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
+        <source>Open debug launch profiles UI</source>
+        <target state="new">Open debug launch profiles UI</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.pl.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
-        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.pt-BR.xlf
@@ -13,13 +13,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</source>
-        <target state="new">The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">
         <source>Ignored</source>
         <target state="new">Ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
+        <source>Open debug launch profiles UI</source>
+        <target state="new">Open debug launch profiles UI</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.pt-BR.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
-        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ru.xlf
@@ -13,13 +13,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</source>
-        <target state="new">The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">
         <source>Ignored</source>
         <target state="new">Ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
+        <source>Open debug launch profiles UI</source>
+        <target state="new">Open debug launch profiles UI</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ru.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
-        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.tr.xlf
@@ -13,13 +13,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</source>
-        <target state="new">The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">
         <source>Ignored</source>
         <target state="new">Ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
+        <source>Open debug launch profiles UI</source>
+        <target state="new">Open debug launch profiles UI</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.tr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
-        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.zh-Hans.xlf
@@ -13,13 +13,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</source>
-        <target state="new">The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">
         <source>Ignored</source>
         <target state="new">Ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
+        <source>Open debug launch profiles UI</source>
+        <target state="new">Open debug launch profiles UI</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.zh-Hans.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
-        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.zh-Hant.xlf
@@ -13,13 +13,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</source>
-        <target state="new">The new Project Properties UI is under development, and the ability to edit launch profiles has not yet been completed. Please either edit the launchProfiles.json file manually, or revert to the previous Property Pages as described in the banner at the top of this page. We will be adding this feature very soon.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">
         <source>Ignored</source>
         <target state="new">Ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
+        <source>Open debug launch profiles UI</source>
+        <target state="new">Open debug launch profiles UI</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.zh-Hant.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Description">
-        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</source>
-        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed directly from the Debug menu, or via the Start button the tool bar. Alternatively, click the link below.</target>
+        <source>The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</source>
+        <target state="new">The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|DisplayName">


### PR DESCRIPTION
This PR adds a link action that invokes a command in CPS to show the new Launch Profile UI. The link is displayed on the "Debug" page of the new Project Properties UI.

Sibling CPS PR (Internal): https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/310621



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7023)