### PR TITLE
Atomically read and update profiles and global settings

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             await QueryDebugTargetsAsync(launchOptions, activeProfile, validateSettings: false) ?? throw new Exception(VSResources.ProjectNotRunnableDirectly);
 
         /// <summary>
-        /// Returns <c>null</c> if the debug launch settings are <c>null</c>. Otherwise, the list of debug launch settings.
+        /// Returns <see langword="null"/> if the debug launch settings are <see langword="null"/>. Otherwise, the list of debug launch settings.
         /// </summary>
         private async Task<IReadOnlyList<IDebugLaunchSettings>?> QueryDebugTargetsAsync(DebugLaunchOptions launchOptions, ILaunchProfile activeProfile, bool validateSettings)
         {
@@ -200,7 +200,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// This is called on F5 to return the list of debug targets. What we return depends on the type
         /// of project.
         /// </summary>
-        /// <returns><c>null</c> if the runnable project information is <c>null</c>. Otherwise, the debug launch settings.</returns>
+        /// <returns><see langword="null"/> if the runnable project information is <see langword="null"/>. Otherwise, the debug launch settings.</returns>
         private async Task<DebugLaunchSettings?> GetConsoleTargetForProfile(ILaunchProfile resolvedProfile, DebugLaunchOptions launchOptions, bool validateSettings)
         {
             var settings = new DebugLaunchSettings(launchOptions);
@@ -415,7 +415,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// Queries properties from the project to get information on how to run the application. The returned Tuple contains:
         /// exeToRun, arguments, workingDir
         /// </summary>
-        /// <returns><c>null</c> if the command string is <c>null</c>. Otherwise, the tuple containing the runnable project information.</returns>
+        /// <returns><see langword="null"/> if the command string is <see langword="null"/>. Otherwise, the tuple containing the runnable project information.</returns>
         private async Task<(string Command, string Arguments, string WorkingDirectory)?> GetRunnableProjectInformationAsync(
             ConfiguredProject configuredProject,
             bool validateSettings)
@@ -443,7 +443,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         /// <summary>
-        /// Returns <c>null</c> if it is not a valid debug target. Otherwise, returns the command string for debugging.
+        /// Returns <see langword="null"/> if it is not a valid debug target. Otherwise, returns the command string for debugging.
         /// </summary>
         private async Task<string?> GetTargetCommandAsync(
             IProjectProperties properties,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryProjectPropertiesContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryProjectPropertiesContext.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         /// <remarks>
         /// Note that if an <see cref="IProjectPropertiesContext"/> has the <see cref="IProjectPropertiesContext.IsProjectFile"/>
         /// property is set to <c>true</c> and the <see cref="IProjectPropertiesContext.ItemType"/>
-        /// and <see cref="IProjectPropertiesContext.ItemName"/> properties are <c>null</c>
+        /// and <see cref="IProjectPropertiesContext.ItemName"/> properties are <see langword="null"/>
         /// then the properties system treats it as referring to the project file as a whole
         /// regardless of the <see cref="IProjectPropertiesContext.File"/> property. This
         /// lets us get away with setting it to the empty string and re-using the same

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider3.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider3.cs
@@ -41,8 +41,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         ///     Supports the retrieval and update of a given global setting as a single
         ///     operation. When <paramref name="updateFunction"/> is called it is given the
         ///     current value of the <paramref name="settingName"/> global setting (which may be
-        ///     <c>null</c> if no such setting exists and returns the updated object (or
-        ///     <c>null</c> if the setting is to be removed).
+        ///     <see langword="null"/> if no such setting exists and returns the updated object (or
+        ///     <see langword="null"/> if the setting is to be removed).
         /// </summary>
         /// <param name="settingName"></param>
         /// <param name="updateFunction"></param>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider3.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider3.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    /// <summary>
+    ///     Provides an implementation of <see cref="ILaunchSettingsProvider"/> with
+    ///     additional methods for atomically updating a launch profile or global setting.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    ///     The existing <see cref="ILaunchSettingsProvider.AddOrUpdateProfileAsync"/> method
+    ///     does not work well in situations where multiple update operations may run
+    ///     concurrently because the retrieval of the current set of values is separated from
+    ///     the later update. If operations A and B each retrieve the current profile, make
+    ///     their changes, and then apply them there is a very good chance that A's changes
+    ///     will overwrite B's or the other way around. The new method introduced here makes
+    ///     retrieving and updating a profile an single operation.
+    /// </para>
+    /// <para>
+    ///     The <see cref="ILaunchSettingsProvider.AddOrUpdateGlobalSettingAsync"/> method has
+    ///     similar problems.
+    /// </para>
+    /// </remarks>
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    public interface ILaunchSettingsProvider3 : ILaunchSettingsProvider2
+    {
+        /// <summary>
+        ///     Supports the retrieval and update of a given launch profile as a single
+        ///     operation. When <paramref name="updateAction"/> is called it is given an
+        ///     <see cref="IWritableLaunchProfile"/> with the current state of the
+        ///     <paramref name="profileName"/> profile. It will update the profile as
+        ///     appropriate and when it is done the profile is applied to the settings.
+        /// </summary>
+        Task UpdateProfileAsync(string profileName, Action<IWritableLaunchProfile> updateAction);
+
+        /// <summary>
+        ///     Supports the retrieval and update of a given global setting as a single
+        ///     operation. When <paramref name="updateFunction"/> is called it is given the
+        ///     current value of the <paramref name="settingName"/> global setting (which may be
+        ///     <c>null</c> if no such setting exists and returns the updated object (or
+        ///     <c>null</c> if the setting is to be removed).
+        /// </summary>
+        /// <param name="settingName"></param>
+        /// <param name="updateFunction"></param>
+        /// <returns></returns>
+        Task UpdateGlobalSettingAsync(string settingName, Func<object?, object?> updateFunction);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider3.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider3.cs
@@ -35,7 +35,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         ///     <paramref name="profileName"/> profile. It will update the profile as
         ///     appropriate and when it is done the profile is applied to the settings.
         /// </summary>
-        Task UpdateProfileAsync(string profileName, Action<IWritableLaunchProfile> updateAction);
+        /// <returns>
+        ///     <see langword="true"/> if <paramref name="profileName"/> was found and <paramref name="updateAction"/>
+        ///     executed; <see langword="false"/> if <paramref name="profileName"/> was not found.
+        /// </returns>
+        Task<bool> TryUpdateProfileAsync(string profileName, Action<IWritableLaunchProfile> updateAction);
 
         /// <summary>
         ///     Supports the retrieval and update of a given global setting as a single
@@ -44,9 +48,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         ///     <see langword="null"/> if no such setting exists and returns the updated object (or
         ///     <see langword="null"/> if the setting is to be removed).
         /// </summary>
-        /// <param name="settingName"></param>
-        /// <param name="updateFunction"></param>
-        /// <returns></returns>
         Task UpdateGlobalSettingAsync(string settingName, Func<object?, object?> updateFunction);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProjectPropertiesProvider.cs
@@ -147,8 +147,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         /// <returns>
-        /// If the profile does not exist, returns <c>null</c>. Otherwise, returns the value
-        /// of the property if the property is not defined, or <c>null</c> otherwise. The
+        /// If the profile does not exist, returns <see langword="null"/>. Otherwise, returns the value
+        /// of the property if the property is not defined, or <see langword="null"/> otherwise. The
         /// standard properties are always considered to be defined.
         /// </returns>
         private async Task<string?> GetUnevaluatedPropertyValueAsync(string profileName, string propertyName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -751,7 +751,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Updates need to be sequenced
             return _sequentialTaskQueue.ExecuteTask(async () =>
             {
-                ILaunchSettings currentSettings = await GetSnapshotThrowIfErrors();
+                ILaunchSettings currentSettings = await GetSnapshotThrowIfErrorsAsync();
                 ILaunchProfile? existingProfile = null;
                 int insertionIndex = 0;
                 foreach (ILaunchProfile p in currentSettings.Profiles)
@@ -802,7 +802,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Updates need to be sequenced
             return _sequentialTaskQueue.ExecuteTask(async () =>
             {
-                ILaunchSettings currentSettings = await GetSnapshotThrowIfErrors();
+                ILaunchSettings currentSettings = await GetSnapshotThrowIfErrorsAsync();
                 ILaunchProfile existingProfile = currentSettings.Profiles.FirstOrDefault(p => LaunchProfile.IsSameProfileName(p.Name, profileName));
                 if (existingProfile != null)
                 {
@@ -821,7 +821,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Updates need to be sequenced
             return _sequentialTaskQueue.ExecuteTask(async () =>
             {
-                ILaunchSettings currentSettings = await GetSnapshotThrowIfErrors();
+                ILaunchSettings currentSettings = await GetSnapshotThrowIfErrorsAsync();
                 ILaunchProfile? existingProfile = null;
                 int insertionIndex = 0;
                 foreach (ILaunchProfile p in currentSettings.Profiles)
@@ -866,7 +866,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Updates need to be sequenced
             return _sequentialTaskQueue.ExecuteTask(async () =>
             {
-                ILaunchSettings currentSettings = await GetSnapshotThrowIfErrors();
+                ILaunchSettings currentSettings = await GetSnapshotThrowIfErrorsAsync();
                 ImmutableDictionary<string, object> globalSettings = ImmutableStringDictionary<object>.EmptyOrdinal;
                 if (currentSettings.GlobalSettings.TryGetValue(settingName, out object? currentValue))
                 {
@@ -892,7 +892,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Updates need to be sequenced
             return _sequentialTaskQueue.ExecuteTask(async () =>
             {
-                ILaunchSettings currentSettings = await GetSnapshotThrowIfErrors();
+                ILaunchSettings currentSettings = await GetSnapshotThrowIfErrorsAsync();
                 if (currentSettings.GlobalSettings.TryGetValue(settingName, out object? currentValue))
                 {
                     bool saveToDisk = !currentValue.IsInMemoryObject();
@@ -912,7 +912,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             return _sequentialTaskQueue.ExecuteTask(async () =>
             {
-                ILaunchSettings currentSettings = await GetSnapshotThrowIfErrors();
+                ILaunchSettings currentSettings = await GetSnapshotThrowIfErrorsAsync();
                 ImmutableDictionary<string, object> globalSettings = ImmutableStringDictionary<object>.EmptyOrdinal;
                 currentSettings.GlobalSettings.TryGetValue(settingName, out object? currentValue);
 
@@ -938,7 +938,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// Helper retrieves the current snapshot (waiting up to 5s) and if there were errors in the launchsettings.json file
         /// or there isn't a snapshot, it throws an error. There should always be a snapshot of some kind returned
         /// </summary>
-        public async Task<ILaunchSettings> GetSnapshotThrowIfErrors()
+        public async Task<ILaunchSettings> GetSnapshotThrowIfErrorsAsync()
         {
             ILaunchSettings? currentSettings = await WaitForFirstSnapshot(WaitForFirstSnapshotDelayMillis);
             if (currentSettings == null || (currentSettings.Profiles.Count == 1 && string.Equals(currentSettings.Profiles[0].CommandName, ErrorProfileCommandName, StringComparisons.LaunchProfileCommandNames)))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -816,7 +816,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             });
         }
 
-        public Task UpdateProfileAsync(string profileName, Action<IWritableLaunchProfile> updateAction)
+        public Task<bool> TryUpdateProfileAsync(string profileName, Action<IWritableLaunchProfile> updateAction)
         {
             // Updates need to be sequenced
             return _sequentialTaskQueue.ExecuteTask(async () =>
@@ -836,7 +836,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
                 if (existingProfile is null)
                 {
-                    return;
+                    return false;
                 }
 
                 var writableProfile = new WritableLaunchProfile(existingProfile);
@@ -854,6 +854,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
                 var newSnapshot = new LaunchSettings(profiles, currentSettings?.GlobalSettings, currentSettings?.ActiveProfile?.Name);
                 await UpdateAndSaveSettingsInternalAsync(newSnapshot, saveToDisk);
+
+                return true;
             });
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/LaunchSettingsValueProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/LaunchSettingsValueProviderBase.cs
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// </summary>
         /// <returns>
         /// The value of the property if it is found in the <paramref name="launchSettings"/>;
-        /// otherwise a default value or <c>null</c> if there is no applicable default.
+        /// otherwise a default value or <see langword="null"/> if there is no applicable default.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         /// Thrown if the given <paramref name="propertyName"/> is not known (that is, it is

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider3
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider3.TryUpdateProfileAsync(string! profileName, System.Action<Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile!>! updateAction) -> System.Threading.Tasks.Task<bool>!
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider3.UpdateGlobalSettingAsync(string! settingName, System.Func<object?, object?>! updateFunction) -> System.Threading.Tasks.Task!
-Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider3.UpdateProfileAsync(string! profileName, System.Action<Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile!>! updateAction) -> System.Threading.Tasks.Task!
 const Microsoft.VisualStudio.ProjectSystem.Debug.UIProfilePropertyName.JSWebView2Debugging = "JSWebView2Debugging" -> string!

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider3
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider3.UpdateGlobalSettingAsync(string! settingName, System.Func<object?, object?>! updateFunction) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider3.UpdateProfileAsync(string! profileName, System.Action<Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile!>! updateAction) -> System.Threading.Tasks.Task!
 const Microsoft.VisualStudio.ProjectSystem.Debug.UIProfilePropertyName.JSWebView2Debugging = "JSWebView2Debugging" -> string!

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -658,7 +658,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             var newProfile = new LaunchProfile() { Name = "test", CommandName = "Test", DoNotPersist = isInMemory };
 
-            await provider.UpdateProfileAsync("test", p =>
+            await provider.TryUpdateProfileAsync("test", p =>
             {
                 p.CommandName = "Test";
                 var persist = (IWritablePersistOption)p;


### PR DESCRIPTION
The `LaunchSettingsProvider` allows multiple concurrent changes to a project's launch settings by forcing them into a serialized order (via the `SequentialTaskExecutor`). However, two different changes to the same launch profile or global setting could still stomp over each other as there is no way to read and update these settings as a single operation.

Say operation A and operation B want to update different parts of the same launch profile. They each grab the current state, P0. They then each make their own changes to produce PA and PB, respectively. Then they both call `AddOrUpdateProfileAsync` to apply their changes. This method replaces the entire profile at once, so depending on the order in which the calls are processed we'll either end up with PA (in which case B's changes are lost) or PB (A's changes are lost) when what we really want is PAB (with both changes).

Global settings have a similar update mechanism, and a similar problem.

To fix this, this change adds new update methods that take callbacks to make the actual changes. When the update is processed, the `LaunchSettingsProvider` invokes the callback, providing the current state of the profile or global settings. The callback makes its changes, and returns the resulting object which is applied to the settings immediately. Any caller making use of these methods is guaranteed to see the current state of the profile/global setting when they make their changes.

Eventually these methods will be used by the new Launch Settings UI back end, but we should also consider adopting it in other places as well.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7032)