### PR TITLE
Add a version differentiator for P1 and P2 packages

### DIFF
--- a/build/import/Versions.props
+++ b/build/import/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- IMPORTANT: These assembly versions must always be 3 digits -->
     <MinimumRequiredVSVersion>16.8.1</MinimumRequiredVSVersion> <!-- We should try to keep this up to date with the highest version available on build machines -->
-    <ProjectSystemVersion>17.0.0</ProjectSystemVersion> <!-- This should always match with the VS release we're targeting -->
+    <ProjectSystemVersion>17.0.1</ProjectSystemVersion> <!-- This should always match with the VS release we're targeting -->
     <VersionBase>$(ProjectSystemVersion)</VersionBase>
     <PreReleaseVersionLabel>beta1</PreReleaseVersionLabel>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>


### PR DESCRIPTION
change to version 17.0.1 on Preview 2 packages. This will make it easier in identifying packages for our partners

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7194)