### PR TITLE
Add properties to support CPS VS hierarchy queries

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -46,6 +46,10 @@
   <StringProperty Name="BaseIntermediateOutputPath"
                   Visible="False" />
 
+  <StringProperty Name="CmdUIContextGuid"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <StringProperty Name="Configuration"
                   Visible="False" />
 
@@ -57,6 +61,22 @@
 
   <StringProperty Name="DefaultPlatform"
                   Visible="False" />
+
+  <EnumProperty Name="DesignerFunctionVisibility"
+                Visible="False">
+    <EnumValue Name="Friend" />
+    <EnumValue Name="Private" />
+    <EnumValue Name="Public" />
+  </EnumProperty>
+
+  <StringListProperty Name="DesignerHiddenCodeGeneration"
+                      Visible="False" />
+
+  <EnumProperty Name="DesignerVariableNaming"
+                Visible="False">
+    <EnumValue Name="Camel" />
+    <EnumValue Name="VB" />
+  </EnumProperty>
 
   <BoolProperty Name="DisableFastUpToDateCheck"
                 Visible="False">
@@ -206,6 +226,14 @@
                   SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>
   </BoolProperty>
+
+  <StringProperty Name="SupportedMyApplicationTypes"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringListProperty Name="SupportedOutputTypes"
+                      ReadOnly="True"
+                      Visible="False" />
 
   <BoolProperty Name="SuppressOutOfDateMessageOnBuild"
                 Visible="False" />


### PR DESCRIPTION
Fixes #7103

CPS's `ProjectNode` handles VS hierarchy requests on behalf of the project. For several of those hierarchy properties, the value comes from the project evaluation.

In order for CPS to retrieve the evaluated value, the corresponding MSBuild property must be defined in our ConfigurationGeneral.xaml rule file.

This commit adds several missing properties so that CPS can provide the correct value in response to hierarchy queries.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7104)