### PR TITLE
Fix dependency tree node customization via extensions

### DIFF
--- a/docs/repo/dependencies-node.md
+++ b/docs/repo/dependencies-node.md
@@ -1,0 +1,35 @@
+# Dependencies Node
+
+A high-level overview of this feature is available in [Dependencies Node Roadmap](dependencies-node-roadmap.md).
+
+## Customizing nodes
+
+It is possible to modify the caption, icon and `ProjectTreeFlags` of nodes in the dependencies tree.
+
+To do so, export an instance of `IProjectTreePropertiesProvider` as shown below. This example will rename the "Projects" node to "Applications":
+
+```c#
+[Export(ReferencesProjectTreeCustomizablePropertyValues.ContractName, typeof(IProjectTreePropertiesProvider))]
+[AppliesTo(ProjectCapabilities.AlwaysApplicable)]
+internal sealed class MyDependenciesTreePropertiesProvider : IProjectTreePropertiesProvider
+{
+    private static readonly ProjectTreeFlags ProjectDependencyGroup = ProjectTreeFlags.Create("ProjectDependencyGroup");
+
+    public void CalculatePropertyValues(
+        IProjectTreeCustomizablePropertyContext propertyContext,
+        IProjectTreeCustomizablePropertyValues propertyValues)
+    {
+        if (propertyValues.Flags.Contains(ProjectDependencyGroup))
+        {
+            if (propertyValues is ReferencesProjectTreeCustomizablePropertyValues values)
+            {
+                // Change the caption (should be a localized string in production code)
+                values.Caption = "Applications";
+
+                // Change the icon
+                values.Icon = values.ExpandedIcon = KnownMonikers.Application.ToProjectSystemType();
+            }
+        }
+    }
+}
+```

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -341,26 +341,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 return UpdateTreeNode();
             }
 
-            ProjectTreeFlags filteredFlags = FilterFlags(viewModel.Flags);
-
             return isProjectItem
                 ? CreateProjectItemTreeNode()
                 : CreateProjectTreeNode();
 
             IProjectTree CreateProjectTreeNode()
             {
+                (string caption, ProjectImageMoniker icon, ProjectImageMoniker expandedIcon, ProjectTreeFlags flags) = FilterValues();
+
                 return _treeServices.CreateTree(
-                    caption: viewModel.Caption,
+                    caption: caption,
                     filePath: viewModel.FilePath,
                     browseObjectProperties: browseObjectProperties,
-                    icon: viewModel.Icon.ToProjectSystemType(),
-                    expandedIcon: viewModel.ExpandedIcon.ToProjectSystemType(),
+                    icon: icon,
+                    expandedIcon: expandedIcon,
                     visible: true,
-                    flags: filteredFlags);
+                    flags: flags);
             }
 
             IProjectTree CreateProjectItemTreeNode()
             {
+                (string caption, ProjectImageMoniker icon, ProjectImageMoniker expandedIcon, ProjectTreeFlags flags) = FilterValues();
+               
                 var itemContext = ProjectPropertiesContext.GetContext(
                     _commonServices.Project,
                     file: viewModel.FilePath,
@@ -368,27 +370,46 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                     itemName: viewModel.FilePath);
 
                 return _treeServices.CreateTree(
-                    caption: viewModel.Caption,
+                    caption: caption,
                     itemContext: itemContext,
                     browseObjectProperties: browseObjectProperties,
-                    icon: viewModel.Icon.ToProjectSystemType(),
-                    expandedIcon: viewModel.ExpandedIcon.ToProjectSystemType(),
+                    icon: icon,
+                    expandedIcon: expandedIcon,
                     visible: true,
-                    flags: filteredFlags);
+                    flags: flags);
             }
 
             IProjectTree UpdateTreeNode()
             {
+                (string caption, ProjectImageMoniker icon, ProjectImageMoniker expandedIcon, ProjectTreeFlags flags) = FilterValues();
+
+                return node.SetProperties(
+                    caption: caption,
+                    browseObjectProperties: browseObjectProperties,
+                    icon: icon,
+                    expandedIcon: expandedIcon,
+                    flags: flags);
+            }
+
+            (string Caption, ProjectImageMoniker Icon, ProjectImageMoniker ExpandedIcon, ProjectTreeFlags Flags) FilterValues()
+            {
+                ProjectTreeFlags filteredFlags = FilterFlags(viewModel.Flags);
+
+                if (_projectTreePropertiesProviders.Count == 0)
+                {
+                    return (viewModel.Caption, viewModel.Icon.ToProjectSystemType(), viewModel.ExpandedIcon.ToProjectSystemType(), filteredFlags);
+                }
+
                 var updatedNodeParentContext = new ProjectTreeCustomizablePropertyContext
                 {
                     ExistsOnDisk = false,
-                    ParentNodeFlags = node!.Parent?.Flags ?? default
+                    ParentNodeFlags = node?.Parent?.Flags ?? default
                 };
 
                 var updatedValues = new ReferencesProjectTreeCustomizablePropertyValues
                 {
                     Caption = viewModel.Caption,
-                    Flags = viewModel.Flags,
+                    Flags = filteredFlags,
                     Icon = viewModel.Icon.ToProjectSystemType(),
                     ExpandedIcon = viewModel.ExpandedIcon.ToProjectSystemType()
                 };
@@ -398,27 +419,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                     provider.Value.CalculatePropertyValues(updatedNodeParentContext, updatedValues);
                 }
 
-                return node.SetProperties(
-                    caption: updatedValues.Caption,
-                    browseObjectProperties: browseObjectProperties,
-                    icon: updatedValues.Icon,
-                    expandedIcon: updatedValues.ExpandedIcon,
-                    flags: updatedValues.Flags);
-            }
+                return (updatedValues.Caption, updatedValues.Icon, updatedValues.ExpandedIcon, updatedValues.Flags);
 
-            ProjectTreeFlags FilterFlags(ProjectTreeFlags flags)
-            {
-                if (additionalFlags.HasValue)
+                ProjectTreeFlags FilterFlags(ProjectTreeFlags flags)
                 {
-                    flags = flags.Union(additionalFlags.Value);
-                }
+                    if (additionalFlags.HasValue)
+                    {
+                        flags = flags.Union(additionalFlags.Value);
+                    }
 
-                if (excludedFlags.HasValue)
-                {
-                    flags = flags.Except(excludedFlags.Value);
-                }
+                    if (excludedFlags.HasValue)
+                    {
+                        flags = flags.Except(excludedFlags.Value);
+                    }
 
-                return flags;
+                    return flags;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #6604

Previously `IProjectTreePropertiesProvider` implementations would only be invoked on _updates_ to tree nodes. With this change, they are invoked on both _creation_ and updates.

This change also improves performance in the common case by avoiding allocating instances of `ProjectTreeCustomizablePropertyContext` and `ReferencesProjectTreeCustomizablePropertyValues` when no relevant `IProjectTreePropertiesProvider` imports exist. Most projects will not have such an import.

Finally, we add a documentation file for the dependencies node, and include an example showing how to customize nodes.

---

This change supports the WAP team who are integrating with the dependencies tree in 16.10.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7078)