### PR TITLE
Support looking up a Launch Profile by ID

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileByIdDataProducer.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
+{
+    internal class LaunchProfileByIdDataProducer : QueryDataByIdProducerBase
+    {
+        private readonly ILaunchProfilePropertiesAvailableStatus _properties;
+        private readonly IProjectService2 _projectService;
+        private readonly IPropertyPageQueryCacheProvider _queryCacheProvider;
+
+        public LaunchProfileByIdDataProducer(ILaunchProfilePropertiesAvailableStatus properties, IProjectService2 projectService, IPropertyPageQueryCacheProvider queryCacheProvider)
+        {
+            _properties = properties;
+            _projectService = projectService;
+            _queryCacheProvider = queryCacheProvider;
+        }
+
+        protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext executionContext, EntityIdentity id)
+        {
+            if (QueryProjectPropertiesContext.TryCreateFromEntityId(id, out QueryProjectPropertiesContext? context)
+                && StringComparers.ItemTypes.Equals(context.ItemType, "LaunchProfile"))
+            {
+                return CreateLaunchProfileValueAsync(executionContext, id, context);
+            }
+
+            return NullEntityValue;
+        }
+
+        private async Task<IEntityValue?> CreateLaunchProfileValueAsync(IQueryExecutionContext executionContext, EntityIdentity id, QueryProjectPropertiesContext context)
+        {
+            if (_projectService.GetLoadedProject(context.File) is UnconfiguredProject project
+                && project.Services.ExportProvider.GetExportedValueOrDefault<ILaunchSettingsProvider>() is ILaunchSettingsProvider launchSettingsProvider
+                && await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
+                && await launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite) is ILaunchSettings launchSettings)
+            {
+                foreach ((int index, ProjectSystem.Debug.ILaunchProfile profile) in launchSettings.Profiles.WithIndices())
+                {
+                    if (StringComparers.LaunchProfileNames.Equals(profile.Name, context.ItemName)
+                        && !Strings.IsNullOrEmpty(profile.CommandName))
+                    {
+                        foreach (Rule rule in DebugUtilities.GetDebugChildRules(projectCatalog))
+                        {
+                            if (rule.Metadata.TryGetValue("CommandName", out object? commandNameObj)
+                                && commandNameObj is string commandName
+                                && StringComparers.LaunchProfileCommandNames.Equals(commandName, profile.CommandName))
+                            {
+                                IPropertyPageQueryCache? queryCache = _queryCacheProvider.CreateCache(project);
+
+                                IEntityValue launchProfileValue = LaunchProfileDataProducer.CreateLaunchProfileValue(
+                                    executionContext,
+                                    id,
+                                    context,
+                                    rule,
+                                    index,
+                                    queryCache,
+                                    _properties);
+                                return launchProfileValue;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileDataProducer.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
+using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
+using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
+{
+    internal static class LaunchProfileDataProducer
+    {
+        public static IEntityValue CreateLaunchProfileValue(IQueryExecutionContext executionContext, EntityIdentity id, QueryProjectPropertiesContext context, Rule rule, int order, IPropertyPageQueryCache cache, ILaunchProfilePropertiesAvailableStatus properties)
+        {
+            LaunchProfileValue newLaunchProfile = new(executionContext.EntityRuntime, id, new LaunchProfilePropertiesAvailableStatus());
+
+            if (properties.Name)
+            {
+                newLaunchProfile.Name = context.ItemName;
+            }
+
+            if (properties.CommandName)
+            {
+                if (rule.Metadata.TryGetValue("CommandName", out object? commandNameObj)
+                    && commandNameObj is string commandName)
+                {
+                    newLaunchProfile.CommandName = commandName;
+                }
+            }
+
+            if (properties.Order)
+            {
+                newLaunchProfile.Order = order;
+            }
+
+            ((IEntityValueFromProvider)newLaunchProfile).ProviderState = new PropertyPageProviderState(cache, context, rule);
+
+            return newLaunchProfile;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileDataProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
@@ -20,8 +21,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
     [QueryDataProvider(LaunchProfileType.TypeName, ProjectModel.ModelName)]
     [RelationshipQueryDataProvider(ProjectSystem.Query.ProjectModel.Metadata.ProjectType.TypeName, ProjectSystem.Query.ProjectModel.Metadata.ProjectType.LaunchProfilesPropertyName)]
     [QueryDataProviderZone(ProjectModelZones.Cps)]
+    [Export(typeof(IQueryByIdDataProvider))]
     [Export(typeof(IQueryByRelationshipDataProvider))]
-    internal class LaunchProfileDataProvider : QueryDataProviderBase, IQueryByRelationshipDataProvider
+    internal class LaunchProfileDataProvider : QueryDataProviderBase, IQueryByIdDataProvider, IQueryByRelationshipDataProvider
     {
         private readonly IPropertyPageQueryCacheProvider _queryCacheProvider;
 
@@ -32,6 +34,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
             : base(projectServiceAccessor)
         {
             _queryCacheProvider = queryCacheProvider;
+        }
+
+        public IQueryDataProducer<IReadOnlyCollection<EntityIdentity>, IEntityValue> CreateQueryDataSource(IPropertiesAvailableStatus properties)
+        {
+            return new LaunchProfileByIdDataProducer((ILaunchProfilePropertiesAvailableStatus)properties, ProjectService, _queryCacheProvider);
         }
 
         IQueryDataProducer<IEntityValue, IEntityValue> IQueryByRelationshipDataProvider.CreateQueryDataSource(IPropertiesAvailableStatus properties)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileFromProjectDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileFromProjectDataProducer.cs
@@ -8,7 +8,6 @@ using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Query;
-using Microsoft.VisualStudio.ProjectSystem.Query.Frameworks;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel;
 using Microsoft.VisualStudio.ProjectSystem.Query.ProjectModel.Implementation;
 using Microsoft.VisualStudio.ProjectSystem.Query.QueryExecution;
@@ -29,10 +28,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
 
         protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext executionContext, IEntityValue parent, UnconfiguredProject providerState)
         {
-            return CreateLaunchProfileValuesAsync(parent, providerState);
+            return CreateLaunchProfileValuesAsync(executionContext, parent, providerState);
         }
 
-        private async Task<IEnumerable<IEntityValue>> CreateLaunchProfileValuesAsync(IEntityValue parent, UnconfiguredProject project)
+        private async Task<IEnumerable<IEntityValue>> CreateLaunchProfileValuesAsync(IQueryExecutionContext executionContext, IEntityValue parent, UnconfiguredProject project)
         {
             if (project.Services.ExportProvider.GetExportedValueOrDefault<ILaunchSettingsProvider>() is ILaunchSettingsProvider launchSettingsProvider
                 && await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
@@ -69,14 +68,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
                             itemType: LaunchProfileProjectItemProvider.ItemType,
                             itemName: profile.Name);
 
-                        IEntityValue launchProfileValue = CreateLaunchProfileValue(parent, context, rule, index, propertyPageQueryCache);
+                        IEntityValue launchProfileValue = CreateLaunchProfileValue(executionContext, parent, context, rule, index, propertyPageQueryCache);
                         yield return launchProfileValue;
                     }
                 }
             }
         }
 
-        private IEntityValue CreateLaunchProfileValue(IEntityValue parent, QueryProjectPropertiesContext context, Rule rule, int order, IPropertyPageQueryCache propertyPageQueryCache)
+        private IEntityValue CreateLaunchProfileValue(IQueryExecutionContext executionContext, IEntityValue parent, QueryProjectPropertiesContext context, Rule rule, int order, IPropertyPageQueryCache propertyPageQueryCache)
         {
             EntityIdentity identity = new(
                 ((IEntityWithId)parent).Id,
@@ -86,35 +85,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
                     { ProjectModelIdentityKeys.SourceItemName, context.ItemName! }
                 });
 
-            return CreateLaunchProfileValue(parent.EntityRuntime, identity, context, rule, order, propertyPageQueryCache);
+            return LaunchProfileDataProducer.CreateLaunchProfileValue(executionContext, identity, context, rule, order, propertyPageQueryCache, _properties);
         }
 
-        private IEntityValue CreateLaunchProfileValue(IEntityRuntimeModel runtimeModel, EntityIdentity id, QueryProjectPropertiesContext context, Rule rule, int order, IPropertyPageQueryCache cache)
-        {
-            LaunchProfileValue newLaunchProfile = new(runtimeModel, id, new LaunchProfilePropertiesAvailableStatus());
-
-            if (_properties.Name)
-            {
-                newLaunchProfile.Name = context.ItemName;
-            }
-
-            if (_properties.CommandName)
-            {
-                if (rule.Metadata.TryGetValue("CommandName", out object? commandNameObj)
-                    && commandNameObj is string commandName)
-                {
-                    newLaunchProfile.CommandName = commandName;
-                }
-            }
-
-            if (_properties.Order)
-            {
-                newLaunchProfile.Order = order;
-            }
-
-            ((IEntityValueFromProvider)newLaunchProfile).ProviderState = new PropertyPageProviderState(cache, context, rule);
-
-            return newLaunchProfile;
-        }
+        
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileFromProjectDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileFromProjectDataProducer.cs
@@ -87,7 +87,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
 
             return LaunchProfileDataProducer.CreateLaunchProfileValue(executionContext, identity, context, rule, order, propertyPageQueryCache, _properties);
         }
-
-        
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryProjectPropertiesContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryProjectPropertiesContext.cs
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             if (id.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string projectPath))
             {
                 id.TryGetValue(ProjectModelIdentityKeys.SourceItemType, out string? itemType);
-                id.TryGetValue(ProjectModelIdentityKeys.SourceItemType, out string? itemName);
+                id.TryGetValue(ProjectModelIdentityKeys.SourceItemName, out string? itemName);
                 context = new QueryProjectPropertiesContext(isProjectFile: true, projectPath, itemType, itemName);
                 return true;
             }


### PR DESCRIPTION
The `LaunchProfileFromProjectDataProducer` can take an `UnconfiguredProject` and produce a set of Project Query API entities representing the launch profiles in that project. However, we currently lack a way to map from an entity ID representing a launch profile to the actual entity. This is necessary in order to support actions on launch profiles via the Project Query API, namely, setting the value of a property in a launch profile. The query engine first tries to look up the launch profile based on its ID, and then applies the action.

The code to create and populate the actual `LaunchProfileValue` is needed in both scenarios (project -> launch profiles, and entity ID -> launch profile) and has been extracted into a new `LaunchProfileDataProducer` type.

With this change, the new property value can make its way from the Launch Profiles front end to the back end and on to the `LaunchProfileProjectProperties` type. A separate change to the `LaunchProfileProjectProperties` is needed to store the value properly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7069)