### PR TITLE
Fix Publishing Symbols to Artifact Services

### DIFF
--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -10,7 +10,7 @@ resources:
 - repo: self
   clean: true
 queue:
-  name: VSEngSS-MicroBuild2019
+  name: VSEng-MicroBuildVS2019
   demands: Cmd
   timeoutInMinutes: 90
 variables:


### PR DESCRIPTION
Task used to publish symbols fails with `ErrorCode: get_user_name_failed`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7116)