### PR TITLE
Restore tools from nuget.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -14,6 +14,7 @@
     <add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="vssdk-unifiedPIAs" value="https://pkgs.dev.azure.com/devdiv/DevDiv/_packaging/vssdk-unifiedPIAs/nuget/v3/index.json" />
+    <add key="ibcmerge" value="https://devdiv.pkgs.visualstudio.com/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
+    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
+    <add key="vs-buildservices" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
+    <add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="vssdk-unifiedPIAs" value="https://pkgs.dev.azure.com/devdiv/DevDiv/_packaging/vssdk-unifiedPIAs/nuget/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -3,6 +3,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <!--TODO: Merged PIAs - evaluate the need of this once packages are in public feeds-->
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -14,7 +14,6 @@
     <add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="vssdk-unifiedPIAs" value="https://pkgs.dev.azure.com/devdiv/DevDiv/_packaging/vssdk-unifiedPIAs/nuget/v3/index.json" />
-    <add key="ibcmerge" value="https://devdiv.pkgs.visualstudio.com/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -32,10 +32,10 @@ steps:
 - task: NuGetCommand@2
   displayName: Restore the 'Microsoft.DotNet.IBCMerge' package
   inputs:
-  command: restore
-  feedsToUse: config
-  restoreSolution: 'build\proj\internal\RestoreIBCMerge.csproj'
-  nugetConfigPath: 'NuGet.config'
+    command: restore
+    feedsToUse: config
+    restoreSolution: 'build\proj\internal\RestoreIBCMerge.csproj'
+    nugetConfigPath: 'NuGet.config'
 
 - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /ibc /no-clearnugetcache /configuration $(BuildConfiguration)
   displayName: Build ProjectSystem.sln

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -10,7 +10,7 @@ resources:
 - repo: self
   clean: true
 queue:
-  name: VSEng-MicroBuildVS2019
+  name: VSEngSS-MicroBuild2019
   demands: Cmd
   timeoutInMinutes: 90
 variables:
@@ -30,7 +30,7 @@ steps:
   displayName: Install Swix Plugin
 
 - task: NuGetCommand@2
-  displayName: Restore the 'Microsoft.DotNet.IBCMerge' package
+  displayName: Restore 'Microsoft.DotNet.IBCMerge' package
   inputs:
     command: restore
     feedsToUse: config

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -37,9 +37,11 @@ steps:
     restoreSolution: 'build\proj\internal\RestoreIBCMerge.csproj'
     nugetConfigPath: 'NuGet.config'
 
+# TODO: Merged PIAs - remove this authenticate once private feeds are removed
 - task: NuGetAuthenticate@0
   displayName: authenticate for internal feed
 
+# TODO: Merged PIAs - reset to /ibc once private feeds are removed and Microsoft.DotNet.IBCMerge is reset
 - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /no-ibc /no-clearnugetcache /configuration $(BuildConfiguration)
   displayName: Build ProjectSystem.sln
 

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -28,12 +28,14 @@ steps:
     
 - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
   displayName: Install Swix Plugin
-  
-- task: NuGetRestore@1
-  displayName: Restore 'Microsoft.DotNet.IBCMerge' package
+
+- task: NuGetCommand@2
+  displayName: Restore the 'Microsoft.DotNet.IBCMerge' package
   inputs:
-    solution: 'build\proj\internal\RestoreIBCMerge.csproj'
-    feed: '8f470c7e-ac49-4afe-a6ee-cf784e438b93'
+  command: restore
+  feedsToUse: config
+  restoreSolution: 'build\proj\internal\RestoreIBCMerge.csproj'
+  nugetConfigPath: 'NuGet.config'
 
 - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /ibc /no-clearnugetcache /configuration $(BuildConfiguration)
   displayName: Build ProjectSystem.sln

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -29,7 +29,7 @@ steps:
 - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
   displayName: Install Swix Plugin
 
-- script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /no-clearnugetcache /configuration $(BuildConfiguration)
+- script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /no-ibc /no-clearnugetcache /configuration $(BuildConfiguration)
   displayName: Build ProjectSystem.sln
 
 - task: Ref12.ref12-analyze-task.ref12-analyze-task.Ref12Analyze@0

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -29,7 +29,15 @@ steps:
 - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
   displayName: Install Swix Plugin
 
-- script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /no-ibc /no-clearnugetcache /configuration $(BuildConfiguration)
+- task: NuGetCommand@2
+  displayName: Restore 'Microsoft.DotNet.IBCMerge' package
+  inputs:
+    command: restore
+    feedsToUse: config
+    restoreSolution: 'build\proj\internal\RestoreIBCMerge.csproj'
+    nugetConfigPath: 'NuGet.config'
+
+- script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /ibc /no-clearnugetcache /configuration $(BuildConfiguration)
   displayName: Build ProjectSystem.sln
 
 - task: Ref12.ref12-analyze-task.ref12-analyze-task.Ref12Analyze@0

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -40,7 +40,7 @@ steps:
 - task: NuGetAuthenticate@0
   displayName: authenticate for internal feed
 
-- script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /ibc /no-clearnugetcache /configuration $(BuildConfiguration)
+- script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /no-ibc /no-clearnugetcache /configuration $(BuildConfiguration)
   displayName: Build ProjectSystem.sln
 
 - task: Ref12.ref12-analyze-task.ref12-analyze-task.Ref12Analyze@0

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -29,15 +29,7 @@ steps:
 - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
   displayName: Install Swix Plugin
 
-- task: NuGetCommand@2
-  displayName: Restore 'Microsoft.DotNet.IBCMerge' package
-  inputs:
-    command: restore
-    feedsToUse: config
-    restoreSolution: 'build\proj\internal\RestoreIBCMerge.csproj'
-    nugetConfigPath: 'NuGet.config'
-
-- script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /ibc /no-clearnugetcache /configuration $(BuildConfiguration)
+- script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /no-clearnugetcache /configuration $(BuildConfiguration)
   displayName: Build ProjectSystem.sln
 
 - task: Ref12.ref12-analyze-task.ref12-analyze-task.Ref12Analyze@0

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -37,6 +37,9 @@ steps:
     restoreSolution: 'build\proj\internal\RestoreIBCMerge.csproj'
     nugetConfigPath: 'NuGet.config'
 
+- task: NuGetAuthenticate@0
+  displayName: authenticate for internal feed
+
 - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /ibc /no-clearnugetcache /configuration $(BuildConfiguration)
   displayName: Build ProjectSystem.sln
 

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -12,6 +12,8 @@
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
+      <!-- TODO: Merged PIAs - Microsoft.VisualStudio.XmlEditor should be on a public feed -->
+      https://pkgs.dev.azure.com/devdiv/_packaging/vs-impl/nuget/v3/index.json;
       <!-- TODO: Merged PIAs - Microsoft.VSDesigner should be on a public feed -->
       https://pkgs.dev.azure.com/devdiv/DevDiv/_packaging/vssdk-unifiedPIAs/nuget/v3/index.json;
     </RestoreSources>

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -14,6 +14,7 @@
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
       <!-- TODO: Merged PIAs - Microsoft.VSDesigner should be on a public feed -->
       https://pkgs.dev.azure.com/devdiv/DevDiv/_packaging/vssdk-unifiedPIAs/nuget/v3/index.json;
+      https://devdiv.pkgs.visualstudio.com/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
 

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -53,6 +53,7 @@
     <PackageReference Update="RoslynTools.SignTool"                                                   Version="$(RoslynToolsSignToolVersion)" />
     <PackageReference Update="XliffTasks"                                                             Version="1.0.0-beta.20574.1" />
     <PackageReference Update="RoslynDependencies.ProjectSystem.OptimizationData"                      Version="$(RoslynDependenciesProjectSystemOptimizationDataVersion)" />
+    <!--TODO: Merged PIAs - evaluate the need of this once packages are in public feeds-->
     <PackageReference Update="Microsoft.DotNet.IBCMerge"                                              Version="[$(MicrosoftDotNetIBCMergeVersion)]" />
     <PackageReference Update="Microsoft.DiaSymReader.Pdb2Pdb"                                         Version="$(MicrosoftDiaSymReaderPdb2PdbVersion)" />
     <PackageReference Update="Microsoft.Net.Compilers.Toolset"                                        Version="3.8.0-5.final" />

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -14,7 +14,6 @@
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
       <!-- TODO: Merged PIAs - Microsoft.VSDesigner should be on a public feed -->
       https://pkgs.dev.azure.com/devdiv/DevDiv/_packaging/vssdk-unifiedPIAs/nuget/v3/index.json;
-      https://devdiv.pkgs.visualstudio.com/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
 

--- a/build/import/Versions.props
+++ b/build/import/Versions.props
@@ -18,7 +18,7 @@
     <RoslynToolsModifyVsixManifestVersion>1.0.0-beta-62327-02</RoslynToolsModifyVsixManifestVersion>
     <RoslynToolsSignToolVersion>1.0.0-beta-62414-01</RoslynToolsSignToolVersion>
     <RoslynDependenciesProjectSystemOptimizationDataVersion>2.6.0-beta1-62205-02</RoslynDependenciesProjectSystemOptimizationDataVersion>
-    <MicrosoftDotNetIBCMergeVersion>4.7.1-alpha-00001</MicrosoftDotNetIBCMergeVersion>
+    <MicrosoftDotNetIBCMergeVersion>5.0.7-beta.20159.1</MicrosoftDotNetIBCMergeVersion>
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta1-62624-01</MicrosoftDiaSymReaderPdb2PdbVersion>
     <MicroBuildPluginsSwixBuildVersion>1.0.147</MicroBuildPluginsSwixBuildVersion>
     <CodecovVersion>1.1.0</CodecovVersion>

--- a/build/proj/internal/RestoreIBCMerge.csproj
+++ b/build/proj/internal/RestoreIBCMerge.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
   <Import Project="..\..\import\Packages.targets" />
   <PropertyGroup>
-    <RestoreSources></RestoreSources>
     <RestoreSources Condition="'$(UsingToolIbcOptimization)' == 'true'">
+      $(RestoreSources);
       https://devdiv.pkgs.visualstudio.com/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json;
     </RestoreSources>
   </PropertyGroup>

--- a/build/proj/internal/RestoreIBCMerge.csproj
+++ b/build/proj/internal/RestoreIBCMerge.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.DotNet.IBCMerge" Condition="'$(UsingToolIbcOptimization)' == 'true'"/>
   </ItemGroup>
   <Import Project="..\..\import\Packages.targets" />
+  <!--TODO: Merged PIAs - evaluate the need of this once packages are in public feeds-->
   <PropertyGroup>
     <RestoreSources Condition="'$(UsingToolIbcOptimization)' == 'true'">
       $(RestoreSources);

--- a/build/proj/internal/RestoreIBCMerge.csproj
+++ b/build/proj/internal/RestoreIBCMerge.csproj
@@ -8,7 +8,13 @@
     <RestoreSources/>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.IBCMerge" />
+    <PackageReference Include="Microsoft.DotNet.IBCMerge" Condition="'$(UsingToolIbcOptimization)' == 'true'"/>
   </ItemGroup>
   <Import Project="..\..\import\Packages.targets" />
+  <PropertyGroup>
+    <RestoreSources></RestoreSources>
+    <RestoreSources Condition="'$(UsingToolIbcOptimization)' == 'true'">
+      https://devdiv.pkgs.visualstudio.com/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json;
+    </RestoreSources>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
We are currently using private feeds as workarounds for dev 17. Our current restore feed has a feed specified which doesn't include vssdk-unifiedPIAs. By using this task we can specify which feeds to use in the restore.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7115)