### PR TITLE
Revert "Use Scale Set pools for Build Pipelines"

### DIFF
--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -10,7 +10,7 @@ resources:
 - repo: self
   clean: true
 queue:
-  name: VSEngSS-MicroBuild2019
+  name: VSEng-MicroBuildVS2019
   demands: Cmd
   timeoutInMinutes: 90
 variables:


### PR DESCRIPTION
Reverts dotnet/project-system#7164 and opens #7163 

There's more work needed than just changing the queue

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7168)