### PR TITLE
Add search terms for launch profile properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/DebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/DebugPropertyPage.xaml
@@ -22,6 +22,7 @@
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>(has-project-capability "LaunchProfiles")</NameValuePair.Value>
       </NameValuePair>
+      <NameValuePair Name="SearchTerms" Value="arguments;command line;working directory;environment variables" />
     </StringProperty.Metadata>
     <StringProperty.ValueEditors>
       <ValueEditor EditorType="Description" />
@@ -34,6 +35,7 @@
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>(has-project-capability "LaunchProfiles")</NameValuePair.Value>
       </NameValuePair>
+      <NameValuePair Name="SearchTerms" Value="arguments;command line;working directory;environment variables" />
     </StringProperty.Metadata>
     <StringProperty.ValueEditors>
       <ValueEditor EditorType="LinkAction">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.cs.xlf
@@ -22,9 +22,19 @@
         <target state="new">Ignored</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
         <source>Open debug launch profiles UI</source>
         <target state="new">Open debug launch profiles UI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.de.xlf
@@ -22,9 +22,19 @@
         <target state="new">Ignored</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
         <source>Open debug launch profiles UI</source>
         <target state="new">Open debug launch profiles UI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.es.xlf
@@ -22,9 +22,19 @@
         <target state="new">Ignored</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
         <source>Open debug launch profiles UI</source>
         <target state="new">Open debug launch profiles UI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.fr.xlf
@@ -22,9 +22,19 @@
         <target state="new">Ignored</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
         <source>Open debug launch profiles UI</source>
         <target state="new">Open debug launch profiles UI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.it.xlf
@@ -22,9 +22,19 @@
         <target state="new">Ignored</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
         <source>Open debug launch profiles UI</source>
         <target state="new">Open debug launch profiles UI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ja.xlf
@@ -22,9 +22,19 @@
         <target state="new">Ignored</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
         <source>Open debug launch profiles UI</source>
         <target state="new">Open debug launch profiles UI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ko.xlf
@@ -22,9 +22,19 @@
         <target state="new">Ignored</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
         <source>Open debug launch profiles UI</source>
         <target state="new">Open debug launch profiles UI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.pl.xlf
@@ -22,9 +22,19 @@
         <target state="new">Ignored</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
         <source>Open debug launch profiles UI</source>
         <target state="new">Open debug launch profiles UI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.pt-BR.xlf
@@ -22,9 +22,19 @@
         <target state="new">Ignored</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
         <source>Open debug launch profiles UI</source>
         <target state="new">Open debug launch profiles UI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ru.xlf
@@ -22,9 +22,19 @@
         <target state="new">Ignored</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
         <source>Open debug launch profiles UI</source>
         <target state="new">Open debug launch profiles UI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.tr.xlf
@@ -22,9 +22,19 @@
         <target state="new">Ignored</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
         <source>Open debug launch profiles UI</source>
         <target state="new">Open debug launch profiles UI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.zh-Hans.xlf
@@ -22,9 +22,19 @@
         <target state="new">Ignored</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
         <source>Open debug launch profiles UI</source>
         <target state="new">Open debug launch profiles UI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.zh-Hant.xlf
@@ -22,9 +22,19 @@
         <target state="new">Ignored</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
         <source>Open debug launch profiles UI</source>
         <target state="new">Open debug launch profiles UI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
+        <source>arguments;command line;working directory;environment variables</source>
+        <target state="new">arguments;command line;working directory;environment variables</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
Helps with #7133

As launch profiles have moved to a dedicated UI, users attempting to search for these terms in the Project Properties UI would not previously have seen a match. This commit adds some keywords which will direct the user to the new Launch Profiles UI when they search.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7143)