### PR TITLE
Update an Assembly.Load

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/ExportedRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/ExportedRuleTests.cs
@@ -100,7 +100,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
         {
             Assert.NotNull(attribute);
 
-            var assembly = Assembly.Load(attribute.XamlResourceAssemblyName);
+            // HERE BE DRAGONS
+            // Note the following are *not* equivalent:
+            //   Assembly.Load(assemblyNameString)
+            //   Assembly.Load(new AssemblyName(assemblyNameString))
+            // The first will accept certain malformed assembly names that the second does not,
+            // and will successfully load the assembly where the second throws an exception.
+            // CPS uses the second form when loading assemblies to extract embedded XAML, and
+            // so we must do the same in this test.
+            var assemblyName = new AssemblyName(attribute.XamlResourceAssemblyName);
+            var assembly = Assembly.Load(assemblyName);
 
             using Stream stream = assembly.GetManifestResourceStream(attribute.XamlResourceStreamName);
 


### PR DESCRIPTION
In #6885 we updated the version number we provide to the project system assemblies. However, the new number had only two parts (16.10) while the old number had three (16.8.1). This led us to generate a somewhat malformed assembly name stored in `ThisAssembly.FullName`. For example, we expected:

```
Microsoft.VisualStudio.ProjectSystem.Managed, Version=16.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
```

but actually generated:

```
Microsoft.VisualStudio.ProjectSystem.Managed, Version=16.10.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
```

Note the version has only three parts instead of the usual four.

We utilize the `ThisAssembly.FullName` constant in the `ExportRuleAttribute`, which is used to tag certain XAML `Rule`s that should be embedded in the assembly rather than distributed as files on disk.

CPS takes that assembly full name from the attribute and uses it to load the assembly containing the embedded `Rule` like so:

```
var assembly = Assembly.Load(new AssemblyName(assemblyNameAsString));
```

It seems this form of `Assembly.Load` is very sensitive to the malformed version number, and would fail with an exception--which was then caught and logged but otherwise ignored. The end result is that none of our embedded `Rule`s were actually being applied. The most obvious manifestation of this was an inability to extract project data related to NuGet packages, which meant we couldn't restore NuGet packages within VS.

We have a unit test that is meant to catch these errors before they get merged in. However, the test doesn't use the same assembly loading mechanism as CPS; it uses the simpler form:

```
var assembly = Assembly.Load(assemblyNameAsString);
```

This form appears to be resilient to the malformed version number, and so the expected assembly was always loaded and the test succeeded.

This change updates the test to use the same assembly loading method as CPS.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7097)