### PR TITLE
Handle actions for launch profiles

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -93,9 +93,9 @@
     <PackageReference Include="VSSDK.TemplateWizardInterface"                                         Version="12.0.4"                          ExcludeAssets="All" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.10.162-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.10.162-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="16.10.162-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.10.137-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.10.137-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="16.10.137-pre" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="3.10.0-2.21121.14" />

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -93,9 +93,9 @@
     <PackageReference Include="VSSDK.TemplateWizardInterface"                                         Version="12.0.4"                          ExcludeAssets="All" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.10.127-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.10.127-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="16.10.127-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.10.162-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.10.162-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="16.10.162-pre" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="3.10.0-2.21121.14" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/AddLaunchProfileAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/AddLaunchProfileAction.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Query;
@@ -20,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _executableStep = executableStep;
         }
 
-        protected override Task ExecuteAsync(ILaunchSettingsProvider launchSettingsProvider)
+        protected override Task ExecuteAsync(ILaunchSettingsProvider launchSettingsProvider, CancellationToken cancellationToken)
         {
             return launchSettingsProvider.AddOrUpdateProfileAsync(
                 new WritableLaunchProfile

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/AddLaunchProfileAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/AddLaunchProfileAction.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModelMethods.Actions;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// <see cref="IQueryActionExecutor"/> handling <see cref="ProjectModelActionNames.AddLaunchProfile"/> actions.
+    /// </summary>
+    internal sealed class AddLaunchProfileAction : LaunchProfileActionBase
+    {
+        private readonly AddLaunchProfile _executableStep;
+
+        public AddLaunchProfileAction(AddLaunchProfile executableStep)
+        {
+            _executableStep = executableStep;
+        }
+
+        protected override async Task ExecuteAsync(ILaunchSettingsProvider launchSettingsProvider)
+        {
+            await launchSettingsProvider.AddOrUpdateProfileAsync(
+                new WritableLaunchProfile
+                {
+                    Name = _executableStep.NewProfileName,
+                    CommandName = _executableStep.CommandName
+                }.ToLaunchProfile(),
+                addToFront: false);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/AddLaunchProfileAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/AddLaunchProfileAction.cs
@@ -20,9 +20,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _executableStep = executableStep;
         }
 
-        protected override async Task ExecuteAsync(ILaunchSettingsProvider launchSettingsProvider)
+        protected override Task ExecuteAsync(ILaunchSettingsProvider launchSettingsProvider)
         {
-            await launchSettingsProvider.AddOrUpdateProfileAsync(
+            return launchSettingsProvider.AddOrUpdateProfileAsync(
                 new WritableLaunchProfile
                 {
                     Name = _executableStep.NewProfileName,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/DuplicateLaunchProfileAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/DuplicateLaunchProfileAction.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModelMethods.Actions;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// <see cref="IQueryActionExecutor"/> handling <see cref="ProjectModelActionNames.DuplicateLaunchProfile"/> actions.
+    /// </summary>
+    internal sealed class DuplicateLaunchProfileAction : LaunchProfileActionBase
+    {
+        private readonly DuplicateLaunchProfile _executableStep;
+
+        public DuplicateLaunchProfileAction(DuplicateLaunchProfile executableStep)
+        {
+            _executableStep = executableStep;
+        }
+
+        protected override async Task ExecuteAsync(ILaunchSettingsProvider launchSettingsProvider)
+        {
+            ILaunchSettings? launchSettings = await launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            Assumes.NotNull(launchSettings);
+
+            ILaunchProfile? existingProfile = launchSettings.Profiles.FirstOrDefault(p => StringComparers.LaunchProfileNames.Equals(p.Name, _executableStep.CurrentProfileName));
+            if (existingProfile is not null)
+            {
+                var writableProfile = new WritableLaunchProfile(existingProfile);
+                writableProfile.Name = _executableStep.NewProfileName;
+                writableProfile.CommandName = _executableStep.NewProfileCommandName;
+
+                await launchSettingsProvider.AddOrUpdateProfileAsync(writableProfile.ToLaunchProfile(), addToFront: false);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/DuplicateLaunchProfileAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/DuplicateLaunchProfileAction.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModelMethods.Actions;
 using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {
@@ -22,9 +23,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _executableStep = executableStep;
         }
 
-        protected override async Task ExecuteAsync(ILaunchSettingsProvider launchSettingsProvider)
+        protected override async Task ExecuteAsync(ILaunchSettingsProvider launchSettingsProvider, CancellationToken cancellationToken)
         {
-            ILaunchSettings? launchSettings = await launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            ILaunchSettings? launchSettings = await launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite).WithCancellation(cancellationToken);
             Assumes.NotNull(launchSettings);
 
             ILaunchProfile? existingProfile = launchSettings.Profiles.FirstOrDefault(p => StringComparers.LaunchProfileNames.Equals(p.Name, _executableStep.CurrentProfileName));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchProfileActionBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchProfileActionBase.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Query;
@@ -25,12 +26,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             if (((IEntityValueFromProvider)result.Result).ProviderState is UnconfiguredProject project
                 && project.Services.ExportProvider.GetExportedValueOrDefault<ILaunchSettingsProvider>() is ILaunchSettingsProvider launchSettingsProvider)
             {
-                await ExecuteAsync(launchSettingsProvider);
+                await ExecuteAsync(launchSettingsProvider, result.Request.QueryExecutionContext.CancellationToken);
             }
 
             await ResultReceiver.ReceiveResultAsync(result);
         }
 
-        protected abstract Task ExecuteAsync(ILaunchSettingsProvider launchSettingsProvider);
+        protected abstract Task ExecuteAsync(ILaunchSettingsProvider launchSettingsProvider, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchProfileActionBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchProfileActionBase.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Base class for <see cref="IQueryActionExecutor"/>s that modify launch settings and launch profiles.
+    /// </summary>
+    internal abstract class LaunchProfileActionBase : QueryDataProducerBase<IEntityValue>, IQueryActionExecutor
+    {
+        public Task OnRequestProcessFinishedAsync(IQueryProcessRequest request)
+        {
+            return ResultReceiver.OnRequestProcessFinishedAsync(request);
+        }
+
+        public async Task ReceiveResultAsync(QueryProcessResult<IEntityValue> result)
+        {
+            result.Request.QueryExecutionContext.CancellationToken.ThrowIfCancellationRequested();
+
+            if (((IEntityValueFromProvider)result.Result).ProviderState is UnconfiguredProject project
+                && project.Services.ExportProvider.GetExportedValueOrDefault<ILaunchSettingsProvider>() is ILaunchSettingsProvider launchSettingsProvider)
+            {
+                await ExecuteAsync(launchSettingsProvider);
+            }
+
+            await ResultReceiver.ReceiveResultAsync(result);
+        }
+
+        protected abstract Task ExecuteAsync(ILaunchSettingsProvider launchSettingsProvider);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchProfileActionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchProfileActionProvider.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Metadata;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModelMethods.Actions;
+using Microsoft.VisualStudio.ProjectSystem.Query.Providers;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// <para>
+    /// Handles Project Query API actions that target the <see cref="ProjectSystem.Query.ProjectModel.ILaunchProfile"/>.
+    /// </para>
+    /// <para>
+    /// Specifically, this type is responsible for creating the appropriate <see cref="IQueryActionExecutor"/>
+    /// for a given <see cref="ExecutableStep"/>, and all further processing is handled by that executor.
+    /// </para>
+    /// </summary>
+    [QueryDataProvider(LaunchProfileType.TypeName, ProjectModel.ModelName)]
+    [QueryActionProvider(ProjectModelActionNames.SetLaunchProfilePropertyValue, typeof(SetLaunchProfilePropertyValue))]
+    [QueryDataProviderZone(ProjectModelZones.Cps)]
+    [Export(typeof(IQueryActionProvider))]
+    internal sealed class LaunchProfileActionProvider : IQueryActionProvider
+    {
+        private readonly IPropertyPageQueryCacheProvider _queryCacheProvider;
+
+        [ImportingConstructor]
+        public LaunchProfileActionProvider(IPropertyPageQueryCacheProvider queryCacheProvider)
+        {
+            _queryCacheProvider = queryCacheProvider;
+        }
+
+        public IQueryActionExecutor CreateQueryActionDataTransformer(ExecutableStep executableStep)
+        {
+            Requires.NotNull(executableStep, nameof(executableStep));
+
+            return executableStep.Action switch
+            {
+                ProjectModelActionNames.SetLaunchProfilePropertyValue => new SetLaunchProfilePropertyAction((SetLaunchProfilePropertyValue)executableStep),
+
+                _ => throw new InvalidOperationException($"{nameof(ProjectActionProvider)} does not handle action '{executableStep.Action}'.")
+            };
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/RemoveLaunchProfileAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/RemoveLaunchProfileAction.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Query;
@@ -20,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _executableStep = executableStep;
         }
 
-        protected override Task ExecuteAsync(ILaunchSettingsProvider launchSettingsProvider)
+        protected override Task ExecuteAsync(ILaunchSettingsProvider launchSettingsProvider, CancellationToken cancellationToken)
         {
             return launchSettingsProvider.RemoveProfileAsync(_executableStep.ProfileName);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/RemoveLaunchProfileAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/RemoveLaunchProfileAction.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModelMethods.Actions;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// <see cref="IQueryActionExecutor"/> handling <see cref="ProjectModelActionNames.RemoveLaunchProfile"/> actions.
+    /// </summary>
+    internal sealed class RemoveLaunchProfileAction : LaunchProfileActionBase
+    {
+        private readonly RemoveLaunchProfile _executableStep;
+
+        public RemoveLaunchProfileAction(RemoveLaunchProfile executableStep)
+        {
+            _executableStep = executableStep;
+        }
+
+        protected override Task ExecuteAsync(ILaunchSettingsProvider launchSettingsProvider)
+        {
+            return launchSettingsProvider.RemoveProfileAsync(_executableStep.ProfileName);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/RenameLaunchProfileAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/RenameLaunchProfileAction.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModelMethods.Actions;
 using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {
@@ -22,9 +23,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _executableStep = executableStep;
         }
 
-        protected override async Task ExecuteAsync(ILaunchSettingsProvider launchSettingsProvider)
+        protected override async Task ExecuteAsync(ILaunchSettingsProvider launchSettingsProvider, CancellationToken cancellationToken)
         {
-            ILaunchSettings? launchSettings = await launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            ILaunchSettings? launchSettings = await launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite).WithCancellation(cancellationToken);
             Assumes.NotNull(launchSettings);
 
             ILaunchProfile? existingProfile = launchSettings.Profiles.FirstOrDefault(p => StringComparers.LaunchProfileNames.Equals(p.Name, _executableStep.CurrentProfileName));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/RenameLaunchProfileAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/RenameLaunchProfileAction.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModelMethods.Actions;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// <see cref="IQueryActionExecutor"/> handling <see cref="ProjectModelActionNames.RenameLaunchProfile"/> actions.
+    /// </summary>
+    internal sealed class RenameLaunchProfileAction : LaunchProfileActionBase
+    {
+        private readonly RenameLaunchProfile _executableStep;
+
+        public RenameLaunchProfileAction(RenameLaunchProfile executableStep)
+        {
+            _executableStep = executableStep;
+        }
+
+        protected override async Task ExecuteAsync(ILaunchSettingsProvider launchSettingsProvider)
+        {
+            ILaunchSettings? launchSettings = await launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            Assumes.NotNull(launchSettings);
+
+            ILaunchProfile? existingProfile = launchSettings.Profiles.FirstOrDefault(p => StringComparers.LaunchProfileNames.Equals(p.Name, _executableStep.CurrentProfileName));
+            if (existingProfile is not null)
+            {
+                var writableProfile = new WritableLaunchProfile(existingProfile);
+                writableProfile.Name = _executableStep.NewProfileName;
+
+                await launchSettingsProvider.RemoveProfileAsync(_executableStep.CurrentProfileName);
+                await launchSettingsProvider.AddOrUpdateProfileAsync(writableProfile.ToLaunchProfile(), addToFront: false);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/SetLaunchProfilePropertyAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/SetLaunchProfilePropertyAction.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModelMethods.Actions;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    internal class SetLaunchProfilePropertyAction : QueryDataProducerBase<IEntityValue>, IQueryActionExecutor
+    {
+        private readonly SetLaunchProfilePropertyValue _executableStep;
+
+        public SetLaunchProfilePropertyAction(SetLaunchProfilePropertyValue executableStep)
+        {
+            _executableStep = executableStep;
+        }
+
+        public Task OnRequestProcessFinishedAsync(IQueryProcessRequest request)
+        {
+            return ResultReceiver.OnRequestProcessFinishedAsync(request);
+        }
+
+        public async Task ReceiveResultAsync(QueryProcessResult<IEntityValue> result)
+        {
+            result.Request.QueryExecutionContext.CancellationToken.ThrowIfCancellationRequested();
+            if (((IEntityValueFromProvider)result.Result).ProviderState is PropertyPageProviderState state)
+            {
+                var cache = state.Cache;
+                if (await cache.GetSuggestedConfigurationAsync() is ProjectConfiguration configuration
+                    && await cache.BindToRule(configuration, state.Rule.Name, state.Context) is IRule boundRule
+                    && boundRule.GetProperty(_executableStep.PropertyName) is IProperty property)
+                {
+                    await property.SetValueAsync(_executableStep.Value);
+                }
+            }
+
+            await ResultReceiver.ReceiveResultAsync(result);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectActionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectActionProvider.cs
@@ -23,6 +23,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     [QueryDataProvider(ProjectSystem.Query.ProjectModel.Metadata.ProjectType.TypeName, ProjectModel.ModelName)]
     [QueryActionProvider(ProjectModelActionNames.SetEvaluatedUIPropertyValue, typeof(SetEvaluatedUIPropertyValue))]
     [QueryActionProvider(ProjectModelActionNames.SetUnevaluatedUIPropertyValue, typeof(SetUnevaluatedUIPropertyValue))]
+    [QueryActionProvider(ProjectModelActionNames.AddLaunchProfile, typeof(AddLaunchProfile))]
+    [QueryActionProvider(ProjectModelActionNames.RemoveLaunchProfile, typeof(RemoveLaunchProfile))]
+    [QueryActionProvider(ProjectModelActionNames.RenameLaunchProfile, typeof(RenameLaunchProfile))]
+    [QueryActionProvider(ProjectModelActionNames.DuplicateLaunchProfile, typeof(DuplicateLaunchProfile))]
     [QueryDataProviderZone(ProjectModelZones.Cps)]
     [Export(typeof(IQueryActionProvider))]
     internal sealed class ProjectActionProvider : IQueryActionProvider
@@ -43,6 +47,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             {
                 ProjectModelActionNames.SetEvaluatedUIPropertyValue => new ProjectSetEvaluatedUIPropertyValueAction(_queryCacheProvider, (SetEvaluatedUIPropertyValue)executableStep),
                 ProjectModelActionNames.SetUnevaluatedUIPropertyValue => new ProjectSetUnevaluatedUIPropertyValueAction(_queryCacheProvider, (SetUnevaluatedUIPropertyValue)executableStep),
+
+                ProjectModelActionNames.AddLaunchProfile => new AddLaunchProfileAction((AddLaunchProfile)executableStep),
+                ProjectModelActionNames.RemoveLaunchProfile => new RemoveLaunchProfileAction((RemoveLaunchProfile)executableStep),
+                ProjectModelActionNames.RenameLaunchProfile => new RenameLaunchProfileAction((RenameLaunchProfile)executableStep),
+                ProjectModelActionNames.DuplicateLaunchProfile => new DuplicateLaunchProfileAction((DuplicateLaunchProfile)executableStep),
+
                 _ => throw new InvalidOperationException($"{nameof(ProjectActionProvider)} does not handle action '{executableStep.Action}'.")
             };
         }


### PR DESCRIPTION
Handles actions to add, remove, rename, and duplicate launch profiles.

The remaining action to handle is setting a property, but the API for that is in a bit of flux at the moment.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7031)