### PR TITLE
Fix a potential hang in LaunchSettingsProvider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -681,6 +681,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                     _projectRuleSubscriptionLink.Dispose();
                     _projectRuleSubscriptionLink = null;
                 }
+
+                _firstSnapshotCompletionSource.TrySetCanceled();
             }
         }
 
@@ -722,7 +724,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         /// <summary>
         /// This function blocks until a snapshot is available. It will return null if the timeout occurs
-        /// prior to the snapshot is available
+        /// prior to the snapshot is available. The wait operation will be cancelled if this object is disposed.
         /// </summary>
         public async Task<ILaunchSettings?> WaitForFirstSnapshot(int timeout)
         {


### PR DESCRIPTION
Quite a few calls into `LaunchSettingsProvider.WaitForFirstSnapshot` pass `Timeout.Infinite`. If such a wait is initiated, and the `LaunchSettingsProvider` is disposed, the wait operation would never complete.

This change ensures the `TaskCompletionSource` via which the wait is implemented is cancelled if it hadn't otherwise completed during disposal of the `LaunchSettingsProvider`, ensuring such hangs can not occur.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7055)