### PR TITLE
Handle exception when invalid document id.

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/Common/DTEUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/DTEUtils.vb
@@ -113,9 +113,15 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="PropertyName">The name of the property to retrieve.</param>
         Public Shared Function GetProjectItemProperty(ProjectItem As ProjectItem, PropertyName As String) As [Property]
-            If ProjectItem.Properties Is Nothing Then
+            Try
+                If ProjectItem.Properties Is Nothing Then
+                    Return Nothing
+                End If
+            Catch ex As KeyNotFoundException
+                ' The issue is a limitation in CPS. The main cause is that CPS, in some cases,
+                ' it is not able to maintain the same item id for items, causing them to not be found
                 Return Nothing
-            End If
+            End Try
 
             For Each Prop As [Property] In ProjectItem.Properties
                 If Prop.Name.Equals(PropertyName, StringComparison.OrdinalIgnoreCase) Then


### PR DESCRIPTION
[AB#1243638](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1243638)

When a resx file is open and then moved to a folder, the resx designer holds a reference to a DTE.ProjectItem that becomes stale when the item id changes. Attempting to use it when stale will cause this exception.

This is a CPS limitation and Dotnet ProjectSystem should handle this exception.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7138)