### PR TITLE
Update the project system version to 16.10.

### DIFF
--- a/build/import/Versions.props
+++ b/build/import/Versions.props
@@ -1,7 +1,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ProjectSystemVersion>16.8.1</ProjectSystemVersion>
+    <ProjectSystemVersion>16.10.0</ProjectSystemVersion>
     <VersionBase>$(ProjectSystemVersion)</VersionBase>
     <PreReleaseVersionLabel>beta1</PreReleaseVersionLabel>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>


### PR DESCRIPTION
#6978 introduced a dependency on 16.10 CPS API (with the CPS SDK updated in #6992). This follow-up change updates the project system version accordingly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7029)