### PR TITLE
Version launch profiles, and pass versions to the Project Query API

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/ILaunchSettingsVersionPublisher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/ILaunchSettingsVersionPublisher.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Used to communicate version changes from <see cref="LaunchSettingsQueryVersionProvider"/>
+    /// to <see cref="LaunchSettingsQueryVersionProviderExport"/> without establishing a
+    /// dependency between the two or on Project Query API types. See <see cref="LaunchSettingsQueryVersionProvider"/>
+    /// for a fuller explanation.
+    /// </summary>
+    internal interface ILaunchSettingsVersionPublisher
+    {
+        void UpdateVersions(ImmutableDictionary<string, long> versions);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchSettingsQueryVersionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchSettingsQueryVersionProvider.cs
@@ -1,0 +1,88 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Aggregates version information from the multiple <see cref="LaunchSettingsTracker" />s
+    /// and passes it on to the bound <see cref="ILaunchSettingsVersionPublisher"/>, if any.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="LaunchSettingsTracker"/> loads automatically for any project
+    /// supporting launch profiles. However, we don't want to load all of the assemblies
+    /// associated with the Project Query API until they are actually needed, so <see cref="LaunchSettingsTracker"/>
+    /// can't refer to any of them directly. Instead, it communicates with this type,
+    /// which will pass on the version information only after being bound to an <see cref="ILaunchSettingsVersionPublisher"/>.
+    /// </remarks>
+    [Export]
+    internal sealed class LaunchSettingsQueryVersionProvider
+    {
+        private readonly object _lock = new();
+
+        private readonly Dictionary<string, LaunchSettingsTracker> _allLaunchSettingsTrackers = new(StringComparer.Ordinal);
+        private ImmutableDictionary<string, long> _versions = ImmutableDictionary<string, long>.Empty;
+
+        private ILaunchSettingsVersionPublisher? _versionPublisher;
+
+        /// <summary>
+        /// Sets the related <see cref="ILaunchSettingsVersionPublisher"/> and pushes
+        /// the current version information to it.
+        /// </summary>
+        internal void BindToVersionPublisher(ILaunchSettingsVersionPublisher versionPublisher)
+        {
+            lock (_lock)
+            {
+                _versionPublisher = versionPublisher;
+                _versionPublisher.UpdateVersions(_versions);
+            }
+        }
+
+        /// <summary>
+        /// Called when the <paramref name="tracker"/> becomes active.
+        /// </summary>
+        internal void OnLaunchSettingsTrackerActivated(LaunchSettingsTracker tracker)
+        {
+            lock (_lock)
+            {
+                string key = tracker.VersionKey;
+
+                _allLaunchSettingsTrackers.Add(key, tracker);
+                _versions = _versions.SetItem(key, tracker.CurrentVersion);
+
+                _versionPublisher?.UpdateVersions(_versions);
+            }
+        }
+
+        /// <summary>
+        /// Called when the <paramref name="tracker"/> has an updated version.
+        /// </summary>
+        internal void OnLaunchSettingsVersionUpdated(LaunchSettingsTracker tracker)
+        {
+            lock (_lock)
+            {
+                _versions = _versions.SetItem(tracker.VersionKey, tracker.CurrentVersion);
+                _versionPublisher?.UpdateVersions(_versions);
+            }
+        }
+
+        /// <summary>
+        /// Called when the <paramref name="tracker"/> is deactivated.
+        /// </summary>
+        internal void OnLaunchSettingsTrackerDeactivated(LaunchSettingsTracker tracker)
+        {
+            lock (_lock)
+            {
+                string key = tracker.VersionKey;
+
+                _versions = _versions.Remove(key);
+                _allLaunchSettingsTrackers.Remove(key);
+
+                _versionPublisher?.UpdateVersions(_versions);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchSettingsQueryVersionProviderExport.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchSettingsQueryVersionProviderExport.cs
@@ -1,0 +1,218 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks.Dataflow;
+using Microsoft.VisualStudio.ProjectSystem.Query;
+using Microsoft.VisualStudio.ProjectSystem.Query.Providers;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Implementation of <see cref="IQueryDataSourceVersionProvider"/> for launch
+    /// settings. Receives data from the <see cref="LaunchSettingsQueryVersionProvider"/>
+    /// and passes it on to subscribed observers.
+    /// </summary>
+    /// <remarks>
+    /// We need to be careful that this type is only loaded by the Project Query API.
+    /// If our code were to load it, then we would cause the load of the Project Query
+    /// assemblies in situations where they weren't actually loaded. To avoid this, our
+    /// code has no direct dependency on this type, only on the <see cref="ILaunchSettingsVersionPublisher"/>
+    /// interface (which is defined in the project system). When this type *is* loaded it
+    /// registers itself with the <see cref="LaunchSettingsQueryVersionProvider"/>.
+    /// </remarks>
+    [Export(typeof(IQueryDataSourceVersionProvider))]
+    [ExportMetadata("Name", LaunchSettingsQueryVersionGroupName)]
+    internal class LaunchSettingsQueryVersionProviderExport : OnceInitializedOnceDisposed, IQueryDataSourceVersionProvider, ILaunchSettingsVersionPublisher
+    {
+        public const string LaunchSettingsQueryVersionGroupName = "LaunchSettings";
+
+        /// <remarks>
+        /// Responsible for generating new version information.
+        /// </remarks>
+        private readonly LaunchSettingsQueryVersionProvider _provider;
+        /// <remarks>
+        /// Processes notifications to the <see cref="_observers"/>.
+        /// </remarks>
+        private readonly ITargetBlock<Action> _processingBlock;
+        /// <summary>
+        /// The set of change notification observers.
+        /// </summary>
+        private ImmutableHashSet<IObserver<QueryDataSourceChangeNotification>> _observers = ImmutableHashSet<IObserver<QueryDataSourceChangeNotification>>.Empty;
+        /// <remarks>
+        /// Used to keep track of whether or not a new subscriber has received its initial snapshot.
+        /// </remarks>
+        private long _processedNotificationCount;
+        /// <remarks>
+        /// The current set of versions.
+        /// </remarks>
+        private QueryDataVersions _versions = QueryDataVersions.Empty;
+        /// <remarks>
+        /// The most recent set of versions sent to subscribers.
+        /// </remarks>
+        private QueryDataVersions _latestPostedVersions = QueryDataVersions.Empty;
+
+        [ImportingConstructor]
+        public LaunchSettingsQueryVersionProviderExport(LaunchSettingsQueryVersionProvider provider)
+        {
+            _provider = provider;
+#pragma warning disable RS0030 // Do not used banned APIs
+            _processingBlock = DataflowBlockSlim.CreateActionBlock<Action>(callback => callback(), nameFormat: nameof(LaunchSettingsQueryVersionProviderExport));
+#pragma warning restore RS0030 // Do not used banned APIs
+
+            _provider.BindToVersionPublisher(this);
+        }
+
+        public void UpdateVersions(ImmutableDictionary<string, long> versions)
+        {
+            lock (SyncObject)
+            {
+                _versions = QueryDataVersions.Empty.AddRange(versions);
+
+                PostVersionUpdate();
+            }
+        }
+
+        public IDisposable SubscribeChangeNotifications(IObserver<QueryDataSourceChangeNotification> observer)
+        {
+            EnsureInitialized();
+
+            lock (SyncObject)
+            {
+                if (_observers.Contains(observer))
+                {
+                    Requires.Fail($"This observer is already subscribed to change notifications from the {nameof(LaunchSettingsQueryVersionProviderExport)}.");
+                }
+
+                _observers = _observers.Add(observer);
+
+                // We don't immediately send the current set of versions to the observer. Instead,
+                // we post a message to send that data later. However, by that point the observer
+                // may have already received an up-to-date set of versions. To avoid double-sending
+                // the data we keep track of how many version updates we've already sent. If that
+                // number hasn't changed when we process the posted message, we know the observer
+                // has not received any version data yet.
+                long processedNotificationCountAtTimeOfSubscription = _processedNotificationCount;
+
+                _processingBlock.Post(() =>
+                {
+                    bool observerRequiresNotification = false;
+                    lock (SyncObject)
+                    {
+                        if (_observers.Contains(observer)
+                            && processedNotificationCountAtTimeOfSubscription == _processedNotificationCount)
+                        {
+                            observerRequiresNotification = true;
+                        }
+                    }
+
+                    if (observerRequiresNotification
+                        && _latestPostedVersions != QueryDataVersions.Empty)
+                    {
+                        observer.OnNext(new QueryDataSourceChangeNotification(updates: _latestPostedVersions));
+                    }
+                });
+            }
+
+            return new Unsubscriber(this, observer);
+        }
+
+        public bool TryGetVersion(string versionKey, out long version)
+        {
+            Requires.NotNullOrEmpty(versionKey, nameof(versionKey));
+            lock (SyncObject)
+            {
+                return _versions.TryGetValue(versionKey, out version);
+            }
+        }
+
+        protected override void Initialize()
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _versions = QueryDataVersions.Empty;
+                _processingBlock.Complete();
+            }
+        }
+
+        private void PostVersionUpdate()
+        {
+            lock (SyncObject)
+            {
+                if (IsInitialized)
+                {
+                    _processingBlock.Post(() =>
+                    {
+                        ImmutableHashSet<IObserver<QueryDataSourceChangeNotification>> observers;
+                        QueryDataVersions newVersions;
+                        lock (SyncObject)
+                        {
+                            if (_latestPostedVersions == _versions)
+                            {
+                                return;
+                            }
+
+                            observers = _observers;
+                            newVersions = _versions;
+                            _processedNotificationCount++;
+                        }
+
+                        if (observers.Count == 0)
+                        {
+                            return;
+                        }
+
+                        List<string>? expiredSources = null;
+                        foreach (string versionKey in _latestPostedVersions.Keys)
+                        {
+                            if (!newVersions.ContainsKey(versionKey))
+                            {
+                                if (expiredSources is null)
+                                {
+                                    expiredSources = new List<string>();
+                                }
+
+                                expiredSources.Add(versionKey);
+                            }
+                        }
+
+                        _latestPostedVersions = newVersions;
+                        QueryDataSourceChangeNotification notification = new(newVersions, expiredSources?.ToImmutableArray());
+                        foreach (IObserver<QueryDataSourceChangeNotification> observer in observers)
+                        {
+                            observer.OnNext(notification);
+                        }
+                    });
+                }
+            }
+        }
+
+        private class Unsubscriber : IDisposable
+        {
+            private readonly LaunchSettingsQueryVersionProviderExport _provider;
+            private readonly IObserver<QueryDataSourceChangeNotification> _observer;
+
+            public Unsubscriber(
+                LaunchSettingsQueryVersionProviderExport provider,
+                IObserver<QueryDataSourceChangeNotification> observer)
+            {
+                _provider = provider;
+                _observer = observer;
+            }
+
+            public void Dispose()
+            {
+                lock (_provider.SyncObject)
+                {
+                    _provider._observers = _provider._observers.Remove(_observer);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchSettingsTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchSettingsTracker.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
+{
+    /// <summary>
+    /// Tracks the launch settings version for a particular project, and reports the version information to the <see cref="LaunchSettingsQueryVersionProvider"/>.
+    /// </summary>
+    /// <remarks>
+    /// Note that as an <see cref="IProjectDynamicLoadComponent"/> the <see cref="LoadAsync"/>
+    /// and <see cref="UnloadAsync"/> may be called multiple times as the project is
+    /// loaded, unloaded, and as the capabilities change.
+    /// </remarks>
+    [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
+    [AppliesTo(ProjectCapability.LaunchProfiles)]
+    internal class LaunchSettingsTracker : IProjectDynamicLoadComponent
+    {
+        /// <remarks>
+        /// Ensures each <see cref="LaunchSettingsTracker"/> is given a unique version key.
+        /// </remarks>
+        private static int s_nextTrackerId;
+
+        private readonly UnconfiguredProject _project;
+        private readonly LaunchSettingsQueryVersionProvider _versionProvider;
+
+        private string? _versionKey;
+        private IDisposable? _launchSettingsProviderLink;
+
+        [ImportingConstructor]
+        public LaunchSettingsTracker(
+            UnconfiguredProject project,
+            LaunchSettingsQueryVersionProvider versionProvider)
+        {
+            _project = project;
+            _versionProvider = versionProvider;
+        }
+
+        public Task LoadAsync()
+        {
+            ILaunchSettingsProvider launchSettingsProvider = _project.Services.ExportProvider.GetExportedValue<ILaunchSettingsProvider>();
+            _launchSettingsProviderLink = launchSettingsProvider.SourceBlock.LinkToAction(OnLaunchSettingsChanged, _project);
+
+            ILaunchSettings? currentSnapshot = launchSettingsProvider.CurrentSnapshot;
+            if (currentSnapshot is IVersionedLaunchSettings versionedSettings)
+            {
+                CurrentVersion = versionedSettings.Version;
+                _versionProvider.OnLaunchSettingsTrackerActivated(this);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task UnloadAsync()
+        {
+            if (_launchSettingsProviderLink is not null)
+            {
+                _launchSettingsProviderLink.Dispose();
+                _launchSettingsProviderLink = null;
+            }
+
+            _versionProvider.OnLaunchSettingsTrackerDeactivated(this);
+
+            return Task.CompletedTask;
+        }
+
+        internal void OnLaunchSettingsChanged(ILaunchSettings newSettings)
+        {
+            if (newSettings is IVersionedLaunchSettings versionedSettings)
+            {
+                CurrentVersion = versionedSettings.Version;
+                _versionProvider.OnLaunchSettingsVersionUpdated(this);
+            }
+        }
+
+        internal long CurrentVersion { get; private set; }
+
+        internal string VersionKey
+        {
+            get
+            {
+                if (_versionKey is null)
+                {
+                    // Get a unique ID number
+                    int trackerIdNumber = Interlocked.Increment(ref s_nextTrackerId);
+
+                    // The project name is only for diagnostic purposes. It is not guaranteed to be unique, 
+                    // and it is OK that this won't get updated if the project is renamed.
+                    string projectName = Path.GetFileNameWithoutExtension(_project.FullPath);
+
+                    // Assemble the version key.
+                    string versionKey = $"LaunchSettings:{trackerIdNumber}:{projectName}";
+
+                    // Ensure that the field is only set once, even when called from multiple threads.
+                    Interlocked.CompareExchange(location1: ref _versionKey, value: versionKey, comparand: null);
+                }
+
+                return _versionKey!;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IVersionedLaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IVersionedLaunchSettings.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    /// <summary>
+    /// Exposes the version number of an <see cref="ILaunchSettings"/>.
+    /// </summary>
+    internal interface IVersionedLaunchSettings
+    {
+        long Version { get; }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
@@ -8,14 +8,14 @@ using Newtonsoft.Json;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
-    internal class LaunchSettings : ILaunchSettings
+    internal class LaunchSettings : ILaunchSettings, IVersionedLaunchSettings
     {
         private readonly string? _activeProfileName;
 
         /// <summary>
         /// Represents the current set of launch settings. Creation from an existing set of profiles.
         /// </summary>
-        public LaunchSettings(IEnumerable<ILaunchProfile> profiles, IDictionary<string, object>? globalSettings, string? activeProfile = null)
+        public LaunchSettings(IEnumerable<ILaunchProfile> profiles, IDictionary<string, object>? globalSettings, string? activeProfile = null, long version = 0)
         {
             Profiles = ImmutableList<ILaunchProfile>.Empty;
             foreach (ILaunchProfile profile in profiles)
@@ -25,9 +25,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             GlobalSettings = globalSettings == null ? ImmutableStringDictionary<object>.EmptyOrdinal : globalSettings.ToImmutableDictionary();
             _activeProfileName = activeProfile;
+            Version = version;
         }
 
-        public LaunchSettings(LaunchSettingsData settingsData, string? activeProfile = null)
+        public LaunchSettings(LaunchSettingsData settingsData, string? activeProfile = null, long version = 0)
         {
             Requires.NotNull(settingsData.Profiles!, nameof(settingsData.Profiles));
 
@@ -39,9 +40,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             GlobalSettings = settingsData.OtherSettings == null ? ImmutableStringDictionary<object>.EmptyOrdinal : settingsData.OtherSettings.ToImmutableDictionary();
             _activeProfileName = activeProfile;
+            Version = version;
         }
 
-        public LaunchSettings(IWritableLaunchSettings settings)
+        public LaunchSettings(IWritableLaunchSettings settings, long version = 0)
         {
             Profiles = ImmutableList<ILaunchProfile>.Empty;
             foreach (IWritableLaunchProfile profile in settings.Profiles)
@@ -69,12 +71,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             }
 
             _activeProfileName = settings.ActiveProfile?.Name;
+            Version = version;
         }
 
         public LaunchSettings()
         {
             Profiles = ImmutableList<ILaunchProfile>.Empty;
             GlobalSettings = ImmutableStringDictionary<object>.EmptyOrdinal;
+            Version = 0;
         }
 
         public ImmutableList<ILaunchProfile> Profiles { get; }
@@ -106,6 +110,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 return _activeProfile;
             }
         }
+
+        public long Version { get; }
     }
 
     internal static class LaunchSettingsExtension

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -133,12 +133,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             using var provider = GetLaunchSettingsProvider(moqFS);
             moqFS.WriteAllText(provider.LaunchSettingsFile, JsonString1);
             await provider.UpdateProfilesAsyncTest(null);
+            provider.SetNextVersionTest(123);
 
             // don't change file on disk, just active one
             await provider.UpdateProfilesAsyncTest("Docker");
             Assert.Equal(4, provider.CurrentSnapshot.Profiles.Count);
             Assert.Empty(provider.CurrentSnapshot.GlobalSettings);
             Assert.Equal("Docker", provider.CurrentSnapshot.ActiveProfile!.Name);
+            Assert.Equal(123, ((IVersionedLaunchSettings)provider.CurrentSnapshot).Version);
         }
 
         [Fact]
@@ -385,12 +387,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var moqFS = new IFileSystemMock();
             using var provider = GetLaunchSettingsProvider(moqFS);
+            provider.SetNextVersionTest(123);
             moqFS.WriteAllText(provider.LaunchSettingsFile, JsonString1);
             // Wait for completion of task
             await provider.LaunchSettingsFile_ChangedTest();
 
             Assert.NotNull(provider.CurrentSnapshot);
             Assert.Equal(4, provider.CurrentSnapshot.Profiles.Count);
+            Assert.Equal(123, ((IVersionedLaunchSettings)provider.CurrentSnapshot).Version);
         }
 
         [Fact]
@@ -487,6 +491,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                     mockScc.Object
                 };
             provider.SetSourceControlProviderCollection(sccProviders);
+            provider.SetNextVersionTest(123);
 
             await provider.UpdateAndSaveSettingsAsync(testSettings.Object);
 
@@ -496,6 +501,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Check snapshot
             AssertEx.CollectionLength(provider.CurrentSnapshot.Profiles, 2);
             Assert.Single(provider.CurrentSnapshot.GlobalSettings);
+            Assert.Equal(123, ((IVersionedLaunchSettings)provider.CurrentSnapshot).Version);
 
             // Verify the activeProfile is set to the first one since no existing snapshot
             Assert.Equal("IIS Express", provider.CurrentSnapshot.ActiveProfile!.Name);
@@ -587,6 +593,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             testSettings.Setup(m => m.Profiles).Returns(profiles.ToImmutableList());
 
             provider.SetCurrentSnapshot(testSettings.Object);
+            provider.SetNextVersionTest(123);
 
             var newProfile = new LaunchProfile() { Name = "test", CommandName = "Test", DoNotPersist = isInMemory };
 
@@ -599,6 +606,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             AssertEx.CollectionLength(provider.CurrentSnapshot.Profiles, 3);
             Assert.Equal("Test", provider.CurrentSnapshot.Profiles[expectedIndex].CommandName);
             Assert.Null(provider.CurrentSnapshot.Profiles[expectedIndex].ExecutablePath);
+            Assert.True(((IVersionedLaunchSettings)provider.CurrentSnapshot).Version >= 123);
         }
 
         [Theory]
@@ -621,6 +629,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             testSettings.Setup(m => m.Profiles).Returns(profiles.ToImmutableList());
 
             provider.SetCurrentSnapshot(testSettings.Object);
+            provider.SetNextVersionTest(123);
 
             var newProfile = new LaunchProfile() { Name = "test", CommandName = "Test", DoNotPersist = isInMemory };
 
@@ -634,6 +643,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.Equal("test", provider.CurrentSnapshot.Profiles[expectedIndex].Name);
             Assert.Equal("Test", provider.CurrentSnapshot.Profiles[expectedIndex].CommandName);
             Assert.Null(provider.CurrentSnapshot.Profiles[expectedIndex].ExecutablePath);
+            Assert.True(((IVersionedLaunchSettings)provider.CurrentSnapshot).Version >= 123);
         }
 
         [Theory]
@@ -655,6 +665,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             testSettings.Setup(m => m.Profiles).Returns(profiles.ToImmutableList());
 
             provider.SetCurrentSnapshot(testSettings.Object);
+            provider.SetNextVersionTest(123);
 
             var newProfile = new LaunchProfile() { Name = "test", CommandName = "Test", DoNotPersist = isInMemory };
 
@@ -673,6 +684,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.Equal("test", provider.CurrentSnapshot.Profiles[expectedIndex].Name);
             Assert.Equal("Test", provider.CurrentSnapshot.Profiles[expectedIndex].CommandName);
             Assert.Equal("c:\\test\\project\\bin\\test.exe", provider.CurrentSnapshot.Profiles[expectedIndex].ExecutablePath);
+            Assert.True(((IVersionedLaunchSettings)provider.CurrentSnapshot).Version >= 123);
         }
 
         [Theory]
@@ -693,6 +705,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             testSettings.Setup(m => m.Profiles).Returns(profiles.ToImmutableList());
 
             provider.SetCurrentSnapshot(testSettings.Object);
+            provider.SetNextVersionTest(123);
 
             await provider.RemoveProfileAsync("test");
 
@@ -702,6 +715,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Check snapshot
             AssertEx.CollectionLength(provider.CurrentSnapshot.Profiles, 2);
             Assert.Null(provider.CurrentSnapshot.Profiles.FirstOrDefault(p => p.Name!.Equals("test")));
+            Assert.True(((IVersionedLaunchSettings)provider.CurrentSnapshot).Version >= 123);
         }
 
         [Fact]
@@ -717,8 +731,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             var testSettings = new Mock<ILaunchSettings>();
             testSettings.Setup(m => m.Profiles).Returns(profiles.ToImmutableList());
+            var versionedTestSettings = testSettings.As<IVersionedLaunchSettings>();
+            versionedTestSettings.Setup(m => m.Version).Returns(42);
 
             provider.SetCurrentSnapshot(testSettings.Object);
+            provider.SetNextVersionTest(123);
 
             await provider.RemoveProfileAsync("test");
 
@@ -727,6 +744,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             // Check snapshot
             AssertEx.CollectionLength(provider.CurrentSnapshot.Profiles, 2);
+            Assert.Equal(42, ((IVersionedLaunchSettings)provider.CurrentSnapshot).Version);
         }
 
         [Theory]
@@ -745,6 +763,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             testSettings.Setup(m => m.Profiles).Returns(ImmutableList<ILaunchProfile>.Empty);
 
             provider.SetCurrentSnapshot(testSettings.Object);
+            provider.SetNextVersionTest(123);
 
             var newSettings = new IISSettingsData() { WindowsAuthentication = true, DoNotPersist = isInMemory };
 
@@ -753,10 +772,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Check disk file was written
             Assert.Equal(!isInMemory, moqFS.FileExists(provider.LaunchSettingsFile));
             AssertEx.CollectionLength(provider.CurrentSnapshot.GlobalSettings, 2);
+
             // Check snapshot
             Assert.True(provider.CurrentSnapshot.GlobalSettings.TryGetValue("iisSettings", out object? updatedSettings));
-
             Assert.True(((IISSettingsData)updatedSettings!).WindowsAuthentication);
+            Assert.True(((IVersionedLaunchSettings)provider.CurrentSnapshot).Version >= 123);
         }
 
         [Theory]
@@ -775,6 +795,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             testSettings.Setup(m => m.Profiles).Returns(ImmutableList<ILaunchProfile>.Empty);
 
             provider.SetCurrentSnapshot(testSettings.Object);
+            provider.SetNextVersionTest(123);
 
             var newSettings = new IISSettingsData() { WindowsAuthentication = true, DoNotPersist = isInMemory };
 
@@ -787,10 +808,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Check disk file was written
             Assert.Equal(!isInMemory, moqFS.FileExists(provider.LaunchSettingsFile));
             AssertEx.CollectionLength(provider.CurrentSnapshot.GlobalSettings, 2);
+
             // Check snapshot
             Assert.True(provider.CurrentSnapshot.GlobalSettings.TryGetValue("iisSettings", out object? updatedSettings));
-
             Assert.True(((IISSettingsData)updatedSettings!).WindowsAuthentication);
+            Assert.True(((IVersionedLaunchSettings)provider.CurrentSnapshot).Version >= 123);
         }
 
         [Theory]
@@ -813,6 +835,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             testSettings.Setup(m => m.Profiles).Returns(ImmutableList<ILaunchProfile>.Empty);
 
             provider.SetCurrentSnapshot(testSettings.Object);
+            provider.SetNextVersionTest(123);
 
             var newSettings = new IISSettingsData() { WindowsAuthentication = true, DoNotPersist = isInMemory };
 
@@ -824,8 +847,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Check snapshot
             AssertEx.CollectionLength(provider.CurrentSnapshot.GlobalSettings, 2);
             Assert.True(provider.CurrentSnapshot.GlobalSettings.TryGetValue("iisSettings", out object? updatedSettings));
-
             Assert.True(((IISSettingsData)updatedSettings!).WindowsAuthentication);
+            Assert.True(((IVersionedLaunchSettings)provider.CurrentSnapshot).Version >= 123);
         }
 
         [Theory]
@@ -848,6 +871,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             testSettings.Setup(m => m.Profiles).Returns(ImmutableList<ILaunchProfile>.Empty);
 
             provider.SetCurrentSnapshot(testSettings.Object);
+            provider.SetNextVersionTest(123);
 
             var newSettings = new IISSettingsData() { WindowsAuthentication = true, DoNotPersist = isInMemory };
 
@@ -863,8 +887,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Check snapshot
             AssertEx.CollectionLength(provider.CurrentSnapshot.GlobalSettings, 2);
             Assert.True(provider.CurrentSnapshot.GlobalSettings.TryGetValue("iisSettings", out object? updatedSettings));
-
             Assert.True(((IISSettingsData)updatedSettings!).WindowsAuthentication);
+            Assert.True(((IVersionedLaunchSettings)provider.CurrentSnapshot).Version >= 123);
         }
 
         [Fact]
@@ -879,8 +903,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var testSettings = new Mock<ILaunchSettings>();
             testSettings.Setup(m => m.GlobalSettings).Returns(globalSettings);
             testSettings.Setup(m => m.Profiles).Returns(ImmutableList<ILaunchProfile>.Empty);
+            var versionedTestSettings = testSettings.As<IVersionedLaunchSettings>();
+            versionedTestSettings.Setup(m => m.Version).Returns(42);
 
             provider.SetCurrentSnapshot(testSettings.Object);
+            provider.SetNextVersionTest(123);
 
             await provider.RemoveGlobalSettingAsync("iisSettings");
 
@@ -889,6 +916,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             // Check snapshot
             Assert.Single(provider.CurrentSnapshot.GlobalSettings);
+            Assert.Equal(42, ((IVersionedLaunchSettings)provider.CurrentSnapshot).Version);
         }
 
         [Fact]
@@ -907,6 +935,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             testSettings.Setup(m => m.Profiles).Returns(ImmutableList<ILaunchProfile>.Empty);
 
             provider.SetCurrentSnapshot(testSettings.Object);
+            provider.SetNextVersionTest(123);
 
             await provider.RemoveGlobalSettingAsync("iisSettings");
 
@@ -916,6 +945,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Check snapshot
             Assert.Single(provider.CurrentSnapshot.GlobalSettings);
             Assert.False(provider.CurrentSnapshot.GlobalSettings.TryGetValue("iisSettings", out _));
+            Assert.True(((IVersionedLaunchSettings)provider.CurrentSnapshot).Version >= 123);
         }
 
         private readonly string JsonString1 = @"{
@@ -1014,6 +1044,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public Task<LaunchSettingsData> ReadSettingsFileFromDiskTestAsync() { return ReadSettingsFileFromDiskAsync(); }
         public Task SaveSettingsToDiskAsyncTest(ILaunchSettings curSettings) { return SaveSettingsToDiskAsync(curSettings); }
         public Task UpdateAndSaveSettingsInternalAsyncTest(ILaunchSettings curSettings, bool persistToDisk) { return UpdateAndSaveSettingsInternalAsync(curSettings, persistToDisk); }
+        public void SetNextVersionTest(long nextVersion) { SetNextVersion(nextVersion); }
 
         public DateTime LastSettingsFileSyncTimeTest { get { return LastSettingsFileSyncTimeUtc; } set { LastSettingsFileSyncTimeUtc = value; } }
         public Task UpdateProfilesAsyncTest(string? activeProfile) { return UpdateProfilesAsync(activeProfile); }


### PR DESCRIPTION
The first commit adds versioning of launch profiles. The change introduces a new interface, `IVersionedLaunchSettings`, that returns a version number. The `LaunchSettings` type is updated to implement the new interface, and `LaunchSettingsProvider` now supplies and increments the version every time it produces a new instance of `LaunchSettings`.

The second commit uses these versions as the basis of an `IQueryDataSourceVersionProvider`. The `IQueryDataSourceVersionProvider` is responsible for informing the Project Query engine that there have been updates to data sources of interest to queries. When a client is observing a query (meaning they are interested in receiving push updates to the query data), the engine subscribes to the appropriate `IQueryDataSourceVersionProvider`s so it knows when it needs to re-run the query to get updated data and send it to the client.

There are three main parts to this implementation:

1. At the `UnconfiguredProject` level, the `LaunchSettingsTracker` continually watches for changes to the set of launch settings. As they change, it notifies the `LaunchSettingsQueryVersionProvider`.
2. The `LaunchSettingsQueryVersionProvider` is a singleton that aggregates the data from the trackers to create the total set of launch profile versions that may be needed by the Project Query API. It passes the aggregated data on to `LaunchSettingsQueryVersionProviderExport`.
3. `LaunchSettingsQueryVersionProviderExport` is the Project Query-facing counterpart to `LaunchSettingsQueryVersionProvider`. Logically, they work together as a single unit. However, we don't want the `LaunchSettingsQueryVersionProvider` to depend directly on types from the Project Query API as that would cause the query assemblies to load even in scenarios where we aren't using them. To avoid this we need the functionality into these two types, with communication occuring via the `ILaunchSettingsVersionPublisher` interface. The "export" type manages the set of subscribers and asynchronously passes along new version information.

The last piece, to come in a future PR, is to report version information for launch profiles along with query data. The query engine checks those reported versions against the versions supplied by the `IQueryDataSourceVersionProvider` to know when the query needs to be re-run.