### PR TITLE
Update <c>null</c> to <see langword="null"/>

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProjectProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileProjectProperties.cs
@@ -165,8 +165,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         /// <returns>
-        /// If the profile does not exist, returns <c>null</c>. Otherwise, returns the value
-        /// of the property if the property is not defined, or <c>null</c> otherwise. The
+        /// If the profile does not exist, returns <see langword="null"/>. Otherwise, returns the value
+        /// of the property if the property is not defined, or <see langword="null"/> otherwise. The
         /// standard properties are always considered to be defined.
         /// </returns>
         public async Task<string?> GetUnevaluatedPropertyValueAsync(string propertyName)


### PR DESCRIPTION
I had copy-pasted the use of `<c>null</c>` previously, instead of using `<see langword="null"/>`. This fixes those doc comments.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7063)