### PR TITLE
Fix bugs and quirks

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/DebugUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/DebugUtilities.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public static IEnumerable<Rule> GetDebugChildRules(IPropertyPagesCatalog projectCatalog)
         {
-            foreach (string schemaName in projectCatalog.GetProjectLevelPropertyPagesSchemas())
+            foreach (string schemaName in projectCatalog.GetPropertyPagesSchemas(itemType: "LaunchProfile"))
             {
                 if (projectCatalog.GetSchema(schemaName) is Rule possibleChildRule
                     && !possibleChildRule.PropertyPagesHidden

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileFromProjectDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileFromProjectDataProducer.cs
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
 
             if (_properties.Name)
             {
-                newLaunchProfile.Name = context.ItemType;
+                newLaunchProfile.Name = context.ItemName;
             }
 
             if (_properties.CommandName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
@@ -20,7 +20,8 @@
 
   <Rule.DataSource>
     <DataSource Persistence="LaunchProfile"
-                HasConfigurationCondition="False" />
+                HasConfigurationCondition="False"
+                ItemType="LaunchProfile"/>
   </Rule.DataSource>
 
   <StringProperty Name="ExecutablePath"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
@@ -20,7 +20,8 @@
 
   <Rule.DataSource>
     <DataSource Persistence="LaunchProfile"
-                HasConfigurationCondition="False" />
+                HasConfigurationCondition="False"
+                ItemType="LaunchProfile" />
   </Rule.DataSource>
 
   <StringProperty Name="CommandLineArguments"


### PR DESCRIPTION
1. When populating the `Name` property of a launch profile entity we were incorrectly using the "item type" which will always be "LaunchProfile". Here we fix this to return the actual name.
2. I discovered a quirk in the CPS properties system. Basically, if you try to set a property value on a specific item (as opposed to the project) but the `DataSource` used in that operation is not tied to a specific item _type_, the system thinks you are accidentally trying to set the property for all items with that particular name. E.g., you could have a `<None>` item and an `<EmbeddedResource>` item with the same name, and unless the `DataSource` is bound to one or the other the system thinks you're trying to change both. The system blocks the operation by effectively treating the property as read-only. Now, this won't be a problem with launch profiles because they could only ever refer to things in the launchSettings.json file, and profiles are uniquely idenftified by name (whereas MSBuild items are uniquely identified by the combination of item type and name) and I question if this is ever really an issue. At this point, however, it's not worth updating CPS and possible regressing something else. Instead, we'll bring our code in line with the system's expectations: the relevant .xaml `Rule` files are updated to specify that they relate to the "LaunchProfile" item type, and when we retrieve those `Rules` we now need to specify the item type, as well. Since they have an `ItemType` they are no longer considered "project-level".

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7054)