### PR TITLE
Enable indexing of sources when publishing symbols

### DIFF
--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -86,7 +86,7 @@ steps:
       '**/*.pdb
       **/*.dll
       **/*.exe'
-    indexSources: false
+    indexSources: true
     publishSymbols: true
     SymbolServerType: TeamServices
     SymbolsProduct: 'Roslyn Project System'

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -86,7 +86,6 @@ steps:
       '**/*.pdb
       **/*.dll
       **/*.exe'
-    indexSources: true
     publishSymbols: true
     SymbolServerType: TeamServices
     SymbolsProduct: 'Roslyn Project System'


### PR DESCRIPTION
Indexing of sources in this pipeline needs to be enabled until there is a different process in place that handles this. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7064)