### PR TITLE
Unreverting changes from https://github.com/dotnet/project-system/pull/7053

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/TreatWarningsAsErrorsValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/TreatWarningsAsErrorsValueProvider.cs
@@ -21,20 +21,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
-            if (StringComparers.PropertyLiteralValues.Equals(unevaluatedPropertyValue, "true"))
+            if (!bool.TryParse(unevaluatedPropertyValue, out bool value))
             {
-                // When setting this to "true", remove WarningsAsErrors
-                await defaultProperties.SaveValueIfCurrentlySetAsync(WarningsAsErrorsProperty, _temporaryPropertyStorage);
-                await defaultProperties.DeletePropertyAsync(WarningsAsErrorsProperty, dimensionalConditions);
-                await defaultProperties.RestoreValueIfNotCurrentlySetAsync(WarningsNotAsErrorsProperty, _temporaryPropertyStorage);
+                return null;
             }
-            else
-            {
-                // When settings this to "false", remove WarningsNotAsErrors
-                await defaultProperties.SaveValueIfCurrentlySetAsync(WarningsNotAsErrorsProperty, _temporaryPropertyStorage);
-                await defaultProperties.DeletePropertyAsync(WarningsNotAsErrorsProperty, dimensionalConditions);
-                await defaultProperties.RestoreValueIfNotCurrentlySetAsync(WarningsAsErrorsProperty, _temporaryPropertyStorage);
-            }
+
+            // When true, remove WarningsAsErrors. Otherwise, remove WarningsNotAsErrors.
+            string removePropertyName = value ? WarningsAsErrorsProperty : WarningsNotAsErrorsProperty;
+            string restorePropertyName = value ? WarningsNotAsErrorsProperty : WarningsAsErrorsProperty;
+
+            await defaultProperties.SaveValueIfCurrentlySetAsync(removePropertyName, _temporaryPropertyStorage);
+            await defaultProperties.DeletePropertyAsync(removePropertyName, dimensionalConditions);
+            await defaultProperties.RestoreValueIfNotCurrentlySetAsync(restorePropertyName, _temporaryPropertyStorage);
 
             return await base.OnSetPropertyValueAsync(propertyName, unevaluatedPropertyValue, defaultProperties, dimensionalConditions);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -180,49 +180,43 @@
   </EnumProperty>
 
   <StringProperty Name="NoWarn"
-                  DisplayName="Suppress warnings"
-                  Description="Blocks the compiler's ability to generate one or more warnings. Separate multiple warning numbers with a comma (',') or semicolon (';')."
+                  DisplayName="Suppress specific warnings"
+                  Description="Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';')."
                   HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147300"
                   Category="ErrorsAndWarnings" />
 
-  <EnumProperty Name="TreatWarningsAsErrors"
+  <BoolProperty Name="TreatWarningsAsErrors"
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147301"
                 DisplayName="Treat warnings as errors"
-                Description="Used to specify which warnings are treated as errors."
+                Description="Instruct the compiler to treat warnings as errors."
                 Category="ErrorsAndWarnings" >
-
-    <EnumProperty.DataSource>
+    <BoolProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception" />
-    </EnumProperty.DataSource>
-
-    <EnumValue Name="false"
-               DisplayName="None" />
-    <EnumValue Name="true"
-               DisplayName="All" />
-  </EnumProperty>
+    </BoolProperty.DataSource>
+  </BoolProperty>
 
   <StringProperty Name="WarningsAsErrors"
                   DisplayName="Treat specific warnings as errors"
                   HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147301"
-                  Description="Treats the specified warnings as errors. Separate multiple warning numbers with a comma (',') or semicolon (';')."
+                  Description="Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';')."
                   Category="ErrorsAndWarnings">
     <StringProperty.Metadata>
       <NameValuePair Name="DependsOn" Value="Build::TreatWarningsAsErrors" />
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(has-evaluated-value "Build" "TreatWarningsAsErrors" "false")</NameValuePair.Value>
+        <NameValuePair.Value>(has-evaluated-value "Build" "TreatWarningsAsErrors" false)</NameValuePair.Value>
       </NameValuePair>
     </StringProperty.Metadata>
   </StringProperty>
 
   <StringProperty Name="WarningsNotAsErrors"
-                  DisplayName="Exempt specific warnings from being treated as errors"
+                  DisplayName="Exclude specific warnings as errors"
                   HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147301"
-                  Description="Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';')."
+                  Description="Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';')."
                   Category="ErrorsAndWarnings">
     <StringProperty.Metadata>
       <NameValuePair Name="DependsOn" Value="Build::TreatWarningsAsErrors" />
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(has-evaluated-value "Build" "TreatWarningsAsErrors" "true")</NameValuePair.Value>
+        <NameValuePair.Value>(has-evaluated-value "Build" "TreatWarningsAsErrors" true)</NameValuePair.Value>
       </NameValuePair>
     </StringProperty.Metadata>
   </StringProperty>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.cs.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Podepsat sestavení</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|Description">
+        <source>Instruct the compiler to treat warnings as errors.</source>
+        <target state="new">Instruct the compiler to treat warnings as errors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|ErrorsAndWarnings|Description">
         <source>Configures the error and warning options for the build process.</source>
         <target state="translated">Konfiguruje možnosti pro chyby a upozornění při procesu sestavení.</target>
@@ -160,16 +170,6 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Cílová platforma</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
-        <source>Used to specify which warnings are treated as errors.</source>
-        <target state="translated">Slouží k určení, která upozornění se zpracovávají jako chyby.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|DisplayName">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Zpracovávat upozornění jako chyby</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -260,16 +260,6 @@
       <trans-unit id="EnumValue|PlatformTarget.x86|DisplayName">
         <source>x86</source>
         <target state="translated">x86</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.false|DisplayName">
-        <source>None</source>
-        <target state="translated">Žádné</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.true|DisplayName">
-        <source>All</source>
-        <target state="translated">Vše</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
@@ -368,18 +358,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Blocks the compiler's ability to generate one or more warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Blokuje schopnost kompilátoru generovat jedno nebo více upozornění. Více čísel upozornění oddělte čárkou (,) nebo středníkem (;).</target>
+        <source>Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Potlačit upozornění</target>
+        <source>Suppress specific warnings</source>
+        <target state="new">Suppress specific warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">
-        <source>Treats the specified warnings as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Zpracovává určená upozornění jako chyby. Více čísel upozornění oddělte čárkou (,) nebo středníkem (;).</target>
+        <source>Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|DisplayName">
@@ -388,13 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
-        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Vyloučí zadaná upozornění, která se tak nebudou považovat za chyby. Více čísel upozornění oddělte čárkou (,) nebo středníkem (;).</target>
+        <source>Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
-        <source>Exempt specific warnings from being treated as errors</source>
-        <target state="translated">Vyloučit zadaná upozornění, která se tak nebudou považovat za chyby</target>
+        <source>Exclude specific warnings as errors</source>
+        <target state="new">Exclude specific warnings as errors</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.de.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Assembly signieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|Description">
+        <source>Instruct the compiler to treat warnings as errors.</source>
+        <target state="new">Instruct the compiler to treat warnings as errors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|ErrorsAndWarnings|Description">
         <source>Configures the error and warning options for the build process.</source>
         <target state="translated">Hiermit werden die Fehler- und Warnungsoptionen für den Buildprozess konfiguriert.</target>
@@ -160,16 +170,6 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Zielplattform</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
-        <source>Used to specify which warnings are treated as errors.</source>
-        <target state="translated">Hiermit wird angegeben, welche Warnungen als Fehler behandelt werden.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|DisplayName">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Warnungen als Fehler behandeln</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -260,16 +260,6 @@
       <trans-unit id="EnumValue|PlatformTarget.x86|DisplayName">
         <source>x86</source>
         <target state="translated">x86</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.false|DisplayName">
-        <source>None</source>
-        <target state="translated">Keine</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.true|DisplayName">
-        <source>All</source>
-        <target state="translated">Alle</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
@@ -368,18 +358,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Blocks the compiler's ability to generate one or more warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Hiermit wird die Fähigkeit des Compilers blockiert, mindestens eine Warnung zu generieren. Trennen Sie mehrere Warnungsnummern durch ein Komma (",") oder ein Semikolon (";").</target>
+        <source>Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Warnungen unterdrücken</target>
+        <source>Suppress specific warnings</source>
+        <target state="new">Suppress specific warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">
-        <source>Treats the specified warnings as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Hiermit werden die angegebenen Warnungen als Fehler behandelt. Trennen Sie mehrere Warnungsnummern durch ein Komma (",") oder ein Semikolon (";").</target>
+        <source>Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|DisplayName">
@@ -388,13 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
-        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Hiermit werden die angegebenen Warnungen von der Behandlung als Fehler ausgenommen. Trennen Sie mehrere Warnungsnummern durch ein Komma (",") oder ein Semikolon (";").</target>
+        <source>Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
-        <source>Exempt specific warnings from being treated as errors</source>
-        <target state="translated">Bestimmte Warnungen von der Behandlung als Fehler ausnehmen</target>
+        <source>Exclude specific warnings as errors</source>
+        <target state="new">Exclude specific warnings as errors</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.es.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Firmar el ensamblado</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|Description">
+        <source>Instruct the compiler to treat warnings as errors.</source>
+        <target state="new">Instruct the compiler to treat warnings as errors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|ErrorsAndWarnings|Description">
         <source>Configures the error and warning options for the build process.</source>
         <target state="translated">Configura las opciones de error y advertencia del proceso de compilación.</target>
@@ -160,16 +170,6 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Destino de la plataforma</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
-        <source>Used to specify which warnings are treated as errors.</source>
-        <target state="translated">Se usa para especificar las advertencias que se tratan como errores.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|DisplayName">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Tratar advertencias como errores</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -260,16 +260,6 @@
       <trans-unit id="EnumValue|PlatformTarget.x86|DisplayName">
         <source>x86</source>
         <target state="translated">x86</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.false|DisplayName">
-        <source>None</source>
-        <target state="translated">Ninguno</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.true|DisplayName">
-        <source>All</source>
-        <target state="translated">Todo</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
@@ -368,18 +358,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Blocks the compiler's ability to generate one or more warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Bloquea la capacidad del compilador para generar una o más advertencias. Separe varios números de advertencia con una coma (",") o punto y coma (";").</target>
+        <source>Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Suprimir las advertencias</target>
+        <source>Suppress specific warnings</source>
+        <target state="new">Suppress specific warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">
-        <source>Treats the specified warnings as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Trata las advertencias especificadas como errores. Separe varios números de advertencia con una coma (",") o punto y coma (";").</target>
+        <source>Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|DisplayName">
@@ -388,13 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
-        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Exime las advertencias especificadas de que se traten como errores. Separe varios números de advertencia con una coma (",") o con punto y coma (";").</target>
+        <source>Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
-        <source>Exempt specific warnings from being treated as errors</source>
-        <target state="translated">Excluir advertencias específicas para que no se traten como errores</target>
+        <source>Exclude specific warnings as errors</source>
+        <target state="new">Exclude specific warnings as errors</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.fr.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Signer l'assembly</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|Description">
+        <source>Instruct the compiler to treat warnings as errors.</source>
+        <target state="new">Instruct the compiler to treat warnings as errors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|ErrorsAndWarnings|Description">
         <source>Configures the error and warning options for the build process.</source>
         <target state="translated">Configure les options d'erreur et d'avertissement pour le processus de génération.</target>
@@ -160,16 +170,6 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Plateforme cible</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
-        <source>Used to specify which warnings are treated as errors.</source>
-        <target state="translated">Permet de spécifier les avertissements qui doivent être traités en tant qu'erreurs.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|DisplayName">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Considérer les avertissements comme des erreurs</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -260,16 +260,6 @@
       <trans-unit id="EnumValue|PlatformTarget.x86|DisplayName">
         <source>x86</source>
         <target state="translated">x86</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.false|DisplayName">
-        <source>None</source>
-        <target state="translated">Aucun</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.true|DisplayName">
-        <source>All</source>
-        <target state="translated">Tout</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
@@ -368,18 +358,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Blocks the compiler's ability to generate one or more warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Bloque la capacité du compilateur à générer un ou plusieurs avertissements. Séparez plusieurs numéros d'avertissement par une virgule (',') ou un point-virgule (';').</target>
+        <source>Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Supprimer les avertissements</target>
+        <source>Suppress specific warnings</source>
+        <target state="new">Suppress specific warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">
-        <source>Treats the specified warnings as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Traite les avertissements spécifiés en tant qu'erreurs. Séparez plusieurs numéros d'avertissement par une virgule (',') ou un point-virgule (';').</target>
+        <source>Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|DisplayName">
@@ -388,13 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
-        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Ne traite pas les avertissements spécifiés en tant qu'erreurs. Séparez plusieurs numéros d'avertissement par une virgule (',') ou un point-virgule (';').</target>
+        <source>Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
-        <source>Exempt specific warnings from being treated as errors</source>
-        <target state="translated">Ne traite pas des avertissements spécifiques en tant qu'erreurs</target>
+        <source>Exclude specific warnings as errors</source>
+        <target state="new">Exclude specific warnings as errors</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.it.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Firma l'assembly</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|Description">
+        <source>Instruct the compiler to treat warnings as errors.</source>
+        <target state="new">Instruct the compiler to treat warnings as errors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|ErrorsAndWarnings|Description">
         <source>Configures the error and warning options for the build process.</source>
         <target state="translated">Consente di configurare le opzioni di errore e avviso per il processo di compilazione.</target>
@@ -160,16 +170,6 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Destinazione piattaforma</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
-        <source>Used to specify which warnings are treated as errors.</source>
-        <target state="translated">Viene usato per specificare quali avvertenze vengono considerate come errori.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|DisplayName">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Considera gli avvisi come errori</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -260,16 +260,6 @@
       <trans-unit id="EnumValue|PlatformTarget.x86|DisplayName">
         <source>x86</source>
         <target state="translated">x86</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.false|DisplayName">
-        <source>None</source>
-        <target state="translated">Nessuno</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.true|DisplayName">
-        <source>All</source>
-        <target state="translated">Tutti</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
@@ -368,18 +358,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Blocks the compiler's ability to generate one or more warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Impedisce al compilatore di generare uno o più avvisi. Separare più numeri di avviso con una virgola (',') o un punto e virgola (';').</target>
+        <source>Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Non visualizzare avvisi</target>
+        <source>Suppress specific warnings</source>
+        <target state="new">Suppress specific warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">
-        <source>Treats the specified warnings as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Considera gli avvisi specificati come errori. Separare più numeri di avviso con una virgola (',') o un punto e virgola (';').</target>
+        <source>Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|DisplayName">
@@ -388,13 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
-        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Evita che gli avvisi specificati vengano considerati come errori. Separare più numeri di avviso con una virgola (',') o un punto e virgola (';').</target>
+        <source>Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
-        <source>Exempt specific warnings from being treated as errors</source>
-        <target state="translated">Evita che avvisi specifici vengano considerati come errori</target>
+        <source>Exclude specific warnings as errors</source>
+        <target state="new">Exclude specific warnings as errors</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ja.xlf
@@ -87,6 +87,16 @@
         <target state="translated">アセンブリに署名する</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|Description">
+        <source>Instruct the compiler to treat warnings as errors.</source>
+        <target state="new">Instruct the compiler to treat warnings as errors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|ErrorsAndWarnings|Description">
         <source>Configures the error and warning options for the build process.</source>
         <target state="translated">ビルド プロセスのエラーと警告のオプションを構成します。</target>
@@ -160,16 +170,6 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">プラットフォーム ターゲット</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
-        <source>Used to specify which warnings are treated as errors.</source>
-        <target state="translated">どの警告をエラーとして扱うかを指定するために使用します。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|DisplayName">
-        <source>Treat warnings as errors</source>
-        <target state="translated">警告をエラーとして扱う</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -260,16 +260,6 @@
       <trans-unit id="EnumValue|PlatformTarget.x86|DisplayName">
         <source>x86</source>
         <target state="translated">x86</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.false|DisplayName">
-        <source>None</source>
-        <target state="translated">なし</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.true|DisplayName">
-        <source>All</source>
-        <target state="translated">すべて</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
@@ -368,18 +358,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Blocks the compiler's ability to generate one or more warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">1 つ以上の警告を生成するコンパイラの機能をブロックします。複数の警告番号はコンマ (',') またはセミコロン (';') を使用して区切ります。</target>
+        <source>Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">警告の抑制</target>
+        <source>Suppress specific warnings</source>
+        <target state="new">Suppress specific warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">
-        <source>Treats the specified warnings as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">指定された警告をエラーとして扱います。複数の警告番号はコンマ (',') またはセミコロン (';') を使用して区切ります。</target>
+        <source>Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|DisplayName">
@@ -388,13 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
-        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">指定された警告がエラーとして扱われないよう適用対象外にします。複数の警告番号はコンマ (',') またはセミコロン (';') を使用して区切ります。</target>
+        <source>Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
-        <source>Exempt specific warnings from being treated as errors</source>
-        <target state="translated">特定の警告がエラーとして扱われないよう適用対象外にする</target>
+        <source>Exclude specific warnings as errors</source>
+        <target state="new">Exclude specific warnings as errors</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ko.xlf
@@ -87,6 +87,16 @@
         <target state="translated">어셈블리 서명</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|Description">
+        <source>Instruct the compiler to treat warnings as errors.</source>
+        <target state="new">Instruct the compiler to treat warnings as errors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|ErrorsAndWarnings|Description">
         <source>Configures the error and warning options for the build process.</source>
         <target state="translated">빌드 프로세스의 오류 및 경고 옵션을 구성합니다.</target>
@@ -160,16 +170,6 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">플랫폼 대상</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
-        <source>Used to specify which warnings are treated as errors.</source>
-        <target state="translated">어느 경고를 오류로 처리할지 지정하는 데 사용됩니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|DisplayName">
-        <source>Treat warnings as errors</source>
-        <target state="translated">경고를 오류로 처리</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -260,16 +260,6 @@
       <trans-unit id="EnumValue|PlatformTarget.x86|DisplayName">
         <source>x86</source>
         <target state="translated">x86</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.false|DisplayName">
-        <source>None</source>
-        <target state="translated">없음</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.true|DisplayName">
-        <source>All</source>
-        <target state="translated">모두</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
@@ -368,18 +358,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Blocks the compiler's ability to generate one or more warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">하나 이상의 경고를 생성하는 컴파일러의 기능을 차단합니다. 여러 개의 경고 번호는 쉼표(',') 또는 세미콜론(';')으로 구분합니다.</target>
+        <source>Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">경고 표시 안 함</target>
+        <source>Suppress specific warnings</source>
+        <target state="new">Suppress specific warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">
-        <source>Treats the specified warnings as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">지정된 경고를 오류로 처리합니다. 여러 개의 경고 번호는 쉼표(',') 또는 세미콜론(';')으로 구분합니다.</target>
+        <source>Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|DisplayName">
@@ -388,13 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
-        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">지정된 경고가 오류로 처리되지 않도록 합니다. 여러 개의 경고 번호는 쉼표(',') 또는 세미콜론(';')으로 구분합니다.</target>
+        <source>Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
-        <source>Exempt specific warnings from being treated as errors</source>
-        <target state="translated">특정 경고가 오류로 처리되지 않도록 함</target>
+        <source>Exclude specific warnings as errors</source>
+        <target state="new">Exclude specific warnings as errors</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pl.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Podpisz zestaw</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|Description">
+        <source>Instruct the compiler to treat warnings as errors.</source>
+        <target state="new">Instruct the compiler to treat warnings as errors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|ErrorsAndWarnings|Description">
         <source>Configures the error and warning options for the build process.</source>
         <target state="translated">Konfiguruje opcje błędów i ostrzeżeń procesu kompilowania.</target>
@@ -160,16 +170,6 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Platforma docelowa</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
-        <source>Used to specify which warnings are treated as errors.</source>
-        <target state="translated">Służy do określania, które ostrzeżenia są traktowane jak błędy.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|DisplayName">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Traktuj ostrzeżenia jako błędy</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -260,16 +260,6 @@
       <trans-unit id="EnumValue|PlatformTarget.x86|DisplayName">
         <source>x86</source>
         <target state="translated">x86</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.false|DisplayName">
-        <source>None</source>
-        <target state="translated">Brak</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.true|DisplayName">
-        <source>All</source>
-        <target state="translated">Wszystko</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
@@ -368,18 +358,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Blocks the compiler's ability to generate one or more warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Blokuje możliwość generowania jednego lub większej liczby ostrzeżeń przez kompilator. Rozdziel wiele numerów ostrzeżeń przecinkami („,”) lub średnikami („;”).</target>
+        <source>Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Pomiń ostrzeżenia</target>
+        <source>Suppress specific warnings</source>
+        <target state="new">Suppress specific warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">
-        <source>Treats the specified warnings as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Traktuje określone ostrzeżenia jak błędy. Rozdziel wiele numerów ostrzeżeń przecinkami („,”) lub średnikami („;”).</target>
+        <source>Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|DisplayName">
@@ -388,13 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
-        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Wyklucza określone ostrzeżenia z traktowania ich jako błędy. Poszczególne numery ostrzeżeń oddziel przecinkiem („,”) lub średnikiem („;”).</target>
+        <source>Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
-        <source>Exempt specific warnings from being treated as errors</source>
-        <target state="translated">Wyklucz określone ostrzeżenia z traktowania ich jako błędy\</target>
+        <source>Exclude specific warnings as errors</source>
+        <target state="new">Exclude specific warnings as errors</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pt-BR.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Assinar o assembly</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|Description">
+        <source>Instruct the compiler to treat warnings as errors.</source>
+        <target state="new">Instruct the compiler to treat warnings as errors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|ErrorsAndWarnings|Description">
         <source>Configures the error and warning options for the build process.</source>
         <target state="translated">Configura as opções de erro e de aviso do processo de build.</target>
@@ -160,16 +170,6 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Destino de plataforma</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
-        <source>Used to specify which warnings are treated as errors.</source>
-        <target state="translated">Usado para especificar quais avisos são tratados como erros.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|DisplayName">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Tratar avisos como erros</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -260,16 +260,6 @@
       <trans-unit id="EnumValue|PlatformTarget.x86|DisplayName">
         <source>x86</source>
         <target state="translated">x86</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.false|DisplayName">
-        <source>None</source>
-        <target state="translated">Nenhum</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.true|DisplayName">
-        <source>All</source>
-        <target state="translated">Tudo</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
@@ -368,18 +358,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Blocks the compiler's ability to generate one or more warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Bloqueia a capacidade do compilador de gerar um ou mais avisos. Separe vários números de aviso com uma vírgula (',') ou um ponto e vírgula (';').</target>
+        <source>Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Suprimir avisos</target>
+        <source>Suppress specific warnings</source>
+        <target state="new">Suppress specific warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">
-        <source>Treats the specified warnings as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Trata os avisos especificados como erros. Separe vários números de aviso com uma vírgula (',') ou um ponto e vírgula (';').</target>
+        <source>Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|DisplayName">
@@ -388,13 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
-        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Isenta os avisos especificados de serem tratados como erros. Separe vários números de aviso com uma vírgula (',') ou um ponto e vírgula (';').</target>
+        <source>Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
-        <source>Exempt specific warnings from being treated as errors</source>
-        <target state="translated">Isentar avisos específicos de serem tratados como erros</target>
+        <source>Exclude specific warnings as errors</source>
+        <target state="new">Exclude specific warnings as errors</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ru.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Подписать сборку</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|Description">
+        <source>Instruct the compiler to treat warnings as errors.</source>
+        <target state="new">Instruct the compiler to treat warnings as errors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|ErrorsAndWarnings|Description">
         <source>Configures the error and warning options for the build process.</source>
         <target state="translated">Настраивает параметры ошибок и предупреждений для процесса сборки.</target>
@@ -160,16 +170,6 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Целевая платформа</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
-        <source>Used to specify which warnings are treated as errors.</source>
-        <target state="translated">Используется для указания предупреждений, которые считаются ошибками.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|DisplayName">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Обрабатывать предупреждения как ошибки</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -260,16 +260,6 @@
       <trans-unit id="EnumValue|PlatformTarget.x86|DisplayName">
         <source>x86</source>
         <target state="translated">x86</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.false|DisplayName">
-        <source>None</source>
-        <target state="translated">Нет</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.true|DisplayName">
-        <source>All</source>
-        <target state="translated">Все</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
@@ -368,18 +358,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Blocks the compiler's ability to generate one or more warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Запрещает компилятору создавать одно или несколько предупреждений. При указании нескольких номеров предупреждений их следует разделить запятыми (",") или точками с запятой (";").</target>
+        <source>Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Отключить предупреждения</target>
+        <source>Suppress specific warnings</source>
+        <target state="new">Suppress specific warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">
-        <source>Treats the specified warnings as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Обрабатывает указанные предупреждения как ошибки. При указании нескольких номеров предупреждений их следует разделить запятыми (",") или точками с запятой (";").</target>
+        <source>Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|DisplayName">
@@ -388,13 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
-        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Исключает указанные предупреждения из числа ошибок. При указании нескольких номеров предупреждений их следует разделить запятыми (",") или точками с запятой (";").</target>
+        <source>Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
-        <source>Exempt specific warnings from being treated as errors</source>
-        <target state="translated">Исключить указанные предупреждения из числа ошибок</target>
+        <source>Exclude specific warnings as errors</source>
+        <target state="new">Exclude specific warnings as errors</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.tr.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Bütünleştirilmiş kodu imzala</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|Description">
+        <source>Instruct the compiler to treat warnings as errors.</source>
+        <target state="new">Instruct the compiler to treat warnings as errors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|ErrorsAndWarnings|Description">
         <source>Configures the error and warning options for the build process.</source>
         <target state="translated">Derleme işlemi için hata ve uyarı seçeneklerini yapılandırır.</target>
@@ -160,16 +170,6 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Platform hedefi</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
-        <source>Used to specify which warnings are treated as errors.</source>
-        <target state="translated">Hangi uyarıların hata olarak değerlendirileceğini belirtmek için kullanılır.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|DisplayName">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Uyarıları hata olarak değerlendir</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -260,16 +260,6 @@
       <trans-unit id="EnumValue|PlatformTarget.x86|DisplayName">
         <source>x86</source>
         <target state="translated">x86</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.false|DisplayName">
-        <source>None</source>
-        <target state="translated">Hiçbiri</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.true|DisplayName">
-        <source>All</source>
-        <target state="translated">Tümü</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
@@ -368,18 +358,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Blocks the compiler's ability to generate one or more warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Derleyicinin bir veya daha fazla uyarı oluşturulabilmesini engeller. Birden çok uyarı numarasını virgül (',') veya noktalı virgül (';') ile ayırın.</target>
+        <source>Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">Uyarıları Gizle</target>
+        <source>Suppress specific warnings</source>
+        <target state="new">Suppress specific warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">
-        <source>Treats the specified warnings as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Belirtilen uyarıları hata olarak değerlendirir. Birden çok uyarı numarasını virgül (',') veya noktalı virgül (';') ile ayırın.</target>
+        <source>Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|DisplayName">
@@ -388,13 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
-        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">Belirtilen uyarıları hata olarak değerlendirmenin dışında tutar. Birden çok uyarı numarasını virgül (',') veya noktalı virgül (';') ile ayırın.</target>
+        <source>Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
-        <source>Exempt specific warnings from being treated as errors</source>
-        <target state="translated">Belirli uyarıları hata olarak değerlendirilme dışında tut</target>
+        <source>Exclude specific warnings as errors</source>
+        <target state="new">Exclude specific warnings as errors</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hans.xlf
@@ -87,6 +87,16 @@
         <target state="translated">对程序集签名</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|Description">
+        <source>Instruct the compiler to treat warnings as errors.</source>
+        <target state="new">Instruct the compiler to treat warnings as errors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|ErrorsAndWarnings|Description">
         <source>Configures the error and warning options for the build process.</source>
         <target state="translated">为生成过程配置错误和警告选项。</target>
@@ -160,16 +170,6 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">平台目标</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
-        <source>Used to specify which warnings are treated as errors.</source>
-        <target state="translated">用于指定将哪些警告视为错误。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|DisplayName">
-        <source>Treat warnings as errors</source>
-        <target state="translated">将警告视为错误</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -260,16 +260,6 @@
       <trans-unit id="EnumValue|PlatformTarget.x86|DisplayName">
         <source>x86</source>
         <target state="translated">x86</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.false|DisplayName">
-        <source>None</source>
-        <target state="translated">无</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.true|DisplayName">
-        <source>All</source>
-        <target state="translated">全部</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
@@ -368,18 +358,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Blocks the compiler's ability to generate one or more warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">阻止编译器生成一个或多个警告的能力。使用逗号(",")或分号(";")来分隔多个警告编号。</target>
+        <source>Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">取消显示警告</target>
+        <source>Suppress specific warnings</source>
+        <target state="new">Suppress specific warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">
-        <source>Treats the specified warnings as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">将指定的警告视为错误。使用逗号(",")或分号(";")来分隔多个警告编号。</target>
+        <source>Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|DisplayName">
@@ -388,13 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
-        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">不将指定的警告视为错误。请使用逗号(",")或分号(";")分隔多个警告编号。</target>
+        <source>Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
-        <source>Exempt specific warnings from being treated as errors</source>
-        <target state="translated">不将指定的警告视为错误</target>
+        <source>Exclude specific warnings as errors</source>
+        <target state="new">Exclude specific warnings as errors</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hant.xlf
@@ -87,6 +87,16 @@
         <target state="translated">簽署組件</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|Description">
+        <source>Instruct the compiler to treat warnings as errors.</source>
+        <target state="new">Instruct the compiler to treat warnings as errors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|ErrorsAndWarnings|Description">
         <source>Configures the error and warning options for the build process.</source>
         <target state="translated">設定建置過程的錯誤和警告選項。</target>
@@ -160,16 +170,6 @@
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">平台目標</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|Description">
-        <source>Used to specify which warnings are treated as errors.</source>
-        <target state="translated">用以指定哪些警告會視為錯誤。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|TreatWarningsAsErrors|DisplayName">
-        <source>Treat warnings as errors</source>
-        <target state="translated">將警告視為錯誤</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -260,16 +260,6 @@
       <trans-unit id="EnumValue|PlatformTarget.x86|DisplayName">
         <source>x86</source>
         <target state="translated">x86</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.false|DisplayName">
-        <source>None</source>
-        <target state="translated">無</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|TreatWarningsAsErrors.true|DisplayName">
-        <source>All</source>
-        <target state="translated">全部</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
@@ -368,18 +358,18 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Blocks the compiler's ability to generate one or more warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">使編譯器無法產生一或多個警告。請以逗號 (',') 或分號 (';') 分隔多個警告編號。</target>
+        <source>Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>Suppress warnings</source>
-        <target state="translated">隱藏警告</target>
+        <source>Suppress specific warnings</source>
+        <target state="new">Suppress specific warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|Description">
-        <source>Treats the specified warnings as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">將指定的警告視為錯誤。請以逗號 (',') 或分號 (';') 分隔多個警告編號。</target>
+        <source>Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsAsErrors|DisplayName">
@@ -388,13 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|Description">
-        <source>Exempts the specified warnings from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
-        <target state="translated">避免將指定的警告視為錯誤。請以逗號 (',') 或分號 (';') 分隔多個警告編號。</target>
+        <source>Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</source>
+        <target state="new">Specifies which warnings are excluded from being treated as errors. Separate multiple warning numbers with a comma (',') or semicolon (';').</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|WarningsNotAsErrors|DisplayName">
-        <source>Exempt specific warnings from being treated as errors</source>
-        <target state="translated">避免將特定警告視為錯誤</target>
+        <source>Exclude specific warnings as errors</source>
+        <target state="new">Exclude specific warnings as errors</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
These changes were reverted in https://github.com/dotnet/project-system/pull/7091. That was done because it was thought to be the cause of the insertion failure from the other week. We found it these changes were not the culprit. So, this is to un-revert (reintroduce) the changes from https://github.com/dotnet/project-system/pull/7053.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7127)