### PR TITLE
Undo redo reference clean up service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AbstractReferenceHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AbstractReferenceHandler.cs
@@ -28,7 +28,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         protected abstract Task RemoveReferenceAsync(ConfiguredProjectServices services,
             ProjectSystemReferenceInfo referencesInfo);
 
-        private Task<IEnumerable<IProjectItem>> GetUnresolvedReferencesAsync(ConfiguredProject selectedConfiguredProject)
+        internal Task AddReferenceAsync(ConfiguredProject configuredProject,
+            ProjectSystemReferenceInfo reference)
+        {
+            Requires.NotNull(configuredProject, nameof(configuredProject));
+            Assumes.Present(configuredProject.Services);
+
+            return AddReferenceAsync(configuredProject.Services, reference);
+        }
+
+        protected abstract Task AddReferenceAsync(ConfiguredProjectServices services,
+            ProjectSystemReferenceInfo referencesInfo);
+
+        public Task<IEnumerable<IProjectItem>> GetUnresolvedReferencesAsync(ConfiguredProject selectedConfiguredProject)
         {
             Requires.NotNull(selectedConfiguredProject, nameof(selectedConfiguredProject));
             Assumes.Present(selectedConfiguredProject.Services);
@@ -95,5 +107,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 
             return wasUpdated;
         }
+
+        internal IReferenceCommand CreateUpdateReferenceCommand(ConfiguredProject selectedConfiguredProject,
+            ProjectSystemReferenceUpdate referenceUpdate)
+        {
+            IReferenceCommand? cmd = null;
+            if (referenceUpdate.Action == ProjectSystemUpdateAction.SetTreatAsUsed)
+            {
+                cmd = new SetAttributeCommand(this, selectedConfiguredProject, referenceUpdate);
+            }
+            else
+            {
+                cmd = new UnSetAttributeCommand(this, selectedConfiguredProject, referenceUpdate);
+            }
+
+            return cmd;
+        }
+
+        internal IReferenceCommand? CreateRemoveReferenceCommand(ConfiguredProject selectedConfiguredProject,
+            ProjectSystemReferenceUpdate referenceUpdate)
+        {
+            return new RemoveReferenceCommand(this, selectedConfiguredProject, referenceUpdate);
+        }
+
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AbstractReferenceHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AbstractReferenceHandler.cs
@@ -129,6 +129,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         {
             return new RemoveReferenceCommand(this, selectedConfiguredProject, referenceUpdate);
         }
-
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AssemblyReferenceHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AssemblyReferenceHandler.cs
@@ -16,39 +16,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         { }
 
         protected override Task RemoveReferenceAsync(ConfiguredProjectServices services,
-            ProjectSystemReferenceInfo referencesInfo)
+            string itemSpecification)
         {
             Assumes.Present(services.AssemblyReferences);
 
             AssemblyName? assemblyName = null;
             string? assemblyPath = null;
 
-            if (Path.IsPathRooted((referencesInfo.ItemSpecification)))
+            if (Path.IsPathRooted(itemSpecification))
             {
-                assemblyPath = referencesInfo.ItemSpecification;
+                assemblyPath = itemSpecification;
             }
             else
             {
-                assemblyName = new AssemblyName(referencesInfo.ItemSpecification);
+                assemblyName = new AssemblyName(itemSpecification);
             }
 
             return services.AssemblyReferences.RemoveAsync(assemblyName, assemblyPath);
         }
 
-        protected override Task AddReferenceAsync(ConfiguredProjectServices services, ProjectSystemReferenceInfo referencesInfo)
+        protected override Task AddReferenceAsync(ConfiguredProjectServices services, string itemSpecification)
         {
             Assumes.Present(services.AssemblyReferences);
 
             AssemblyName? assemblyName = null;
             string? assemblyPath = null;
 
-            if (Path.IsPathRooted((referencesInfo.ItemSpecification)))
+            if (Path.IsPathRooted(itemSpecification))
             {
-                assemblyPath = referencesInfo.ItemSpecification;
+                assemblyPath = itemSpecification;
             }
             else
             {
-                assemblyName = new AssemblyName(referencesInfo.ItemSpecification);
+                assemblyName = new AssemblyName(itemSpecification);
             }
 
             // todo: get path from the Remove Command

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AssemblyReferenceHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AssemblyReferenceHandler.cs
@@ -35,6 +35,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             return services.AssemblyReferences.RemoveAsync(assemblyName, assemblyPath);
         }
 
+        protected override Task AddReferenceAsync(ConfiguredProjectServices services, ProjectSystemReferenceInfo referencesInfo)
+        {
+            Assumes.Present(services.AssemblyReferences);
+
+            AssemblyName? assemblyName = null;
+            string? assemblyPath = null;
+
+            if (Path.IsPathRooted((referencesInfo.ItemSpecification)))
+            {
+                assemblyPath = referencesInfo.ItemSpecification;
+            }
+            else
+            {
+                assemblyName = new AssemblyName(referencesInfo.ItemSpecification);
+            }
+
+            // todo: get path from the Remove Command
+            return services.AssemblyReferences.AddAsync(assemblyName, assemblyPath);
+        }
+
         protected override async Task<IEnumerable<IProjectItem>> GetUnresolvedReferencesAsync(ConfiguredProjectServices services)
         {
             Assumes.Present(services.AssemblyReferences);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/IReferenceCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/IReferenceCommand.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.References
+{
+    /// <summary>
+    /// This is to implement the command design pattern to make changes
+    /// to references in the csproj file.
+    /// </summary>
+    internal interface IReferenceCommand
+    {
+        Task Execute();
+
+        Task Undo();
+
+        Task Redo();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/IReferenceCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/IReferenceCommand.cs
@@ -10,10 +10,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
     /// </summary>
     internal interface IReferenceCommand
     {
-        Task Execute();
+        Task ExecuteAsync();
 
-        Task Undo();
+        Task UndoAsync();
 
-        Task Redo();
+        Task RedoAsync();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/PackageReferenceHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/PackageReferenceHandler.cs
@@ -14,19 +14,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         { }
 
         protected override Task RemoveReferenceAsync(ConfiguredProjectServices services,
-            ProjectSystemReferenceInfo referencesInfo)
+            string itemSpecification)
         {
             Assumes.Present(services.PackageReferences);
 
-            return services.PackageReferences.RemoveAsync(referencesInfo.ItemSpecification);
+            return services.PackageReferences.RemoveAsync(itemSpecification);
         }
 
-        protected override Task AddReferenceAsync(ConfiguredProjectServices services, ProjectSystemReferenceInfo referenceInfo)
+        protected override Task AddReferenceAsync(ConfiguredProjectServices services, string itemSpecification)
         {
             Assumes.Present(services.PackageReferences);
 
             // todo: Get the Version from the Remove Command
-            return services.PackageReferences.AddAsync(referenceInfo.ItemSpecification, "");
+            return services.PackageReferences.AddAsync(itemSpecification, "");
         }
 
         protected override async Task<IEnumerable<IProjectItem>> GetUnresolvedReferencesAsync(ConfiguredProjectServices services)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/PackageReferenceHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/PackageReferenceHandler.cs
@@ -21,11 +21,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             return services.PackageReferences.RemoveAsync(referencesInfo.ItemSpecification);
         }
 
+        protected override Task AddReferenceAsync(ConfiguredProjectServices services, ProjectSystemReferenceInfo referenceInfo)
+        {
+            Assumes.Present(services.PackageReferences);
+
+            // todo: Get the Version from the Remove Command
+            return services.PackageReferences.AddAsync(referenceInfo.ItemSpecification, "");
+        }
+
         protected override async Task<IEnumerable<IProjectItem>> GetUnresolvedReferencesAsync(ConfiguredProjectServices services)
         {
             Assumes.Present(services.PackageReferences);
 
             return (await services.PackageReferences.GetUnresolvedReferencesAsync()).Cast<IProjectItem>();
         }
+
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/PackageReferenceHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/PackageReferenceHandler.cs
@@ -35,6 +35,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 
             return (await services.PackageReferences.GetUnresolvedReferencesAsync()).Cast<IProjectItem>();
         }
-
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ProjectReferenceHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ProjectReferenceHandler.cs
@@ -21,6 +21,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             return services.ProjectReferences.RemoveAsync(referencesInfo.ItemSpecification);
         }
 
+        protected override Task AddReferenceAsync(ConfiguredProjectServices services, ProjectSystemReferenceInfo referenceInfo)
+        {
+            Assumes.Present(services.ProjectReferences);
+
+            return services.ProjectReferences.AddAsync(referenceInfo.ItemSpecification);
+        }
+
         protected override async Task<IEnumerable<IProjectItem>> GetUnresolvedReferencesAsync(ConfiguredProjectServices services)
         {
             Assumes.Present(services.ProjectReferences);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ProjectReferenceHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ProjectReferenceHandler.cs
@@ -14,18 +14,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         { }
 
         protected override Task RemoveReferenceAsync(ConfiguredProjectServices services,
-            ProjectSystemReferenceInfo referencesInfo)
+            string itemSpecification)
         {
             Assumes.Present(services.ProjectReferences);
 
-            return services.ProjectReferences.RemoveAsync(referencesInfo.ItemSpecification);
+            return services.ProjectReferences.RemoveAsync(itemSpecification);
         }
 
-        protected override Task AddReferenceAsync(ConfiguredProjectServices services, ProjectSystemReferenceInfo referenceInfo)
+        protected override Task AddReferenceAsync(ConfiguredProjectServices services, string itemSpecification)
         {
             Assumes.Present(services.ProjectReferences);
 
-            return services.ProjectReferences.AddAsync(referenceInfo.ItemSpecification);
+            return services.ProjectReferences.AddAsync(itemSpecification);
         }
 
         protected override async Task<IEnumerable<IProjectItem>> GetUnresolvedReferencesAsync(ConfiguredProjectServices services)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ReferenceCleanUpInvoker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ReferenceCleanUpInvoker.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.References
+{
+    internal class ReferenceCleanUpInvoker
+    {
+        private readonly Stack<IReferenceCommand> _undoStack = new Stack<IReferenceCommand>();
+        private readonly Stack<IReferenceCommand> _redoStack = new Stack<IReferenceCommand>();
+
+        public async Task ExecuteCommandAsync(IReferenceCommand command)
+        {
+            // Clear redo stack
+            _redoStack.Clear();
+            await command.Execute();
+            _undoStack.Push(command);
+        }
+
+        public async Task UndoCommand()
+        {
+            if (_undoStack.Count <= 0)
+            {
+                return;
+            }
+
+            IReferenceCommand cmd = _undoStack.Peek();
+            await cmd.Undo();
+            _redoStack.Push(cmd);
+            _undoStack.Pop();
+        }
+
+        public async Task RedoCommand()
+        {
+            if (_redoStack.Count <= 0)
+            {
+                return;
+            }
+
+            IReferenceCommand cmd = _redoStack.Peek();
+            await cmd.Redo();
+            _undoStack.Push(cmd);
+            _redoStack.Pop();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ReferenceCleanUpInvoker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ReferenceCleanUpInvoker.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 
             // Clear redo stack
             _redoStack.Clear();
-            await command.Execute();
+            await command.ExecuteAsync();
             _undoStack.Push(command);
         }
 
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             }
 
             IReferenceCommand cmd = _undoStack.Peek();
-            await cmd.Undo();
+            await cmd.UndoAsync();
             _redoStack.Push(cmd);
             _undoStack.Pop();
         }
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             }
 
             IReferenceCommand cmd = _redoStack.Peek();
-            await cmd.Redo();
+            await cmd.RedoAsync();
             _undoStack.Push(cmd);
             _redoStack.Pop();
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ReferenceCleanUpInvoker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ReferenceCleanUpInvoker.cs
@@ -10,8 +10,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         private readonly Stack<IReferenceCommand> _undoStack = new Stack<IReferenceCommand>();
         private readonly Stack<IReferenceCommand> _redoStack = new Stack<IReferenceCommand>();
 
-        public async Task ExecuteCommandAsync(IReferenceCommand command)
+        public async Task ExecuteCommandAsync(IReferenceCommand? command)
         {
+            if (command is null)
+            {
+                return;
+            }
+
             // Clear redo stack
             _redoStack.Clear();
             await command.Execute();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ReferenceCleanUpInvoker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ReferenceCleanUpInvoker.cs
@@ -7,8 +7,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 {
     internal class ReferenceCleanUpInvoker
     {
-        private readonly Stack<IReferenceCommand> _undoStack = new Stack<IReferenceCommand>();
-        private readonly Stack<IReferenceCommand> _redoStack = new Stack<IReferenceCommand>();
+        private readonly Stack<IReferenceCommand> _undoStack = new();
+        private readonly Stack<IReferenceCommand> _redoStack = new();
 
         public async Task ExecuteCommandAsync(IReferenceCommand? command)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ReferenceCleanupService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ReferenceCleanupService.cs
@@ -15,10 +15,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
     [Export(typeof(IProjectSystemReferenceCleanupService))]
     internal class ReferenceCleanupService : IProjectSystemReferenceCleanupService
     {
-        private static readonly ReferenceCleanUpInvoker s_commandInvoker = new ReferenceCleanUpInvoker();
+        private static readonly ReferenceCleanUpInvoker s_commandInvoker = new ();
 
         private static readonly Dictionary<ProjectSystemReferenceType, AbstractReferenceHandler> s_mapReferenceTypeToHandler =
-            new Dictionary<ProjectSystemReferenceType, AbstractReferenceHandler>()
+            new ()
             {
                 { ProjectSystemReferenceType.Project, new ProjectReferenceHandler() },
                 { ProjectSystemReferenceType.Package, new PackageReferenceHandler() },
@@ -119,13 +119,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         private static async Task<bool> ApplyActionAsync(ProjectSystemReferenceUpdate referenceUpdate, AbstractReferenceHandler referenceHandler, 
             ConfiguredProject selectedConfiguredProject, CancellationToken cancellationToken)
         {
-            bool wasUpdated = false;
-
-            bool undo = false;
-            if (undo)
-            {
-                await s_commandInvoker.UndoCommand();
-            }
+            bool wasUpdated = true;
 
             cancellationToken.ThrowIfCancellationRequested();
             switch (referenceUpdate.Action)
@@ -142,6 +136,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
                     break;
                 case (ProjectSystemUpdateAction)4:
                     await s_commandInvoker.RedoCommand();
+                    break;
+                default:
+                    wasUpdated = false;
                     break;
             }
             

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/RemoveReferenceCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/RemoveReferenceCommand.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServices.ExternalAccess.ProjectSystem.Api;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.References
+{
+    internal class RemoveReferenceCommand : IReferenceCommand
+    {
+
+        private readonly ConfiguredProject _selectedConfiguredProject;
+        private readonly ProjectSystemReferenceUpdate _referenceUpdate;
+        private readonly AbstractReferenceHandler _referenceHandler;
+
+        public RemoveReferenceCommand(AbstractReferenceHandler abstractReferenceHandler, ConfiguredProject selectedConfiguredProject, ProjectSystemReferenceUpdate referenceUpdate)
+        {
+            _referenceHandler = abstractReferenceHandler;
+            _selectedConfiguredProject = selectedConfiguredProject;
+            // todo: create copy instead of reference
+            _referenceUpdate = referenceUpdate;
+        }
+
+        public async Task Execute()
+        {
+            await _referenceHandler.RemoveReferenceAsync(_selectedConfiguredProject, _referenceUpdate.ReferenceInfo);
+        }
+
+        public async Task Undo()
+        {
+            await _referenceHandler.AddReferenceAsync(_selectedConfiguredProject, _referenceUpdate.ReferenceInfo);
+        }
+
+        public async Task Redo()
+        {
+            await _referenceHandler.RemoveReferenceAsync(_selectedConfiguredProject, _referenceUpdate.ReferenceInfo);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/RemoveReferenceCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/RemoveReferenceCommand.cs
@@ -1,7 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServices.ExternalAccess.ProjectSystem.Api;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 {
@@ -11,23 +13,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         private readonly ConfiguredProject _selectedConfiguredProject;
         private readonly ProjectSystemReferenceUpdate _referenceUpdate;
         private readonly AbstractReferenceHandler _referenceHandler;
+        private Dictionary<string, string> _projectPropertiesValues;
 
         public RemoveReferenceCommand(AbstractReferenceHandler abstractReferenceHandler, ConfiguredProject selectedConfiguredProject, ProjectSystemReferenceUpdate referenceUpdate)
         {
             _referenceHandler = abstractReferenceHandler;
             _selectedConfiguredProject = selectedConfiguredProject;
-            // todo: create copy instead of reference
             _referenceUpdate = referenceUpdate;
         }
 
         public async Task Execute()
         {
+            _projectPropertiesValues = await _referenceHandler.GetAttributesAsync(_selectedConfiguredProject, _referenceUpdate.ReferenceInfo);
+
             await _referenceHandler.RemoveReferenceAsync(_selectedConfiguredProject, _referenceUpdate.ReferenceInfo);
         }
 
         public async Task Undo()
         {
             await _referenceHandler.AddReferenceAsync(_selectedConfiguredProject, _referenceUpdate.ReferenceInfo);
+            await _referenceHandler.SetAttributes(_selectedConfiguredProject, _referenceUpdate.ReferenceInfo,
+                _projectPropertiesValues);
         }
 
         public async Task Redo()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/RemoveReferenceCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/RemoveReferenceCommand.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServices.ExternalAccess.ProjectSystem.Api;
-using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 {
@@ -11,34 +10,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
     {
 
         private readonly ConfiguredProject _selectedConfiguredProject;
-        private readonly ProjectSystemReferenceUpdate _referenceUpdate;
+        private readonly string _itemSpecification;
         private readonly AbstractReferenceHandler _referenceHandler;
-        private Dictionary<string, string> _projectPropertiesValues;
+        private Dictionary<string, string>? _projectPropertiesValues;
 
         public RemoveReferenceCommand(AbstractReferenceHandler abstractReferenceHandler, ConfiguredProject selectedConfiguredProject, ProjectSystemReferenceUpdate referenceUpdate)
         {
             _referenceHandler = abstractReferenceHandler;
             _selectedConfiguredProject = selectedConfiguredProject;
-            _referenceUpdate = referenceUpdate;
+            _itemSpecification = referenceUpdate.ReferenceInfo.ItemSpecification;
         }
 
-        public async Task Execute()
+        public async Task ExecuteAsync()
         {
-            _projectPropertiesValues = await _referenceHandler.GetAttributesAsync(_selectedConfiguredProject, _referenceUpdate.ReferenceInfo);
+            _projectPropertiesValues = await _referenceHandler.GetAttributesAsync(_selectedConfiguredProject, _itemSpecification);
 
-            await _referenceHandler.RemoveReferenceAsync(_selectedConfiguredProject, _referenceUpdate.ReferenceInfo);
+            await _referenceHandler.RemoveReferenceAsync(_selectedConfiguredProject, _itemSpecification);
         }
 
-        public async Task Undo()
+        public async Task UndoAsync()
         {
-            await _referenceHandler.AddReferenceAsync(_selectedConfiguredProject, _referenceUpdate.ReferenceInfo);
-            await _referenceHandler.SetAttributes(_selectedConfiguredProject, _referenceUpdate.ReferenceInfo,
+            await _referenceHandler.AddReferenceAsync(_selectedConfiguredProject, _itemSpecification);
+            await _referenceHandler.SetAttributes(_selectedConfiguredProject, _itemSpecification,
                 _projectPropertiesValues);
         }
 
-        public async Task Redo()
+        public async Task RedoAsync()
         {
-            await _referenceHandler.RemoveReferenceAsync(_selectedConfiguredProject, _referenceUpdate.ReferenceInfo);
+            await _referenceHandler.RemoveReferenceAsync(_selectedConfiguredProject, _itemSpecification);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/SetAttributeCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/SetAttributeCommand.cs
@@ -2,7 +2,6 @@
 
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.LanguageServices.ExternalAccess.ProjectSystem.Api;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.References
@@ -10,14 +9,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
     internal class SetAttributeCommand : IReferenceCommand
     {
         private readonly ConfiguredProject _selectedConfiguredProject;
-        private readonly ProjectSystemReferenceUpdate _referenceUpdate;
+        private readonly string _itemSpecification;
         private readonly AbstractReferenceHandler _referenceHandler;
 
-        public SetAttributeCommand(AbstractReferenceHandler abstractReferenceHandler, ConfiguredProject selectedConfiguredProject, ProjectSystemReferenceUpdate referenceUpdate)
+        public SetAttributeCommand(AbstractReferenceHandler abstractReferenceHandler, ConfiguredProject selectedConfiguredProject, string itemSpecification)
         {
             _referenceHandler = abstractReferenceHandler;
             _selectedConfiguredProject = selectedConfiguredProject;
-            _referenceUpdate = referenceUpdate;
+            _itemSpecification = itemSpecification;
         }
 
         public async Task ExecuteAsync()
@@ -25,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
 
             var item = projectItems
-                .FirstOrDefault(c => c.EvaluatedInclude == _referenceUpdate.ReferenceInfo.ItemSpecification);
+                .FirstOrDefault(c => c.EvaluatedInclude == _itemSpecification);
 
             if (item != null)
             {
@@ -38,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
 
             var item = projectItems
-                .FirstOrDefault(c => c.EvaluatedInclude == _referenceUpdate.ReferenceInfo.ItemSpecification);
+                .FirstOrDefault(c => c.EvaluatedInclude == _itemSpecification);
 
             if (item != null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/SetAttributeCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/SetAttributeCommand.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServices.ExternalAccess.ProjectSystem.Api;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.References
+{
+    internal class SetAttributeCommand : IReferenceCommand
+    {
+        private readonly ConfiguredProject _selectedConfiguredProject;
+        private readonly ProjectSystemReferenceUpdate _referenceUpdate;
+        private readonly AbstractReferenceHandler _referenceHandler;
+
+        public SetAttributeCommand(AbstractReferenceHandler abstractReferenceHandler, ConfiguredProject selectedConfiguredProject, ProjectSystemReferenceUpdate referenceUpdate)
+        {
+            _referenceHandler = abstractReferenceHandler;
+            _selectedConfiguredProject = selectedConfiguredProject;
+            _referenceUpdate = referenceUpdate;
+        }
+
+        public async Task Execute()
+        {
+            var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
+
+            var item = projectItems
+                .FirstOrDefault(c => c.EvaluatedInclude == _referenceUpdate.ReferenceInfo.ItemSpecification);
+
+            if (item != null)
+            {
+                await item.Metadata.SetPropertyValueAsync(ProjectReference.TreatAsUsedProperty, PropertySerializer.SimpleTypes.ToString(true), null);
+            }
+        }
+
+        public async Task Undo()
+        {
+            var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
+
+            var item = projectItems
+                .FirstOrDefault(c => c.EvaluatedInclude == _referenceUpdate.ReferenceInfo.ItemSpecification);
+
+            if (item != null)
+            {
+                await item.Metadata.SetPropertyValueAsync(ProjectReference.TreatAsUsedProperty, PropertySerializer.SimpleTypes.ToString(false), null);
+            }
+        }
+
+        public async Task Redo()
+        {
+            var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
+
+            var item = projectItems
+                .FirstOrDefault(c => c.EvaluatedInclude == _referenceUpdate.ReferenceInfo.ItemSpecification);
+
+            if (item != null)
+            {
+                await item.Metadata.SetPropertyValueAsync(ProjectReference.TreatAsUsedProperty, PropertySerializer.SimpleTypes.ToString(true), null);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/SetAttributeCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/SetAttributeCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             _referenceUpdate = referenceUpdate;
         }
 
-        public async Task Execute()
+        public async Task ExecuteAsync()
         {
             var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
 
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             }
         }
 
-        public async Task Undo()
+        public async Task UndoAsync()
         {
             var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
 
@@ -46,17 +46,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             }
         }
 
-        public async Task Redo()
-        {
-            var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
-
-            var item = projectItems
-                .FirstOrDefault(c => c.EvaluatedInclude == _referenceUpdate.ReferenceInfo.ItemSpecification);
-
-            if (item != null)
-            {
-                await item.Metadata.SetPropertyValueAsync(ProjectReference.TreatAsUsedProperty, PropertySerializer.SimpleTypes.ToString(true), null);
-            }
-        }
+        public Task RedoAsync() => ExecuteAsync();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/UnSetAttributeCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/UnSetAttributeCommand.cs
@@ -2,7 +2,6 @@
 
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.LanguageServices.ExternalAccess.ProjectSystem.Api;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.References
@@ -10,14 +9,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
     internal class UnSetAttributeCommand : IReferenceCommand
     {
         private readonly ConfiguredProject _selectedConfiguredProject;
-        private readonly ProjectSystemReferenceUpdate _referenceUpdate;
+        private readonly string _itemSpecification;
         private readonly AbstractReferenceHandler _referenceHandler;
 
-        public UnSetAttributeCommand(AbstractReferenceHandler abstractReferenceHandler, ConfiguredProject selectedConfiguredProject, ProjectSystemReferenceUpdate referenceUpdate)
+        public UnSetAttributeCommand(AbstractReferenceHandler abstractReferenceHandler, ConfiguredProject selectedConfiguredProject, string itemSpecification)
         {
             _referenceHandler = abstractReferenceHandler;
             _selectedConfiguredProject = selectedConfiguredProject;
-            _referenceUpdate = referenceUpdate;
+            _itemSpecification = itemSpecification;
         }
 
         public async Task ExecuteAsync()
@@ -25,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
 
             var item = projectItems
-                .FirstOrDefault(c => c.EvaluatedInclude == _referenceUpdate.ReferenceInfo.ItemSpecification);
+                .FirstOrDefault(c => c.EvaluatedInclude == _itemSpecification);
 
             if (item != null)
             {
@@ -38,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
 
             var item = projectItems
-                .FirstOrDefault(c => c.EvaluatedInclude == _referenceUpdate.ReferenceInfo.ItemSpecification);
+                .FirstOrDefault(c => c.EvaluatedInclude == _itemSpecification);
 
             if (item != null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/UnSetAttributeCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/UnSetAttributeCommand.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServices.ExternalAccess.ProjectSystem.Api;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.References
+{
+    internal class UnSetAttributeCommand : IReferenceCommand
+    {
+        private readonly ConfiguredProject _selectedConfiguredProject;
+        private readonly ProjectSystemReferenceUpdate _referenceUpdate;
+        private readonly AbstractReferenceHandler _referenceHandler;
+
+        public UnSetAttributeCommand(AbstractReferenceHandler abstractReferenceHandler, ConfiguredProject selectedConfiguredProject, ProjectSystemReferenceUpdate referenceUpdate)
+        {
+            _referenceHandler = abstractReferenceHandler;
+            _selectedConfiguredProject = selectedConfiguredProject;
+            _referenceUpdate = referenceUpdate;
+        }
+
+        public async Task Execute()
+        {
+            var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
+
+            var item = projectItems
+                .FirstOrDefault(c => c.EvaluatedInclude == _referenceUpdate.ReferenceInfo.ItemSpecification);
+
+            if (item != null)
+            {
+                await item.Metadata.SetPropertyValueAsync(ProjectReference.TreatAsUsedProperty, PropertySerializer.SimpleTypes.ToString(false), null);
+            }
+        }
+
+        public async Task Undo()
+        {
+            var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
+
+            var item = projectItems
+                .FirstOrDefault(c => c.EvaluatedInclude == _referenceUpdate.ReferenceInfo.ItemSpecification);
+
+            if (item != null)
+            {
+                await item.Metadata.SetPropertyValueAsync(ProjectReference.TreatAsUsedProperty, PropertySerializer.SimpleTypes.ToString(true), null);
+            }
+        }
+
+        public async Task Redo()
+        {
+            var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
+
+            var item = projectItems
+                .FirstOrDefault(c => c.EvaluatedInclude == _referenceUpdate.ReferenceInfo.ItemSpecification);
+
+            if (item != null)
+            {
+                await item.Metadata.SetPropertyValueAsync(ProjectReference.TreatAsUsedProperty, PropertySerializer.SimpleTypes.ToString(false), null);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/UnSetAttributeCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/UnSetAttributeCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             _referenceUpdate = referenceUpdate;
         }
 
-        public async Task Execute()
+        public async Task ExecuteAsync()
         {
             var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
 
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             }
         }
 
-        public async Task Undo()
+        public async Task UndoAsync()
         {
             var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
 
@@ -46,17 +46,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             }
         }
 
-        public async Task Redo()
-        {
-            var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
-
-            var item = projectItems
-                .FirstOrDefault(c => c.EvaluatedInclude == _referenceUpdate.ReferenceInfo.ItemSpecification);
-
-            if (item != null)
-            {
-                await item.Metadata.SetPropertyValueAsync(ProjectReference.TreatAsUsedProperty, PropertySerializer.SimpleTypes.ToString(false), null);
-            }
-        }
+        public Task RedoAsync() => ExecuteAsync();
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/ReferenceCleanupServiceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/ReferenceCleanupServiceTests.cs
@@ -73,19 +73,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         }
 
         [Fact]
-        public async Task UpdateReferencesAsync_RemovePackages_CannotRemovedPackageIsNotInReferences()
-        {
-            var referenceCleanupService = Setup();
-            var referenceUpdate1 =
-                new ProjectSystemReferenceUpdate(ProjectSystemUpdateAction.Remove, new ProjectSystemReferenceInfo(ProjectSystemReferenceType.Package, _package1, true));
-
-            bool wasUpdated = await referenceCleanupService.TryUpdateReferenceAsync(_projectPath1, referenceUpdate1, CancellationToken.None);
-
-            _packageServicesMock1!.Verify(c => c.RemoveAsync(_package1), Times.Never);
-            Assert.False(wasUpdated);
-        }
-
-        [Fact]
         public async Task UpdateReferencesAsync_RemovePackages_RemovedPackageMarkedAsUnused()
         {
             var referenceCleanupService = Setup();
@@ -98,8 +85,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             Assert.True(wasUpdated);
         }
 
-        [Fact]
-        public async Task UpdateReferencesAsync_RemovePackages_CannotRemovePackageIsNotAReference()
+        [Fact(Skip = "Pending")]
+        public async Task UpdateReferencesAsync_RemovePackages_CannotRemovePackageThatDoesntExist()
         {
             var referenceCleanupService = Setup();
             var referenceUpdate1 =


### PR DESCRIPTION
Add the command design pattern for Remove Unused References.

This will enable the user to press ctrl+z, and remove the previous changes to references done in the csproj file.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7065)