### PR TITLE
Adapt ReferenceCleanupService to the new interface.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AbstractReferenceHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AbstractReferenceHandler.cs
@@ -17,18 +17,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             => _referenceType = referenceType;
 
         internal Task RemoveReferenceAsync(ConfiguredProject configuredProject,
-            ProjectSystemReferenceInfo reference)
+            string itemSpecification)
         {
             Requires.NotNull(configuredProject, nameof(configuredProject));
             Assumes.Present(configuredProject.Services);
 
-            return RemoveReferenceAsync(configuredProject.Services, reference);
+            return RemoveReferenceAsync(configuredProject.Services, itemSpecification);
         }
 
         protected abstract Task RemoveReferenceAsync(ConfiguredProjectServices services,
-            ProjectSystemReferenceInfo referencesInfo);
+            string itemSpecification);
 
-        private Task<IEnumerable<IProjectItem>> GetUnresolvedReferencesAsync(ConfiguredProject selectedConfiguredProject)
+        internal Task AddReferenceAsync(ConfiguredProject configuredProject,
+            string itemSpecification)
+        {
+            Requires.NotNull(configuredProject, nameof(configuredProject));
+            Assumes.Present(configuredProject.Services);
+
+            return AddReferenceAsync(configuredProject.Services, itemSpecification);
+        }
+
+        protected abstract Task AddReferenceAsync(ConfiguredProjectServices services,
+            string itemSpecification);
+
+        public Task<IEnumerable<IProjectItem>> GetUnresolvedReferencesAsync(ConfiguredProject selectedConfiguredProject)
         {
             Requires.NotNull(selectedConfiguredProject, nameof(selectedConfiguredProject));
             Assumes.Present(selectedConfiguredProject.Services);
@@ -37,15 +49,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         }
 
         protected abstract Task<IEnumerable<IProjectItem>> GetUnresolvedReferencesAsync(ConfiguredProjectServices services);
-
-        internal async Task<bool> CanRemoveReferenceAsync(ConfiguredProject selectedConfiguredProject, ProjectSystemReferenceUpdate referenceUpdate, CancellationToken cancellationToken)
-        {
-            var references = await GetReferencesAsync(selectedConfiguredProject, cancellationToken);
-
-            ProjectSystemReferenceInfo referenceInfo = references.FirstOrDefault(c => c.ItemSpecification == referenceUpdate.ReferenceInfo.ItemSpecification);
-
-            return !(referenceInfo is null);
-        }
 
         internal async Task<List<ProjectSystemReferenceInfo>> GetReferencesAsync(ConfiguredProject selectedConfiguredProject, CancellationToken cancellationToken)
         {
@@ -68,32 +71,73 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 
         private static async Task<bool> GetAttributeTreatAsUsedAsync(IProjectProperties metadata)
         {
+            var propertyNames = await metadata.GetPropertyNamesAsync();
             string? value = await metadata.GetEvaluatedPropertyValueAsync(ProjectReference.TreatAsUsedProperty);
 
             return value != null && PropertySerializer.SimpleTypes.ToValue<bool>(value);
         }
 
-        internal async Task<bool> UpdateReferenceAsync(ConfiguredProject selectedConfiguredProject, ProjectSystemReferenceUpdate referenceUpdate, CancellationToken cancellationToken)
+        private async Task<IProjectItem> GetProjectItems(ConfiguredProject selectedConfiguredProject,
+            string itemSpecification)
         {
-            bool wasUpdated = false;
-
-            cancellationToken.ThrowIfCancellationRequested();
-
             var projectItems = await GetUnresolvedReferencesAsync(selectedConfiguredProject);
 
             var item = projectItems
-                .FirstOrDefault(c => c.EvaluatedInclude == referenceUpdate.ReferenceInfo.ItemSpecification);
+                .FirstOrDefault(c => c.EvaluatedInclude == itemSpecification);
+            return item;
+        }
 
-            if (item != null)
+        internal IProjectSystemUpdateReferenceOperation CreateSetAttributeCommand(ConfiguredProject selectedConfiguredProject,
+            ProjectSystemReferenceUpdate referenceUpdate)
+        {
+            return new SetAttributeCommand(this, selectedConfiguredProject, referenceUpdate.ReferenceInfo.ItemSpecification);
+        }
+
+        internal IProjectSystemUpdateReferenceOperation CreateUnSetAttributeCommand(ConfiguredProject selectedConfiguredProject,
+            ProjectSystemReferenceUpdate referenceUpdate)
+        {
+            return new UnSetAttributeCommand(this, selectedConfiguredProject, referenceUpdate.ReferenceInfo.ItemSpecification);
+        }
+
+        internal IProjectSystemUpdateReferenceOperation? CreateRemoveReferenceCommand(ConfiguredProject selectedConfiguredProject,
+            ProjectSystemReferenceUpdate referenceUpdate)
+        {
+            return new RemoveReferenceCommand(this, selectedConfiguredProject, referenceUpdate);
+        }
+
+        public async Task<Dictionary<string, string>> GetAttributesAsync(ConfiguredProject selectedConfiguredProject, string itemSpecification)
+        {
+            Dictionary<string, string> propertyValues = new ();
+
+            IProjectItem items = await GetProjectItems(selectedConfiguredProject, itemSpecification);
+
+            var propertyNames = await items.Metadata.GetPropertyNamesAsync();
+
+            foreach (var property in propertyNames)
             {
-                string newValue = PropertySerializer.SimpleTypes.ToString(referenceUpdate.Action == ProjectSystemUpdateAction.SetTreatAsUsed);
-
-                await item.Metadata.SetPropertyValueAsync(ProjectReference.TreatAsUsedProperty, newValue, null);
-
-                wasUpdated = true;
+                var value = await items.Metadata.GetEvaluatedPropertyValueAsync(property);
+                propertyValues.Add(string.Copy(property), string.Copy(value));
             }
 
-            return wasUpdated;
+            return propertyValues;
+        }
+
+        public async Task SetAttributes(ConfiguredProject selectedConfiguredProject, string itemSpecification, Dictionary<string, string>? projectPropertiesValues)
+        {
+            if (projectPropertiesValues is null)
+            {
+                return;
+            }
+
+            IProjectItem items = await GetProjectItems(selectedConfiguredProject, itemSpecification);
+
+            if (items != null)
+            {
+                foreach (var property in projectPropertiesValues)
+                {
+                    await items.Metadata.SetPropertyValueAsync(property.Key, property.Value, null);
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AssemblyReferenceHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AssemblyReferenceHandler.cs
@@ -16,23 +16,43 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         { }
 
         protected override Task RemoveReferenceAsync(ConfiguredProjectServices services,
-            ProjectSystemReferenceInfo referencesInfo)
+            string itemSpecification)
         {
             Assumes.Present(services.AssemblyReferences);
 
             AssemblyName? assemblyName = null;
             string? assemblyPath = null;
 
-            if (Path.IsPathRooted((referencesInfo.ItemSpecification)))
+            if (Path.IsPathRooted(itemSpecification))
             {
-                assemblyPath = referencesInfo.ItemSpecification;
+                assemblyPath = itemSpecification;
             }
             else
             {
-                assemblyName = new AssemblyName(referencesInfo.ItemSpecification);
+                assemblyName = new AssemblyName(itemSpecification);
             }
 
             return services.AssemblyReferences.RemoveAsync(assemblyName, assemblyPath);
+        }
+
+        protected override Task AddReferenceAsync(ConfiguredProjectServices services, string itemSpecification)
+        {
+            Assumes.Present(services.AssemblyReferences);
+
+            AssemblyName? assemblyName = null;
+            string? assemblyPath = null;
+
+            if (Path.IsPathRooted(itemSpecification))
+            {
+                assemblyPath = itemSpecification;
+            }
+            else
+            {
+                assemblyName = new AssemblyName(itemSpecification);
+            }
+
+            // todo: get path from the Remove Command
+            return services.AssemblyReferences.AddAsync(assemblyName, assemblyPath);
         }
 
         protected override async Task<IEnumerable<IProjectItem>> GetUnresolvedReferencesAsync(ConfiguredProjectServices services)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/NullCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/NullCommand.cs
@@ -2,19 +2,20 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 {
-    class NullCommand : IProjectSystemUpdateReferenceOperation
+    internal class NullCommand : IProjectSystemUpdateReferenceOperation
     {
         public Task<bool> ApplyAsync(CancellationToken cancellationToken)
         {
-            return Task.FromResult(false);
+            return TaskResult.False;
         }
 
         public Task<bool> RevertAsync(CancellationToken cancellationToken)
         {
-            return Task.FromResult(false);
+            return TaskResult.False;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/NullCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/NullCommand.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.References
+{
+    class NullCommand : IProjectSystemUpdateReferenceOperation
+    {
+        public Task<bool> ApplyAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(false);
+        }
+
+        public Task<bool> RevertAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/PackageReferenceHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/PackageReferenceHandler.cs
@@ -14,11 +14,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         { }
 
         protected override Task RemoveReferenceAsync(ConfiguredProjectServices services,
-            ProjectSystemReferenceInfo referencesInfo)
+            string itemSpecification)
         {
             Assumes.Present(services.PackageReferences);
 
-            return services.PackageReferences.RemoveAsync(referencesInfo.ItemSpecification);
+            return services.PackageReferences.RemoveAsync(itemSpecification);
+        }
+
+        protected override Task AddReferenceAsync(ConfiguredProjectServices services, string itemSpecification)
+        {
+            Assumes.Present(services.PackageReferences);
+
+            // todo: Get the Version from the Remove Command
+            return services.PackageReferences.AddAsync(itemSpecification, "");
         }
 
         protected override async Task<IEnumerable<IProjectItem>> GetUnresolvedReferencesAsync(ConfiguredProjectServices services)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ProjectReferenceHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ProjectReferenceHandler.cs
@@ -14,11 +14,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         { }
 
         protected override Task RemoveReferenceAsync(ConfiguredProjectServices services,
-            ProjectSystemReferenceInfo referencesInfo)
+            string itemSpecification)
         {
             Assumes.Present(services.ProjectReferences);
 
-            return services.ProjectReferences.RemoveAsync(referencesInfo.ItemSpecification);
+            return services.ProjectReferences.RemoveAsync(itemSpecification);
+        }
+
+        protected override Task AddReferenceAsync(ConfiguredProjectServices services, string itemSpecification)
+        {
+            Assumes.Present(services.ProjectReferences);
+
+            return services.ProjectReferences.AddAsync(itemSpecification);
         }
 
         protected override async Task<IEnumerable<IProjectItem>> GetUnresolvedReferencesAsync(ConfiguredProjectServices services)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ReferenceCleanupService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ReferenceCleanupService.cs
@@ -93,6 +93,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             return references;
         }
 
+        public Task<bool> TryUpdateReferenceAsync(string projectPath,
+            ProjectSystemReferenceUpdate referenceUpdate, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Gets an operation that can update the project’s references by removing or marking references as
         /// TreatAsUsed in the project file.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ReferenceCleanupService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ReferenceCleanupService.cs
@@ -121,26 +121,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             return command;
         }
 
-        private IProjectSystemUpdateReferenceOperation? CreateCommand(ProjectSystemReferenceUpdate referenceUpdate, AbstractReferenceHandler referenceHandler,
-            ConfiguredProject selectedConfiguredProject, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            IProjectSystemUpdateReferenceOperation? command;
-            if (referenceUpdate.Action == ProjectSystemUpdateAction.SetTreatAsUsed)
+        private IProjectSystemUpdateReferenceOperation? CreateCommand(ProjectSystemReferenceUpdate referenceUpdate,
+            AbstractReferenceHandler referenceHandler,
+            ConfiguredProject selectedConfiguredProject, CancellationToken cancellationToken) =>
+            referenceUpdate.Action switch
             {
-                command = referenceHandler.CreateSetAttributeCommand(selectedConfiguredProject, referenceUpdate);
-            }
-            else if (referenceUpdate.Action == ProjectSystemUpdateAction.UnsetTreatAsUsed)
-            {
-                command = referenceHandler.CreateUnSetAttributeCommand(selectedConfiguredProject, referenceUpdate);
-            }
-            else
-            {
-                // ProjectSystemUpdateAction.Remove:
-                command = referenceHandler.CreateRemoveReferenceCommand(selectedConfiguredProject, referenceUpdate);
-            }
-            return command;
-        }
+                ProjectSystemUpdateAction.SetTreatAsUsed => referenceHandler.CreateSetAttributeCommand(
+                    selectedConfiguredProject, referenceUpdate),
+                ProjectSystemUpdateAction.UnsetTreatAsUsed => referenceHandler.CreateUnSetAttributeCommand(
+                    selectedConfiguredProject, referenceUpdate),
+                ProjectSystemUpdateAction.Remove => referenceHandler.CreateRemoveReferenceCommand(
+                    selectedConfiguredProject, referenceUpdate)
+            };
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/RemoveReferenceCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/RemoveReferenceCommand.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServices.ExternalAccess.ProjectSystem.Api;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.References
+{
+    internal class RemoveReferenceCommand : IProjectSystemUpdateReferenceOperation
+    {
+        private readonly AbstractReferenceHandler _referenceHandler;
+        private readonly ConfiguredProject _selectedConfiguredProject;
+        private readonly string _itemSpecification;
+
+        private Dictionary<string, string>? _projectPropertiesValues;
+
+        public RemoveReferenceCommand(AbstractReferenceHandler abstractReferenceHandler, ConfiguredProject selectedConfiguredProject, ProjectSystemReferenceUpdate referenceUpdate)
+        {
+            _referenceHandler = abstractReferenceHandler;
+            _selectedConfiguredProject = selectedConfiguredProject;
+            _itemSpecification = referenceUpdate.ReferenceInfo.ItemSpecification;
+        }
+
+        public async Task<bool> ApplyAsync(CancellationToken cancellationToken)
+        {
+            _projectPropertiesValues = await _referenceHandler.GetAttributesAsync(_selectedConfiguredProject, _itemSpecification);
+
+            await _referenceHandler.RemoveReferenceAsync(_selectedConfiguredProject, _itemSpecification);
+            return true;
+        }
+
+        public async Task<bool> RevertAsync(CancellationToken cancellationToken)
+        {
+            await _referenceHandler.AddReferenceAsync(_selectedConfiguredProject, _itemSpecification);
+            await _referenceHandler.SetAttributes(_selectedConfiguredProject, _itemSpecification, _projectPropertiesValues);
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/SetAttributeCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/SetAttributeCommand.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.References
+{
+    internal class SetAttributeCommand : IProjectSystemUpdateReferenceOperation
+    {
+        private readonly ConfiguredProject _selectedConfiguredProject;
+        private readonly string _itemSpecification;
+        private readonly AbstractReferenceHandler _referenceHandler;
+
+        public SetAttributeCommand(AbstractReferenceHandler abstractReferenceHandler, ConfiguredProject selectedConfiguredProject, string itemSpecification)
+        {
+            _referenceHandler = abstractReferenceHandler;
+            _selectedConfiguredProject = selectedConfiguredProject;
+            _itemSpecification = itemSpecification;
+        }
+
+        public async Task<bool> ApplyAsync(CancellationToken cancellationToken)
+        {
+            IProjectItem item = await GetProjectItem();
+
+            if (item != null)
+            {
+                await item.Metadata.SetPropertyValueAsync(ProjectReference.TreatAsUsedProperty, PropertySerializer.SimpleTypes.ToString(true), null);
+            }
+
+            return true;
+        }
+        
+        public async Task<bool> RevertAsync(CancellationToken cancellationToken)
+        {
+            IProjectItem item = await GetProjectItem();
+
+            if (item != null)
+            {
+                await item.Metadata.SetPropertyValueAsync(ProjectReference.TreatAsUsedProperty, PropertySerializer.SimpleTypes.ToString(false), null);
+            }
+
+            return true;
+        }
+
+        private async Task<IProjectItem> GetProjectItem()
+        {
+            var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
+
+            var item = projectItems
+                .FirstOrDefault(c => c.EvaluatedInclude == _itemSpecification);
+            return item;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/UnSetAttributeCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/UnSetAttributeCommand.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.References
+{
+    internal class UnSetAttributeCommand : IProjectSystemUpdateReferenceOperation
+    {
+        private readonly ConfiguredProject _selectedConfiguredProject;
+        private readonly string _itemSpecification;
+        private readonly AbstractReferenceHandler _referenceHandler;
+
+        public UnSetAttributeCommand(AbstractReferenceHandler abstractReferenceHandler, ConfiguredProject selectedConfiguredProject, string itemSpecification)
+        {
+            _referenceHandler = abstractReferenceHandler;
+            _selectedConfiguredProject = selectedConfiguredProject;
+            _itemSpecification = itemSpecification;
+        }
+
+        public async Task<bool> ApplyAsync(CancellationToken cancellationToken)
+        {
+            IProjectItem item = await GetProjectItem();
+
+            if (item != null)
+            {
+                await item.Metadata.SetPropertyValueAsync(ProjectReference.TreatAsUsedProperty, PropertySerializer.SimpleTypes.ToString(false), null);
+            }
+
+            return true;
+        }
+
+        public async Task<bool> RevertAsync(CancellationToken cancellationToken)
+        {
+            IProjectItem item = await GetProjectItem();
+
+            if (item != null)
+            {
+                await item.Metadata.SetPropertyValueAsync(ProjectReference.TreatAsUsedProperty, PropertySerializer.SimpleTypes.ToString(true), null);
+            }
+
+            return true;
+        }
+
+        private async Task<IProjectItem> GetProjectItem()
+        {
+            var projectItems = await _referenceHandler.GetUnresolvedReferencesAsync(_selectedConfiguredProject);
+
+            var item = projectItems
+                .FirstOrDefault(c => c.EvaluatedInclude == _itemSpecification);
+            return item;
+        }
+    }
+}


### PR DESCRIPTION
The new interface IProjectSystemReferenceCleanupService2 replaced TryUpdateReferenceAsync() with GetUpdateReferenceOperationAsync().

This new method is needed to implement the command pattern where the commands are created in DotNet ProjectSystem and Roslyn executes them when needed.
https://github.com/dotnet/roslyn/pull/52434

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7101)