### PR TITLE
Hide some properties based on project capabilities

### DIFF
--- a/docs/repo/property-pages/visibility-conditions.md
+++ b/docs/repo/property-pages/visibility-conditions.md
@@ -75,24 +75,25 @@ Now, the property will only be visible if _MyProperty_ has value _MyEnumValue_.
 
 The following table details the default set of visibility expression functions:
 
-| Function               | Arity    | Description                                                                                     |
-|------------------------|----------|-------------------------------------------------------------------------------------------------|
-| `add`                  | Variadic | Adds integer arguments                                                                          |
-| `concat`               | Variadic | Concatenates string arguments                                                                   |
-| `eq`                   | 2        | Computes `arg0 == arg1`                                                                         |
-| `ne`                   | 2        | Computes `arg0 != arg1`                                                                         |
-| `lt`                   | 2        | Computes `arg0 <  arg1`                                                                         |
-| `lte`                  | 2        | Computes `arg0 <= arg1`                                                                         |
-| `gt`                   | 2        | Computes `arg0 >  arg1`                                                                         |
-| `gte`                  | 2        | Computes `arg0 >= arg1`                                                                         |
-| `and`                  | Variadic | Computes logical AND of arguments                                                               |
-| `or`                   | Variadic | Computes logical OR of arguments                                                                |
-| `xor`                  | 2        | Computes exclusive logical OR of arguments                                                      |
-| `not`                  | 1        | Computes logical NOT of argument                                                                |
-| `evaluated`            | 2        | Returns the evaluated value of property on page `arg0` with name `arg1`                         |
-| `unevaluated`          | 2        | Returns the unevaluated value of property on page `arg0` with name `arg1`                       |
-| `has-evaluated-value`  | 3        | Returns true if property on page `arg0` with name `arg1` has an evaluated value matching `arg2` |
-| `is-codespaces-client` | 0        | Returns true if the Project Properties UI is running in a Codespaces client                     |
+| Function                 | Arity    | Description                                                                                     |
+|--------------------------|----------|-------------------------------------------------------------------------------------------------|
+| `add`                    | Variadic | Adds integer arguments                                                                          |
+| `concat`                 | Variadic | Concatenates string arguments                                                                   |
+| `eq`                     | 2        | Computes `arg0 == arg1`                                                                         |
+| `ne`                     | 2        | Computes `arg0 != arg1`                                                                         |
+| `lt`                     | 2        | Computes `arg0 <  arg1`                                                                         |
+| `lte`                    | 2        | Computes `arg0 <= arg1`                                                                         |
+| `gt`                     | 2        | Computes `arg0 >  arg1`                                                                         |
+| `gte`                    | 2        | Computes `arg0 >= arg1`                                                                         |
+| `and`                    | Variadic | Computes logical AND of arguments                                                               |
+| `or`                     | Variadic | Computes logical OR of arguments                                                                |
+| `xor`                    | 2        | Computes exclusive logical OR of arguments                                                      |
+| `not`                    | 1        | Computes logical NOT of argument                                                                |
+| `evaluated`              | 2        | Returns the evaluated value of property on page `arg0` with name `arg1`                         |
+| `unevaluated`            | 2        | Returns the unevaluated value of property on page `arg0` with name `arg1`                       |
+| `has-evaluated-value`    | 3        | Returns true if property on page `arg0` with name `arg1` has an evaluated value matching `arg2` |
+| `is-codespaces-client`   | 0        | Returns true if the Project Properties UI is running in a Codespaces client                     |
+| `has-project-capability` | 1        | Returns true if the project has the specified capability.                                       |
 
 These functions are defined in class `VisibilityConditionEvaluator`.
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -260,6 +260,11 @@
     <BoolProperty.DataSource>
       <DataSource HasConfigurationCondition="False" />
     </BoolProperty.DataSource>
+    <BoolProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-project-capability "GenerateDocumentationFile")</NameValuePair.Value>
+      </NameValuePair>
+    </BoolProperty.Metadata>
   </BoolProperty>
 
   <!-- TODO consider removing this property from the UI altogether -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/DebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/DebugPropertyPage.xaml
@@ -18,6 +18,11 @@
   <StringProperty Name="DebugPagePlaceholderDescription"
                   DisplayName="Ignored"
                   Description="The management of launch profiles has moved to a dedicated dialog. It may be accessed via the link below.">
+    <StringProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-project-capability "LaunchProfiles")</NameValuePair.Value>
+      </NameValuePair>
+    </StringProperty.Metadata>
     <StringProperty.ValueEditors>
       <ValueEditor EditorType="Description" />
     </StringProperty.ValueEditors>
@@ -25,6 +30,11 @@
 
   <StringProperty Name="OpenLaunchProfilesEditor"
                   DisplayName="Open debug launch profiles UI">
+    <StringProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-project-capability "LaunchProfiles")</NameValuePair.Value>
+      </NameValuePair>
+    </StringProperty.Metadata>
     <StringProperty.ValueEditors>
       <ValueEditor EditorType="LinkAction">
         <ValueEditor.Metadata>


### PR DESCRIPTION
This uses the new `has-project-capability` conditional visibility function, introduced in https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/317749.

We hide:

- properties related to launch profiles when the `LaunchProfile` project capability is absent, and
- the `GeneratedDocumentationFile` property when the `GeneratedDocumentationFile` project capability is absent.

---

This should not be merged until the corresponding CPS PR has inserted.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7126)