### PR TITLE
Reorder properties on Application page

### DIFF
--- a/docs/repo/property-pages/property-specification.md
+++ b/docs/repo/property-pages/property-specification.md
@@ -225,7 +225,8 @@ XAML files in the dotnet/project-system repo are configured for automatic locali
 
 ## Examples
 
-- [Implement WarningsNotAsErrors in the new property pages](https://github.com/dotnet/project-system/pull/6971) - Demonstrates the addition of a new property, the use of `VisibilityCondition` and `DependsOn` metadata, and the implementation of an `IInterceptingPropertyValueProvider`. Includes an extensive explanation of the change in the commit message.
+- [Add `WarningsNotAsErrors` property](https://github.com/dotnet/project-system/pull/6971) &mdash; Demonstrates the addition of a new property, the use of `VisibilityCondition` and `DependsOn` metadata, and the implementation of an `IInterceptingPropertyValueProvider`. Includes an extensive explanation of the change in the commit message.
+- [Reorder properties within a page](https://github.com/dotnet/project-system/pull/7038) &mdash; Demonstrates reordering properties within a single category on a single page. This simple change is made entirely within a XAML rule file.
 - [Add a new page of properties](https://github.com/dotnet/project-system/commit/a442d8e91fec98cb493d924f0903308efe188344) &mdash; Adds a new, empty, page that will appear as a top-level navigation item in the Project Properties UI.
 - [Add a description property](https://github.com/dotnet/project-system/commit/64b7693e104a725fc0ac9d2bbda76909d9a7b9d1) &mdash; Adds a single synthetic property which appears in the UI as a fixed (localized) block of text.
 - [Add search term alias](https://github.com/dotnet/project-system/pull/7041) &mdash; shows how to add additional terms for the purposes of search. These terms will not appear in the UI, but will cause a search operation to match the property. Useful for synonyms and common misspellings.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -22,15 +22,17 @@
                 HasConfigurationCondition="False" />
   </Rule.DataSource>
 
-  <StringProperty Name="AssemblyName"
-                  DisplayName="Assembly name"
-                  Description="Specifies the name of the output file that will hold the assembly manifest."
-                  Category="General" />
-
-  <StringProperty Name="RootNamespace"
-                  DisplayName="Default namespace"
-                  Description="Specifies the base namespace for files added to the project."
-                  Category="General" />
+  <EnumProperty Name="OutputType"
+                DisplayName="Output type"
+                Description="Specifies the type of application to build."
+                Category="General">
+    <EnumValue Name="Library"
+               DisplayName="Class Library" />
+    <EnumValue Name="Exe"
+               DisplayName="Console Application" />
+    <EnumValue Name="WinExe"
+               DisplayName="Windows Application" />
+  </EnumProperty>
 
   <BoolProperty Name="TargetMultipleFrameworks"
                 DisplayName="Target multiple frameworks"
@@ -94,18 +96,6 @@
     </StringProperty.ValueEditors>
   </StringProperty>
 
-  <EnumProperty Name="OutputType"
-                DisplayName="Output type"
-                Description="Specifies the type of application to build."
-                Category="General">
-    <EnumValue Name="Library"
-               DisplayName="Class Library" />
-    <EnumValue Name="Exe"
-               DisplayName="Console Application" />
-    <EnumValue Name="WinExe"
-               DisplayName="Windows Application" />
-  </EnumProperty>
-
   <DynamicEnumProperty Name="StartupObject"
                        DisplayName="Startup object"
                        Description="Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point."
@@ -117,6 +107,16 @@
       </NameValuePair>
     </DynamicEnumProperty.Metadata>
   </DynamicEnumProperty>
+
+  <StringProperty Name="AssemblyName"
+                  DisplayName="Assembly name"
+                  Description="Specifies the name of the output file that will hold the assembly manifest."
+                  Category="General" />
+
+  <StringProperty Name="RootNamespace"
+                  DisplayName="Default namespace"
+                  Description="Specifies the base namespace for files added to the project."
+                  Category="General" />
 
   <EnumProperty Name="ResourceSpecificationKind"
                 DisplayName="Resources"


### PR DESCRIPTION
Historically in legacy projects, the _Assembly Name_ and _Default Namespace_ properties were manually kept in sync with the project by the user.

With SDK-style projects, it's more common to go with the default behaviour of picking up the `MSBuildProjectName` property, which is computed from the project's file name.

Given these properties are far less likely to be user edited, we move them further down the UI, allowing more commonly modified properties to rise to the top.

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/350947/112084021-3862d800-8bdc-11eb-956f-47a83a1413f2.png) | ![image](https://user-images.githubusercontent.com/350947/112084087-4f092f00-8bdc-11eb-8e3f-bc4bf586f6b8.png) |


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7038)