### PR TITLE
Move warnaserror+ to the end of the command line arguments.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
@@ -153,12 +153,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             // The order of options matters and we should use warnaserror- and then warnaserror+
             // Depending which comes first, the compiler produces different diagnostics.
             // We just need to move warnaserror+ to the end.
-            var warnaserrorPlus = snapshot.Items.Where(a => a.Key.Contains("/warnaserror+")).FirstOrDefault();
-            ImmutableArray<string> commandLineArguments = warnaserrorPlus.Key is null ? snapshot.Items.Keys.ToImmutableArray() : 
-                snapshot.Items.Remove(warnaserrorPlus.Key).Keys.ToArray().Append(warnaserrorPlus.Key).ToImmutableArray();
- 
+            var warnaserrorPlus = snapshot.Items.FirstOrDefault(a => a.Key.Contains("/warnaserror+"));
+            IEnumerable<string> commandLineArguments = warnaserrorPlus.Key is null ? snapshot.Items.Keys :
+                    snapshot.Items.Remove(warnaserrorPlus.Key).Keys.Append(warnaserrorPlus.Key);
+
             // We just pass all options to Roslyn
-            _context.SetOptions(commandLineArguments);
+            _context.SetOptions(commandLineArguments.ToImmutableArray());
         }
 
         private Task ProcessCommandLineAsync(IComparable version, IProjectChangeDiff differences, ContextState state, CancellationToken cancellationToken)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
@@ -150,8 +150,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             Assumes.NotNull(_context);
 
+            // The order of options matters and we should use warnaserror- and then warnaserror+
+            // Depending which comes first, the compiler produces different diagnostics.
+            // We just need to move warnaserror+ to the end.
+            var warnaserrorPlus = snapshot.Items.Where(a => a.Key.Contains("/warnaserror+")).FirstOrDefault();
+            ImmutableArray<string> commandLineArguments = warnaserrorPlus.Key is null ? snapshot.Items.Keys.ToImmutableArray() : 
+                snapshot.Items.Remove(warnaserrorPlus.Key).Keys.ToArray().Append(warnaserrorPlus.Key).ToImmutableArray();
+ 
             // We just pass all options to Roslyn
-            _context.SetOptions(snapshot.Items.Keys.ToImmutableArray());
+            _context.SetOptions(commandLineArguments);
         }
 
         private Task ProcessCommandLineAsync(IComparable version, IProjectChangeDiff differences, ContextState state, CancellationToken cancellationToken)


### PR DESCRIPTION
Current implementation gets the command line arguments from from the rules and this changes the order of the arguments which causes Build to behave differently.
When using the _WarningsNotAsErrors_ feature from Intellisense some errors and warnings were showed as warnings in the Error List, but as errors in the Output window.

We can get the correct order of command line arguments by subscribing to `ProjectBuildSnapshotService`, and then parse the output result from the build target, but since the structure implies iterating over all the elements, extract the arguments, and also changes some interfaces we are  not using this approach, unless we want to preserve ALL the arguments in the same order.

A simple change is to change move _warnaserror+_ to the end of the command line arguments to make sure _WarningsNotAsErrors_ behave correctly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7152)