### PR TITLE
Keep the order of command line arguments for build.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
@@ -69,7 +69,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 IComparable version = GetConfiguredProjectVersion(update);
 
-                ProcessOptions(projectChange.After);
                 await ProcessCommandLineAsync(version, projectChange.Difference, state, cancellationToken);
                 ProcessProjectBuildFailure(projectChange.After);
             }
@@ -146,12 +145,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             }
         }
 
-        private void ProcessOptions(IProjectRuleSnapshot snapshot)
+        public void SetCommandLineArgumentsToBuild(IEnumerable<string> arguments)
         {
             Assumes.NotNull(_context);
 
             // We just pass all options to Roslyn
-            _context.SetOptions(snapshot.Items.Keys.ToImmutableArray());
+            _context.SetOptions(arguments.ToImmutableArray());
         }
 
         private Task ProcessCommandLineAsync(IComparable version, IProjectChangeDiff differences, ContextState state, CancellationToken cancellationToken)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         /// <summary>
         ///     Returns an enumerable of project build rules that should passed to
-        ///     <see cref="ApplyProjectBuildAsync(IProjectVersionedValue{IProjectSubscriptionUpdate}, ContextState, CancellationToken)"/>.
+        ///     <see cref="ApplyProjectBuildAsync(IProjectVersionedValue{IProjectSubscriptionUpdate}, IProjectBuildSnapshot, ContextState, CancellationToken)"/>.
         /// </summary>
         IEnumerable<string> GetProjectBuildRules();
 
@@ -83,6 +83,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     to the project snapshot state. The cancellation token should only be cancelled with the
         ///     intention that the <see cref="IWorkspaceProjectContext"/> will be immediately disposed.
         /// </remarks>
-        Task ApplyProjectBuildAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, IProjectVersionedValue<IProjectBuildSnapshot> buildSnapshot, ContextState state, CancellationToken cancellationToken);
+        Task ApplyProjectBuildAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, IProjectBuildSnapshot buildSnapshot, ContextState state, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
@@ -83,5 +83,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     intention that the <see cref="IWorkspaceProjectContext"/> will be immediately disposed.
         /// </remarks>
         Task ApplyProjectBuildAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, ContextState state, CancellationToken cancellationToken);
+
+        /// <summary>
+        ///     Sets project build command line options to the underlying <see cref="IWorkspaceProjectContext"/>.
+        /// </summary>
+        /// <param name="arguments">List of command line arguments in the Build</param>
+        /// <remarks>
+        ///     Note: The compiler is sensitive to ordering of command-line arguments.
+        /// </remarks>
+        void SetCommandLineArgumentsToBuild(IEnumerable<string> arguments);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Build;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
@@ -82,15 +83,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     to the project snapshot state. The cancellation token should only be cancelled with the
         ///     intention that the <see cref="IWorkspaceProjectContext"/> will be immediately disposed.
         /// </remarks>
-        Task ApplyProjectBuildAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, ContextState state, CancellationToken cancellationToken);
-
-        /// <summary>
-        ///     Sets project build command line options to the underlying <see cref="IWorkspaceProjectContext"/>.
-        /// </summary>
-        /// <param name="arguments">List of command line arguments in the Build</param>
-        /// <remarks>
-        ///     Note: The compiler is sensitive to ordering of command-line arguments.
-        /// </remarks>
-        void SetCommandLineArgumentsToBuild(IEnumerable<string> arguments);
+        Task ApplyProjectBuildAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, IProjectVersionedValue<IProjectBuildSnapshot> buildSnapshot, ContextState state, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
@@ -180,7 +179,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                 IWorkspaceProjectContext context = _contextAccessor.Context;
                 IProjectVersionedValue<IProjectSubscriptionUpdate> subscription = update.Derive(u => u.subscription);
-                IProjectVersionedValue<IProjectBuildSnapshot> buildSnapshot = update.Derive(u => u.buildSnapshot);
                 bool isActiveEditorContext = _activeWorkspaceProjectContextTracker.IsActiveEditorContext(_contextAccessor.ContextId);
                 bool isActiveConfiguration = update.Value.project == _project;
 
@@ -196,7 +194,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     }
                     else
                     {
-                        await _applyChangesToWorkspaceContext!.Value.ApplyProjectBuildAsync(subscription, buildSnapshot, state, cancellationToken);
+                        await _applyChangesToWorkspaceContext!.Value.ApplyProjectBuildAsync(subscription, update.Value.buildSnapshot, state, cancellationToken);
                     }
                 }
                 finally

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Build;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
@@ -26,6 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         private readonly IActiveConfiguredProjectProvider _activeConfiguredProjectProvider;
         private readonly ExportFactory<IApplyChangesToWorkspaceContext> _applyChangesToWorkspaceContextFactory;
         private readonly IDataProgressTrackerService _dataProgressTrackerService;
+        private readonly IProjectBuildSnapshotService _projectBuildSnapshotService;
 
         [ImportingConstructor]
         public WorkspaceProjectContextHost(ConfiguredProject project,
@@ -36,7 +38,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                            IActiveEditorContextTracker activeWorkspaceProjectContextTracker,
                                            IActiveConfiguredProjectProvider activeConfiguredProjectProvider,
                                            ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory,
-                                           IDataProgressTrackerService dataProgressTrackerService)
+                                           IDataProgressTrackerService dataProgressTrackerService,
+                                           IProjectBuildSnapshotService projectBuildSnapshotService)
             : base(threadingService.JoinableTaskContext)
         {
             _project = project;
@@ -48,6 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             _activeConfiguredProjectProvider = activeConfiguredProjectProvider;
             _applyChangesToWorkspaceContextFactory = applyChangesToWorkspaceContextFactory;
             _dataProgressTrackerService = dataProgressTrackerService;
+            _projectBuildSnapshotService = projectBuildSnapshotService;
         }
 
         public Task ActivateAsync()
@@ -96,7 +100,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 _activeWorkspaceProjectContextTracker,
                 _activeConfiguredProjectProvider,
                 _applyChangesToWorkspaceContextFactory,
-                _dataProgressTrackerService);
+                _dataProgressTrackerService,
+                _projectBuildSnapshotService);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IApplyChangesToWorkspaceContextFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IApplyChangesToWorkspaceContextFactory.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return Mock.Of<IApplyChangesToWorkspaceContext>();
         }
 
-        public static IApplyChangesToWorkspaceContext ImplementApplyProjectBuildAsync(Action<IProjectVersionedValue<IProjectSubscriptionUpdate>, ContextState, CancellationToken> action)
+        public static IApplyChangesToWorkspaceContext ImplementApplyProjectBuildAsync(Action<IProjectVersionedValue<IProjectSubscriptionUpdate>, IProjectBuildSnapshot, ContextState, CancellationToken> action)
         {
             var mock = new Mock<IApplyChangesToWorkspaceContext>();
             mock.Setup(c => c.ApplyProjectBuildAsync(It.IsAny<IProjectVersionedValue<IProjectSubscriptionUpdate>>(), It.IsAny<IProjectBuildSnapshot>(), It.IsAny<ContextState>(), It.IsAny<CancellationToken>()))

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IApplyChangesToWorkspaceContextFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IApplyChangesToWorkspaceContextFactory.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Build;
 using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
@@ -17,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         public static IApplyChangesToWorkspaceContext ImplementApplyProjectBuildAsync(Action<IProjectVersionedValue<IProjectSubscriptionUpdate>, ContextState, CancellationToken> action)
         {
             var mock = new Mock<IApplyChangesToWorkspaceContext>();
-            mock.Setup(c => c.ApplyProjectBuildAsync(It.IsAny<IProjectVersionedValue<IProjectSubscriptionUpdate>>(), It.IsAny<ContextState>(), It.IsAny<CancellationToken>()))
+            mock.Setup(c => c.ApplyProjectBuildAsync(It.IsAny<IProjectVersionedValue<IProjectSubscriptionUpdate>>(), It.IsAny<IProjectBuildSnapshot>(), It.IsAny<ContextState>(), It.IsAny<CancellationToken>()))
                 .Callback(action)
                 .Returns(Task.CompletedTask);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectBuildSnapshotFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectBuildSnapshotFactory.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+using Moq;
+
+namespace Microsoft.VisualStudio.Mocks
+{
+    internal static class IProjectBuildSnapshotFactory
+    {
+        public static IProjectBuildSnapshot Create()
+        {
+            var buildSnapshotMock = new Mock<IProjectBuildSnapshot>();
+
+            IImmutableDictionary<string, IImmutableList<KeyValuePair<string, IImmutableDictionary<string, string>>>>
+                targetOutputs = 
+                    ImmutableDictionary<string, IImmutableList<KeyValuePair<string, IImmutableDictionary<string, string>>>>.Empty
+                        .Add("CompileDesignTime", ImmutableArray<KeyValuePair<string, IImmutableDictionary<string, string>>>.Empty);
+
+            buildSnapshotMock.SetupGet(s => s.TargetOutputs)
+                .Returns(targetOutputs);
+
+            return buildSnapshotMock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectBuildSnapshotServiceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectBuildSnapshotServiceFactory.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading.Tasks.Dataflow;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IProjectBuildSnapshotServiceFactory
+    {
+        public static IProjectBuildSnapshotService Create()
+        {
+            var sourceBlock = new Mock<IReceivableSourceBlock<IProjectVersionedValue<IProjectBuildSnapshot>>>().Object;
+
+            var mock = new Mock<IProjectBuildSnapshotService>();
+            mock.SetupGet(s => s.SourceBlock)
+                .Returns(sourceBlock);
+
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContextTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContextTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
-using Microsoft.VisualStudio.ProjectSystem.Build;
+using Microsoft.VisualStudio.Mocks;
 using Microsoft.VisualStudio.ProjectSystem.Logging;
 using Moq;
 using Xunit;
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var applyChangesToWorkspace = CreateInstance();
 
             var update = Mock.Of<IProjectVersionedValue<IProjectSubscriptionUpdate>>();
-            var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
+            var buildSnapshot = IProjectBuildSnapshotFactory.Create();
 
             await Assert.ThrowsAsync<InvalidOperationException>(() =>
             {
@@ -204,7 +204,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             await applyChangesToWorkspace.DisposeAsync();
 
             var update = Mock.Of<IProjectVersionedValue<IProjectSubscriptionUpdate>>();
-            var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
+            var buildSnapshot = IProjectBuildSnapshotFactory.Create();
 
             await Assert.ThrowsAsync<ObjectDisposedException>(() =>
             {
@@ -267,7 +267,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler });
 
-            var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
+            var buildSnapshot = IProjectBuildSnapshotFactory.Create();
             var update = IProjectVersionedValueFactory.FromJson(
 @"{
    ""ProjectChanges"": {
@@ -329,7 +329,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var applyChangesToWorkspace = CreateInitializedInstance(commandLineParser: parser, handlers: new[] { handler });
 
-            var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
+            var buildSnapshot = IProjectBuildSnapshotFactory.Create();
             var update = IProjectVersionedValueFactory.FromJson(version: 2,
 @"{
    ""ProjectChanges"": {
@@ -412,7 +412,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler1, handler2 });
 
-            var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
+            var buildSnapshot = IProjectBuildSnapshotFactory.Create();
             var update = IProjectVersionedValueFactory.FromJson(
 @"{
    ""ProjectChanges"": {
@@ -468,7 +468,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler });
 
-            var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
+            var buildSnapshot = IProjectBuildSnapshotFactory.Create();
             var update = IProjectVersionedValueFactory.FromJson(
 @"{
    ""ProjectChanges"": {
@@ -495,7 +495,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var applyChangesToWorkspace = CreateInitializedInstance(out var context);
             context.LastDesignTimeBuildSucceeded = true;
 
-            var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
+            var buildSnapshot = IProjectBuildSnapshotFactory.Create();
+
             var update = IProjectVersionedValueFactory.FromJson(
 @"{
    ""ProjectChanges"": {
@@ -520,7 +521,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             var applyChangesToWorkspace = CreateInitializedInstance(out var context);
 
-            var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
+            var buildSnapshot = IProjectBuildSnapshotFactory.Create();
             var update = IProjectVersionedValueFactory.FromJson(
 @"{
    ""ProjectChanges"": {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContextTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContextTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Build;
 using Microsoft.VisualStudio.ProjectSystem.Logging;
 using Moq;
 using Xunit;
@@ -132,10 +133,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var applyChangesToWorkspace = CreateInstance();
 
             var update = Mock.Of<IProjectVersionedValue<IProjectSubscriptionUpdate>>();
+            var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
 
             await Assert.ThrowsAsync<InvalidOperationException>(() =>
             {
-                return applyChangesToWorkspace.ApplyProjectBuildAsync(update, new ContextState(), CancellationToken.None);
+                return applyChangesToWorkspace.ApplyProjectBuildAsync(update, buildSnapshot,new ContextState(), CancellationToken.None);
             });
         }
 
@@ -202,10 +204,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             await applyChangesToWorkspace.DisposeAsync();
 
             var update = Mock.Of<IProjectVersionedValue<IProjectSubscriptionUpdate>>();
+            var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
 
             await Assert.ThrowsAsync<ObjectDisposedException>(() =>
             {
-                return applyChangesToWorkspace.ApplyProjectBuildAsync(update, new ContextState(), CancellationToken.None);
+                return applyChangesToWorkspace.ApplyProjectBuildAsync(update, buildSnapshot, new ContextState(), CancellationToken.None);
             });
         }
 
@@ -264,6 +267,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler });
 
+            var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
             var update = IProjectVersionedValueFactory.FromJson(
 @"{
    ""ProjectChanges"": {
@@ -275,7 +279,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     }
 }");
 
-            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, new ContextState(), CancellationToken.None);
+            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, buildSnapshot, new ContextState(), CancellationToken.None);
 
             Assert.Equal(0, callCount);
         }
@@ -325,6 +329,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var applyChangesToWorkspace = CreateInitializedInstance(commandLineParser: parser, handlers: new[] { handler });
 
+            var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
             var update = IProjectVersionedValueFactory.FromJson(version: 2,
 @"{
    ""ProjectChanges"": {
@@ -337,7 +342,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
     }
 }");
-            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), CancellationToken.None);
+            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, buildSnapshot, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), CancellationToken.None);
 
             Assert.Equal(2, result.version);
             Assert.True(result.state.IsActiveEditorContext);
@@ -407,6 +412,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler1, handler2 });
 
+            var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
             var update = IProjectVersionedValueFactory.FromJson(
 @"{
    ""ProjectChanges"": {
@@ -419,7 +425,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 }");
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
             {
-                return applyChangesToWorkspace.ApplyProjectBuildAsync(update, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), cancellationTokenSource.Token);
+                return applyChangesToWorkspace.ApplyProjectBuildAsync(update, buildSnapshot, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), cancellationTokenSource.Token);
             });
 
             Assert.True(cancellationTokenSource.IsCancellationRequested);
@@ -462,6 +468,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler });
 
+            var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
             var update = IProjectVersionedValueFactory.FromJson(
 @"{
    ""ProjectChanges"": {
@@ -477,7 +484,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
     }
 }");
-            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), CancellationToken.None);
+            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, buildSnapshot, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), CancellationToken.None);
 
             Assert.Equal(0, callCount);
         }
@@ -488,6 +495,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var applyChangesToWorkspace = CreateInitializedInstance(out var context);
             context.LastDesignTimeBuildSucceeded = true;
 
+            var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
             var update = IProjectVersionedValueFactory.FromJson(
 @"{
    ""ProjectChanges"": {
@@ -502,7 +510,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     }
 }");
 
-            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, new ContextState(), CancellationToken.None);
+            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, buildSnapshot, new ContextState(), CancellationToken.None);
 
             Assert.False(context.LastDesignTimeBuildSucceeded);
         }
@@ -512,6 +520,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             var applyChangesToWorkspace = CreateInitializedInstance(out var context);
 
+            var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
             var update = IProjectVersionedValueFactory.FromJson(
 @"{
    ""ProjectChanges"": {
@@ -526,7 +535,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     }
 }");
 
-            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, new ContextState(true, false), CancellationToken.None);
+            await applyChangesToWorkspace.ApplyProjectBuildAsync(update, buildSnapshot, new ContextState(true, false), CancellationToken.None);
 
             Assert.True(context.LastDesignTimeBuildSucceeded);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
@@ -5,6 +5,8 @@ using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+using Moq;
 using Xunit;
 using static Microsoft.VisualStudio.ProjectSystem.LanguageServices.WorkspaceProjectContextHost;
 
@@ -252,6 +254,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             applyChangesToWorkspaceContext ??= IApplyChangesToWorkspaceContextFactory.Create();
             IActiveConfiguredProjectProvider activeConfiguredProjectProvider = IActiveConfiguredProjectProviderFactory.Create();
             IDataProgressTrackerService dataProgressTrackerService = IDataProgressTrackerServiceFactory.Create();
+            IProjectBuildSnapshotService projectBuildSnapshotService = new Mock<IProjectBuildSnapshotService>().Object;
 
             return new WorkspaceProjectContextHostInstance(project,
                                                            threadingService,
@@ -261,7 +264,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                                            activeEditorContextTracker,
                                                            activeConfiguredProjectProvider,
                                                            ExportFactoryFactory.ImplementCreateValueWithAutoDispose(() => applyChangesToWorkspaceContext),
-                                                           dataProgressTrackerService);
+                                                           dataProgressTrackerService,
+                                                           projectBuildSnapshotService);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var instance = await CreateInitializedInstanceAsync(tasksService: tasksService, applyChangesToWorkspaceContext: applyChangesToWorkspaceContext);
 
-            var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate)>(default);
+            var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>(default);
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
             {
                 return instance.OnProjectChangedAsync(update, evaluation);
@@ -179,7 +179,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             instance = await CreateInitializedInstanceAsync(applyChangesToWorkspaceContext: applyChangesToWorkspaceContext);
 
-            var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate)>(default);
+            var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>(default);
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
             {
                 return instance.OnProjectChangedAsync(update, evaluation);
@@ -202,8 +202,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var instance = await CreateInitializedInstanceAsync(applyChangesToWorkspaceContext: applyChangesToWorkspaceContext);
 
+            var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
             var subscription = IProjectSubscriptionUpdateFactory.CreateEmpty();
-            var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate)>((null!, subscription));
+            var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>((null!, subscription, buildSnapshot));
             await instance.OnProjectChangedAsync(update, evaluation);
 
             Assert.Same(subscriptionResult!.Value, subscription);
@@ -228,7 +229,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var instance = await CreateInitializedInstanceAsync(applyChangesToWorkspaceContext: applyChangesToWorkspaceContext, activeWorkspaceProjectContextTracker: activeWorkspaceProjectContextTracker);
 
-            var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate)>(default);
+            var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>(default);
             await instance.OnProjectChangedAsync(update, evaluation);
 
             Assert.Equal(isActiveContext, isActiveContextResult);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostTests.cs
@@ -4,7 +4,6 @@ using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Build;
-using Moq;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
@@ -134,7 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             applyChangesToWorkspaceContext ??= IApplyChangesToWorkspaceContextFactory.Create();
             IDataProgressTrackerService dataProgressTrackerService = IDataProgressTrackerServiceFactory.Create();
             IActiveConfiguredProjectProvider activeConfiguredProjectProvider = IActiveConfiguredProjectProviderFactory.Create();
-            IProjectBuildSnapshotService projectBuildSnapshotService = new Mock<IProjectBuildSnapshotService>().Object;
+            IProjectBuildSnapshotService projectBuildSnapshotService = IProjectBuildSnapshotServiceFactory.Create();
 
             return new WorkspaceProjectContextHost(project,
                                                    threadingService,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostTests.cs
@@ -3,6 +3,8 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+using Moq;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
@@ -132,6 +134,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             applyChangesToWorkspaceContext ??= IApplyChangesToWorkspaceContextFactory.Create();
             IDataProgressTrackerService dataProgressTrackerService = IDataProgressTrackerServiceFactory.Create();
             IActiveConfiguredProjectProvider activeConfiguredProjectProvider = IActiveConfiguredProjectProviderFactory.Create();
+            IProjectBuildSnapshotService projectBuildSnapshotService = new Mock<IProjectBuildSnapshotService>().Object;
 
             return new WorkspaceProjectContextHost(project,
                                                    threadingService,
@@ -141,7 +144,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                                    activeWorkspaceProjectContextTracker,
                                                    activeConfiguredProjectProvider,
                                                    ExportFactoryFactory.ImplementCreateValueWithAutoDispose(() => applyChangesToWorkspaceContext),
-                                                   dataProgressTrackerService);
+                                                   dataProgressTrackerService,
+                                                   projectBuildSnapshotService);
         }
     }
 }


### PR DESCRIPTION
What are the changes:
Get the command line arguments from IProjectBuildSnapshotService instead of IProjectSubscriptionService.

Subscribe to the ProjectBuildSnapshotService directly using the build targets, instead of rules.

What is the bug:
Getting the data from the rules changes the order of the commands which causes the Build to behave differently.

How this change fixes the bug:
Get the original order from ProjectBuildSnapshotService and pass it directly to roslyn.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7174)