### PR TITLE
Update to latest PIAs and re-enable tests

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -38,8 +38,6 @@
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop" Version="$(VSSDK_GeneralVersion)" Pack="false" ExcludeAssets="compile" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.8.0" Version="$(VSSDK_GeneralVersion)" Pack="false" ExcludeAssets="compile" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="10.0.30320" Pack="false" ExcludeAssets="compile" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(VSSDK_GeneralVersion)" Pack="false" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectAggregator" Version="$(VSSDK_GeneralVersion)" Pack="false" />
   </ItemGroup>
 
   <ItemGroup>
@@ -65,35 +63,35 @@
     <PackageReference Update="Microsoft.DevDiv.Validation.MediaRecorder"                              Version="15.0.199" />
 
     <!-- VS SDK -->
-    <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="17.0.53-Dev17PIAs-g1a257589" />
-    <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.0.28-g439d20ddd3"/>
-    <PackageReference Update="Microsoft.VisualStudio.Composition"                                     Version="16.5.13"/>
+    <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="17.0.63-dev17-g3f11f5ab" />
+    <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.0.30-g62d2639511"/>
+    <PackageReference Update="Microsoft.VisualStudio.Composition"                                     Version="16.9.20"/>
     <PackageReference Update="Microsoft.VisualStudio.Data.Core"                                       Version="9.0.21023" />
-    <PackageReference Update="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.0.0-preview-1-31209-1111"/>
+    <PackageReference Update="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.0.0-preview-2-31221-277"/>
     <PackageReference Update="Microsoft.VisualStudio.Data.Services"                                   Version="9.0.21023" />
-    <PackageReference Update="Microsoft.VisualStudio.DataTools.Interop"                               Version="17.0.0-preview-1-31209-1111" />
-    <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces"                             Version="17.0.0-preview-1-30928-1112" />
-    <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.0.0-preview-1-31204-1114" />
+    <PackageReference Update="Microsoft.VisualStudio.DataTools.Interop"                               Version="17.0.0-preview-2-31221-277" />
+    <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces"                             Version="17.0.0-preview-2-31221-277" />
+    <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.0.0-preview-2-31221-277" />
     <PackageReference Update="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50728" />
-    <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="16.10.14-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Telemetry"                                       Version="16.3.109" />
+    <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="16.10.17-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Telemetry"                                       Version="16.3.110" />
     <PackageReference Update="Microsoft.VisualStudio.Settings.15.0"                                   Version="16.8.30406.155-pre" />
     <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="2.3.2262-g94fae01e" />
     <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes"                           Version="15.0.34" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.15.0"                                      Version="17.0.0-preview-1-31204-1114" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Design"                                    Version="17.0.0-preview-1-31204-1114" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.0.0-preview-1-31204-1114" />
-    <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.0.0-preview-1-30928-1111" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="16.10.51-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="16.10.51-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="17.0.0-preview-1-31204-1114" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.15.0"                                      Version="17.0.0-preview-2-31221-277" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Design"                                    Version="17.0.0-preview-2-31221-277" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.0.0-preview-2-31221-277" />
+    <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.0.0-preview-2-31221-277" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="16.10.53-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="16.10.53-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="17.0.0-preview-2-31221-277" />
     <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="16.9.32" />
     <PackageReference Update="Microsoft.VisualStudio.Workspace.VSIntegration"                         Version="16.7.47-preview-0001" />
-    <PackageReference Update="Microsoft.VisualStudio.XmlEditor"                                       Version="17.0.0-preview-1-30928-1112" />
-    <PackageReference Update="Microsoft.VSDesigner"                                                   Version="17.0.0-preview-1-31209-1111" />
+    <PackageReference Update="Microsoft.VisualStudio.XmlEditor"                                       Version="17.0.0-preview-2-31221-277" />
+    <PackageReference Update="Microsoft.VSDesigner"                                                   Version="17.0.0-preview-2-31221-277" />
     <PackageReference Update="VsWebSite.Interop"                                                      Version="16.8.30523.219"/>
-    <PackageReference Include="Microsoft.VisualStudio.Interop"                                        Version="17.0.0-preview-1-31209-1111"/>
-    <PackageReference Include="Microsoft.Internal.VisualStudio.Interop"                               Version="17.0.0-preview-1-31204-1114"/>
+    <PackageReference Include="Microsoft.VisualStudio.Interop"                                        Version="17.0.0-preview-2-31221-277"/>
+    <PackageReference Include="Microsoft.Internal.VisualStudio.Interop"                               Version="17.0.0-preview-2-31221-277"/>
     
 
     <!-- Avoid double-writes, can remove when https://github.com/NuGet/Home/issues/8343 is fixed -->
@@ -101,9 +99,9 @@
     <PackageReference Include="VSSDK.TemplateWizardInterface"                                         Version="12.0.4"                          ExcludeAssets="All" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.0.58-pre-g6e3d071e55" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.0.77-pre-g62a6cb5699" />
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.10.127-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.0.58-pre-g6e3d071e55" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.0.77-pre-g62a6cb5699" />
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="16.10.127-pre" />
     
     <!-- Roslyn -->
@@ -141,7 +139,7 @@
     <!-- Integration Tests -->
     <PackageReference Update="MSTest.TestFramework"                                                   Version="2.1.2" />
     <PackageReference Update="MSTest.TestAdapter"                                                     Version="2.1.2" />
-    <PackageReference Update="Microsoft.Test.Apex.VisualStudio"                                       Version="16.3.29003.189" />
+    <PackageReference Update="Microsoft.Test.Apex.VisualStudio"                                       Version="17.0.0-preview-2-31221-277" />
     <PackageReference Update="Microsoft.TestPlatform"                                                 Version="16.2.0" />
     <PackageReference Update="Microsoft.DotNet.Test.ProjectTemplates.1.x"                             Version="1.0.0-beta2-20170629-269" />
     <PackageReference Update="Microsoft.DotNet.Common.ProjectTemplates.1.x"                           Version="1.0.0-beta2-20170629-269" />

--- a/build/import/Versions.props
+++ b/build/import/Versions.props
@@ -25,6 +25,5 @@
 
     <!-- VS SDK -->
     <VSSDK_GeneralVersion>17.0.0-preview-1-31205-065</VSSDK_GeneralVersion>
-    <VisualStudioInteropVersion>17.0.0-preview-1-30928-1112</VisualStudioInteropVersion>
   </PropertyGroup>
 </Project>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/DependencyNodeIntegrationTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/DependencyNodeIntegrationTests.cs
@@ -176,15 +176,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 "XmpCore"
             };
 
-            // TODO: Merged PIAs - uncomment this once Microsoft.Test.Apex.VisualStudio is updated
-            //var projects = (Array)VisualStudio.Dte.ActiveSolutionProjects;
-            //var vsproject = (VSLangProj.VSProject)projects.Cast<EnvDTE.Project>().First().Object;
-            //var actual = vsproject.References
-            //    .Cast<VSLangProj.Reference>()
-            //    .Select(r => r.Name)
-            //    .ToList();
+            var projects = (Array)VisualStudio.Dte.ActiveSolutionProjects;
+            var vsproject = (VSLangProj.VSProject)projects.Cast<EnvDTE.Project>().First().Object;
+            var actual = vsproject.References
+                .Cast<VSLangProj.Reference>()
+                .Select(r => r.Name)
+                .ToList();
 
-            //CollectionAssert.AreEquivalent(expected, actual);
+            CollectionAssert.AreEquivalent(expected, actual);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Resources/ResourceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Resources/ResourceTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.Resources
 {
     public sealed class ResourceTests
     {
-        [Theory(Skip = "TODO: Merged PIAs  - uncomment this once Microsoft.Test.Apex.VisualStudio is updated")]
+        [Theory]
         [InlineData(@"src\Microsoft.VisualStudio.AppDesigner\Resources\Designer.Designer.vb", "Microsoft.VisualStudio.AppDesigner.Designer")]
         [InlineData(@"src\Microsoft.VisualStudio.Editors\AddImportsDialogs\AddImports.Designer.vb", "AddImports")]
         [InlineData(@"src\Microsoft.VisualStudio.Editors\OptionPages\GeneralOptionPageResources.Designer.vb", "GeneralOptionPageResources")]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             AssertFailed(result, hierarchyResult, itemIdResult, containedLanguageFactoryResult);
         }
 
-        [Fact]
+        [Fact(Skip = "TODO: Merged PIAs - uncomment this once IOleAsyncServiceProviderFactory code is updated")]
         public void GetContainedLanguageFactoryForFile_WhenReturnsResult_ReturnsS_OK()
         {
             var hierarchy = IVsHierarchyFactory.Create();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
     {
         private const string LanguageServiceId = "{517FA117-46EB-4402-A0D5-D4B7D89FCC33}";
 
-        [Fact(Skip = "TODO: Merged PIAs - uncomment this once Microsoft.Test.Apex.VisualStudio is updated")]
+        [Fact]
         public void GetContainedLanguageFactoryForFile_WhenIsDocumentInProjectFails_ReturnE_FAIL()
         {
             var project = IVsProject_Factory.ImplementIsDocumentInProject(HResult.Fail);
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             AssertFailed(result, hierarchyResult, itemIdResult, containedLanguageFactoryResult);
         }
 
-        [Fact(Skip = "TODO: Merged PIAs - uncomment this once Microsoft.Test.Apex.VisualStudio is updated")]
+        [Fact]
         public void GetContainedLanguageFactoryForFile_WhenFilePathNotFound_ReturnE_FAIL()
         {
             var project = IVsProject_Factory.ImplementIsDocumentInProject(found: false);
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             AssertFailed(result, hierarchyResult, itemIdResult, containedLanguageFactoryResult);
         }
 
-        [Fact(Skip = "TODO: Merged PIAs - uncomment this once Microsoft.Test.Apex.VisualStudio is updated")]
+        [Fact]
         public void GetContainedLanguageFactoryForFile_WhenNoContainedLanguageFactory_ReturnE_FAIL()
         {
             var project = IVsProject_Factory.ImplementIsDocumentInProject(found: true);
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             AssertFailed(result, hierarchyResult, itemIdResult, containedLanguageFactoryResult);
         }
 
-        [Fact(Skip = "TODO: Merged PIAs - uncomment this once Microsoft.Test.Apex.VisualStudio is updated")]
+        [Fact]
         public void GetContainedLanguageFactoryForFile_WhenReturnsResult_ReturnsS_OK()
         {
             var hierarchy = IVsHierarchyFactory.Create();


### PR DESCRIPTION
Updating to latest available packages which allow us to enable tests again. We still need to use private feeds so builds are expected to fail but internal users can validate using [this build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4682651&view=results).

Additionally one test is still failing due to workarounds that are still in place for breaking changes. These will be addressed in the next PR but I'm merging this to unblock partners.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7142)