### PR TITLE
Fast up-to-date check performance

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
@@ -12,17 +12,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private sealed class Log
         {
             private readonly TextWriter _writer;
-            private readonly LogLevel _requestedLogLevel;
             private readonly Stopwatch _stopwatch;
             private readonly TimestampCache _timestampCache;
             private readonly string _fileName;
             private readonly ITelemetryService _telemetryService;
             private readonly UpToDateCheckConfiguredInput _upToDateCheckConfiguredInput;
 
+            public LogLevel Level { get; }
+
             public Log(TextWriter writer, LogLevel requestedLogLevel, Stopwatch stopwatch, TimestampCache timestampCache, string projectPath, ITelemetryService telemetryService, UpToDateCheckConfiguredInput upToDateCheckConfiguredInput)
             {
                 _writer = writer;
-                _requestedLogLevel = requestedLogLevel;
+                Level = requestedLogLevel;
                 _stopwatch = stopwatch;
                 _timestampCache = timestampCache;
                 _telemetryService = telemetryService;
@@ -32,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             private void Write(LogLevel level, string message, object arg0)
             {
-                if (level <= _requestedLogLevel)
+                if (level <= Level)
                 {
                     // These are user visible, so we want them in local times so that 
                     // they correspond with dates/times that Explorer, etc shows
@@ -44,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             private void Write(LogLevel level, string message, object arg0, object arg1)
             {
-                if (level <= _requestedLogLevel)
+                if (level <= Level)
                 {
                     // These are user visible, so we want them in local times so that 
                     // they correspond with dates/times that Explorer, etc shows
@@ -57,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             private void Write(LogLevel level, string message, params object[] values)
             {
-                if (level <= _requestedLogLevel)
+                if (level <= Level)
                 {
                     // These are user visible, so we want them in local times so that 
                     // they correspond with dates/times that Explorer, etc shows

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.TimestampCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.TimestampCache.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return time;
             }
 
-            public bool TryGetLatestInput(ImmutableHashSet<string> inputs, [NotNullWhen(returnValue: true)] out string? latestPath, out DateTime latestTime)
+            public bool TryGetLatestInput(ImmutableArray<string> inputs, [NotNullWhen(returnValue: true)] out string? latestPath, out DateTime latestTime)
             {
                 latestTime = DateTime.MinValue;
                 latestPath = null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -195,7 +195,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     
                     if (log.Level <= LogLevel.Info)
                     {
-                        foreach ((bool isAdd, string itemType, string path, string? link, CopyType copyType) in state.LastItemChanges)
+                        foreach ((bool isAdd, string itemType, string path, string? link, CopyType copyType) in state.LastItemChanges.OrderBy(change => change.ItemType).ThenBy(change => change.Path))
                         {
                             if (Strings.IsNullOrEmpty(link))
                                 log.Info("    {0} item {1} '{2}' (CopyType={3})", itemType, isAdd ? "added" : "removed", path, copyType);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -404,7 +404,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             // here if the project actually produced a marker and we only check it against references that
             // actually produced a marker.
 
-            if (Strings.IsNullOrWhiteSpace(state.CopyUpToDateMarkerItem) || !state.CopyReferenceInputs.Any())
+            if (Strings.IsNullOrWhiteSpace(state.CopyUpToDateMarkerItem) || state.CopyReferenceInputs.IsEmpty)
             {
                 return true;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -316,6 +316,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     log.Verbose("Adding " + ResolvedCompilationReference.SchemaName + " inputs:");
                     foreach (string path in state.ResolvedCompilationReferencePaths)
                     {
+                        System.Diagnostics.Debug.Assert(Path.IsPathRooted(path), "ResolvedCompilationReference path should be rooted");
                         log.Verbose("    '{0}'", path);
                         yield return (Path: path, IsRequired: true);
                     }
@@ -339,6 +340,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     log.Verbose("Adding " + nameof(state.AdditionalDependentFileTimes) + " inputs:");
                     foreach ((string path, DateTime _) in state.AdditionalDependentFileTimes)
                     {
+                        System.Diagnostics.Debug.Assert(Path.IsPathRooted(path), "AdditionalDependentFileTimes path should be rooted");
                         log.Verbose("    '{0}'", path);
                         yield return (Path: path, IsRequired: false);
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -273,7 +273,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     yield return (Path: state.NewestImportInput, IsRequired: true);
                 }
 
-                foreach ((string itemType, ImmutableHashSet<(string path, string? link, CopyType copyType)> changes) in state.ItemsByItemType)
+                foreach ((string itemType, ImmutableArray<(string path, string? link, CopyType copyType)> changes) in state.ItemsByItemType)
                 {
                     if (!NonCompilationItemTypes.Contains(itemType))
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -315,7 +315,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     }
                 }
 
-                if (state.UpToDateCheckInputItemsBySetName.TryGetValue(DefaultSetName, out ImmutableHashSet<string>? upToDateCheckInputItems))
+                if (state.UpToDateCheckInputItemsBySetName.TryGetValue(DefaultSetName, out ImmutableArray<string> upToDateCheckInputItems))
                 {
                     log.Verbose("Adding " + UpToDateCheckInput.SchemaName + " inputs:");
                     foreach (string input in upToDateCheckInputItems.Select(_configuredProject.UnconfiguredProject.MakeRooted))
@@ -341,7 +341,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             IEnumerable<string> CollectDefaultOutputs()
             {
-                if (state.UpToDateCheckOutputItemsBySetName.TryGetValue(DefaultSetName, out ImmutableHashSet<string>? upToDateCheckOutputItems))
+                if (state.UpToDateCheckOutputItemsBySetName.TryGetValue(DefaultSetName, out ImmutableArray<string> upToDateCheckOutputItems))
                 {
                     log.Verbose("Adding " + UpToDateCheckOutput.SchemaName + " outputs:");
 
@@ -352,7 +352,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     }
                 }
 
-                if (state.UpToDateCheckBuiltItemsBySetName.TryGetValue(DefaultSetName, out ImmutableHashSet<string>? upToDateCheckBuiltItems))
+                if (state.UpToDateCheckBuiltItemsBySetName.TryGetValue(DefaultSetName, out ImmutableArray<string> upToDateCheckBuiltItems))
                 {
                     log.Verbose("Adding " + UpToDateCheckBuilt.SchemaName + " outputs:");
 
@@ -366,7 +366,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             IEnumerable<(string Path, bool IsRequired)> CollectSetInputs(string setName)
             {
-                if (state.UpToDateCheckInputItemsBySetName.TryGetValue(setName, out ImmutableHashSet<string>? upToDateCheckInputItems))
+                if (state.UpToDateCheckInputItemsBySetName.TryGetValue(setName, out ImmutableArray<string> upToDateCheckInputItems))
                 {
                     log.Verbose("Adding " + UpToDateCheckInput.SchemaName + " inputs in set '{0}':", setName);
                     foreach (string input in upToDateCheckInputItems.Select(_configuredProject.UnconfiguredProject.MakeRooted))
@@ -379,7 +379,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             IEnumerable<string> CollectSetOutputs(string setName)
             {
-                if (state.UpToDateCheckOutputItemsBySetName.TryGetValue(setName, out ImmutableHashSet<string>? upToDateCheckOutputItems))
+                if (state.UpToDateCheckOutputItemsBySetName.TryGetValue(setName, out ImmutableArray<string> upToDateCheckOutputItems))
                 {
                     log.Verbose("Adding " + UpToDateCheckOutput.SchemaName + " outputs in set '{0}':", setName);
 
@@ -390,7 +390,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     }
                 }
 
-                if (state.UpToDateCheckBuiltItemsBySetName.TryGetValue(setName, out ImmutableHashSet<string>? upToDateCheckBuiltItems))
+                if (state.UpToDateCheckBuiltItemsBySetName.TryGetValue(setName, out ImmutableArray<string> upToDateCheckBuiltItems))
                 {
                     log.Verbose("Adding " + UpToDateCheckBuilt.SchemaName + " outputs in set '{0}':", setName);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -191,7 +191,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 if (earliestOutputTime < state.LastItemsChangedAtUtc)
                 {
-                    bool fail = log.Fail("Outputs", "The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up to date.", state.LastItemsChangedAtUtc, earliestOutputPath, earliestOutputTime);
+                    log.Fail("Outputs", "The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up to date.", state.LastItemsChangedAtUtc, earliestOutputPath, earliestOutputTime);
                     
                     if (log.Level <= LogLevel.Info)
                     {
@@ -204,7 +204,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         }
                     }
 
-                    return fail;
+                    return false;
                 }
 
 #if FALSE // https://github.com/dotnet/project-system/issues/6227

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -192,13 +192,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 if (earliestOutputTime < state.LastItemsChangedAtUtc)
                 {
                     bool fail = log.Fail("Outputs", "The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up to date.", state.LastItemsChangedAtUtc, earliestOutputPath, earliestOutputTime);
-                    foreach ((bool isAdd, string itemType, string path, string? link, CopyType copyType) in state.LastItemChanges)
+                    
+                    if (log.Level <= LogLevel.Info)
                     {
-                        if (Strings.IsNullOrEmpty(link))
-                            log.Info("    {0} item {1} '{2}' (CopyType={3})", itemType, isAdd ? "added" : "removed", path, copyType);
-                        else
-                            log.Info("    {0} item {1} '{2}' (CopyType={3}, Link='{4}')", itemType, isAdd ? "added" : "removed", path, copyType, link);
+                        foreach ((bool isAdd, string itemType, string path, string? link, CopyType copyType) in state.LastItemChanges)
+                        {
+                            if (Strings.IsNullOrEmpty(link))
+                                log.Info("    {0} item {1} '{2}' (CopyType={3})", itemType, isAdd ? "added" : "removed", path, copyType);
+                            else
+                                log.Info("    {0} item {1} '{2}' (CopyType={3}, Link='{4}')", itemType, isAdd ? "added" : "removed", path, copyType, link);
+                        }
                     }
+
                     return fail;
                 }
 
@@ -241,17 +246,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     hasInput = true;
                 }
 
-                if (!hasInput)
+                if (log.Level <= LogLevel.Info)
                 {
-                    log.Info(setName == DefaultSetName ? "No inputs defined." : "No inputs defined in set '{0}'.", setName);
-                }
-                else if (setName == DefaultSetName)
-                {
-                    log.Info("No inputs are newer than earliest output '{0}' ({1}).", earliestOutputPath, earliestOutputTime);
-                }
-                else
-                {
-                    log.Info("In set '{0}', no inputs are newer than earliest output '{1}' ({2}).", setName, earliestOutputPath, earliestOutputTime);
+                    if (!hasInput)
+                    {
+                        log.Info(setName == DefaultSetName ? "No inputs defined." : "No inputs defined in set '{0}'.", setName);
+                    }
+                    else if (setName == DefaultSetName)
+                    {
+                        log.Info("No inputs are newer than earliest output '{0}' ({1}).", earliestOutputPath, earliestOutputTime);
+                    }
+                    else
+                    {
+                        log.Info("In set '{0}', no inputs are newer than earliest output '{1}' ({2}).", setName, earliestOutputPath, earliestOutputTime);
+                    }
                 }
 
                 return true;
@@ -411,15 +419,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             string markerFile = _configuredProject.UnconfiguredProject.MakeRooted(state.CopyUpToDateMarkerItem);
 
-            log.Verbose("Adding input reference copy markers:");
-
-            foreach (string referenceMarkerFile in state.CopyReferenceInputs)
+            if (log.Level <= LogLevel.Verbose)
             {
-                log.Verbose("    '{0}'", referenceMarkerFile);
-            }
+                log.Verbose("Adding input reference copy markers:");
 
-            log.Verbose("Adding output reference copy marker:");
-            log.Verbose("    '{0}'", markerFile);
+                foreach (string referenceMarkerFile in state.CopyReferenceInputs)
+                {
+                    log.Verbose("    '{0}'", referenceMarkerFile);
+                }
+
+                log.Verbose("Adding output reference copy marker:");
+                log.Verbose("    '{0}'", markerFile);
+            }
 
             if (timestampCache.TryGetLatestInput(state.CopyReferenceInputs, out string? latestInputMarkerPath, out DateTime latestInputMarkerTime))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -126,7 +126,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         private UpToDateCheckImplicitConfiguredInput()
         {
-            var emptyPathSet = ImmutableHashSet.Create<string>(StringComparers.Paths);
             var emptyItemBySetName = ImmutableDictionary.Create<string, ImmutableHashSet<string>>(BuildUpToDateCheck.SetNameComparer);
 
             LastItemsChangedAtUtc = DateTime.MinValue;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// </remarks>
         public DateTime LastItemsChangedAtUtc { get; }
 
-        public ImmutableArray<(bool IsAdd, string ItemType, string Path, string? Link, BuildUpToDateCheck.CopyType)> LastItemChanges { get; }
+        public ImmutableArray<(bool IsAdd, string ItemType, string Path, string? Link, BuildUpToDateCheck.CopyType CopyType)> LastItemChanges { get; }
 
         public ImmutableArray<string> ItemTypes { get; }
 
@@ -163,7 +163,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             IImmutableDictionary<string, DateTime> additionalDependentFileTimes,
             DateTime lastAdditionalDependentFileTimesChangedAtUtc,
             DateTime lastItemsChangedAtUtc,
-            ImmutableArray<(bool IsAdd, string ItemType, string Path, string? Link, BuildUpToDateCheck.CopyType)> lastItemChanges)
+            ImmutableArray<(bool IsAdd, string ItemType, string Path, string? Link, BuildUpToDateCheck.CopyType CopyType)> lastItemChanges)
         {
             MSBuildProjectFullPath = msBuildProjectFullPath;
             MSBuildProjectDirectory = msBuildProjectDirectory;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// </remarks>
         public ImmutableDictionary<string, string> CopiedOutputFiles { get; }
 
-        public ImmutableHashSet<string> ResolvedAnalyzerReferencePaths { get; }
+        public ImmutableArray<string> ResolvedAnalyzerReferencePaths { get; }
 
         public ImmutableHashSet<string> ResolvedCompilationReferencePaths { get; }
 
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             UpToDateCheckOutputItemsBySetName = emptyItemBySetName;
             UpToDateCheckBuiltItemsBySetName = emptyItemBySetName;
             CopiedOutputFiles = ImmutableDictionary.Create<string, string>(StringComparers.Paths);
-            ResolvedAnalyzerReferencePaths = emptyPathSet;
+            ResolvedAnalyzerReferencePaths = ImmutableArray<string>.Empty;
             ResolvedCompilationReferencePaths = emptyPathSet;
             CopyReferenceInputs = emptyPathSet;
             AdditionalDependentFileTimes = ImmutableDictionary.Create<string, DateTime>(StringComparers.Paths);
@@ -158,7 +158,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             ImmutableDictionary<string, ImmutableHashSet<string>> upToDateCheckOutputItemsBySetName,
             ImmutableDictionary<string, ImmutableHashSet<string>> upToDateCheckBuiltItemsBySetName,
             ImmutableDictionary<string, string> copiedOutputFiles,
-            ImmutableHashSet<string> resolvedAnalyzerReferencePaths,
+            ImmutableArray<string> resolvedAnalyzerReferencePaths,
             ImmutableHashSet<string> resolvedCompilationReferencePaths,
             ImmutableHashSet<string> copyReferenceInputs,
             IImmutableDictionary<string, DateTime> additionalDependentFileTimes,
@@ -224,10 +224,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             // save memory and time by only considering this first path (dotnet/project-system#4333).
             string? newestImportInput = new LazyStringSplit(msBuildAllProjects, ';').FirstOrDefault();
 
-            ImmutableHashSet<string> resolvedAnalyzerReferencePaths;
+            ImmutableArray<string> resolvedAnalyzerReferencePaths;
             if (jointRuleUpdate.ProjectChanges.TryGetValue(ResolvedAnalyzerReference.SchemaName, out IProjectChangeDescription change) && change.Difference.AnyChanges)
             {
-                resolvedAnalyzerReferencePaths = change.After.Items.Select(item => item.Value[ResolvedAnalyzerReference.ResolvedPathProperty]).ToImmutableHashSet(StringComparers.Paths);
+                resolvedAnalyzerReferencePaths = change.After.Items.Select(item => item.Value[ResolvedAnalyzerReference.ResolvedPathProperty]).Distinct(StringComparers.Paths).ToImmutableArray();
             }
             else
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         public ImmutableArray<string> ResolvedAnalyzerReferencePaths { get; }
 
-        public ImmutableHashSet<string> ResolvedCompilationReferencePaths { get; }
+        public ImmutableArray<string> ResolvedCompilationReferencePaths { get; }
 
         /// <summary>
         /// Holds the set of observed <see cref="CopyUpToDateMarker"/> metadata values from all
@@ -138,7 +138,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             UpToDateCheckBuiltItemsBySetName = emptyItemBySetName;
             CopiedOutputFiles = ImmutableDictionary.Create<string, string>(StringComparers.Paths);
             ResolvedAnalyzerReferencePaths = ImmutableArray<string>.Empty;
-            ResolvedCompilationReferencePaths = emptyPathSet;
+            ResolvedCompilationReferencePaths = ImmutableArray<string>.Empty;
             CopyReferenceInputs = emptyPathSet;
             AdditionalDependentFileTimes = ImmutableDictionary.Create<string, DateTime>(StringComparers.Paths);
             LastAdditionalDependentFileTimesChangedAtUtc = DateTime.MinValue;
@@ -159,7 +159,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             ImmutableDictionary<string, ImmutableHashSet<string>> upToDateCheckBuiltItemsBySetName,
             ImmutableDictionary<string, string> copiedOutputFiles,
             ImmutableArray<string> resolvedAnalyzerReferencePaths,
-            ImmutableHashSet<string> resolvedCompilationReferencePaths,
+            ImmutableArray<string> resolvedCompilationReferencePaths,
             ImmutableHashSet<string> copyReferenceInputs,
             IImmutableDictionary<string, DateTime> additionalDependentFileTimes,
             DateTime lastAdditionalDependentFileTimesChangedAtUtc,
@@ -268,11 +268,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 copyUpToDateMarkerItem = CopyUpToDateMarkerItem;
             }
 
-            ImmutableHashSet<string> resolvedCompilationReferencePaths;
+            ImmutableArray<string> resolvedCompilationReferencePaths;
             ImmutableHashSet<string> copyReferenceInputs;
             if (jointRuleUpdate.ProjectChanges.TryGetValue(ResolvedCompilationReference.SchemaName, out change) && change.Difference.AnyChanges)
             {
-                ImmutableHashSet<string>.Builder resolvedCompilationReferencePathsBuilder = ImmutableHashSet.CreateBuilder(StringComparers.Paths);
+                HashSet<string> resolvedCompilationReferencePathsBuilder = new(StringComparers.Paths);
                 ImmutableHashSet<string>.Builder copyReferenceInputsBuilder = ImmutableHashSet.CreateBuilder(StringComparers.Paths);
 
                 foreach (IImmutableDictionary<string, string> itemMetadata in change.After.Items.Values)
@@ -294,7 +294,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     }
                 }
 
-                resolvedCompilationReferencePaths = resolvedCompilationReferencePathsBuilder.ToImmutable();
+                resolvedCompilationReferencePaths = resolvedCompilationReferencePathsBuilder.ToImmutableArray();
                 copyReferenceInputs = copyReferenceInputsBuilder.ToImmutable();
             }
             else

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -349,6 +349,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             List<(bool IsAdd, string ItemType, string Path, string? Link, BuildUpToDateCheck.CopyType)> changes = new();
 
+            // If an item type was removed, remove all items of that type
             foreach (string removedItemType in itemTypeDiff.Removed)
             {
                 itemTypesChanged = true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// Holds the set of observed <see cref="CopyUpToDateMarker"/> metadata values from all
         /// <see cref="ResolvedCompilationReference"/> items in the project.
         /// </summary>
-        public ImmutableHashSet<string> CopyReferenceInputs { get; }
+        public ImmutableArray<string> CopyReferenceInputs { get; }
 
         /// <summary>
         /// Contains files such as:
@@ -139,7 +139,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             CopiedOutputFiles = ImmutableDictionary.Create<string, string>(StringComparers.Paths);
             ResolvedAnalyzerReferencePaths = ImmutableArray<string>.Empty;
             ResolvedCompilationReferencePaths = ImmutableArray<string>.Empty;
-            CopyReferenceInputs = emptyPathSet;
+            CopyReferenceInputs = ImmutableArray<string>.Empty;
             AdditionalDependentFileTimes = ImmutableDictionary.Create<string, DateTime>(StringComparers.Paths);
             LastAdditionalDependentFileTimesChangedAtUtc = DateTime.MinValue;
         }
@@ -160,7 +160,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             ImmutableDictionary<string, string> copiedOutputFiles,
             ImmutableArray<string> resolvedAnalyzerReferencePaths,
             ImmutableArray<string> resolvedCompilationReferencePaths,
-            ImmutableHashSet<string> copyReferenceInputs,
+            ImmutableArray<string> copyReferenceInputs,
             IImmutableDictionary<string, DateTime> additionalDependentFileTimes,
             DateTime lastAdditionalDependentFileTimesChangedAtUtc,
             DateTime lastItemsChangedAtUtc,
@@ -269,11 +269,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             }
 
             ImmutableArray<string> resolvedCompilationReferencePaths;
-            ImmutableHashSet<string> copyReferenceInputs;
+            ImmutableArray<string> copyReferenceInputs;
             if (jointRuleUpdate.ProjectChanges.TryGetValue(ResolvedCompilationReference.SchemaName, out change) && change.Difference.AnyChanges)
             {
                 HashSet<string> resolvedCompilationReferencePathsBuilder = new(StringComparers.Paths);
-                ImmutableHashSet<string>.Builder copyReferenceInputsBuilder = ImmutableHashSet.CreateBuilder(StringComparers.Paths);
+                HashSet<string> copyReferenceInputsBuilder = new(StringComparers.Paths);
 
                 foreach (IImmutableDictionary<string, string> itemMetadata in change.After.Items.Values)
                 {
@@ -295,7 +295,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 }
 
                 resolvedCompilationReferencePaths = resolvedCompilationReferencePathsBuilder.ToImmutableArray();
-                copyReferenceInputs = copyReferenceInputsBuilder.ToImmutable();
+                copyReferenceInputs = copyReferenceInputsBuilder.ToImmutableArray();
             }
             else
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         public ImmutableArray<(bool IsAdd, string ItemType, string Path, string? Link, BuildUpToDateCheck.CopyType)> LastItemChanges { get; }
 
-        public ImmutableHashSet<string> ItemTypes { get; }
+        public ImmutableArray<string> ItemTypes { get; }
 
         public ImmutableDictionary<string, ImmutableHashSet<(string Path, string? Link, BuildUpToDateCheck.CopyType CopyType)>> ItemsByItemType { get; }
 
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var emptyItemBySetName = ImmutableDictionary.Create<string, ImmutableHashSet<string>>(BuildUpToDateCheck.SetNameComparer);
 
             LastItemsChangedAtUtc = DateTime.MinValue;
-            ItemTypes = ImmutableHashSet.Create<string>(StringComparers.ItemTypes);
+            ItemTypes = ImmutableArray<string>.Empty;
             ItemsByItemType = ImmutableDictionary.Create<string, ImmutableHashSet<(string Path, string? Link, BuildUpToDateCheck.CopyType CopyType)>>(StringComparers.ItemTypes);
             SetNames = ImmutableArray<string>.Empty;
             UpToDateCheckInputItemsBySetName = emptyItemBySetName;
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             string? newestImportInput,
             IComparable? lastVersionSeen,
             bool isDisabled,
-            ImmutableHashSet<string> itemTypes,
+            ImmutableArray<string> itemTypes,
             ImmutableDictionary<string, ImmutableHashSet<(string, string?, BuildUpToDateCheck.CopyType)>> itemsByItemType,
             ImmutableDictionary<string, ImmutableHashSet<string>> upToDateCheckInputItemsBySetName,
             ImmutableDictionary<string, ImmutableHashSet<string>> upToDateCheckOutputItemsBySetName,
@@ -344,7 +344,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var itemTypes = projectItemSchema
                 .GetKnownItemTypes()
                 .Where(itemType => projectItemSchema.GetItemType(itemType).UpToDateCheckInput)
-                .ToImmutableHashSet(StringComparers.ItemTypes);
+                .ToHashSet(StringComparers.ItemTypes);
 
             var itemTypeDiff = new SetDiff<string>(ItemTypes, itemTypes, StringComparers.ItemTypes);
 
@@ -426,7 +426,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 newestImportInput,
                 lastVersionSeen: configuredProjectVersion,
                 isDisabled: isDisabled,
-                itemTypes: itemTypes,
+                itemTypes: itemTypes.ToImmutableArray(),
                 itemsByItemType: itemsByItemTypeBuilder.ToImmutable(),
                 upToDateCheckInputItemsBySetName: upToDateCheckInputItems,
                 upToDateCheckOutputItemsBySetName: upToDateCheckOutputItems,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -682,8 +682,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     Items = ImmutableStringDictionary<IImmutableDictionary<string, string>>.EmptyOrdinal
                         .Add("Reference1", ImmutableStringDictionary<string>.EmptyOrdinal
                             .Add("CopyUpToDateMarker", "Reference1MarkerPath")
-                            .Add("ResolvedPath", "Reference1ResolvedPath")
-                            .Add("OriginalPath", "Reference1OriginalPath"))
+                            .Add("ResolvedPath", "C:\\Dev\\Solution\\Project\\Reference1ResolvedPath")
+                            .Add("OriginalPath", "..\\Project\\Reference1OriginalPath"))
                 }
             };
 
@@ -698,10 +698,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\BuiltOutputPath1", outputTime);
-            _fileSystem.AddFile("Reference1ResolvedPath", inputTime);
+            _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\Reference1ResolvedPath", inputTime);
 
             await AssertNotUpToDateAsync(
-                $"Input 'Reference1ResolvedPath' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({outputTime.ToLocalTime()}), not up to date.",
+                $"Input 'C:\\Dev\\Solution\\Project\\Reference1ResolvedPath' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({outputTime.ToLocalTime()}), not up to date.",
                 "Outputs");
         }
 


### PR DESCRIPTION
General performance work on the fast up-to-date check. Breaks down into the following categories:

1. Use `ImmutableArray` over `ImmutableHashSet`.
   In several places the in-memory state of the up-to-date check used the immutable hash set, which internally stores its data as a binary tree. This tree structure introduces two pointers per element, which requires a lot of additional memory. **This is especially the case for 64-bit VS.** Items in the tree may also be scattered through memory, creating extra work for the GC and losing the benefits of locality of reference. This PR converts to array storage instead, meaning items are packed closely together into less overall memory. Our usage does not include "contains" or other set-based operations, so there is no algorithmic degredation here, only upside.
1. Avoid enumerator/delegate allocations.
   Our usages of `Select` and `SelectMany` were allocating memory which could be easily avoided by rewriting the `foreach` loops.
1.  Avoid redundant logging work.
   There were a few places where we could avoid some work done to log information to the output pane by testing the log level first.

I recommend reviewing commit-by-commit.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7150)