### PR TITLE
Add pre/post build events to the Build page

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
@@ -45,7 +45,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
 
             public string? GetProperty(ProjectRootElement projectXml)
             {
-                return GetFromTargets(projectXml);
+                ProjectTaskElement? execTask = FindExecTaskInTargets(projectXml);
+
+                if (execTask == null)
+                {
+                    return null;
+                }
+
+                if (execTask.Parameters.TryGetValue(Command, out string commandText))
+                {
+                    return commandText.Replace("%25", "%");
+                }
+
+                return null; // exec task as written in the project file is invalid, we should be resilient to this case.
             }
 
             public async Task<bool> TrySetPropertyAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties)
@@ -80,23 +92,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
                 }
 
                 SetParameter(projectXml, unevaluatedPropertyValue);
-            }
-
-            private string? GetFromTargets(ProjectRootElement projectXml)
-            {
-                ProjectTaskElement? execTask = FindExecTaskInTargets(projectXml);
-
-                if (execTask == null)
-                {
-                    return null;
-                }
-
-                if (execTask.Parameters.TryGetValue(Command, out string commandText))
-                {
-                    return commandText.Replace("%25", "%");
-                }
-
-                return null; // exec task as written in the project file is invalid, we should be resilient to this case.
             }
 
             private static bool OnlyWhitespaceCharacters(string unevaluatedPropertyValue)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             private string BuildEvent { get; }
             private string TargetName { get; }
 
-            public async Task<(bool success, string? property)> TryGetPropertyAsync(IProjectProperties defaultProperties)
+            public async Task<(bool success, string? value)> TryGetUnevaluatedPropertyValueAsync(IProjectProperties defaultProperties)
             {
                 // check if value already exists
                 string? unevaluatedPropertyValue = await defaultProperties.GetUnevaluatedPropertyValueAsync(BuildEvent);
@@ -41,6 +41,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
                 }
 
                 return (false, null);
+            }
+
+            public async Task<(bool success, string value)> TryGetEvaluatedPropertyValueAsync(IProjectProperties defaultProperties)
+            {
+                string? unevaluatedPropertyValue = await defaultProperties.GetUnevaluatedPropertyValueAsync(BuildEvent);
+
+                if (unevaluatedPropertyValue is null)
+                {
+                    return (false, "");
+                }
+
+                string evaluatedPropertyValue = await defaultProperties.GetEvaluatedPropertyValueAsync(BuildEvent);
+                return (true, evaluatedPropertyValue);
             }
 
             public string? TryGetValueFromTarget(ProjectRootElement projectXml)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
                 return (false, null);
             }
 
-            public string? GetProperty(ProjectRootElement projectXml)
+            public string? TryGetValueFromTarget(ProjectRootElement projectXml)
             {
                 ProjectTaskElement? execTask = FindExecTaskInTargets(projectXml);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
@@ -22,16 +22,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             _helper = helper;
         }
 
+        public override async Task<string> OnGetUnevaluatedPropertyValueAsync(
+            string propertyName,
+            string unevaluatedPropertyValue,
+            IProjectProperties defaultProperties)
+        {
+            (bool success, string? property) = await _helper.TryGetUnevaluatedPropertyValueAsync(defaultProperties);
+
+            if (success)
+            {
+                return property ?? string.Empty;
+            }
+
+            return await _projectAccessor.OpenProjectXmlForReadAsync(_unconfiguredProject, projectXml => _helper.TryGetValueFromTarget(projectXml)) ?? string.Empty;
+        }
+
         public override async Task<string> OnGetEvaluatedPropertyValueAsync(
             string propertyName,
             string evaluatedPropertyValue,
             IProjectProperties defaultProperties)
         {
-            (bool success, string? property) = await _helper.TryGetPropertyAsync(defaultProperties);
+            (bool success, string property) = await _helper.TryGetEvaluatedPropertyValueAsync(defaultProperties);
 
             if (success)
             {
-                return property ?? string.Empty;
+                return property;
             }
 
             return await _projectAccessor.OpenProjectXmlForReadAsync(_unconfiguredProject, projectXml => _helper.TryGetValueFromTarget(projectXml)) ?? string.Empty;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
@@ -22,6 +22,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             _helper = helper;
         }
 
+        // There are two ways of storing pre/post build events in the project.
+        //
+        // 1. As MSBuild properties (PreBuildEvent / PostBuildEvent)
+        // 2. As MSBuild tasks (PreBuild / PostBuild)
+        //
+        // Properties were used in legacy projects.
+        //
+        // For SDK style projects, we should use tasks.
+        //
+        // In legacy projects, the properties were defined _after_ the import of common targets,
+        // meaning that the properties had access to a full range of property values for use in their
+        // bodies.
+        //
+        // In SDK projects, it's not possible to define a property in the project after the common
+        // targets, so an MSBuild task is used instead.
+        //
+        // Some projects still define these events using properties, and the below code will work
+        // with such properties when they exist. However if these properties are absent, then
+        // tasks are used instead.
+        //
+        // Examples of MSBuild properties that are not available to PreBuildEvent/PostBuildEvent
+        // properties (but which are available to PreBuild/PostBuild targets) are ProjectExt,
+        // PlatformName, ProjectDir, TargetDir, TargetFileName, TargetExt, ProjectFileName,
+        // ProjectPath, TargetPath, TargetName, ProjectName, ConfigurationName, and OutDir.
+        //
+        // Tasks are defined as:
+        //
+        // <Target Name="PreBuild" AfterTargets="PreBuildEvent">
+        //   <Exec Command="echo Hello World" />
+        // </Target>
+        // <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+        //   <Exec Command="echo Hello World" />
+        // </Target>
+
         public override async Task<string> OnGetUnevaluatedPropertyValueAsync(
             string propertyName,
             string unevaluatedPropertyValue,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
                 return property ?? string.Empty;
             }
 
-            return await _projectAccessor.OpenProjectXmlForReadAsync(_unconfiguredProject, projectXml => _helper.GetProperty(projectXml)) ?? string.Empty;
+            return await _projectAccessor.OpenProjectXmlForReadAsync(_unconfiguredProject, projectXml => _helper.TryGetValueFromTarget(projectXml)) ?? string.Empty;
         }
 
         public override async Task<string?> OnSetPropertyValueAsync(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -19,6 +19,10 @@
               Description="Configures the output options for the build process."
               DisplayName="Output" />
 
+    <Category Name="Events"
+              Description="Configures custom events that run before and after build."
+              DisplayName="Events" />
+
     <Category Name="StrongNaming"
               Description="Configures strong name signing of build outputs."
               DisplayName="Strong naming" />
@@ -274,6 +278,63 @@
       </NameValuePair>
     </StringProperty.Metadata>
   </StringProperty>
+
+  <!-- TODO create fwlink -->
+  <StringProperty Name="PreBuildEvent"
+                  DisplayName="Pre-build event"
+                  Description="Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs."
+                  HelpUrl="https://docs.microsoft.com/en-us/visualstudio/ide/how-to-specify-build-events-csharp?view=vs-2019"
+                  Category="Events">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFileWithInterception"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+    <StringProperty.ValueEditors>
+      <ValueEditor EditorType="MultiLineString">
+        <ValueEditor.Metadata>
+          <NameValuePair Name="UseMonospaceFont" Value="True" />
+        </ValueEditor.Metadata>
+      </ValueEditor>
+    </StringProperty.ValueEditors>
+  </StringProperty>
+
+  <!-- TODO create fwlink -->
+  <StringProperty Name="PostBuildEvent"
+                  DisplayName="Post-build event"
+                  Description="Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build."
+                  HelpUrl="https://docs.microsoft.com/en-us/visualstudio/ide/how-to-specify-build-events-csharp?view=vs-2019"
+                  Category="Events">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFileWithInterception"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+    <StringProperty.ValueEditors>
+      <ValueEditor EditorType="MultiLineString">
+        <ValueEditor.Metadata>
+          <NameValuePair Name="UseMonospaceFont" Value="True" />
+        </ValueEditor.Metadata>
+      </ValueEditor>
+    </StringProperty.ValueEditors>
+  </StringProperty>
+
+  <!-- TODO create fwlink -->
+  <EnumProperty Name="RunPostBuildEvent"
+                DisplayName="When to run the post-build event"
+                Description="Specifies under which condition the post-build event will be executed."
+                HelpUrl="https://docs.microsoft.com/en-us/visualstudio/ide/how-to-specify-build-events-csharp?view=vs-2019"
+                Category="Events">
+    <EnumProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="RunPostBuildEvent"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </EnumProperty.DataSource>
+    <EnumValue Name="Always" />
+    <EnumValue Name="OnBuildSuccess" IsDefault="True" />
+    <EnumValue Name="OnOutputUpdated" />
+  </EnumProperty>
 
   <BoolProperty Name="SignAssembly"
                 Description="Sign the output assembly to give it a strong name."

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.cs.xlf
@@ -97,6 +97,16 @@
         <target state="translated">Chyby a upozornění</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|General|DisplayName">
         <source>General</source>
         <target state="translated">Obecné</target>
@@ -160,6 +170,16 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Cílová platforma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
@@ -375,6 +395,26 @@
       <trans-unit id="StringProperty|NoWarn|DisplayName">
         <source>Suppress warnings</source>
         <target state="translated">Potlačit upozornění</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.de.xlf
@@ -97,6 +97,16 @@
         <target state="translated">Fehler und Warnungen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|General|DisplayName">
         <source>General</source>
         <target state="translated">Allgemein</target>
@@ -160,6 +170,16 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Zielplattform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
@@ -375,6 +395,26 @@
       <trans-unit id="StringProperty|NoWarn|DisplayName">
         <source>Suppress warnings</source>
         <target state="translated">Warnungen unterdrücken</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.es.xlf
@@ -97,6 +97,16 @@
         <target state="translated">Errores y advertencias</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|General|DisplayName">
         <source>General</source>
         <target state="translated">General</target>
@@ -160,6 +170,16 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Destino de la plataforma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
@@ -375,6 +395,26 @@
       <trans-unit id="StringProperty|NoWarn|DisplayName">
         <source>Suppress warnings</source>
         <target state="translated">Suprimir las advertencias</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.fr.xlf
@@ -97,6 +97,16 @@
         <target state="translated">Erreurs et avertissements</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|General|DisplayName">
         <source>General</source>
         <target state="translated">Général</target>
@@ -160,6 +170,16 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Plateforme cible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
@@ -375,6 +395,26 @@
       <trans-unit id="StringProperty|NoWarn|DisplayName">
         <source>Suppress warnings</source>
         <target state="translated">Supprimer les avertissements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.it.xlf
@@ -97,6 +97,16 @@
         <target state="translated">Errori e avvisi</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|General|DisplayName">
         <source>General</source>
         <target state="translated">Generale</target>
@@ -160,6 +170,16 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Destinazione piattaforma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
@@ -375,6 +395,26 @@
       <trans-unit id="StringProperty|NoWarn|DisplayName">
         <source>Suppress warnings</source>
         <target state="translated">Non visualizzare avvisi</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ja.xlf
@@ -97,6 +97,16 @@
         <target state="translated">エラーおよび警告</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|General|DisplayName">
         <source>General</source>
         <target state="translated">全般</target>
@@ -160,6 +170,16 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">プラットフォーム ターゲット</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
@@ -375,6 +395,26 @@
       <trans-unit id="StringProperty|NoWarn|DisplayName">
         <source>Suppress warnings</source>
         <target state="translated">警告の抑制</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ko.xlf
@@ -97,6 +97,16 @@
         <target state="translated">오류 및 경고</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|General|DisplayName">
         <source>General</source>
         <target state="translated">일반</target>
@@ -160,6 +170,16 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">플랫폼 대상</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
@@ -375,6 +395,26 @@
       <trans-unit id="StringProperty|NoWarn|DisplayName">
         <source>Suppress warnings</source>
         <target state="translated">경고 표시 안 함</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pl.xlf
@@ -97,6 +97,16 @@
         <target state="translated">Błędy i ostrzeżenia</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|General|DisplayName">
         <source>General</source>
         <target state="translated">Ogólne</target>
@@ -160,6 +170,16 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Platforma docelowa</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
@@ -375,6 +395,26 @@
       <trans-unit id="StringProperty|NoWarn|DisplayName">
         <source>Suppress warnings</source>
         <target state="translated">Pomiń ostrzeżenia</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pt-BR.xlf
@@ -97,6 +97,16 @@
         <target state="translated">Erros e avisos</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|General|DisplayName">
         <source>General</source>
         <target state="translated">Geral</target>
@@ -160,6 +170,16 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Destino de plataforma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
@@ -375,6 +395,26 @@
       <trans-unit id="StringProperty|NoWarn|DisplayName">
         <source>Suppress warnings</source>
         <target state="translated">Suprimir avisos</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ru.xlf
@@ -97,6 +97,16 @@
         <target state="translated">Ошибки и предупреждения</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|General|DisplayName">
         <source>General</source>
         <target state="translated">Общие</target>
@@ -160,6 +170,16 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Целевая платформа</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
@@ -375,6 +395,26 @@
       <trans-unit id="StringProperty|NoWarn|DisplayName">
         <source>Suppress warnings</source>
         <target state="translated">Отключить предупреждения</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.tr.xlf
@@ -97,6 +97,16 @@
         <target state="translated">Hatalar ve uyarılar</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|General|DisplayName">
         <source>General</source>
         <target state="translated">Genel</target>
@@ -160,6 +170,16 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Platform hedefi</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
@@ -375,6 +395,26 @@
       <trans-unit id="StringProperty|NoWarn|DisplayName">
         <source>Suppress warnings</source>
         <target state="translated">Uyarıları Gizle</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hans.xlf
@@ -97,6 +97,16 @@
         <target state="translated">错误和警告</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|General|DisplayName">
         <source>General</source>
         <target state="translated">常规</target>
@@ -160,6 +170,16 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">平台目标</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
@@ -375,6 +395,26 @@
       <trans-unit id="StringProperty|NoWarn|DisplayName">
         <source>Suppress warnings</source>
         <target state="translated">取消显示警告</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hant.xlf
@@ -97,6 +97,16 @@
         <target state="translated">錯誤與警告</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|General|DisplayName">
         <source>General</source>
         <target state="translated">一般</target>
@@ -160,6 +170,16 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">平台目標</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
@@ -375,6 +395,26 @@
       <trans-unit id="StringProperty|NoWarn|DisplayName">
         <source>Suppress warnings</source>
         <target state="translated">隱藏警告</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var actual = systemUnderTest.GetProperty(root);
+            var actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Equal(@"echo ""post build output""", actual);
         }
 
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var actual = systemUnderTest.GetProperty(root);
+            var actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Equal(@"echo ""post build output""", actual);
         }
 
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var actual = systemUnderTest.GetProperty(root);
+            var actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Equal(@"echo ""post build output""", actual);
         }
 
@@ -92,7 +92,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var actual = systemUnderTest.GetProperty(root);
+            var actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Null(actual);
         }
 
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>
 ".AsProjectRootElement();
-            var result = systemUnderTest.GetProperty(root);
+            var result = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Null(result);
         }
 
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>
 ".AsProjectRootElement();
-            var result = systemUnderTest.GetProperty(root);
+            var result = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Null(result);
         }
 
@@ -620,7 +620,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 ".AsProjectRootElement();
 
             const string expected = "echo %DATE%";
-            string? actual = systemUnderTest.GetProperty(root);
+            string? actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Equal(expected, actual);
         }
 
@@ -639,7 +639,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 ".AsProjectRootElement();
 
             const string expected = "echo %25DATE%";
-            string? actual = systemUnderTest.GetProperty(root);
+            string? actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Equal(expected, actual);
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         {
             var expected = "echo $(ProjectDir)";
             var projectProperties = IProjectPropertiesFactory.CreateWithPropertyAndValue("PostBuildEvent", expected);
-            var (success, actual) = await systemUnderTest.TryGetPropertyAsync(projectProperties);
+            var (success, actual) = await systemUnderTest.TryGetUnevaluatedPropertyValueAsync(projectProperties);
             Assert.True(success);
             Assert.Equal(expected, actual);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var actual = systemUnderTest.GetProperty(root);
+            var actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Equal(@"echo ""prebuild output""", actual);
         }
 
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var actual = systemUnderTest.GetProperty(root);
+            var actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Equal(@"echo ""prebuild output""", actual);
         }
 
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var actual = systemUnderTest.GetProperty(root);
+            var actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Equal(@"echo ""prebuild output""", actual);
         }
 
@@ -92,7 +92,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var actual = systemUnderTest.GetProperty(root);
+            var actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Null(actual);
         }
 
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var result = systemUnderTest.GetProperty(root);
+            var result = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Null(result);
         }
 
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>
 ".AsProjectRootElement();
-            var result = systemUnderTest.GetProperty(root);
+            var result = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Null(result);
         }
 
@@ -627,7 +627,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 ".AsProjectRootElement();
 
             const string expected = "echo %DATE%";
-            string? actual = systemUnderTest.GetProperty(root);
+            string? actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Equal(expected, actual);
         }
 
@@ -646,7 +646,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 ".AsProjectRootElement();
 
             const string expected = "echo %25DATE%";
-            string? actual = systemUnderTest.GetProperty(root);
+            string? actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Equal(expected, actual);
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         {
             var expected = "echo $(ProjectDir)";
             var projectProperties = IProjectPropertiesFactory.CreateWithPropertyAndValue("PreBuildEvent", expected);
-            var (success, actual) = await systemUnderTest.TryGetPropertyAsync(projectProperties);
+            var (success, actual) = await systemUnderTest.TryGetUnevaluatedPropertyValueAsync(projectProperties);
             Assert.True(success);
             Assert.Equal(expected, actual);
         }


### PR DESCRIPTION
Fixes #5953 

Add build event interception support for unevaluated value. Previously, the interception code for pre/post build event properties only handled requests for the _evaluated_ value of these properties. For the new Project Properties UI we need both the evaluated _and_ unevaluated values.

Also previously, requests for the evaluated property value were actually returning the unevaluated property value.

Document use of properties/tasks for pre/post build events.

Adds entries to the Build page for events.

![image](https://user-images.githubusercontent.com/350947/114558111-af583180-9cad-11eb-8c45-785f83a457c3.png)

Produces:

```xml
<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
  <Exec Command="echo &quot;Pre-build&quot; &#xD;&#xA;echo &quot;Configuration: $(Configuration)&quot;" />
</Target>

<Target Name="PostBuild" AfterTargets="PostBuildEvent">
  <Exec Command="echo &quot;Post-build&quot; &#xD;&#xA;echo &quot;Configuration: $(Configuration)&quot;" />
</Target>
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7119)