### PR TITLE
Hide `Target multiple frameworks` checkbox

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -43,6 +43,11 @@
       <DataSource Persistence="ProjectFileWithInterception"
                   HasConfigurationCondition="False" />
     </BoolProperty.DataSource>
+    <BoolProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>false</NameValuePair.Value>
+      </NameValuePair>
+    </BoolProperty.Metadata>
   </BoolProperty>
 
   <DynamicEnumProperty Name="TargetFramework"


### PR DESCRIPTION
Related: https://github.com/dotnet/project-system/issues/6989

Currently, there is a CPS bug (TODO: create bug and link here) that causes a yellow banner to appear asking for the project to reload when changing `TargetFramework` to `TargetFrameworks` or visa-versa. This would happen as soon as you un/checked the `Target multiple frameworks` checkbox. To avoid this currently (since multi-targeting is a more advanced scenario anyway), the easiest solution is to hide the checkbox. The visibility of the dependent properties still works the same way, based on the `TargetMultipleFrameworks` value, but the user can no longer modify this value in the property pages, since this checkbox is hidden. The code to calculating this value is still ran, and thus will show the proper property, `TargetFramework` or `TargetFrameworks`, in the UI depending on which is set. Until the CPS bug is fixed, this is the best way to hide this functionality from the user without removing it entirely.

I've made a clip here showing how the property UI properly switches depending on if `TargetFramework` or `TargetFrameworks` is set in a given project file. You'll also see the yellow bars that appear if you do this change by hand in the project file.
![HideMultiTargetCheckbox](https://user-images.githubusercontent.com/17788297/112917791-4753f980-90b8-11eb-8de3-a82180e39cb0.gif)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7068)