### PR TITLE
Fix "Startup object" UI

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
@@ -31,7 +30,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public Task<IDynamicEnumValuesGenerator> GetProviderAsync(IList<NameValuePair>? options)
         {
-            return Task.FromResult<IDynamicEnumValuesGenerator>(new StartupObjectsEnumGenerator(_workspace, _unconfiguredProject));
+            // We only include a value representing the "not set" state if requested. This is
+            // because the old property pages explicitly add the "(Not set)" value at the UI
+            // layer; the new property pages do not have that option and so the value must come
+            // from the enum provider.
+            // When this project system no longer needs to support the old property pages we can
+            // remove this and always include the "(Not set)" value.
+            bool includeEmptyValue = options?.Any(pair =>
+                pair.Name == "IncludeEmptyValue"
+                && bool.TryParse(pair.Value, out bool optionValue)
+                && optionValue) ?? false;
+
+            return Task.FromResult<IDynamicEnumValuesGenerator>(new StartupObjectsEnumGenerator(_workspace, _unconfiguredProject, includeEmptyValue));
         }
     }
 
@@ -40,6 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public bool AllowCustomValues => true;
         private readonly Workspace _workspace;
         private readonly UnconfiguredProject _unconfiguredProject;
+        private readonly bool _includeEmptyValue;
 
         /// <summary>
         /// When we implement WinForms support, we need to set this for VB WinForms projects
@@ -47,10 +58,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private static bool SearchForEntryPointsInFormsOnly => false;
 
         [ImportingConstructor]
-        public StartupObjectsEnumGenerator(Workspace workspace, UnconfiguredProject project)
+        public StartupObjectsEnumGenerator(Workspace workspace, UnconfiguredProject project, bool includeEmptyValue)
         {
             _workspace = workspace;
             _unconfiguredProject = project;
+            _includeEmptyValue = includeEmptyValue;
         }
 
         public async Task<ICollection<IEnumValue>> GetListedValuesAsync()
@@ -58,13 +70,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             Project project = _workspace.CurrentSolution.Projects.First(p => PathHelper.IsSamePath(p.FilePath!, _unconfiguredProject.FullPath));
             Compilation? compilation = await project.GetCompilationAsync();
 
+            List<IEnumValue> enumValues = new();
+            if (_includeEmptyValue)
+            {
+                enumValues.Add(new PageEnumValue(new EnumValue { Name = "", DisplayName = VSResources.StartupObjectNotSet }));
+            }
+
             IEntryPointFinderService? entryPointFinderService = project.LanguageServices.GetService<IEntryPointFinderService>();
             IEnumerable<INamedTypeSymbol>? entryPoints = entryPointFinderService?.FindEntryPoints(compilation?.GlobalNamespace, SearchForEntryPointsInFormsOnly);
-            return entryPoints?.Select(ep =>
+            if (entryPoints is not null)
             {
-                string name = ep.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
-                return new PageEnumValue(new EnumValue { Name = name, DisplayName = name });
-            }).ToArray() ?? Array.Empty<IEnumValue>();
+                enumValues.AddRange(entryPoints.Select(ep =>
+                {
+                    string name = ep.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
+                    return new PageEnumValue(new EnumValue { Name = name, DisplayName = name });
+                }));
+            }
+
+            return enumValues;
         }
 
         public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -405,6 +405,15 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to (Not set).
+        /// </summary>
+        internal static string StartupObjectNotSet {
+            get {
+                return ResourceManager.GetString("StartupObjectNotSet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to User Control (Windows Forms) Designer.
         /// </summary>
         internal static string UserControlEditor_DisplayName {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -245,4 +245,8 @@ In order to debug this project, add an executable project to this solution which
   <data name="FrameworkAssemblyFileVersionDescription" xml:space="preserve">
     <value>The file version of the framework assembly.</value>
   </data>
+  <data name="StartupObjectNotSet" xml:space="preserve">
+    <value>(Not set)</value>
+    <comment>Text to display to the user in the property page UI when the "startup object" property is not set.</comment>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -101,6 +101,11 @@ Pokud chcete projekt ladit, přidejte do řešení spustitelný projekt, který 
         <target state="translated">Laděný spustitelný soubor {0} zadaný v ladicím profilu {1} neexistuje.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StartupObjectNotSet">
+        <source>(Not set)</source>
+        <target state="new">(Not set)</target>
+        <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">Pracovní adresář {0} zadaný v ladicím profilu {1} neexistuje.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -101,6 +101,11 @@ Um das Projekt zu debuggen, fügen Sie dieser Projektmappe ein ausführbares Pro
         <target state="translated">Die im Debugprofil "{1}" angegebene ausführbare Debugdatei "{0}" ist nicht vorhanden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StartupObjectNotSet">
+        <source>(Not set)</source>
+        <target state="new">(Not set)</target>
+        <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">Das im Debugprofil "{1}" angegebene Arbeitsverzeichnis "{0}" ist nicht vorhanden.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -101,6 +101,11 @@ Para depurar este proyecto, agregue un proyecto ejecutable a esta solución con 
         <target state="translated">El archivo ejecutable de depuración '{0}' especificado en el perfil de depuración '{1}' no existe.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StartupObjectNotSet">
+        <source>(Not set)</source>
+        <target state="new">(Not set)</target>
+        <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">El directorio de trabajo '{0}' especificado en el perfil de depuración '{1}' no existe.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -101,6 +101,11 @@ Pour déboguer ce projet, ajoutez à cette solution un projet exécutable qui fa
         <target state="translated">L'exécutable de débogage '{0}' spécifié dans le profil de débogage '{1}' n'existe pas.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StartupObjectNotSet">
+        <source>(Not set)</source>
+        <target state="new">(Not set)</target>
+        <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">Le répertoire de travail '{0}' spécifié dans le profil de débogage '{1}' n'existe pas.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -101,6 +101,11 @@ Per eseguire il debug del progetto, aggiungere a questa soluzione un progetto es
         <target state="translated">L'eseguibile di debug '{0}' specificato nel profilo di debug '{1}' non esiste.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StartupObjectNotSet">
+        <source>(Not set)</source>
+        <target state="new">(Not set)</target>
+        <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">La directory di lavoro '{0}' specificata nel profilo di debug '{1}' non esiste.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -101,6 +101,11 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">'{1}' デバッグ プロファイルに指定したデバッグ実行可能ファイル '{0}' が存在しません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StartupObjectNotSet">
+        <source>(Not set)</source>
+        <target state="new">(Not set)</target>
+        <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">'{1}' デバッグ プロファイルに指定した作業ディレクトリ '{0}' が存在しません。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -101,6 +101,11 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">'{1}' 디버그 프로필에 지정된 디버그 실행 파일 '{0}'이(가) 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StartupObjectNotSet">
+        <source>(Not set)</source>
+        <target state="new">(Not set)</target>
+        <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">'{1}' 디버그 프로필에 지정된 작업 디렉터리 '{0}'이(가) 없습니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -101,6 +101,11 @@ Aby debugować ten projekt, dodaj projekt wykonywalny do tego rozwiązania, któ
         <target state="translated">Plik wykonywalny debugowania „{0}” określony w profilu debugowania „{1}” nie istnieje.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StartupObjectNotSet">
+        <source>(Not set)</source>
+        <target state="new">(Not set)</target>
+        <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">Katalog roboczy „{0}” określony w profilu debugowania „{1}” nie istnieje.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -101,6 +101,11 @@ Para depurar esse projeto, adicione um projeto executável a essa solução que 
         <target state="translated">A depuração executável '{0}' especificada no perfil de depuração '{1}' não existe.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StartupObjectNotSet">
+        <source>(Not set)</source>
+        <target state="new">(Not set)</target>
+        <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">O diretório de trabalho '{0}' especificado no perfil de depuração '{1}' não existe.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -101,6 +101,11 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">Исполняемый файл для отладки "{0}", указанный в профиле отладки "{1}", не существует.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StartupObjectNotSet">
+        <source>(Not set)</source>
+        <target state="new">(Not set)</target>
+        <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">Рабочий каталог "{0}", указанный в профиле отладки "{1}", не существует.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -101,6 +101,11 @@ Bu projede hata ayıklamak için bu çözüme, kitaplık projesine başvuran bir
         <target state="translated">'{1}' hata ayıklama profilinde belirtilen '{0}' hata ayıklama yürütülebilir dosyası yok.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StartupObjectNotSet">
+        <source>(Not set)</source>
+        <target state="new">(Not set)</target>
+        <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">'{1}' hata ayıklama profilinde belirtilen '{0}' çalışma dizini yok.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -101,6 +101,11 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">“{1}”调试配置文件中指定的调试可执行文件“{0}”不存在。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StartupObjectNotSet">
+        <source>(Not set)</source>
+        <target state="new">(Not set)</target>
+        <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">“{1}”调试配置文件中指定的工作目录“{0}”不存在。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -101,6 +101,11 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">'{1}' 偵錯設定檔中指定的偵錯可執行檔 '{0}' 不存在。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StartupObjectNotSet">
+        <source>(Not set)</source>
+        <target state="new">(Not set)</target>
+        <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">'{1}' 偵錯設定檔中指定的工作目錄 '{0}' 不存在。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -111,6 +111,11 @@
         <NameValuePair.Value>(ne (evaluated "Application" "OutputType") "Library")</NameValuePair.Value>
       </NameValuePair>
     </DynamicEnumProperty.Metadata>
+    <DynamicEnumProperty.ProviderSettings>
+      <!-- We want an explicit item representing the empty value. We can remove this setting
+           when the enum provider starts including it by default. -->
+      <NameValuePair Name="IncludeEmptyValue" Value="true" />
+    </DynamicEnumProperty.ProviderSettings>
   </DynamicEnumProperty>
 
   <StringProperty Name="AssemblyName"


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1320092.

The property pages for executables include a "Startup object" property where you can specify which `Main` method or `Form` to run at startup. In both the old and new UI, the drop down displays all applicable methods and forms. The old UI includes a "(Not set)" item representing the empty value; however, the new UI does not. If you set it to one of the other options there is no way to unset it.

The old UI gets the values for the drop down from the `StartupObjectsEnumProvider`, but then explicitly adds in the "(Not set)" value in the UI code. Since the new UI is generated, this option isn't available to us. Instead, we need `StartupObjectsEnumProvider` to include "(Not set)" along with all the other values, but only when the new UI is in use.

To achieve this we make use of the `DynamicEnumProperty.ProviderSettings`--a bag of name/value pairs that is passed along to the enum provider. ApplicationPropertyPage.xaml is updated to pass along an "IncludeEmptyValue" setting, and `StartupObjectsEnumProvider` is updated to check for the setting.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7172)