### PR TITLE
Use conditional visibility for remote debugging properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
@@ -44,12 +44,26 @@
 
   <StringProperty Name="RemoteDebugMachine"
                   DisplayName="Remote machine name"
-                  Description="The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled."/>
+                  Description="The name and port number of the remote machine in 'name:port' format.">
+    <StringProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(evaluated "Executable" "RemoteDebugEnabled")</NameValuePair.Value>
+      </NameValuePair>
+      <NameValuePair Name="DependsOn" Value="Executable::RemoteDebugMachine" />
+    </StringProperty.Metadata>
+  </StringProperty>
 
   <DynamicEnumProperty Name="AuthenticationMode"
                        DisplayName="Authentication mode"
-                       Description="The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled."
-                       EnumProvider="AuthenticationModeEnumProvider" />
+                       Description="The authentication scheme to use when connecting to the remote machine."
+                       EnumProvider="AuthenticationModeEnumProvider">
+    <DynamicEnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(evaluated "Executable" "RemoteDebugEnabled")</NameValuePair.Value>
+      </NameValuePair>
+      <NameValuePair Name="DependsOn" Value="Executable::RemoteDebugMachine" />
+    </DynamicEnumProperty.Metadata>
+  </DynamicEnumProperty>
 
   <StringProperty Name="EnvironmentVariables"
                   DisplayName="Environment variables"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
@@ -35,16 +35,30 @@
 
   <BoolProperty Name="RemoteDebugEnabled"
                 DisplayName="Use remote machine"
-                Description="Indicates that the debugger should attach to a process on a remote machine."/>
+                Description="Indicates that the debugger should attach to a process on a remote machine." />
 
   <StringProperty Name="RemoteDebugMachine"
                   DisplayName="Remote machine name"
-                  Description="The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled."/>
+                  Description="The name and port number of the remote machine in 'name:port' format.">
+    <StringProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(evaluated "Project" "RemoteDebugEnabled")</NameValuePair.Value>
+      </NameValuePair>
+      <NameValuePair Name="DependsOn" Value="Project::RemoteDebugMachine" />
+    </StringProperty.Metadata>
+  </StringProperty>
 
   <DynamicEnumProperty Name="AuthenticationMode"
                        DisplayName="Authentication mode"
-                       Description="The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled."
-                       EnumProvider="AuthenticationModeEnumProvider" />
+                       Description="The authentication scheme to use when connecting to the remote machine."
+                       EnumProvider="AuthenticationModeEnumProvider">
+    <DynamicEnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(evaluated "Project" "RemoteDebugEnabled")</NameValuePair.Value>
+      </NameValuePair>
+      <NameValuePair Name="DependsOn" Value="Project::RemoteDebugMachine" />
+    </DynamicEnumProperty.Metadata>
+  </DynamicEnumProperty>
 
   <StringProperty Name="EnvironmentVariables"
                   DisplayName="Environment variables"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.cs.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Schéma ověřování, které se má použít při připojování na vzdáleném počítači. Dá se použít jen v případě, že je povolená možnost Použít vzdálený počítač.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">Schéma ověřování, které se má použít při připojování na vzdáleném počítači. Dá se použít jen v případě, že je povolená možnost Použít vzdálený počítač.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Název a číslo portu vzdáleného počítače ve formátu název:port. Dá se použít jen v případě, že je povolená možnost Použít vzdálený počítač.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">Název a číslo portu vzdáleného počítače ve formátu název:port. Dá se použít jen v případě, že je povolená možnost Použít vzdálený počítač.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.de.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Das Authentifizierungsschema, das beim Herstellen einer Verbindung mit dem Remotecomputer verwendet werden soll. Gilt nur, wenn "Remotecomputer verwenden" aktiviert ist.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">Das Authentifizierungsschema, das beim Herstellen einer Verbindung mit dem Remotecomputer verwendet werden soll. Gilt nur, wenn "Remotecomputer verwenden" aktiviert ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Der Name und die Portnummer des Remotecomputers im Format "Name:Port". Gilt nur, wenn "Remotecomputer verwenden" aktiviert ist.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">Der Name und die Portnummer des Remotecomputers im Format "Name:Port". Gilt nur, wenn "Remotecomputer verwenden" aktiviert ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.es.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Esquema de autenticación que se va a usar al conectarse a la máquina remota. Solo es aplicable cuando la opción "Usar máquina remota" está habilitada.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">Esquema de autenticación que se va a usar al conectarse a la máquina remota. Solo es aplicable cuando la opción "Usar máquina remota" está habilitada.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">El nombre y el número de puerto de la máquina remota con el formato "nombre:puerto". Solo es aplicable cuando la opción "Usar máquina remota" está habilitada.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">El nombre y el número de puerto de la máquina remota con el formato "nombre:puerto". Solo es aplicable cuando la opción "Usar máquina remota" está habilitada.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.fr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Schéma d'authentification à utiliser au moment de la connexion à la machine distante. Applicable uniquement quand l'option Utiliser une machine distante est activée.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">Schéma d'authentification à utiliser au moment de la connexion à la machine distante. Applicable uniquement quand l'option Utiliser une machine distante est activée.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Nom et numéro de port de la machine distante au format 'nom:port'. Applicable uniquement quand l'option Utiliser une machine distante est activée.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">Nom et numéro de port de la machine distante au format 'nom:port'. Applicable uniquement quand l'option Utiliser une machine distante est activée.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.it.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Schema di autenticazione da usare per la connessione al computer remoto. Applicabile solo quando l'opzione 'Usa computer remoto' è abilitata.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">Schema di autenticazione da usare per la connessione al computer remoto. Applicabile solo quando l'opzione 'Usa computer remoto' è abilitata.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Nome e numero di porta del computer remoto nel formato 'nome:porta'. Applicabile solo quando l'opzione 'Usa computer remoto' è abilitata.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">Nome e numero di porta del computer remoto nel formato 'nome:porta'. Applicabile solo quando l'opzione 'Usa computer remoto' è abilitata.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ja.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">リモート マシンへの接続時に使用する認証方式。[リモート マシンを使用する] が有効になっている場合にのみ適用されます。</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">リモート マシンへの接続時に使用する認証方式。[リモート マシンを使用する] が有効になっている場合にのみ適用されます。</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">'name:port' 形式のリモート マシンの名前とポート番号。[リモート マシンを使用する] が有効になっている場合にのみ適用されます。</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">'name:port' 形式のリモート マシンの名前とポート番号。[リモート マシンを使用する] が有効になっている場合にのみ適用されます。</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ko.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">원격 머신에 연결할 때 사용할 인증 체계입니다. '원격 머신 사용'이 사용하도록 설정된 경우에만 적용 가능합니다.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">원격 머신에 연결할 때 사용할 인증 체계입니다. '원격 머신 사용'이 사용하도록 설정된 경우에만 적용 가능합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">'name:port' 형식으로 된 원격 머신의 이름과 포트 번호입니다. '원격 머신 사용'이 사용하도록 설정된 경우에만 적용 가능합니다.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">'name:port' 형식으로 된 원격 머신의 이름과 포트 번호입니다. '원격 머신 사용'이 사용하도록 설정된 경우에만 적용 가능합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pl.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Schemat uwierzytelniania, który ma być używany podczas nawiązywania połączenia z maszyną zdalną. Ma zastosowanie tylko wtedy, gdy jest włączona funkcja „Użyj maszyny zdalnej”.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">Schemat uwierzytelniania, który ma być używany podczas nawiązywania połączenia z maszyną zdalną. Ma zastosowanie tylko wtedy, gdy jest włączona funkcja „Użyj maszyny zdalnej”.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Nazwa i numer portu maszyny zdalnej w formacie „Nazwa:Port”. Ma zastosowanie tylko wtedy, gdy jest włączona funkcja „Użyj maszyny zdalnej”.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">Nazwa i numer portu maszyny zdalnej w formacie „Nazwa:Port”. Ma zastosowanie tylko wtedy, gdy jest włączona funkcja „Użyj maszyny zdalnej”.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.pt-BR.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">O esquema de autenticação a ser usado durante a conexão com o computador remoto. Aplica-se somente quando 'Usar computador remoto' está habilitado.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">O esquema de autenticação a ser usado durante a conexão com o computador remoto. Aplica-se somente quando 'Usar computador remoto' está habilitado.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">O nome e o número da porta do computador remoto no formato 'name:port'. Aplica-se somente quando 'Usar computador remoto' está habilitado.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">O nome e o número da porta do computador remoto no formato 'name:port'. Aplica-se somente quando 'Usar computador remoto' está habilitado.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.ru.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Схема проверки подлинности, используемая для подключения к удаленному компьютеру. Применяется, только если включено "Использование удаленного компьютера".</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">Схема проверки подлинности, используемая для подключения к удаленному компьютеру. Применяется, только если включено "Использование удаленного компьютера".</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Имя и номер порта удаленного компьютера в формате "имя:порт". Применяется, только если включено "Использование удаленного компьютера".</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">Имя и номер порта удаленного компьютера в формате "имя:порт". Применяется, только если включено "Использование удаленного компьютера".</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.tr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Uzak makineye bağlanırken kullanılacak kimlik doğrulaması düzeni. Yalnızca 'Uzak makine kullan' etkin olduğunda uygulanabilir.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">Uzak makineye bağlanırken kullanılacak kimlik doğrulaması düzeni. Yalnızca 'Uzak makine kullan' etkin olduğunda uygulanabilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Uzak makinenin 'ad:bağlantı noktası' biçimindeki adı ve bağlantı noktası numarası. Yalnızca 'Uzak makine kullan' etkin olduğunda uygulanabilir.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">Uzak makinenin 'ad:bağlantı noktası' biçimindeki adı ve bağlantı noktası numarası. Yalnızca 'Uzak makine kullan' etkin olduğunda uygulanabilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hans.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">连接到远程计算机时要使用的身份验证方案。仅在启用“使用远程计算机”时适用。</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">连接到远程计算机时要使用的身份验证方案。仅在启用“使用远程计算机”时适用。</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">采用 "name:port" 格式的远程计算机的名称和端口号。仅在启用“使用远程计算机”时适用。</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">采用 "name:port" 格式的远程计算机的名称和端口号。仅在启用“使用远程计算机”时适用。</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ExecutableDebugPropertyPage.xaml.zh-Hant.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">連線至遠端電腦時所要使用的驗證配置。只有在啟用 [使用遠端電腦] 時才適用。</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">連線至遠端電腦時所要使用的驗證配置。只有在啟用 [使用遠端電腦] 時才適用。</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">遠端電腦的名稱及連接埠號碼，採用 'name:port' 格式。只有在啟用 [使用遠端電腦] 時才適用。</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">遠端電腦的名稱及連接埠號碼，採用 'name:port' 格式。只有在啟用 [使用遠端電腦] 時才適用。</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.cs.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Schéma ověřování, které se má použít při připojování na vzdáleném počítači. Dá se použít jen v případě, že je povolená možnost Použít vzdálený počítač.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">Schéma ověřování, které se má použít při připojování na vzdáleném počítači. Dá se použít jen v případě, že je povolená možnost Použít vzdálený počítač.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Název a číslo portu vzdáleného počítače ve formátu název:port. Dá se použít jen v případě, že je povolená možnost Použít vzdálený počítač.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">Název a číslo portu vzdáleného počítače ve formátu název:port. Dá se použít jen v případě, že je povolená možnost Použít vzdálený počítač.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.de.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Das Authentifizierungsschema, das beim Herstellen einer Verbindung mit dem Remotecomputer verwendet werden soll. Gilt nur, wenn "Remotecomputer verwenden" aktiviert ist.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">Das Authentifizierungsschema, das beim Herstellen einer Verbindung mit dem Remotecomputer verwendet werden soll. Gilt nur, wenn "Remotecomputer verwenden" aktiviert ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Der Name und die Portnummer des Remotecomputers im Format "Name:Port". Gilt nur, wenn "Remotecomputer verwenden" aktiviert ist.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">Der Name und die Portnummer des Remotecomputers im Format "Name:Port". Gilt nur, wenn "Remotecomputer verwenden" aktiviert ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.es.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Esquema de autenticación que se va a usar al conectarse a la máquina remota. Solo es aplicable cuando la opción "Usar máquina remota" está habilitada.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">Esquema de autenticación que se va a usar al conectarse a la máquina remota. Solo es aplicable cuando la opción "Usar máquina remota" está habilitada.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">El nombre y el número de puerto de la máquina remota con el formato "nombre:puerto". Solo es aplicable cuando la opción "Usar máquina remota" está habilitada.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">El nombre y el número de puerto de la máquina remota con el formato "nombre:puerto". Solo es aplicable cuando la opción "Usar máquina remota" está habilitada.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.fr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Schéma d'authentification à utiliser au moment de la connexion à la machine distante. Applicable uniquement quand l'option Utiliser une machine distante est activée.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">Schéma d'authentification à utiliser au moment de la connexion à la machine distante. Applicable uniquement quand l'option Utiliser une machine distante est activée.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Nom et numéro de port de la machine distante au format 'nom:port'. Applicable uniquement quand l'option Utiliser une machine distante est activée.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">Nom et numéro de port de la machine distante au format 'nom:port'. Applicable uniquement quand l'option Utiliser une machine distante est activée.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.it.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Schema di autenticazione da usare per la connessione al computer remoto. Applicabile solo quando l'opzione 'Usa computer remoto' è abilitata.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">Schema di autenticazione da usare per la connessione al computer remoto. Applicabile solo quando l'opzione 'Usa computer remoto' è abilitata.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Nome e numero di porta del computer remoto nel formato 'nome:porta'. Applicabile solo quando l'opzione 'Usa computer remoto' è abilitata.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">Nome e numero di porta del computer remoto nel formato 'nome:porta'. Applicabile solo quando l'opzione 'Usa computer remoto' è abilitata.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ja.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">リモート マシンへの接続時に使用する認証方式。[リモート マシンを使用する] が有効になっている場合にのみ適用されます。</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">リモート マシンへの接続時に使用する認証方式。[リモート マシンを使用する] が有効になっている場合にのみ適用されます。</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">'name:port' 形式のリモート マシンの名前とポート番号。[リモート マシンを使用する] が有効になっている場合にのみ適用されます。</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">'name:port' 形式のリモート マシンの名前とポート番号。[リモート マシンを使用する] が有効になっている場合にのみ適用されます。</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ko.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">원격 머신에 연결할 때 사용할 인증 체계입니다. '원격 머신 사용'이 사용하도록 설정된 경우에만 적용 가능합니다.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">원격 머신에 연결할 때 사용할 인증 체계입니다. '원격 머신 사용'이 사용하도록 설정된 경우에만 적용 가능합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">'name:port' 형식으로 된 원격 머신의 이름과 포트 번호입니다. '원격 머신 사용'이 사용하도록 설정된 경우에만 적용 가능합니다.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">'name:port' 형식으로 된 원격 머신의 이름과 포트 번호입니다. '원격 머신 사용'이 사용하도록 설정된 경우에만 적용 가능합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pl.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Schemat uwierzytelniania, który ma być używany podczas nawiązywania połączenia z maszyną zdalną. Ma zastosowanie tylko wtedy, gdy jest włączona funkcja „Użyj maszyny zdalnej”.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">Schemat uwierzytelniania, który ma być używany podczas nawiązywania połączenia z maszyną zdalną. Ma zastosowanie tylko wtedy, gdy jest włączona funkcja „Użyj maszyny zdalnej”.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Nazwa i numer portu maszyny zdalnej w formacie „Nazwa:Port”. Ma zastosowanie tylko wtedy, gdy jest włączona funkcja „Użyj maszyny zdalnej”.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">Nazwa i numer portu maszyny zdalnej w formacie „Nazwa:Port”. Ma zastosowanie tylko wtedy, gdy jest włączona funkcja „Użyj maszyny zdalnej”.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.pt-BR.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">O esquema de autenticação a ser usado durante a conexão com o computador remoto. Aplica-se somente quando 'Usar computador remoto' está habilitado.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">O esquema de autenticação a ser usado durante a conexão com o computador remoto. Aplica-se somente quando 'Usar computador remoto' está habilitado.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">O nome e o número da porta do computador remoto no formato 'name:port'. Aplica-se somente quando 'Usar computador remoto' está habilitado.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">O nome e o número da porta do computador remoto no formato 'name:port'. Aplica-se somente quando 'Usar computador remoto' está habilitado.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.ru.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Схема проверки подлинности, используемая для подключения к удаленному компьютеру. Применяется, только если включено "Использование удаленного компьютера".</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">Схема проверки подлинности, используемая для подключения к удаленному компьютеру. Применяется, только если включено "Использование удаленного компьютера".</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Имя и номер порта удаленного компьютера в формате "имя:порт". Применяется, только если включено "Использование удаленного компьютера".</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">Имя и номер порта удаленного компьютера в формате "имя:порт". Применяется, только если включено "Использование удаленного компьютера".</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.tr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Uzak makineye bağlanırken kullanılacak kimlik doğrulaması düzeni. Yalnızca 'Uzak makine kullan' etkin olduğunda uygulanabilir.</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">Uzak makineye bağlanırken kullanılacak kimlik doğrulaması düzeni. Yalnızca 'Uzak makine kullan' etkin olduğunda uygulanabilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">Uzak makinenin 'ad:bağlantı noktası' biçimindeki adı ve bağlantı noktası numarası. Yalnızca 'Uzak makine kullan' etkin olduğunda uygulanabilir.</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">Uzak makinenin 'ad:bağlantı noktası' biçimindeki adı ve bağlantı noktası numarası. Yalnızca 'Uzak makine kullan' etkin olduğunda uygulanabilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hans.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">连接到远程计算机时要使用的身份验证方案。仅在启用“使用远程计算机”时适用。</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">连接到远程计算机时要使用的身份验证方案。仅在启用“使用远程计算机”时适用。</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">采用 "name:port" 格式的远程计算机的名称和端口号。仅在启用“使用远程计算机”时适用。</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">采用 "name:port" 格式的远程计算机的名称和端口号。仅在启用“使用远程计算机”时适用。</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ProjectDebugPropertyPage.xaml.zh-Hant.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|Description">
-        <source>The authentication scheme to use when connecting to the remote machine. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">連線至遠端電腦時所要使用的驗證配置。只有在啟用 [使用遠端電腦] 時才適用。</target>
+        <source>The authentication scheme to use when connecting to the remote machine.</source>
+        <target state="needs-review-translation">連線至遠端電腦時所要使用的驗證配置。只有在啟用 [使用遠端電腦] 時才適用。</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|AuthenticationMode|DisplayName">
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|Description">
-        <source>The name and port number of the remote machine in 'name:port' format. Only applicable when 'Use remote machine' is enabled.</source>
-        <target state="translated">遠端電腦的名稱及連接埠號碼，採用 'name:port' 格式。只有在啟用 [使用遠端電腦] 時才適用。</target>
+        <source>The name and port number of the remote machine in 'name:port' format.</source>
+        <target state="needs-review-translation">遠端電腦的名稱及連接埠號碼，採用 'name:port' 格式。只有在啟用 [使用遠端電腦] 時才適用。</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|RemoteDebugMachine|DisplayName">


### PR DESCRIPTION
Add `VisibilityCondition` metadata to launch profile rule files so that remote-debugging properties are only visible when remote debugging is enabled.

Also removes _"Only applicable when 'Use remote machine' is enabled."_ from the descriptions of these properties, as we can now show the user that, rather than tell them.

### Before

![remote-debugging-before](https://user-images.githubusercontent.com/350947/112774643-0511c480-9086-11eb-8e43-d5b51941f6b6.gif)

### After

![remote-debugging-after](https://user-images.githubusercontent.com/350947/112774633-004d1080-9086-11eb-815d-518be6bc6645.gif)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7061)