### PR TITLE
Support reading/writing arbitrary values to launch profiles

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ExportLaunchProfileExtensionValueProviderAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ExportLaunchProfileExtensionValueProviderAttribute.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    /// <summary>
+    /// Exports a <see cref="ILaunchProfileExtensionValueProvider" /> or <see cref="IGlobalSettingExtensionValueProvider"/>.
+    /// </summary>
+    [MetadataAttribute]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+    public sealed class ExportLaunchProfileExtensionValueProviderAttribute : ExportAttribute
+    {
+        public string[] PropertyNames { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExportLaunchProfileExtensionValueProviderAttribute"/>
+        /// class for a single intercepted property.
+        /// </summary>
+        public ExportLaunchProfileExtensionValueProviderAttribute(string propertyName, ExportLaunchProfileExtensionValueProviderScope scope)
+            : this(new[] { propertyName }, scope)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExportLaunchProfileExtensionValueProviderAttribute"/>
+        /// class for multiple intercepted properties.
+        /// </summary>
+        public ExportLaunchProfileExtensionValueProviderAttribute(string[] propertyNames, ExportLaunchProfileExtensionValueProviderScope scope)
+            : base(GetType(scope))
+        {
+            PropertyNames = propertyNames;
+        }
+
+        private static Type? GetType(ExportLaunchProfileExtensionValueProviderScope scope)
+        {
+            return scope switch
+            {
+                ExportLaunchProfileExtensionValueProviderScope.LaunchProfile => typeof(ILaunchProfileExtensionValueProvider),
+                ExportLaunchProfileExtensionValueProviderScope.GlobalSettings => typeof(IGlobalSettingExtensionValueProvider),
+
+                _ => null
+            };
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ExportLaunchProfileExtensionValueProviderScope.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ExportLaunchProfileExtensionValueProviderScope.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    /// <summary>
+    /// Specifies the "backing store" for an <see cref="ILaunchProfileExtensionValueProvider"/>
+    /// or <see cref="IGlobalSettingExtensionValueProvider"/>. This determines where the
+    /// property value is read from/stored to.
+    /// </summary>
+    public enum ExportLaunchProfileExtensionValueProviderScope
+    {
+        /// <summary>
+        /// Extension properties are backed by an <see cref="ILaunchProfile"/>. The related
+        /// type must implement <see cref="ILaunchProfileExtensionValueProvider"/>.
+        /// </summary>
+        LaunchProfile,
+        /// <summary>
+        /// Extensions properties are backed by <see cref="ILaunchSettings.GlobalSettings"/>.
+        /// The related type must implement <see cref="IGlobalSettingExtensionValueProvider"/>.
+        /// </summary>
+        GlobalSettings
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IGlobalSettingExtensionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IGlobalSettingExtensionValueProvider.cs
@@ -31,6 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     /// for a similar interface for intercepting callbacks for properties stored in
     /// MSBuild files.
     /// </remarks>
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Extension, Cardinality = Composition.ImportCardinality.ZeroOrMore)]
     public interface IGlobalSettingExtensionValueProvider
     {
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IGlobalSettingExtensionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IGlobalSettingExtensionValueProvider.cs
@@ -1,0 +1,84 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    /// <summary>
+    /// <para>
+    /// A property provider that extends <see cref="ILaunchSettings.GlobalSettings"/> to
+    /// support reading and writing arbitrary properties.
+    /// </para>
+    /// <para>
+    /// This is necessary to convert back and forth between the <see cref="string"/>
+    /// representation of the property value used by the properties system and the <see cref="object"/>
+    /// representation stored in the global settings. However, it can also be used for
+    /// validation and transformation of the property value, or to update other global
+    /// settings in response. 
+    /// </para>
+    /// <para>
+    /// Implementations of this must be tagged with the <see cref="ExportLaunchProfileExtensionValueProviderAttribute"/>
+    /// using the <see cref="ExportLaunchProfileExtensionValueProviderScope.GlobalSettings"/>
+    /// scope.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// See also <see cref="ILaunchProfileExtensionValueProvider"/> for the equivalent
+    /// interface for global launch settings, and <see cref="IInterceptingPropertyValueProvider"/>
+    /// for a similar interface for intercepting callbacks for properties stored in
+    /// MSBuild files.
+    /// </remarks>
+    public interface IGlobalSettingExtensionValueProvider
+    {
+        /// <summary>
+        /// Reads the given property from the <paramref name="globalSettings"/>, converting
+        /// it to a <see cref="string"/>.
+        /// </summary>
+        /// <param name="propertyName">
+        /// The name of the property, as known to the CPS properties system.
+        /// </param>
+        /// <param name="globalSettings">
+        /// The current set of global launch settings.
+        /// </param>
+        /// <param name="rule">
+        /// An optional <see cref="Rule"/> associated with the <see cref="IProjectProperties"/>
+        /// calling this provider.
+        /// </param>
+        /// <returns>
+        /// The value of the given property, as a string.
+        /// </returns>
+        /// <remarks>
+        /// The <paramref name="rule"/> provides access to metadata that may influence the
+        /// conversion of the property to a <see cref="string"/>.
+        /// </remarks>
+        Task<string> OnGetPropertyValueAsync(string propertyName, ImmutableDictionary<string, object> globalSettings, Rule? rule);
+
+        /// <summary>
+        /// Converts the <paramref name="propertyValue"/> from a <see cref="string"/> and
+        /// updates the <paramref name="globalSettings"/> as appropriate.
+        /// </summary>
+        /// <param name="propertyName">
+        /// The name of the property, as known to the CPS properties system.
+        /// </param>
+        /// <param name="propertyValue">
+        /// The new value of the property.
+        /// </param>
+        /// <param name="globalSettings">
+        /// The current set of global launch settings.
+        /// </param>
+        /// <param name="rule">
+        /// An optional <see cref="Rule"/> associated with the <see cref="IProjectProperties"/>
+        /// calling this provider.</param>
+        /// <returns>
+        /// The updated set of global settings.
+        /// </returns>
+        /// <remarks>
+        /// The <paramref name="rule"/> provides access to metadata that may influence the
+        /// conversion of the property from a <see cref="string"/>.
+        /// </remarks>
+        Task<ImmutableDictionary<string, object>> OnSetPropertyValueAsync(string propertyName, string propertyValue, ImmutableDictionary<string, object> globalSettings, Rule? rule);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchProfileExtensionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchProfileExtensionValueProvider.cs
@@ -1,0 +1,88 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    /// <summary>
+    /// <para>
+    /// A property provider that extends a given <see cref="ILaunchProfile"/> to support
+    /// reading and writing arbitrary properties.
+    /// </para>
+    /// <para>
+    /// This is necessary to convert back and forth between the <see cref="string"/>
+    /// representation of the property value used by the properties system and the <see cref="object"/>
+    /// representation stored in the launch profile. However, it can also be used for
+    /// validation and transformation of the property value, or to update other launch
+    /// profile properties in response. 
+    /// </para>
+    /// <para>
+    /// Implementations of this must be tagged with the <see cref="ExportLaunchProfileExtensionValueProviderAttribute"/>
+    /// using the <see cref="ExportLaunchProfileExtensionValueProviderScope.LaunchProfile"/>
+    /// scope.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// See also <see cref="IGlobalSettingExtensionValueProvider"/> for the equivalent
+    /// interface for global launch settings, and <see cref="IInterceptingPropertyValueProvider"/>
+    /// for a similar interface for intercepting callbacks for properties stored in
+    /// MSBuild files.
+    /// </remarks>
+    public interface ILaunchProfileExtensionValueProvider
+    {
+        /// <summary>
+        /// Reads the given property from the <paramref name="launchProfile"/>, converting it
+        /// to a <see cref="string"/>.
+        /// </summary>
+        /// <param name="propertyName">
+        /// The name of the property, as known to the CPS properties system.
+        /// </param>
+        /// <param name="launchProfile">
+        /// The launch profile from which to read the property value.
+        /// </param>
+        /// <param name="globalSettings">
+        /// The current set of global launch settings.
+        /// </param>
+        /// <param name="rule">
+        /// An optional <see cref="Rule"/> associated with the <see cref="IProjectProperties"/>
+        /// calling this provider.
+        /// </param>
+        /// <returns>
+        /// The value of the given property, as a string.
+        /// </returns>
+        /// <remarks>
+        /// The <paramref name="rule"/> provides access to metadata that may influence the
+        /// conversion of the property to a <see cref="string"/>.
+        /// </remarks>
+        Task<string> OnGetPropertyValueAsync(string propertyName, ILaunchProfile launchProfile, ImmutableDictionary<string, object> globalSettings, Rule? rule);
+
+        /// <summary>
+        /// Converts the <paramref name="propertyValue"/> from a <see cref="string"/> and
+        /// updates the <paramref name="launchProfile"/> as appropriate.
+        /// </summary>
+        /// <param name="propertyName">
+        /// The name of the property, as known to the CPS properties system.
+        /// </param>
+        /// <param name="propertyValue">
+        /// The new value of the property.
+        /// </param>
+        /// <param name="launchProfile">
+        /// The launch profile to update.
+        /// </param>
+        /// <param name="globalSettings">
+        /// The current set of global launch settings.
+        /// </param>
+        /// <param name="rule">
+        /// An optional <see cref="Rule"/> associated with the <see cref="IProjectProperties"/>
+        /// calling this provider.
+        /// </param>
+        /// <remarks>
+        /// The <paramref name="rule"/> provides access to metadata that may influence the
+        /// conversion of the property from a <see cref="string"/>.
+        /// </remarks>
+        Task OnSetPropertyValueAsync(string propertyName, string propertyValue, IWritableLaunchProfile launchProfile, ImmutableDictionary<string, object> globalSettings, Rule? rule);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchProfileExtensionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchProfileExtensionValueProvider.cs
@@ -31,6 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     /// for a similar interface for intercepting callbacks for properties stored in
     /// MSBuild files.
     /// </remarks>
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Extension, Cardinality = Composition.ImportCardinality.ZeroOrMore)]
     public interface ILaunchProfileExtensionValueProvider
     {
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchProfileExtensionValueProviderMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchProfileExtensionValueProviderMetadata.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    /// <summary>
+    /// Metadata mapping interface for the <see cref="ExportLaunchProfileExtensionValueProviderAttribute"/>.
+    /// </summary>
+    public interface ILaunchProfileExtensionValueProviderMetadata
+    {
+#pragma warning disable CA1819 // Properties should not return arrays
+
+        /// <summary>
+        /// Property names handled by the provider.
+        /// This must match <see cref="ExportLaunchProfileExtensionValueProviderAttribute.PropertyNames" />.
+        /// </summary>
+        string[] PropertyNames { get; }
+
+#pragma warning restore CA1819 // Properties should not return arrays
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProjectProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProjectProperties.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
-    internal class LaunchProfileProperties : IProjectProperties
+    internal class LaunchProfileProjectProperties : IProjectProperties
     {
         private const string CommandNamePropertyName = "CommandName";
         private const string ExecutablePathPropertyName = "ExecutablePath";
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         private readonly LaunchProfilePropertiesContext _context;
         private readonly ILaunchSettingsProvider _launchSettingsProvider;
 
-        public LaunchProfileProperties(string filePath, string profileName, ILaunchSettingsProvider launchSettingsProvider)
+        public LaunchProfileProjectProperties(string filePath, string profileName, ILaunchSettingsProvider launchSettingsProvider)
         {
             _context = new LaunchProfilePropertiesContext(filePath, profileName);
             _launchSettingsProvider = launchSettingsProvider;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProjectPropertiesProvider.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Threading;
@@ -15,13 +17,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     {
         private readonly UnconfiguredProject _project;
         private readonly ILaunchSettingsProvider _launchSettingsProvider;
+        private readonly ImmutableArray<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> _launchProfileExtensionValueProviders;
+        private readonly ImmutableArray<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> _globalSettingExtensionValueProviders;
 
         [ImportingConstructor]
-        public LaunchProfileProjectPropertiesProvider(UnconfiguredProject project,
-            ILaunchSettingsProvider launchSettingsProvider)
+        public LaunchProfileProjectPropertiesProvider(
+            UnconfiguredProject project,
+            ILaunchSettingsProvider launchSettingsProvider,
+            [ImportMany]IEnumerable<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> launchProfileExtensionValueProviders,
+            [ImportMany]IEnumerable<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> globalSettingExtensionValueProviders)
         {
             _project = project;
             _launchSettingsProvider = launchSettingsProvider;
+            _launchProfileExtensionValueProviders = launchProfileExtensionValueProviders.ToImmutableArray();
+            _globalSettingExtensionValueProviders = globalSettingExtensionValueProviders.ToImmutableArray();
         }
 
         /// <remarks>
@@ -88,7 +97,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 return null!;
             }
 
-            return new LaunchProfileProjectProperties(file, item, _launchSettingsProvider);
+            return new LaunchProfileProjectProperties(file, item, _launchSettingsProvider, _launchProfileExtensionValueProviders, _globalSettingExtensionValueProviders);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProjectPropertiesProvider.cs
@@ -1,12 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Threading;
 
@@ -16,32 +11,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     [Export(typeof(IProjectPropertiesProvider))]
     [ExportMetadata("Name", "LaunchProfile")]
     [AppliesTo(ProjectCapability.LaunchProfiles)]
-    internal class LaunchProfileProjectPropertiesProvider : IProjectPropertiesProvider
+    internal partial class LaunchProfileProjectPropertiesProvider : IProjectPropertiesProvider
     {
-        private const string CommandNamePropertyName = "CommandName";
-        private const string ExecutablePathPropertyName = "ExecutablePath";
-        private const string CommandLineArgumentsPropertyName = "CommandLineArguments";
-        private const string WorkingDirectoryPropertyName = "WorkingDirectory";
-        private const string LaunchBrowserPropertyName = "LaunchBrowser";
-        private const string LaunchUrlPropertyName = "LaunchUrl";
-        private const string EnvironmentVariablesPropertyName = "EnvironmentVariables";
-
-        /// <remarks>
-        /// These correspond to the properties explicitly declared on <see cref="ILaunchProfile"/>
-        /// and as such they are always considered to exist on the profile, though they may
-        /// not have a value.
-        /// </remarks>
-        private static readonly string[] s_standardPropertyNames = new[]
-        {
-            CommandNamePropertyName,
-            ExecutablePathPropertyName,
-            CommandLineArgumentsPropertyName,
-            WorkingDirectoryPropertyName,
-            LaunchBrowserPropertyName,
-            LaunchUrlPropertyName,
-            EnvironmentVariablesPropertyName
-        };
-
         private readonly UnconfiguredProject _project;
         private readonly ILaunchSettingsProvider _launchSettingsProvider;
 
@@ -117,153 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 return null!;
             }
 
-            return new LaunchProfileProperties(file, item, this);
-        }
-
-        /// <remarks>
-        /// If the profile exists we return all the standard property names (as they are
-        /// always considered defined) plus all of the defined properties supported by
-        /// extenders.
-        /// </remarks>
-        private async Task<IEnumerable<string>> GetPropertyNamesAsync(string profileName)
-        {
-            ILaunchSettings? snapshot = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
-            Assumes.NotNull(snapshot);
-
-            ILaunchProfile? profile = snapshot.Profiles.FirstOrDefault(p => StringComparers.LaunchProfileNames.Equals(p.Name, profileName));
-            if (profile is null)
-            {
-                return Enumerable.Empty<string>();
-            }
-
-            return s_standardPropertyNames;
-
-            // TODO: Handle property names supported by launch profile extenders.
-        }
-
-        private async Task<string> GetEvaluatedPropertyValueAsync(string itemName, string propertyName)
-        {
-            return await GetUnevaluatedPropertyValueAsync(itemName, propertyName) ?? string.Empty;
-        }
-
-        /// <returns>
-        /// If the profile does not exist, returns <see langword="null"/>. Otherwise, returns the value
-        /// of the property if the property is not defined, or <see langword="null"/> otherwise. The
-        /// standard properties are always considered to be defined.
-        /// </returns>
-        private async Task<string?> GetUnevaluatedPropertyValueAsync(string profileName, string propertyName)
-        {
-            ILaunchSettings? snapshot = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
-            Assumes.NotNull(snapshot);
-
-            ILaunchProfile? profile = snapshot.Profiles.FirstOrDefault(p => StringComparers.LaunchProfileNames.Equals(p.Name, profileName));
-            if (profile is null)
-            {
-                return null;
-            }
-
-            return propertyName switch
-            {
-                CommandNamePropertyName => profile.CommandName ?? string.Empty,
-                ExecutablePathPropertyName => profile.ExecutablePath ?? string.Empty,
-                CommandLineArgumentsPropertyName => profile.CommandLineArgs ?? string.Empty,
-                WorkingDirectoryPropertyName => profile.WorkingDirectory ?? string.Empty,
-                LaunchBrowserPropertyName => profile.LaunchBrowser ? "true" : "false",
-                LaunchUrlPropertyName => profile.LaunchUrl ?? string.Empty,
-                EnvironmentVariablesPropertyName => ConvertDictionaryToString(profile.EnvironmentVariables) ?? string.Empty,
-                _ => null
-                // TODO: Handle properties supported by launch profile extenders.
-            };
-        }
-
-        private static string? ConvertDictionaryToString(ImmutableDictionary<string, string>? value)
-        {
-            if (value is null)
-            {
-                return null;
-            }
-
-            return string.Join(",", value.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).Select(kvp => $"{encode(kvp.Key)}={encode(kvp.Value)}"));
-
-            static string encode(string value)
-            {
-                return value.Replace("/", "//").Replace(",", "/,").Replace("=", "/=");
-            }
-        }
-
-        private class LaunchProfileProperties : IProjectProperties
-        {
-            private readonly LaunchProfilePropertiesContext _context;
-            private readonly LaunchProfileProjectPropertiesProvider _provider;
-
-            public LaunchProfileProperties(string filePath, string profileName, LaunchProfileProjectPropertiesProvider provider)
-            {
-                _context = new LaunchProfilePropertiesContext(filePath, profileName);
-                _provider = provider;
-            }
-
-            public IProjectPropertiesContext Context => _context;
-
-            public string FileFullPath => _context.File;
-
-            public PropertyKind PropertyKind => PropertyKind.ItemGroup;
-
-            public Task DeleteDirectPropertiesAsync()
-            {
-                throw new NotImplementedException();
-            }
-
-            public Task DeletePropertyAsync(string propertyName, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
-            {
-                throw new NotImplementedException();
-            }
-
-            public Task<IEnumerable<string>> GetDirectPropertyNamesAsync()
-            {
-                return GetPropertyNamesAsync();
-            }
-
-            public Task<string> GetEvaluatedPropertyValueAsync(string propertyName)
-            {
-                return _provider.GetEvaluatedPropertyValueAsync(_context.ItemName, propertyName);
-            }
-
-            public Task<IEnumerable<string>> GetPropertyNamesAsync()
-            {
-                return _provider.GetPropertyNamesAsync(_context.ItemName);
-            }
-
-            public Task<string?> GetUnevaluatedPropertyValueAsync(string propertyName)
-            {
-                return _provider.GetUnevaluatedPropertyValueAsync(_context.ItemName, propertyName);
-            }
-
-            public Task<bool> IsValueInheritedAsync(string propertyName)
-            {
-                return TaskResult.False;
-            }
-
-            public Task SetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
-            {
-                throw new NotImplementedException();
-            }
-
-            private class LaunchProfilePropertiesContext : IProjectPropertiesContext
-            {
-                public LaunchProfilePropertiesContext(string file, string itemName)
-                {
-                    File = file;
-                    ItemName = itemName;
-                }
-
-                public bool IsProjectFile => true;
-
-                public string File { get; }
-
-                public string ItemType => LaunchProfileProjectItemProvider.ItemType;
-
-                public string ItemName { get; }
-            }
+            return new LaunchProfileProperties(file, item, _launchSettingsProvider);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProjectPropertiesProvider.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 return null!;
             }
 
-            return new LaunchProfileProperties(file, item, _launchSettingsProvider);
+            return new LaunchProfileProjectProperties(file, item, _launchSettingsProvider);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProperties.cs
@@ -1,0 +1,168 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    internal class LaunchProfileProperties : IProjectProperties
+    {
+        private const string CommandNamePropertyName = "CommandName";
+        private const string ExecutablePathPropertyName = "ExecutablePath";
+        private const string CommandLineArgumentsPropertyName = "CommandLineArguments";
+        private const string WorkingDirectoryPropertyName = "WorkingDirectory";
+        private const string LaunchBrowserPropertyName = "LaunchBrowser";
+        private const string LaunchUrlPropertyName = "LaunchUrl";
+        private const string EnvironmentVariablesPropertyName = "EnvironmentVariables";
+
+        /// <remarks>
+        /// These correspond to the properties explicitly declared on <see cref="ILaunchProfile"/>
+        /// and as such they are always considered to exist on the profile, though they may
+        /// not have a value.
+        /// </remarks>
+        private static readonly string[] s_standardPropertyNames = new[]
+        {
+            CommandNamePropertyName,
+            ExecutablePathPropertyName,
+            CommandLineArgumentsPropertyName,
+            WorkingDirectoryPropertyName,
+            LaunchBrowserPropertyName,
+            LaunchUrlPropertyName,
+            EnvironmentVariablesPropertyName
+        };
+
+        private readonly LaunchProfilePropertiesContext _context;
+        private readonly ILaunchSettingsProvider _launchSettingsProvider;
+
+        public LaunchProfileProperties(string filePath, string profileName, ILaunchSettingsProvider launchSettingsProvider)
+        {
+            _context = new LaunchProfilePropertiesContext(filePath, profileName);
+            _launchSettingsProvider = launchSettingsProvider;
+        }
+
+        public IProjectPropertiesContext Context => _context;
+
+        public string FileFullPath => _context.File;
+
+        public PropertyKind PropertyKind => PropertyKind.ItemGroup;
+
+        public Task DeleteDirectPropertiesAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task DeletePropertyAsync(string propertyName, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IEnumerable<string>> GetDirectPropertyNamesAsync()
+        {
+            return GetPropertyNamesAsync();
+        }
+
+        public async Task<string> GetEvaluatedPropertyValueAsync(string propertyName)
+        {
+            return await GetUnevaluatedPropertyValueAsync(propertyName) ?? string.Empty;
+        }
+
+        /// <remarks>
+        /// If the profile exists we return all the standard property names (as they are
+        /// always considered defined) plus all of the defined properties supported by
+        /// extenders.
+        /// </remarks>
+        public async Task<IEnumerable<string>> GetPropertyNamesAsync()
+        {
+            ILaunchSettings? snapshot = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            Assumes.NotNull(snapshot);
+
+            ILaunchProfile? profile = snapshot.Profiles.FirstOrDefault(p => StringComparers.LaunchProfileNames.Equals(p.Name, _context.ItemName));
+            if (profile is null)
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            return s_standardPropertyNames;
+
+            // TODO: Handle property names supported by launch profile extenders.
+        }
+
+        /// <returns>
+        /// If the profile does not exist, returns <c>null</c>. Otherwise, returns the value
+        /// of the property if the property is not defined, or <c>null</c> otherwise. The
+        /// standard properties are always considered to be defined.
+        /// </returns>
+        public async Task<string?> GetUnevaluatedPropertyValueAsync(string propertyName)
+        {
+            ILaunchSettings? snapshot = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
+            Assumes.NotNull(snapshot);
+
+            ILaunchProfile? profile = snapshot.Profiles.FirstOrDefault(p => StringComparers.LaunchProfileNames.Equals(p.Name, _context.ItemName));
+            if (profile is null)
+            {
+                return null;
+            }
+
+            return propertyName switch
+            {
+                CommandNamePropertyName => profile.CommandName ?? string.Empty,
+                ExecutablePathPropertyName => profile.ExecutablePath ?? string.Empty,
+                CommandLineArgumentsPropertyName => profile.CommandLineArgs ?? string.Empty,
+                WorkingDirectoryPropertyName => profile.WorkingDirectory ?? string.Empty,
+                LaunchBrowserPropertyName => profile.LaunchBrowser ? "true" : "false",
+                LaunchUrlPropertyName => profile.LaunchUrl ?? string.Empty,
+                EnvironmentVariablesPropertyName => ConvertDictionaryToString(profile.EnvironmentVariables) ?? string.Empty,
+                _ => null
+                // TODO: Handle properties supported by launch profile extenders.
+            };
+        }
+
+        public Task<bool> IsValueInheritedAsync(string propertyName)
+        {
+            return TaskResult.False;
+        }
+
+        public Task SetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static string? ConvertDictionaryToString(ImmutableDictionary<string, string>? value)
+        {
+            if (value is null)
+            {
+                return null;
+            }
+
+            return string.Join(",", value.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).Select(kvp => $"{encode(kvp.Key)}={encode(kvp.Value)}"));
+
+            static string encode(string value)
+            {
+                return value.Replace("/", "//").Replace(",", "/,").Replace("=", "/=");
+            }
+        }
+
+        private class LaunchProfilePropertiesContext : IProjectPropertiesContext
+        {
+            public LaunchProfilePropertiesContext(string file, string itemName)
+            {
+                File = file;
+                ItemName = itemName;
+            }
+
+            public bool IsProjectFile => true;
+
+            public string File { get; }
+
+            public string ItemType => LaunchProfileProjectItemProvider.ItemType;
+
+            public string ItemName { get; }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ProjectLaunchProfileExtensionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ProjectLaunchProfileExtensionValueProvider.cs
@@ -1,0 +1,146 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    /// <summary>
+    /// <para>
+    /// Reads and writes "extension" properties in the given <see cref="ILaunchProfile"/>.
+    /// </para>
+    /// <para>"Extension" means properties that are stored in the <see cref="ILaunchProfile.OtherSettings"/>
+    /// dictionary, rather than in named properties of <see cref="ILaunchProfile"/>
+    /// itself. Those are handled by <see cref="LaunchProfileProjectProperties"/>.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// Not to be confused with <see cref="ActiveLaunchProfileExtensionValueProvider" />,
+    /// which serves a very similar purpose but reads and writes the _active_ profile
+    /// rather than a particular one, and will go away once the Launch Profiles UI is up
+    /// and running.
+    /// </remarks>
+    [ExportLaunchProfileExtensionValueProvider(
+        new[]
+        {
+            AuthenticationModePropertyName,
+            NativeDebuggingPropertyName,
+            RemoteDebugEnabledPropertyName,
+            RemoteDebugMachinePropertyName,
+            SqlDebuggingPropertyName
+        },
+        ExportLaunchProfileExtensionValueProviderScope.LaunchProfile)]
+    internal class ProjectLaunchProfileExtensionValueProvider : ILaunchProfileExtensionValueProvider
+    {
+        internal const string AuthenticationModePropertyName = "AuthenticationMode";
+        internal const string NativeDebuggingPropertyName = "NativeDebugging";
+        internal const string RemoteDebugEnabledPropertyName = "RemoteDebugEnabled";
+        internal const string RemoteDebugMachinePropertyName = "RemoteDebugMachine";
+        internal const string SqlDebuggingPropertyName = "SqlDebugging";
+
+        // The CPS property system will map "true" and "false" to the localized versions of
+        // "Yes" and "No" for display purposes, but not other casings like "True" and
+        // "False". To ensure consistency we need to map booleans to these constants.
+        private const string True = "true";
+        private const string False = "false";
+
+        public Task<string> OnGetPropertyValueAsync(string propertyName, ILaunchProfile launchProfile, ImmutableDictionary<string, object> globalSettings, Rule? rule)
+        {
+            string propertyValue = propertyName switch
+            {
+                AuthenticationModePropertyName => GetOtherProperty(launchProfile, LaunchProfileExtensions.RemoteAuthenticationModeProperty, string.Empty),
+                NativeDebuggingPropertyName => GetOtherProperty(launchProfile, LaunchProfileExtensions.NativeDebuggingProperty, false) ? True : False,
+                RemoteDebugEnabledPropertyName => GetOtherProperty(launchProfile, LaunchProfileExtensions.RemoteDebugEnabledProperty, false) ? True : False,
+                RemoteDebugMachinePropertyName => GetOtherProperty(launchProfile, LaunchProfileExtensions.RemoteDebugMachineProperty, string.Empty),
+                SqlDebuggingPropertyName => GetOtherProperty(launchProfile, LaunchProfileExtensions.SqlDebuggingProperty, false) ? True : False,
+
+                _ => throw new InvalidOperationException($"{nameof(ProjectLaunchProfileExtensionValueProvider)} does not handle property '{propertyName}'.")
+            };
+
+            return Task.FromResult(propertyValue);
+        }
+
+        public Task OnSetPropertyValueAsync(string propertyName, string propertyValue, IWritableLaunchProfile launchProfile, ImmutableDictionary<string, object> globalSettings, Rule? rule)
+        {
+            switch (propertyName)
+            {
+                case AuthenticationModePropertyName:
+                    TrySetOtherProperty(launchProfile, LaunchProfileExtensions.RemoteAuthenticationModeProperty, propertyValue, string.Empty);
+                    break;
+
+                case NativeDebuggingPropertyName:
+                    TrySetOtherProperty(launchProfile, LaunchProfileExtensions.NativeDebuggingProperty, bool.Parse(propertyValue), false);
+                    break;
+
+                case RemoteDebugEnabledPropertyName:
+                    TrySetOtherProperty(launchProfile, LaunchProfileExtensions.RemoteDebugEnabledProperty, bool.Parse(propertyValue), false);
+                    break;
+
+                case RemoteDebugMachinePropertyName:
+                    TrySetOtherProperty(launchProfile, LaunchProfileExtensions.RemoteDebugMachineProperty, propertyValue, string.Empty);
+                    break;
+
+                case SqlDebuggingPropertyName:
+                    TrySetOtherProperty(launchProfile, LaunchProfileExtensions.SqlDebuggingProperty, bool.Parse(propertyValue), false);
+                    break;
+
+                default:
+                    throw new InvalidOperationException($"{nameof(ProjectLaunchProfileExtensionValueProvider)} does not handle property '{propertyName}'.");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private static T GetOtherProperty<T>(ILaunchProfile launchProfile, string propertyName, T defaultValue)
+        {
+            if (launchProfile.OtherSettings is null)
+            {
+                return defaultValue;
+            }
+
+            if (launchProfile.OtherSettings.TryGetValue(propertyName, out object? value) &&
+                value is T b)
+            {
+                return b;
+            }
+            else if (value is string s &&
+                TypeDescriptor.GetConverter(typeof(T)) is TypeConverter converter &&
+                converter.CanConvertFrom(typeof(string)))
+            {
+                try
+                {
+                    if (converter.ConvertFromString(s) is T o)
+                    {
+                        return o;
+                    }
+                }
+                catch (Exception)
+                {
+                    // ignore bad data in the json file and just let them have the default value
+                }
+            }
+
+            return defaultValue;
+        }
+
+        private static bool TrySetOtherProperty<T>(IWritableLaunchProfile launchProfile, string propertyName, T value, T defaultValue) where T : notnull
+        {
+            if (!launchProfile.OtherSettings.TryGetValue(propertyName, out object current))
+            {
+                current = defaultValue;
+            }
+
+            if (current is not T currentTyped || !Equals(currentTyped, value))
+            {
+                launchProfile.OtherSettings[propertyName] = value;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Unshipped.txt
@@ -1,3 +1,18 @@
+Microsoft.VisualStudio.ProjectSystem.Debug.ExportLaunchProfileExtensionValueProviderAttribute
+Microsoft.VisualStudio.ProjectSystem.Debug.ExportLaunchProfileExtensionValueProviderAttribute.ExportLaunchProfileExtensionValueProviderAttribute(string! propertyName, Microsoft.VisualStudio.ProjectSystem.Debug.ExportLaunchProfileExtensionValueProviderScope scope) -> void
+Microsoft.VisualStudio.ProjectSystem.Debug.ExportLaunchProfileExtensionValueProviderAttribute.ExportLaunchProfileExtensionValueProviderAttribute(string![]! propertyNames, Microsoft.VisualStudio.ProjectSystem.Debug.ExportLaunchProfileExtensionValueProviderScope scope) -> void
+Microsoft.VisualStudio.ProjectSystem.Debug.ExportLaunchProfileExtensionValueProviderAttribute.PropertyNames.get -> string![]!
+Microsoft.VisualStudio.ProjectSystem.Debug.ExportLaunchProfileExtensionValueProviderScope
+Microsoft.VisualStudio.ProjectSystem.Debug.ExportLaunchProfileExtensionValueProviderScope.GlobalSettings = 1 -> Microsoft.VisualStudio.ProjectSystem.Debug.ExportLaunchProfileExtensionValueProviderScope
+Microsoft.VisualStudio.ProjectSystem.Debug.ExportLaunchProfileExtensionValueProviderScope.LaunchProfile = 0 -> Microsoft.VisualStudio.ProjectSystem.Debug.ExportLaunchProfileExtensionValueProviderScope
+Microsoft.VisualStudio.ProjectSystem.Debug.IGlobalSettingExtensionValueProvider
+Microsoft.VisualStudio.ProjectSystem.Debug.IGlobalSettingExtensionValueProvider.OnGetPropertyValueAsync(string! propertyName, System.Collections.Immutable.ImmutableDictionary<string!, object!>! globalSettings, Microsoft.Build.Framework.XamlTypes.Rule? rule) -> System.Threading.Tasks.Task<string!>!
+Microsoft.VisualStudio.ProjectSystem.Debug.IGlobalSettingExtensionValueProvider.OnSetPropertyValueAsync(string! propertyName, string! propertyValue, System.Collections.Immutable.ImmutableDictionary<string!, object!>! globalSettings, Microsoft.Build.Framework.XamlTypes.Rule? rule) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableDictionary<string!, object!>!>!
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfileExtensionValueProvider
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfileExtensionValueProvider.OnGetPropertyValueAsync(string! propertyName, Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile! launchProfile, System.Collections.Immutable.ImmutableDictionary<string!, object!>! globalSettings, Microsoft.Build.Framework.XamlTypes.Rule? rule) -> System.Threading.Tasks.Task<string!>!
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfileExtensionValueProvider.OnSetPropertyValueAsync(string! propertyName, string! propertyValue, Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile! launchProfile, System.Collections.Immutable.ImmutableDictionary<string!, object!>! globalSettings, Microsoft.Build.Framework.XamlTypes.Rule? rule) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfileExtensionValueProviderMetadata
+Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfileExtensionValueProviderMetadata.PropertyNames.get -> string![]!
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider3
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider3.TryUpdateProfileAsync(string! profileName, System.Action<Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile!>! updateAction) -> System.Threading.Tasks.Task<bool>!
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider3.UpdateGlobalSettingAsync(string! settingName, System.Func<object?, object?>! updateFunction) -> System.Threading.Tasks.Task!

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IGlobalSettingExtensionValueProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IGlobalSettingExtensionValueProviderFactory.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Moq;
+
+namespace Microsoft.VisualStudio.Mocks
+{
+    internal class IGlobalSettingExtensionValueProviderFactory
+    {
+        public static IGlobalSettingExtensionValueProvider Create(
+            Func<string, ImmutableDictionary<string, object>, Rule?, Task<string>>? onGetPropertyValueAsync = null,
+            Func<string, string, ImmutableDictionary<string, object>, Rule?, Task<ImmutableDictionary<string, object>>>? onSetPropertyValueAsync = null)
+        {
+            var providerMock = new Mock<IGlobalSettingExtensionValueProvider>();
+
+            if (onGetPropertyValueAsync is not null)
+            {
+                providerMock.Setup(t => t.OnGetPropertyValueAsync(It.IsAny<string>(), It.IsAny<ImmutableDictionary<string, object>>(), It.IsAny<Rule?>()))
+                    .Returns(onGetPropertyValueAsync);
+            }
+
+            if (onSetPropertyValueAsync is not null)
+            {
+                providerMock.Setup(t => t.OnSetPropertyValueAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ImmutableDictionary<string, object>>(), It.IsAny<Rule?>()))
+                    .Returns(onSetPropertyValueAsync);
+            }
+
+            return providerMock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchProfileExtensionValueProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchProfileExtensionValueProviderFactory.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Moq;
+
+namespace Microsoft.VisualStudio.Mocks
+{
+    internal class ILaunchProfileExtensionValueProviderFactory
+    {
+        public static ILaunchProfileExtensionValueProvider Create(
+            Func<string, ILaunchProfile, ImmutableDictionary<string, object>, Rule?, Task<string>>? onGetPropertyValueAsync = null,
+            Func<string, string, IWritableLaunchProfile, ImmutableDictionary<string, object>, Rule?, Task>? onSetPropertyValueAsync = null)
+        {
+            var providerMock = new Mock<ILaunchProfileExtensionValueProvider>();
+
+            if (onGetPropertyValueAsync is not null)
+            {
+                providerMock.Setup(t => t.OnGetPropertyValueAsync(It.IsAny<string>(), It.IsAny<ILaunchProfile>(), It.IsAny<ImmutableDictionary<string, object>>(), It.IsAny<Rule?>()))
+                    .Returns(onGetPropertyValueAsync);
+            }
+
+            if (onSetPropertyValueAsync is not null)
+            {
+                providerMock.Setup(t => t.OnSetPropertyValueAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IWritableLaunchProfile>(), It.IsAny<ImmutableDictionary<string, object>>(), It.IsAny<Rule?>()))
+                    .Returns(onSetPropertyValueAsync);
+            }
+
+            return providerMock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchProfileExtensionValueProviderMetadataFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchProfileExtensionValueProviderMetadataFactory.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Moq;
+
+namespace Microsoft.VisualStudio.Mocks
+{
+    internal class ILaunchProfileExtensionValueProviderMetadataFactory
+    {
+        public static ILaunchProfileExtensionValueProviderMetadata Create(string[]? propertyNames = null)
+        {
+            var metadataMock = new Mock<ILaunchProfileExtensionValueProviderMetadata>();
+
+            if (propertyNames is not null)
+            {
+                metadataMock.Setup(t => t.PropertyNames).Returns(propertyNames);
+            }
+
+            return metadataMock.Object;
+        }
+
+        public static ILaunchProfileExtensionValueProviderMetadata Create(string propertyName)
+        {
+            return Create(new[] { propertyName });
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProviderTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Xunit;
@@ -9,12 +11,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     public class LaunchProfilesProjectPropertiesProviderTests
     {
+        private static readonly IEnumerable<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyLaunchProfileExtensionValueProviders =
+            Enumerable.Empty<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>>();
+        private static readonly IEnumerable<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyGlobalSettingExtensionValueProviders = 
+            Enumerable.Empty<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>>();
+
         [Fact]
         public void DefaultProjectPath_IsTheProjectPath()
         {
             var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
-                ILaunchSettingsProviderFactory.Create());
+                ILaunchSettingsProviderFactory.Create(),
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
 
             var defaultProjectPath = provider.DefaultProjectPath;
             Assert.Equal(expected: DefaultTestProjectPath, actual: defaultProjectPath);
@@ -26,7 +35,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var project = UnconfiguredProjectFactory.Create();
             var provider = new LaunchProfileProjectPropertiesProvider(
                 project,
-                ILaunchSettingsProviderFactory.Create());
+                ILaunchSettingsProviderFactory.Create(),
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
 
             var commonProperties = provider.GetCommonProperties();
 
@@ -39,7 +50,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var project = UnconfiguredProjectFactory.Create();
             var provider = new LaunchProfileProjectPropertiesProvider(
                 project,
-                ILaunchSettingsProviderFactory.Create());
+                ILaunchSettingsProviderFactory.Create(),
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
 
             var itemTypeProperties = provider.GetItemTypeProperties(LaunchProfileProjectItemProvider.ItemType);
 
@@ -52,7 +65,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var project = UnconfiguredProjectFactory.Create();
             var provider = new LaunchProfileProjectPropertiesProvider(
                 project,
-                ILaunchSettingsProviderFactory.Create());
+                ILaunchSettingsProviderFactory.Create(),
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
 
             var itemProperties = provider.GetItemProperties(LaunchProfileProjectItemProvider.ItemType, item: null);
 
@@ -64,7 +79,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var provider = new LaunchProfileProjectPropertiesProvider(
                 UnconfiguredProjectFactory.Create(),
-                CreateDefaultTestLaunchSettings());
+                CreateDefaultTestLaunchSettings(),
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
 
             var properties = provider.GetItemProperties(
                 itemType: LaunchProfileProjectItemProvider.ItemType,
@@ -78,7 +95,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var provider = new LaunchProfileProjectPropertiesProvider(
                 UnconfiguredProjectFactory.Create(),
-                CreateDefaultTestLaunchSettings());
+                CreateDefaultTestLaunchSettings(),
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
 
             var properties = provider.GetItemProperties(
                 itemType: null,
@@ -97,7 +116,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             var provider = new LaunchProfileProjectPropertiesProvider(
                 UnconfiguredProjectFactory.Create(),
-                launchSettingsProvider);
+                launchSettingsProvider,
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
 
             var properties = provider.GetItemProperties(
                 itemType: "RandomItemType",
@@ -111,7 +132,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
-                CreateDefaultTestLaunchSettings());
+                CreateDefaultTestLaunchSettings(),
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
 
             var properties = provider.GetProperties(
                 file: @"C:\sigma\lambda\other.csproj",
@@ -126,7 +149,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
-                CreateDefaultTestLaunchSettings());
+                CreateDefaultTestLaunchSettings(),
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
 
             var properties = provider.GetItemProperties(
                 itemType: LaunchProfileProjectItemProvider.ItemType,
@@ -144,7 +169,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
-                CreateDefaultTestLaunchSettings());
+                CreateDefaultTestLaunchSettings(),
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
 
             var properties = provider.GetItemProperties(
                 itemType: LaunchProfileProjectItemProvider.ItemType,
@@ -158,7 +185,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
-                CreateDefaultTestLaunchSettings());
+                CreateDefaultTestLaunchSettings(),
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
 
             var properties = provider.GetItemProperties(
                 itemType: LaunchProfileProjectItemProvider.ItemType,
@@ -176,7 +205,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
-                launchSettingsProvider);
+                launchSettingsProvider,
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
             var properties = provider.GetItemProperties(
                 itemType: LaunchProfileProjectItemProvider.ItemType,
                 item: "Profile1");
@@ -200,7 +231,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
-                launchSettingsProvider);
+                launchSettingsProvider,
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
             var properties = provider.GetItemProperties(
                 itemType: LaunchProfileProjectItemProvider.ItemType,
                 item: "Profile1");
@@ -233,7 +266,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
-                launchSettingsProvider);
+                launchSettingsProvider,
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
             var properties = provider.GetItemProperties(
                 itemType: LaunchProfileProjectItemProvider.ItemType,
                 item: "Profile1");
@@ -263,7 +298,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 launchProfiles: new[] { profile1.ToLaunchProfile() });
             var provider = new LaunchProfileProjectPropertiesProvider(
                 CreateDefaultTestProject(),
-                launchSettingsProvider);
+                launchSettingsProvider,
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
             var properties = provider.GetItemProperties(
                 itemType: LaunchProfileProjectItemProvider.ItemType,
                 item: "Profile1");

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectPropertiesProviderTests.cs
@@ -3,14 +3,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     public class LaunchProfilesProjectPropertiesProviderTests
     {
+        private const string DefaultTestProjectPath = @"C:\alpha\beta\gamma.csproj";
+
         private static readonly IEnumerable<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyLaunchProfileExtensionValueProviders =
             Enumerable.Empty<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>>();
         private static readonly IEnumerable<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyGlobalSettingExtensionValueProviders = 
@@ -144,187 +144,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.Null(properties);
         }
 
-        [Fact]
-        public void WhenRetrievingItemProperties_TheContextHasTheExpectedValues()
-        {
-            var provider = new LaunchProfileProjectPropertiesProvider(
-                CreateDefaultTestProject(),
-                CreateDefaultTestLaunchSettings(),
-                EmptyLaunchProfileExtensionValueProviders,
-                EmptyGlobalSettingExtensionValueProviders);
-
-            var properties = provider.GetItemProperties(
-                itemType: LaunchProfileProjectItemProvider.ItemType,
-                item: "Profile1");
-            var context = properties.Context;
-
-            Assert.Equal(expected: DefaultTestProjectPath, actual: context.File);
-            Assert.True(context.IsProjectFile);
-            Assert.Equal(expected: "Profile1", actual: context.ItemName);
-            Assert.Equal(expected: LaunchProfileProjectItemProvider.ItemType, actual: context.ItemType);
-        }
-
-        [Fact]
-        public void WhenRetrievingItemProperties_TheFilePathIsTheProjectPath()
-        {
-            var provider = new LaunchProfileProjectPropertiesProvider(
-                CreateDefaultTestProject(),
-                CreateDefaultTestLaunchSettings(),
-                EmptyLaunchProfileExtensionValueProviders,
-                EmptyGlobalSettingExtensionValueProviders);
-
-            var properties = provider.GetItemProperties(
-                itemType: LaunchProfileProjectItemProvider.ItemType,
-                item: "Profile1");
-
-            Assert.Equal(expected: DefaultTestProjectPath, actual: properties.FileFullPath);
-        }
-
-        [Fact]
-        public void WhenRetrievingItemProperties_ThePropertyKindIsItemGroup()
-        {
-            var provider = new LaunchProfileProjectPropertiesProvider(
-                CreateDefaultTestProject(),
-                CreateDefaultTestLaunchSettings(),
-                EmptyLaunchProfileExtensionValueProviders,
-                EmptyGlobalSettingExtensionValueProviders);
-
-            var properties = provider.GetItemProperties(
-                itemType: LaunchProfileProjectItemProvider.ItemType,
-                item: "Profile1");
-
-            Assert.Equal(expected: PropertyKind.ItemGroup, actual: properties.PropertyKind);
-        }
-
-        [Fact]
-        public async Task WhenRetrievingItemPropertyNames_AllStandardProfilePropertyNamesAreReturnedEvenIfNotDefined()
-        {
-            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
-            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
-                launchProfiles: new[] { profile1.ToLaunchProfile() });
-
-            var provider = new LaunchProfileProjectPropertiesProvider(
-                CreateDefaultTestProject(),
-                launchSettingsProvider,
-                EmptyLaunchProfileExtensionValueProviders,
-                EmptyGlobalSettingExtensionValueProviders);
-            var properties = provider.GetItemProperties(
-                itemType: LaunchProfileProjectItemProvider.ItemType,
-                item: "Profile1");
-            var propertyNames = await properties.GetPropertyNamesAsync();
-
-            Assert.Contains("CommandName", propertyNames);
-            Assert.Contains("ExecutablePath", propertyNames);
-            Assert.Contains("CommandLineArguments", propertyNames);
-            Assert.Contains("WorkingDirectory", propertyNames);
-            Assert.Contains("LaunchBrowser", propertyNames);
-            Assert.Contains("LaunchUrl", propertyNames);
-            Assert.Contains("EnvironmentVariables", propertyNames);
-        }
-
-        [Fact]
-        public async Task WhenRetrievingStandardPropertyValues_TheEmptyStringIsReturnedForUndefinedProperties()
-        {
-            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
-            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
-                launchProfiles: new[] { profile1.ToLaunchProfile() });
-
-            var provider = new LaunchProfileProjectPropertiesProvider(
-                CreateDefaultTestProject(),
-                launchSettingsProvider,
-                EmptyLaunchProfileExtensionValueProviders,
-                EmptyGlobalSettingExtensionValueProviders);
-            var properties = provider.GetItemProperties(
-                itemType: LaunchProfileProjectItemProvider.ItemType,
-                item: "Profile1");
-
-            var standardPropertyNames = new[]
-            {
-                "CommandName",
-                "ExecutablePath",
-                "CommandLineArguments",
-                "WorkingDirectory",
-                "LaunchUrl",
-                "EnvironmentVariables"
-            };
-
-            foreach (var standardPropertyName in standardPropertyNames)
-            {
-                var evaluatedValue = await properties.GetEvaluatedPropertyValueAsync(standardPropertyName);
-                Assert.Equal(expected: string.Empty, actual: evaluatedValue);
-                var unevaluatedValue = await properties.GetUnevaluatedPropertyValueAsync(standardPropertyName);
-                Assert.Equal(expected: string.Empty, actual: unevaluatedValue);
-            }
-        }
-
-        [Fact]
-        public async Task WhenRetrievingTheLaunchBrowserValue_TheDefaultValueIsFalse()
-        {
-            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
-            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
-                launchProfiles: new[] { profile1.ToLaunchProfile() });
-
-            var provider = new LaunchProfileProjectPropertiesProvider(
-                CreateDefaultTestProject(),
-                launchSettingsProvider,
-                EmptyLaunchProfileExtensionValueProviders,
-                EmptyGlobalSettingExtensionValueProviders);
-            var properties = provider.GetItemProperties(
-                itemType: LaunchProfileProjectItemProvider.ItemType,
-                item: "Profile1");
-
-            var evaluatedValue = await properties.GetEvaluatedPropertyValueAsync("LaunchBrowser");
-            Assert.Equal(expected: "false", actual: evaluatedValue);
-            var unevaluatedValue = await properties.GetUnevaluatedPropertyValueAsync("LaunchBrowser");
-            Assert.Equal(expected: "false", actual: unevaluatedValue);
-        }
-
-        [Fact]
-        public async Task WhenRetrievingStandardPropertyValues_TheExpectedValuesAreReturned()
-        {
-            var profile1 = new WritableLaunchProfile
-            {
-                Name = "Profile1",
-                CommandLineArgs = "alpha beta gamma",
-                CommandName = "epsilon",
-                EnvironmentVariables = { ["One"] = "1", ["Two"] = "2" },
-                ExecutablePath = @"D:\five\six\seven\eight.exe",
-                LaunchBrowser = true,
-                LaunchUrl = "https://localhost/profile",
-                WorkingDirectory = @"C:\users\other\temp"
-            };
-
-            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
-                launchProfiles: new[] { profile1.ToLaunchProfile() });
-            var provider = new LaunchProfileProjectPropertiesProvider(
-                CreateDefaultTestProject(),
-                launchSettingsProvider,
-                EmptyLaunchProfileExtensionValueProviders,
-                EmptyGlobalSettingExtensionValueProviders);
-            var properties = provider.GetItemProperties(
-                itemType: LaunchProfileProjectItemProvider.ItemType,
-                item: "Profile1");
-
-            var expectedValues = new Dictionary<string, string>
-            {
-                ["CommandLineArguments"] = "alpha beta gamma",
-                ["CommandName"] = "epsilon",
-                ["EnvironmentVariables"] = "One=1,Two=2",
-                ["ExecutablePath"] = @"D:\five\six\seven\eight.exe",
-                ["LaunchBrowser"] = "true",
-                ["LaunchUrl"] = "https://localhost/profile",
-                ["WorkingDirectory"] = @"C:\users\other\temp",
-            };
-
-            foreach (var (propertyName, expectedPropertyValue) in expectedValues)
-            {
-                var actualUnevaluatedValue = await properties.GetUnevaluatedPropertyValueAsync(propertyName);
-                var actualEvaluatedValue = await properties.GetEvaluatedPropertyValueAsync(propertyName);
-                Assert.Equal(expectedPropertyValue, actualUnevaluatedValue);
-                Assert.Equal(expectedPropertyValue, actualEvaluatedValue);
-            }
-        }
-
         /// <summary>
         /// Creates an <see cref="UnconfiguredProject"/> where the <see cref="UnconfiguredProject.FullPath"/>
         /// is set to <see cref="DefaultTestProjectPath"/>.
@@ -347,6 +166,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             return launchSettingsProvider;
         }
 
-        private const string DefaultTestProjectPath = @"C:\alpha\beta\gamma.csproj";
+
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectPropertiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectPropertiesTests.cs
@@ -1,0 +1,224 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    public class LaunchProfilesProjectPropertiesTests
+    {
+        private const string DefaultTestProjectPath = @"C:\alpha\beta\gamma.csproj";
+
+        private static readonly IEnumerable<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyLaunchProfileExtensionValueProviders =
+            Enumerable.Empty<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>>();
+        private static readonly IEnumerable<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyGlobalSettingExtensionValueProviders =
+            Enumerable.Empty<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>>();
+
+        [Fact]
+        public void WhenRetrievingItemProperties_TheContextHasTheExpectedValues()
+        {
+            var provider = new LaunchProfileProjectPropertiesProvider(
+                CreateDefaultTestProject(),
+                CreateDefaultTestLaunchSettings(),
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
+
+            var properties = provider.GetItemProperties(
+                itemType: LaunchProfileProjectItemProvider.ItemType,
+                item: "Profile1");
+            var context = properties.Context;
+
+            Assert.Equal(expected: DefaultTestProjectPath, actual: context.File);
+            Assert.True(context.IsProjectFile);
+            Assert.Equal(expected: "Profile1", actual: context.ItemName);
+            Assert.Equal(expected: LaunchProfileProjectItemProvider.ItemType, actual: context.ItemType);
+        }
+
+        [Fact]
+        public void WhenRetrievingItemProperties_TheFilePathIsTheProjectPath()
+        {
+            var provider = new LaunchProfileProjectPropertiesProvider(
+                CreateDefaultTestProject(),
+                CreateDefaultTestLaunchSettings(),
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
+
+            var properties = provider.GetItemProperties(
+                itemType: LaunchProfileProjectItemProvider.ItemType,
+                item: "Profile1");
+
+            Assert.Equal(expected: DefaultTestProjectPath, actual: properties.FileFullPath);
+        }
+
+        [Fact]
+        public void WhenRetrievingItemProperties_ThePropertyKindIsItemGroup()
+        {
+            var provider = new LaunchProfileProjectPropertiesProvider(
+                CreateDefaultTestProject(),
+                CreateDefaultTestLaunchSettings(),
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
+
+            var properties = provider.GetItemProperties(
+                itemType: LaunchProfileProjectItemProvider.ItemType,
+                item: "Profile1");
+
+            Assert.Equal(expected: PropertyKind.ItemGroup, actual: properties.PropertyKind);
+        }
+
+        [Fact]
+        public async Task WhenRetrievingItemPropertyNames_AllStandardProfilePropertyNamesAreReturnedEvenIfNotDefined()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile() });
+
+            var provider = new LaunchProfileProjectPropertiesProvider(
+                CreateDefaultTestProject(),
+                launchSettingsProvider,
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
+            var properties = provider.GetItemProperties(
+                itemType: LaunchProfileProjectItemProvider.ItemType,
+                item: "Profile1");
+            var propertyNames = await properties.GetPropertyNamesAsync();
+
+            Assert.Contains("CommandName", propertyNames);
+            Assert.Contains("ExecutablePath", propertyNames);
+            Assert.Contains("CommandLineArguments", propertyNames);
+            Assert.Contains("WorkingDirectory", propertyNames);
+            Assert.Contains("LaunchBrowser", propertyNames);
+            Assert.Contains("LaunchUrl", propertyNames);
+            Assert.Contains("EnvironmentVariables", propertyNames);
+        }
+
+        [Fact]
+        public async Task WhenRetrievingStandardPropertyValues_TheEmptyStringIsReturnedForUndefinedProperties()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile() });
+
+            var provider = new LaunchProfileProjectPropertiesProvider(
+                CreateDefaultTestProject(),
+                launchSettingsProvider,
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
+            var properties = provider.GetItemProperties(
+                itemType: LaunchProfileProjectItemProvider.ItemType,
+                item: "Profile1");
+
+            var standardPropertyNames = new[]
+            {
+                "CommandName",
+                "ExecutablePath",
+                "CommandLineArguments",
+                "WorkingDirectory",
+                "LaunchUrl",
+                "EnvironmentVariables"
+            };
+
+            foreach (var standardPropertyName in standardPropertyNames)
+            {
+                var evaluatedValue = await properties.GetEvaluatedPropertyValueAsync(standardPropertyName);
+                Assert.Equal(expected: string.Empty, actual: evaluatedValue);
+                var unevaluatedValue = await properties.GetUnevaluatedPropertyValueAsync(standardPropertyName);
+                Assert.Equal(expected: string.Empty, actual: unevaluatedValue);
+            }
+        }
+
+        [Fact]
+        public async Task WhenRetrievingTheLaunchBrowserValue_TheDefaultValueIsFalse()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile() });
+
+            var provider = new LaunchProfileProjectPropertiesProvider(
+                CreateDefaultTestProject(),
+                launchSettingsProvider,
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
+            var properties = provider.GetItemProperties(
+                itemType: LaunchProfileProjectItemProvider.ItemType,
+                item: "Profile1");
+
+            var evaluatedValue = await properties.GetEvaluatedPropertyValueAsync("LaunchBrowser");
+            Assert.Equal(expected: "false", actual: evaluatedValue);
+            var unevaluatedValue = await properties.GetUnevaluatedPropertyValueAsync("LaunchBrowser");
+            Assert.Equal(expected: "false", actual: unevaluatedValue);
+        }
+
+        [Fact]
+        public async Task WhenRetrievingStandardPropertyValues_TheExpectedValuesAreReturned()
+        {
+            var profile1 = new WritableLaunchProfile
+            {
+                Name = "Profile1",
+                CommandLineArgs = "alpha beta gamma",
+                CommandName = "epsilon",
+                EnvironmentVariables = { ["One"] = "1", ["Two"] = "2" },
+                ExecutablePath = @"D:\five\six\seven\eight.exe",
+                LaunchBrowser = true,
+                LaunchUrl = "https://localhost/profile",
+                WorkingDirectory = @"C:\users\other\temp"
+            };
+
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile() });
+            var provider = new LaunchProfileProjectPropertiesProvider(
+                CreateDefaultTestProject(),
+                launchSettingsProvider,
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
+            var properties = provider.GetItemProperties(
+                itemType: LaunchProfileProjectItemProvider.ItemType,
+                item: "Profile1");
+
+            var expectedValues = new Dictionary<string, string>
+            {
+                ["CommandLineArguments"] = "alpha beta gamma",
+                ["CommandName"] = "epsilon",
+                ["EnvironmentVariables"] = "One=1,Two=2",
+                ["ExecutablePath"] = @"D:\five\six\seven\eight.exe",
+                ["LaunchBrowser"] = "true",
+                ["LaunchUrl"] = "https://localhost/profile",
+                ["WorkingDirectory"] = @"C:\users\other\temp",
+            };
+
+            foreach (var (propertyName, expectedPropertyValue) in expectedValues)
+            {
+                var actualUnevaluatedValue = await properties.GetUnevaluatedPropertyValueAsync(propertyName);
+                var actualEvaluatedValue = await properties.GetEvaluatedPropertyValueAsync(propertyName);
+                Assert.Equal(expectedPropertyValue, actualUnevaluatedValue);
+                Assert.Equal(expectedPropertyValue, actualEvaluatedValue);
+            }
+        }
+
+        /// <summary>
+        /// Creates an <see cref="UnconfiguredProject"/> where the <see cref="UnconfiguredProject.FullPath"/>
+        /// is set to <see cref="DefaultTestProjectPath"/>.
+        /// </summary>
+        private static UnconfiguredProject CreateDefaultTestProject()
+        {
+            return UnconfiguredProjectFactory.ImplementFullPath(DefaultTestProjectPath);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="ILaunchSettingsProvider"/> with two empty profiles named
+        /// "Profile1" and "Profile2".
+        /// </summary>
+        private static ILaunchSettingsProvider CreateDefaultTestLaunchSettings()
+        {
+            var profile1 = new WritableLaunchProfile { Name = "Profile1" };
+            var profile2 = new WritableLaunchProfile { Name = "Profile2" };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile(), profile2.ToLaunchProfile() });
+            return launchSettingsProvider;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectPropertiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfilesProjectPropertiesTests.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Xunit;
@@ -13,23 +13,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     {
         private const string DefaultTestProjectPath = @"C:\alpha\beta\gamma.csproj";
 
-        private static readonly IEnumerable<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyLaunchProfileExtensionValueProviders =
-            Enumerable.Empty<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>>();
-        private static readonly IEnumerable<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyGlobalSettingExtensionValueProviders =
-            Enumerable.Empty<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>>();
+        private static readonly ImmutableArray<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyLaunchProfileExtensionValueProviders =
+            ImmutableArray<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>>.Empty;
+        private static readonly ImmutableArray<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyGlobalSettingExtensionValueProviders =
+            ImmutableArray<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>>.Empty;
 
         [Fact]
         public void WhenRetrievingItemProperties_TheContextHasTheExpectedValues()
         {
-            var provider = new LaunchProfileProjectPropertiesProvider(
-                CreateDefaultTestProject(),
+            var properties = new LaunchProfileProjectProperties(
+                DefaultTestProjectPath,
+                "Profile1",
                 CreateDefaultTestLaunchSettings(),
                 EmptyLaunchProfileExtensionValueProviders,
                 EmptyGlobalSettingExtensionValueProviders);
 
-            var properties = provider.GetItemProperties(
-                itemType: LaunchProfileProjectItemProvider.ItemType,
-                item: "Profile1");
             var context = properties.Context;
 
             Assert.Equal(expected: DefaultTestProjectPath, actual: context.File);
@@ -41,15 +39,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [Fact]
         public void WhenRetrievingItemProperties_TheFilePathIsTheProjectPath()
         {
-            var provider = new LaunchProfileProjectPropertiesProvider(
-                CreateDefaultTestProject(),
+            var properties = new LaunchProfileProjectProperties(
+                DefaultTestProjectPath,
+                "Profile1",
                 CreateDefaultTestLaunchSettings(),
                 EmptyLaunchProfileExtensionValueProviders,
                 EmptyGlobalSettingExtensionValueProviders);
-
-            var properties = provider.GetItemProperties(
-                itemType: LaunchProfileProjectItemProvider.ItemType,
-                item: "Profile1");
 
             Assert.Equal(expected: DefaultTestProjectPath, actual: properties.FileFullPath);
         }
@@ -57,15 +52,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [Fact]
         public void WhenRetrievingItemProperties_ThePropertyKindIsItemGroup()
         {
-            var provider = new LaunchProfileProjectPropertiesProvider(
-                CreateDefaultTestProject(),
+            var properties = new LaunchProfileProjectProperties(
+                DefaultTestProjectPath,
+                "Profile1",
                 CreateDefaultTestLaunchSettings(),
                 EmptyLaunchProfileExtensionValueProviders,
                 EmptyGlobalSettingExtensionValueProviders);
-
-            var properties = provider.GetItemProperties(
-                itemType: LaunchProfileProjectItemProvider.ItemType,
-                item: "Profile1");
 
             Assert.Equal(expected: PropertyKind.ItemGroup, actual: properties.PropertyKind);
         }
@@ -77,14 +69,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile() });
 
-            var provider = new LaunchProfileProjectPropertiesProvider(
-                CreateDefaultTestProject(),
+            var properties = new LaunchProfileProjectProperties(
+                DefaultTestProjectPath,
+                "Profile1",
                 launchSettingsProvider,
                 EmptyLaunchProfileExtensionValueProviders,
                 EmptyGlobalSettingExtensionValueProviders);
-            var properties = provider.GetItemProperties(
-                itemType: LaunchProfileProjectItemProvider.ItemType,
-                item: "Profile1");
+
             var propertyNames = await properties.GetPropertyNamesAsync();
 
             Assert.Contains("CommandName", propertyNames);
@@ -103,14 +94,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile() });
 
-            var provider = new LaunchProfileProjectPropertiesProvider(
-                CreateDefaultTestProject(),
+            var properties = new LaunchProfileProjectProperties(
+                DefaultTestProjectPath,
+                "Profile1",
                 launchSettingsProvider,
                 EmptyLaunchProfileExtensionValueProviders,
                 EmptyGlobalSettingExtensionValueProviders);
-            var properties = provider.GetItemProperties(
-                itemType: LaunchProfileProjectItemProvider.ItemType,
-                item: "Profile1");
 
             var standardPropertyNames = new[]
             {
@@ -138,14 +127,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile() });
 
-            var provider = new LaunchProfileProjectPropertiesProvider(
-                CreateDefaultTestProject(),
+            var properties = new LaunchProfileProjectProperties(
+                DefaultTestProjectPath,
+                "Profile1",
                 launchSettingsProvider,
                 EmptyLaunchProfileExtensionValueProviders,
                 EmptyGlobalSettingExtensionValueProviders);
-            var properties = provider.GetItemProperties(
-                itemType: LaunchProfileProjectItemProvider.ItemType,
-                item: "Profile1");
 
             var evaluatedValue = await properties.GetEvaluatedPropertyValueAsync("LaunchBrowser");
             Assert.Equal(expected: "false", actual: evaluatedValue);
@@ -170,14 +157,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 launchProfiles: new[] { profile1.ToLaunchProfile() });
-            var provider = new LaunchProfileProjectPropertiesProvider(
-                CreateDefaultTestProject(),
+            var properties = new LaunchProfileProjectProperties(
+                DefaultTestProjectPath,
+                "Profile1",
                 launchSettingsProvider,
                 EmptyLaunchProfileExtensionValueProviders,
                 EmptyGlobalSettingExtensionValueProviders);
-            var properties = provider.GetItemProperties(
-                itemType: LaunchProfileProjectItemProvider.ItemType,
-                item: "Profile1");
 
             var expectedValues = new Dictionary<string, string>
             {
@@ -197,15 +182,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 Assert.Equal(expectedPropertyValue, actualUnevaluatedValue);
                 Assert.Equal(expectedPropertyValue, actualEvaluatedValue);
             }
-        }
-
-        /// <summary>
-        /// Creates an <see cref="UnconfiguredProject"/> where the <see cref="UnconfiguredProject.FullPath"/>
-        /// is set to <see cref="DefaultTestProjectPath"/>.
-        /// </summary>
-        private static UnconfiguredProject CreateDefaultTestProject()
-        {
-            return UnconfiguredProjectFactory.ImplementFullPath(DefaultTestProjectPath);
         }
 
         /// <summary>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ProjectLaunchProfileExtensionValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ProjectLaunchProfileExtensionValueProviderTests.cs
@@ -1,0 +1,204 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    public class ProjectLaunchProfileExtensionValueProviderTests
+    {
+        private static readonly ImmutableDictionary<string, object> EmptyGlobalSettings = ImmutableDictionary<string, object>.Empty;
+
+        [Fact]
+        public async Task AuthenticationMode_OnGetPropertyValueAsync_GetsModeFromActiveProfile()
+        {
+            string activeProfileAuthenticationMode = "Windows";
+            var profile = new WritableLaunchProfile
+            {
+                OtherSettings =
+                {
+                    { LaunchProfileExtensions.RemoteAuthenticationModeProperty, activeProfileAuthenticationMode }
+                }
+            }.ToLaunchProfile();
+
+            var provider = new ProjectLaunchProfileExtensionValueProvider();
+
+            var actualValue = await provider.OnGetPropertyValueAsync(ProjectLaunchProfileExtensionValueProvider.AuthenticationModePropertyName, profile, EmptyGlobalSettings, rule: null);
+
+            Assert.Equal(expected: activeProfileAuthenticationMode, actual: actualValue);
+        }
+
+        [Fact]
+        public async Task AuthenticationMode_OnSetPropertyValueAsync_SetsModeInActiveProfile()
+        {
+            string activeProfileAuthenticationMode = "Windows";
+            var profile = new WritableLaunchProfile
+            {
+                OtherSettings =
+                {
+                    { LaunchProfileExtensions.RemoteAuthenticationModeProperty, activeProfileAuthenticationMode }
+                }
+            };
+
+            var provider = new ProjectLaunchProfileExtensionValueProvider();
+
+            await provider.OnSetPropertyValueAsync(ProjectLaunchProfileExtensionValueProvider.AuthenticationModePropertyName, "NotWindows", profile, EmptyGlobalSettings, rule: null);
+
+            Assert.Equal(expected: "NotWindows", actual: profile.OtherSettings[LaunchProfileExtensions.RemoteAuthenticationModeProperty]);
+        }
+
+        [Fact]
+        public async Task NativeDebugging_OnGetPropertyValueAsync_GetsNativeDebuggingFromActiveProfile()
+        {
+            bool activeProfileNativeDebugging = true;
+            var profile = new WritableLaunchProfile
+            {
+                OtherSettings =
+                {
+                    { LaunchProfileExtensions.NativeDebuggingProperty, activeProfileNativeDebugging }
+                }
+            }.ToLaunchProfile();
+
+            var provider = new ProjectLaunchProfileExtensionValueProvider();
+
+            var actualValue = await provider.OnGetPropertyValueAsync(ProjectLaunchProfileExtensionValueProvider.NativeDebuggingPropertyName, profile, EmptyGlobalSettings, rule: null);
+
+            Assert.Equal(expected: "true", actual: actualValue);
+        }
+
+        [Fact]
+        public async Task NativeDebugging_OnSetPropertyValueAsync_SetsNativeDebuggingInActiveProfile()
+        {
+            bool activeProfileNativeDebugging = false;
+            var profile = new WritableLaunchProfile
+            {
+                OtherSettings =
+                {
+                    { LaunchProfileExtensions.NativeDebuggingProperty, activeProfileNativeDebugging }
+                }
+            };
+
+            var provider = new ProjectLaunchProfileExtensionValueProvider();
+
+            await provider.OnSetPropertyValueAsync(ProjectLaunchProfileExtensionValueProvider.NativeDebuggingPropertyName, "true", profile, EmptyGlobalSettings, rule: null);
+
+            Assert.True((bool)profile.OtherSettings[LaunchProfileExtensions.NativeDebuggingProperty]);
+        }
+
+        [Fact]
+        public async Task RemoteDebugEnabled_OnGetPropertyValueAsync_GetsRemoteDebuggingFromActiveProfile()
+        {
+            bool activeProfileRemoteDebugEnabled = true;
+            var profile = new WritableLaunchProfile
+            {
+                OtherSettings =
+                {
+                    { LaunchProfileExtensions.RemoteDebugEnabledProperty, activeProfileRemoteDebugEnabled }
+                }
+            }.ToLaunchProfile();
+
+            var provider = new ProjectLaunchProfileExtensionValueProvider();
+
+            var actualValue = await provider.OnGetPropertyValueAsync(ProjectLaunchProfileExtensionValueProvider.RemoteDebugEnabledPropertyName, profile, EmptyGlobalSettings, rule: null);
+
+            Assert.Equal(expected: "true", actual: actualValue);
+        }
+
+        [Fact]
+        public async Task RemoteDebugEnabled_OnSetPropertyValueAsync_SetsRemoteDebuggingInActiveProfile()
+        {
+            bool activeProfileRemoteDebugEnabled = false;
+            var profile = new WritableLaunchProfile
+            {
+                OtherSettings =
+                {
+                    { LaunchProfileExtensions.RemoteDebugEnabledProperty, activeProfileRemoteDebugEnabled }
+                }
+            };
+
+            var provider = new ProjectLaunchProfileExtensionValueProvider();
+
+            await provider.OnSetPropertyValueAsync(ProjectLaunchProfileExtensionValueProvider.RemoteDebugEnabledPropertyName, "true", profile, EmptyGlobalSettings, rule: null);
+
+            Assert.True((bool)profile.OtherSettings[LaunchProfileExtensions.RemoteDebugEnabledProperty]);
+        }
+
+        [Fact]
+        public async Task RemoteMachineName_OnGetPropertyValueAsync_GetsNameFromActiveProfile()
+        {
+            string activeProfileRemoteMachineName = "alphaMachine";
+            var profile = new WritableLaunchProfile
+            {
+                OtherSettings =
+                {
+                    { LaunchProfileExtensions.RemoteDebugMachineProperty, activeProfileRemoteMachineName }
+                }
+            }.ToLaunchProfile();
+
+            var provider = new ProjectLaunchProfileExtensionValueProvider();
+
+            var actualValue = await provider.OnGetPropertyValueAsync(ProjectLaunchProfileExtensionValueProvider.RemoteDebugMachinePropertyName, profile, EmptyGlobalSettings, rule: null);
+
+            Assert.Equal(expected: activeProfileRemoteMachineName, actual: actualValue);
+        }
+
+        [Fact]
+        public async Task RemoteMachineName_OnSetPropertyValueAsync_SetsNameInActiveProfile()
+        {
+            string activeProfileRemoteMachineName = "Tiger";
+            var profile = new WritableLaunchProfile
+            {
+                OtherSettings =
+                {
+                    { LaunchProfileExtensions.RemoteDebugMachineProperty, activeProfileRemoteMachineName }
+                }
+            };
+
+            var provider = new ProjectLaunchProfileExtensionValueProvider();
+
+            await provider.OnSetPropertyValueAsync(ProjectLaunchProfileExtensionValueProvider.RemoteDebugMachinePropertyName, "Cheetah", profile, EmptyGlobalSettings, rule: null);
+
+            Assert.Equal(expected: "Cheetah", actual: profile.OtherSettings[LaunchProfileExtensions.RemoteDebugMachineProperty]);
+        }
+
+        [Fact]
+        public async Task SqlDebugEnabled_OnGetPropertyValueAsync_GetsSettingFromActiveProfile()
+        {
+            bool activeProfileSqlDebugEnabled = true;
+            var profile = new WritableLaunchProfile
+            {
+                OtherSettings =
+                {
+                    { LaunchProfileExtensions.SqlDebuggingProperty, activeProfileSqlDebugEnabled }
+                }
+            }.ToLaunchProfile();
+
+            var provider = new ProjectLaunchProfileExtensionValueProvider();
+
+            var actualValue = await provider.OnGetPropertyValueAsync(ProjectLaunchProfileExtensionValueProvider.SqlDebuggingPropertyName, profile, EmptyGlobalSettings, rule: null);
+
+            Assert.Equal(expected: "true", actual: actualValue);
+        }
+
+        [Fact]
+        public async Task SqlDebugEnabled_OnSetPropertyValueAsync_SetsSqlDebugInActiveProfile()
+        {
+            bool activeProfileSqlDebugEnabled = false;
+            var profile = new WritableLaunchProfile
+            {
+                OtherSettings =
+                {
+                    { LaunchProfileExtensions.SqlDebuggingProperty, activeProfileSqlDebugEnabled }
+                }
+            };
+
+            var provider = new ProjectLaunchProfileExtensionValueProvider();
+
+            await provider.OnSetPropertyValueAsync(ProjectLaunchProfileExtensionValueProvider.SqlDebuggingPropertyName, "true", profile, EmptyGlobalSettings, rule: null);
+
+            Assert.True((bool)profile.OtherSettings[LaunchProfileExtensions.SqlDebuggingProperty]);
+        }
+    }
+}


### PR DESCRIPTION
`ILaunchProfile` has a few pre-defined properties (like ExecutablePath, CommandLineArgs, LaunchBrowser, etc.) but it also supports storage of arbitrary objects via the `ImmutableDictionary<string, object>` accessible via the `OtherSettings` property, and in practice the bulk of the properties we care about are stored there. Separately, `ILaunchSettings.GlobalSettings` is another `ImmutableDictionary<string, object>` storing launch settings that are global (that is, not tied to a particular launch profile).

There are a few operations we need to support:
1. In each case the property value comes in as a `string`, but needs to be stored in the dictionary as an `object`. While we could store it as a `string` by default this would be incorrect in many cases, and so we need a converter for each property we wish to store.
2. We also need to convert back from an `object` to a string
3. Changing one property may also require changes to other properties, and so we also need a way to modify the launch settings (or global settings) as a whole.

These new interfaces provide the necessary abilities.

Implementation classes must be tagged with the `ExportLaunchProfileExtensionValueProviderAttribute` indicating the names of the properties they handle, as well as whether it applies to the launch profiles or the global settings. In the former case it must implement `ILaunchProfileExtensionValueProvider`; in the latter `IGlobalSettingExtensionValueProvider`. The extensions will be imported by the `LaunchProfileProjectPropertiesProvider` which will redirect all reads and writes of the related properties through them.

These interfaces do almost the same thing, but there are some important differences which lead to different API shapes. When accessing the properties of a launch profile we may want to know the current global settings, and so those are passed along. However, when modifying a global setting we would not expect it to depend on or modify values in individual launch profiles, so those are _not_ available.

This change also adds an implementation of `ILaunchProfileExtensionValueProvider` to handle the extension properties we utilize for profiles using the Project and Executable debug commands.

Note that `LaunchProfileProjectProperties` will use the extension points for reading properties, but it does not yet support setting properties at all.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7043)