### PR TITLE
Populate UIProperty.IsReadOnly

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -66,8 +66,8 @@
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.8.DesignTime"                   Version="16.8.30406.65" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.16.6.DesignTime"                   Version="16.8.30406.65-pre" />
     <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="16.8.30403.137-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="16.9.51" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="16.9.51" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="16.10.53-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="16.10.53-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="16.9.31019.194" />
     <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="16.9.32" />
     <PackageReference Update="Microsoft.VisualStudio.VSHelp"                                          Version="16.0.28321-alpha" />
@@ -91,7 +91,7 @@
     <!-- CPS -->
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.10.137-pre" />
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.10.137-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="16.10.137-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="16.10.337-pre" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="3.10.0-2.21121.14" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
@@ -58,6 +58,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 newUIProperty.ConfigurationIndependent = !property.IsConfigurationDependent();
             }
 
+            if (requestedProperties.IsReadOnly)
+            {
+                newUIProperty.IsReadOnly = property.ReadOnly;
+            }
+
             if (requestedProperties.HelpUrl)
             {
                 newUIProperty.HelpUrl = property.HelpUrl;


### PR DESCRIPTION
Relates to #7035

The `UIProperty.IsReadOnly` property was recently added to CPS's project model. We extend our data provider to include this data.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7141)