### PR TITLE
Only enable the new Project Properties UI for C# projects

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
@@ -230,8 +230,8 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         End Function
 
         Private Function UseNewEditor(vsHierarchy As IVsHierarchy) As Boolean
-            If Not vsHierarchy.IsCapabilityMatch("CPS") Then
-                ' The new editor is only available for CPS-based projects
+            If Not vsHierarchy.IsCapabilityMatch("CPS & CSharp") Then
+                ' The new editor is only available for CPS-based C# projects
                 Return False
             End If
 


### PR DESCRIPTION
So far the new Project Properties UI has good support for most C# project types. VB (#6935) and F# (#6936) support has not been addressed yet.

This change prevents delegation from the legacy editor to the new editor unless the `CSharp` capability is present. This will be important as we start to roll out by default to more MS internal folks.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7047)