### PR TITLE
Use `ProduceReferenceAssembly` for faster incremental builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,6 +36,8 @@
 
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <ForceGenerationOfBindingRedirects>true</ForceGenerationOfBindingRedirects>
+
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <!-- 


### PR DESCRIPTION
This produces a `ref` folder (e.g. `bin/Debug/ref/Project.dll`) that contains the surface API of the project. Other projects which reference that assembly may avoid rebuilding themselves when the referenced project's surface area did not change, even if its internals did. This can help prevent cascading project builds when simple changes are made at low levels in the dependency graph.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7122)