### PR TITLE
Fix duplication of group nodes when filtering captions

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -196,9 +196,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             var currentNodes = new HashSet<IProjectTree>(capacity: groupedByProviderType.Count);
 
             bool isActiveTarget = targetedSnapshot.TargetFramework.Equals(activeTarget);
+
             foreach ((string providerType, List<IDependency> dependencies) in groupedByProviderType)
             {
-                IDependencyViewModel? subTreeViewModel = _viewModelFactory.CreateGroupNodeViewModel(
+                (IDependencyViewModel? subTreeViewModel, ProjectTreeFlags? subtreeFlag) = _viewModelFactory.CreateGroupNodeViewModel(
                     providerType,
                     targetedSnapshot.GetMaximumVisibleDiagnosticLevelForProvider(providerType));
 
@@ -209,7 +210,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                     continue;
                 }
 
-                IProjectTree? subTreeNode = rootNode.FindChildWithCaption(subTreeViewModel.Caption);
+                IProjectTree? subTreeNode = subtreeFlag != null
+                    ? rootNode.FindChildWithFlags(subtreeFlag.Value)
+                    : rootNode.FindChildWithCaption(subTreeViewModel.Caption);
+
                 bool isNewSubTreeNode = subTreeNode == null;
 
                 ProjectTreeFlags excludedFlags = targetedSnapshot.TargetFramework.Equals(TargetFramework.Any)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/IProjectDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/IProjectDependenciesSubTreeProvider.cs
@@ -38,6 +38,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         event EventHandler<DependenciesChangedEventArgs> DependenciesChanged;
     }
 
+    internal interface IProjectDependenciesSubTreeProvider2 : IProjectDependenciesSubTreeProvider
+    {
+        /// <summary>
+        /// Gets a flag that uniquely identifies the group node among its siblings.
+        /// </summary>
+        /// <remarks>
+        /// For example <see cref="DependencyTreeFlags.ProjectDependencyGroup"/>.
+        /// </remarks>
+        ProjectTreeFlags GroupNodeFlag { get; }
+    }
+
     public sealed class DependenciesChangedEventArgs
     {
         [Obsolete("Constructor includes unused properties")]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependenciesViewModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependenciesViewModelFactory.cs
@@ -27,13 +27,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             return new TargetDependencyViewModel(targetFramework, maximumDiagnosticLevel);
         }
 
-        public IDependencyViewModel? CreateGroupNodeViewModel(string providerType, DiagnosticLevel maximumDiagnosticLevel)
+        public (IDependencyViewModel? GroupNodeViewModel, ProjectTreeFlags? GroupNodeFlag) CreateGroupNodeViewModel(string providerType, DiagnosticLevel maximumDiagnosticLevel)
         {
             IProjectDependenciesSubTreeProvider? provider = GetProvider();
 
             IDependencyModel? dependencyModel = provider?.CreateRootDependencyNode();
 
-            return dependencyModel?.ToViewModel(maximumDiagnosticLevel);
+            IDependencyViewModel? groupNodeViewModel = dependencyModel?.ToViewModel(maximumDiagnosticLevel);
+
+            ProjectTreeFlags? groupNodeFlag = provider is IProjectDependenciesSubTreeProvider2 provider2
+                ? provider2.GroupNodeFlag
+                : null;
+
+            return (groupNodeViewModel, groupNodeFlag);
 
             IProjectDependenciesSubTreeProvider? GetProvider()
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/IDependenciesViewModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/IDependenciesViewModelFactory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
         /// <summary>
         /// Returns a view model for a node that groups dependencies from a given provider.
         /// </summary>
-        IDependencyViewModel? CreateGroupNodeViewModel(string providerType, DiagnosticLevel maximumDiagnosticLevel);
+        (IDependencyViewModel? GroupNodeViewModel, ProjectTreeFlags? GroupNodeFlag) CreateGroupNodeViewModel(string providerType, DiagnosticLevel maximumDiagnosticLevel);
 
         /// <summary>
         /// Returns the icon to use for the "Dependencies" root node.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/AnalyzerRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/AnalyzerRuleHandler.cs
@@ -35,6 +35,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
 
         public override string ProviderType => ProviderTypeString;
 
+        public override ProjectTreeFlags GroupNodeFlag => DependencyTreeFlags.AnalyzerDependencyGroup;
+
         protected override bool ResolvedItemRequiresEvaluatedItem => false;
 
         public override IDependencyModel CreateRootDependencyNode() => s_groupModel;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/AssemblyRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/AssemblyRuleHandler.cs
@@ -35,6 +35,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
 
         public override string ProviderType => ProviderTypeString;
 
+        public override ProjectTreeFlags GroupNodeFlag => DependencyTreeFlags.AssemblyDependencyGroup;
+
         public override IDependencyModel CreateRootDependencyNode() => s_groupModel;
 
         protected override IDependencyModel CreateDependencyModel(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/ComRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/ComRuleHandler.cs
@@ -35,6 +35,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
 
         public override string ProviderType => ProviderTypeString;
 
+        public override ProjectTreeFlags GroupNodeFlag => DependencyTreeFlags.ComDependencyGroup;
+
         public override IDependencyModel CreateRootDependencyNode() => s_groupModel;
 
         protected override IDependencyModel CreateDependencyModel(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
@@ -10,10 +10,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
 {
     internal abstract class DependenciesRuleHandlerBase
         : IDependenciesRuleHandler,
-          IProjectDependenciesSubTreeProvider
+          IProjectDependenciesSubTreeProvider2
     {
         public string EvaluatedRuleName { get; }
         public string ResolvedRuleName { get; }
+
+        public abstract ProjectTreeFlags GroupNodeFlag { get; }
 
         protected DependenciesRuleHandlerBase(
             string evaluatedRuleName,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/FrameworkRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/FrameworkRuleHandler.cs
@@ -35,6 +35,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
 
         public override string ProviderType => ProviderTypeString;
 
+        public override ProjectTreeFlags GroupNodeFlag => DependencyTreeFlags.FrameworkDependencyGroup;
+
         public override IDependencyModel CreateRootDependencyNode() => s_groupModel;
 
         protected override IDependencyModel CreateDependencyModel(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -43,6 +43,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
 
         public override string ProviderType => ProviderTypeString;
 
+        public override ProjectTreeFlags GroupNodeFlag => DependencyTreeFlags.PackageDependencyGroup;
+
         protected override void HandleAddedItem(
             string projectFullPath,
             string addedItem,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/ProjectRuleHandler.cs
@@ -35,6 +35,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
 
         public override string ProviderType => ProviderTypeString;
 
+        public override ProjectTreeFlags GroupNodeFlag => DependencyTreeFlags.ProjectDependencyGroup;
+
         public override IDependencyModel CreateRootDependencyNode() => s_groupModel;
 
         protected override IDependencyModel CreateDependencyModel(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/ProjectRuleHandler.cs
@@ -28,13 +28,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
                 implicitExpandedIcon: KnownMonikers.ApplicationPrivate),
             DependencyTreeFlags.ProjectDependencyGroup);
 
-        public override string ProviderType => ProviderTypeString;
-
-        [ImportingConstructor]
         public ProjectRuleHandler()
             : base(ProjectReference.SchemaName, ResolvedProjectReference.SchemaName)
         {
         }
+
+        public override string ProviderType => ProviderTypeString;
 
         public override IDependencyModel CreateRootDependencyNode() => s_groupModel;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/SdkRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/SdkRuleHandler.cs
@@ -35,6 +35,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
 
         public override string ProviderType => ProviderTypeString;
 
+        public override ProjectTreeFlags GroupNodeFlag => DependencyTreeFlags.SdkDependencyGroup;
+
         public override IDependencyModel CreateRootDependencyNode() => s_groupModel;
 
         protected override IDependencyModel CreateDependencyModel(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/SdkRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/SdkRuleHandler.cs
@@ -9,8 +9,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.RuleHandlers
 {
-    [Export(DependencyRulesSubscriber.DependencyRulesSubscriberContract,
-            typeof(IDependenciesRuleHandler))]
+    [Export(DependencyRulesSubscriber.DependencyRulesSubscriberContract, typeof(IDependenciesRuleHandler))]
     [Export(typeof(IProjectDependenciesSubTreeProvider))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
     internal class SdkRuleHandler : DependenciesRuleHandlerBase

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
@@ -31,15 +31,15 @@ namespace Microsoft.VisualStudio.ProjectSystem
                     mock.Setup(x => x.CreateGroupNodeViewModel(
                             It.Is<string>(t => string.Equals(t, d.ProviderType, StringComparison.OrdinalIgnoreCase)),
                             DiagnosticLevel.None))
-                        .Returns(d.ToViewModel(DiagnosticLevel.None));
+                        .Returns((d.ToViewModel(DiagnosticLevel.None), null));
                     mock.Setup(x => x.CreateGroupNodeViewModel(
                             It.Is<string>(t => string.Equals(t, d.ProviderType, StringComparison.OrdinalIgnoreCase)),
                             DiagnosticLevel.Warning))
-                        .Returns(d.ToViewModel(DiagnosticLevel.Warning));
+                        .Returns((d.ToViewModel(DiagnosticLevel.Warning), null));
                     mock.Setup(x => x.CreateGroupNodeViewModel(
                             It.Is<string>(t => string.Equals(t, d.ProviderType, StringComparison.OrdinalIgnoreCase)),
                             DiagnosticLevel.Error))
-                        .Returns(d.ToViewModel(DiagnosticLevel.Error));
+                        .Returns((d.ToViewModel(DiagnosticLevel.Error), null));
                 }
             }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectDependenciesSubTreeProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectDependenciesSubTreeProviderFactory.cs
@@ -7,12 +7,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class IProjectDependenciesSubTreeProviderFactory
     {
-        public static IProjectDependenciesSubTreeProvider Implement(
+        public static IProjectDependenciesSubTreeProvider2 Implement(
             string? providerType = null,
             IDependencyModel? createRootDependencyNode = null,
-            MockBehavior mockBehavior = MockBehavior.Strict)
+            MockBehavior mockBehavior = MockBehavior.Strict,
+            ProjectTreeFlags? groupNodeFlags = null)
         {
-            var mock = new Mock<IProjectDependenciesSubTreeProvider>(mockBehavior);
+            var mock = new Mock<IProjectDependenciesSubTreeProvider2>(mockBehavior);
 
             if (providerType != null)
             {
@@ -22,6 +23,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
             if (createRootDependencyNode != null)
             {
                 mock.Setup(x => x.CreateRootDependencyNode()).Returns(createRootDependencyNode);
+            }
+
+            if (groupNodeFlags != null)
+            {
+                mock.SetupGet(x => x.GroupNodeFlag).Returns(groupNodeFlags.Value);
             }
 
             return mock.Object;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
@@ -62,7 +62,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 
             var subTreeProvider1 = IProjectDependenciesSubTreeProviderFactory.Implement(
                 providerType: "MyProvider1",
-                createRootDependencyNode: dependencyModel);
+                createRootDependencyNode: dependencyModel,
+                groupNodeFlags: DependencyTreeFlags.ProjectDependencyGroup);
             var subTreeProvider2 = IProjectDependenciesSubTreeProviderFactory.Implement(
                 providerType: "MyProvider2");
 
@@ -70,9 +71,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 
             var result = factory.CreateGroupNodeViewModel("MyProvider1", maximumDiagnosticLevel: DiagnosticLevel.None);
 
-            Assert.NotNull(result);
-            Assert.Equal("ZzzDependencyRoot", result!.Caption);
-            Assert.Equal(KnownMonikers.AboutBox, result.Icon);
+            Assert.NotNull(result.GroupNodeViewModel);
+            Assert.Equal(DependencyTreeFlags.ProjectDependencyGroup, result.GroupNodeFlag);
+            Assert.Equal("ZzzDependencyRoot", result.GroupNodeViewModel!.Caption);
+            Assert.Equal(KnownMonikers.AboutBox, result.GroupNodeViewModel!.Icon);
         }
 
         [Fact]
@@ -86,7 +88,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 
             var result = factory.CreateGroupNodeViewModel("UnknownProviderType", maximumDiagnosticLevel: DiagnosticLevel.None);
 
-            Assert.Null(result);
+            Assert.Null(result.GroupNodeViewModel);
+            Assert.Null(result.GroupNodeFlag);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #7089

#7078 fixed a bug that meant exports of `IProjectTreePropertiesProvider` were not being reliably called when nodes were added to the dependencies tree. This interface is not being used in WAP projects to rename the "Projects" node as "Applications".

When the dependencies tree updates itself, it uses the caption to identify the group node to which the update applies. This search was previously using the caption, and if an extension point renamed the node's caption it would not be found, leading to duplicate nodes appearing in the tree.

This fix introduces an internal `IProjectDependenciesSubTreeProvider2` interface via which our rule handlers may specify a `ProjectTreeFlags` value that uniquely identifies the group node. When this implementation is found, it will be used. If it is not found (for example, the WebTools provider for NPM packages) it falls back to using the caption.

Note that `IProjectTreePropertiesProvider` implementations may also modify a node's flags, however it is considerably less reasonable to remove the uniquely identifying flag from a group node than to change its caption, so this pragmatic approach is taken for now. We can replace this in future if needed, as the new interface is internal.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7100)