### PR TITLE
Hotfix for target framework ordering in property pages

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksProvider.cs
@@ -108,7 +108,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
             {
                 EnumCollectionProjectValue snapshot = await SourceBlock.ReceiveAsync();
 
-                return snapshot.Value;
+                // TODO: This is a hotfix for item ordering. Remove this OrderBy when completing: https://github.com/dotnet/project-system/issues/7025
+                return snapshot.Value.OrderBy(e => e.DisplayName).ToArray();
             }
         }
 


### PR DESCRIPTION
Related: https://github.com/dotnet/project-system/issues/6989
Related: https://github.com/dotnet/project-system/issues/7025

This changes the display ordering for the target framework dropdown. The order of values provided by CPS is still preserved. This is only a hotfix to do this. The proper solution is in the [second related link](https://github.com/dotnet/project-system/issues/7025). This PR is only until a proper solution is created.

| Before | After
| ----------- | -----------
| ![image](https://user-images.githubusercontent.com/17788297/111219122-de876000-8594-11eb-8278-863c0304c14b.png) | ![image](https://user-images.githubusercontent.com/17788297/111219164-efd06c80-8594-11eb-8a4c-91c0f2afcf2d.png)
| ![image](https://user-images.githubusercontent.com/17788297/111219136-e515d780-8594-11eb-889c-977ed710e9c9.png) | ![image](https://user-images.githubusercontent.com/17788297/111219181-f3fc8a00-8594-11eb-8d96-9f7e5e26f8fb.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7026)