### PR TITLE
Implements IVsProjectRestoreInfoSource

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ExternalContracts.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ExternalContracts.cs
@@ -16,3 +16,4 @@ using NuGet.VisualStudio;
 [assembly: ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne, ContractType = typeof(IVsSolutionRestoreService3))]
 [assembly: ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne, ContractType = typeof(IVsFrameworkParser))]
 [assembly: ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne, ContractType = typeof(IVsFrameworkCompatibility))]
+[assembly: ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne, ContractType = typeof(IVsSolutionRestoreService4))]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreConfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreConfiguredInputDataSource.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             IProjectValueDataSource<IProjectSubscriptionUpdate> source = _projectSubscriptionService.JointRuleSource;
 
             // Transform the changes from evaluation/design-time build -> restore data
-            DisposableValue<ISourceBlock<RestoreUpdate>> transformBlock = source.SourceBlock.TransformWithNoDelta(update => update.Derive(u => CreateRestoreInput(u.ProjectConfiguration, u.CurrentState)),
+            DisposableValue<ISourceBlock<RestoreUpdate>> transformBlock = source.SourceBlock.TransformWithNoDelta(update => update.Derive(u => CreateRestoreInput(update, u.ProjectConfiguration, u.CurrentState)),
                                                                                                 suppressVersionOnlyUpdates: false,    // We need to coordinate these at the unconfigured-level
                                                                                                 ruleNames: s_rules);
 
@@ -61,11 +61,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             return transformBlock;
         }
 
-        private static PackageRestoreConfiguredInput CreateRestoreInput(ProjectConfiguration projectConfiguration, IImmutableDictionary<string, IProjectRuleSnapshot> update)
+        private static PackageRestoreConfiguredInput CreateRestoreInput(IProjectVersionedValue<IProjectSubscriptionUpdate> projectSubscriptionUpdate, ProjectConfiguration projectConfiguration, IImmutableDictionary<string, IProjectRuleSnapshot> update)
         {
             var restoreInfo = RestoreBuilder.ToProjectRestoreInfo(update);
 
-            return new PackageRestoreConfiguredInput(projectConfiguration, restoreInfo);
+            IComparable configuredProjectVersion = projectSubscriptionUpdate.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion];
+
+            return new PackageRestoreConfiguredInput(projectConfiguration, restoreInfo, configuredProjectVersion);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.ProjectRestoreInfoSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.ProjectRestoreInfoSource.cs
@@ -63,19 +63,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
                     {
                         lock (SyncObject)
                         {
-                            if (_whenNominatedTask is not null)
+                            if (t.IsFaulted)
                             {
-                                if (t.IsFaulted)
-                                {
-                                    _whenNominatedTask.SetException(t.Exception);
-                                }
-                                else
-                                {
-                                    _whenNominatedTask.TrySetCanceled();
-                                }
+                                _whenNominatedTask?.SetException(t.Exception);
+                            }
+                            else
+                            {
+                                _whenNominatedTask?.TrySetCanceled();
                             }
                         }
-                    }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+                    }, TaskScheduler.Default);
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.ProjectRestoreInfoSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.ProjectRestoreInfoSource.cs
@@ -1,0 +1,237 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using NuGet.SolutionRestoreManager;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
+{
+    internal partial class PackageRestoreDataSource : IVsProjectRestoreInfoSource
+    {
+        /// <summary>
+        /// Re-usable task that completes when there is a new nomination
+        /// </summary>
+        private TaskCompletionSource<bool>? _whenNominatedTask;
+
+        private bool _restoreStarted;
+
+        private bool _wasSourceBlockContinuationSet;
+
+        /// <summary>
+        /// Save the configured project versions that might get nominations.
+        /// </summary>
+        private readonly Dictionary<ProjectConfiguration, IComparable> _savedNominatedConfiguredVersion = new();
+
+        /// <summary>
+        /// Project Unique Name used by Nuget Nomination.
+        /// </summary>
+        public string Name => _project.FullPath;
+
+        // True means the project system plans to call NominateProjectAsync in the future.
+        bool IVsProjectRestoreInfoSource.HasPendingNomination => CheckIfHasPendingNomination();
+
+        // NuGet calls this method to wait project to nominate restoring.
+        // If the project has no pending restore data, it will return a completed task.
+        // Otherwise a task which will be completed once the project nominate the next restore
+        // the task will be cancelled, if the project system decide it no longer need restore (for example: the restore state has no change)
+        // the task will be failed, if the project system runs into a problem, so it cannot get correct data to nominate a restore (DT build failed)
+        public Task WhenNominated(CancellationToken cancellationToken)
+        {
+            lock (SyncObject)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                if (!CheckIfHasPendingNomination())
+                {
+                    return Task.CompletedTask;
+                }
+
+                _whenNominatedTask ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                if (!_wasSourceBlockContinuationSet)
+                {
+                    _wasSourceBlockContinuationSet = true;
+
+                    _ = SourceBlock.Completion.ContinueWith(t =>
+                    {
+                        lock (SyncObject)
+                        {
+                            if (_whenNominatedTask is not null)
+                            {
+                                if (t.IsFaulted)
+                                {
+                                    _whenNominatedTask.SetException(t.Exception);
+                                }
+                                else
+                                {
+                                    _whenNominatedTask.TrySetCanceled();
+                                }
+                            }
+                        }
+                    }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+                }
+            }
+
+            return _whenNominatedTask.Task.WithCancellation(cancellationToken);
+        }
+
+        private void RegisterProjectRestoreInfoSource()
+        {
+            // Register before this project receives any data flows containing possible nominations.
+            // This is needed because we need to register before any nuget restore or before the solution load.
+#pragma warning disable RS0030 // Do not used banned APIs
+            var registerRestoreInfoSourceTask = Task.Run(async () =>
+            {
+                try
+                {
+                    await _solutionRestoreService4.RegisterRestoreInfoSourceAsync(this, _projectAsynchronousTasksService.UnloadCancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    throw ex;
+                }
+            });
+#pragma warning restore RS0030 // Do not used banned APIs
+
+            _project.Services.FaultHandler.Forget(registerRestoreInfoSourceTask, _project, ProjectFaultSeverity.Recoverable);
+        }
+
+        private bool CheckIfHasPendingNomination()
+        {
+            lock (SyncObject)
+            {
+                Assumes.Present(_project.Services.ActiveConfiguredProjectProvider);
+                Assumes.Present(_project.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject);
+
+                // Nuget should not wait for projects that failed DTB
+                if (!_enabled || SourceBlock.Completion.IsFaulted || SourceBlock.Completion.IsCompleted)
+                {
+                    return false;
+                }
+
+                // Avoid possible deadlock.
+                // Because RestoreCoreAsync() is called inside a dataflow block it will not be called with new data
+                // until the old task finishes. So, if the project gets nominating restore, it will not get updated data.
+                if (IsPackageRestoreOnGoing())
+                {
+                    return false;
+                }
+
+                ConfiguredProject? activeConfiguredProject = _project.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject;
+
+                // After the first nomination, we should check the saved nominated version
+                return IsSavedNominationOutOfDate(activeConfiguredProject);
+            }
+        }
+
+        private bool IsPackageRestoreOnGoing()
+        {
+            // If NominateForRestoreAsync() has not finished, return false
+            return _restoreStarted;
+        }
+
+        private void SaveNominatedConfiguredVersions(IReadOnlyCollection<PackageRestoreConfiguredInput> configuredInputs)
+        {
+            lock (SyncObject)
+            {
+                _savedNominatedConfiguredVersion.Clear();
+
+                foreach (var configuredInput in configuredInputs)
+                {
+                    _savedNominatedConfiguredVersion[configuredInput.ProjectConfiguration] = configuredInput.ConfiguredProjectVersion;
+                }
+
+                if (_whenNominatedTask is not null)
+                {
+                    if (_whenNominatedTask.TrySetResult(true))
+                    {
+                        _whenNominatedTask = null;
+                    }
+                }
+            }
+        }
+
+        protected virtual bool IsSavedNominationOutOfDate(ConfiguredProject activeConfiguredProject)
+        {
+            if (!_savedNominatedConfiguredVersion.TryGetValue(activeConfiguredProject.ProjectConfiguration,
+                    out IComparable latestSavedVersionForActiveConfiguredProject) ||
+                activeConfiguredProject.ProjectVersion.IsLaterThan(latestSavedVersionForActiveConfiguredProject))
+            {
+                return true;
+            }
+
+            if (_savedNominatedConfiguredVersion.Count == 1)
+            {
+                return false;
+            }
+
+            foreach (var loadedProject in activeConfiguredProject.UnconfiguredProject.LoadedConfiguredProjects)
+            {
+                if (_savedNominatedConfiguredVersion.TryGetValue(loadedProject.ProjectConfiguration, out IComparable savedProjectVersion))
+                {
+                    if (loadedProject.ProjectVersion.IsLaterThan(savedProjectVersion))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        protected virtual bool IsProjectConfigurationVersionOutOfDate(IReadOnlyCollection<PackageRestoreConfiguredInput> configuredInputs)
+        {
+            Assumes.Present(_project.Services.ActiveConfiguredProjectProvider);
+            Assumes.Present(_project.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject);
+
+            if (configuredInputs is null)
+            {
+                return false;
+            }
+
+            var activeConfiguredProject = _project.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject;
+
+            IComparable? activeProjectConfigurationVersionFromConfiguredInputs = null;
+            foreach (var configuredInput in configuredInputs)
+            {
+                if (configuredInput.ProjectConfiguration.Equals(activeConfiguredProject.ProjectConfiguration))
+                {
+                    activeProjectConfigurationVersionFromConfiguredInputs = configuredInput.ConfiguredProjectVersion;
+                }
+            }
+
+            if (activeProjectConfigurationVersionFromConfiguredInputs is null ||
+                activeConfiguredProject.ProjectVersion.IsLaterThan(
+                    activeProjectConfigurationVersionFromConfiguredInputs))
+            {
+                return true;
+            }
+
+            if (configuredInputs.Count == 1)
+            {
+                return false;
+            }
+
+            foreach (var loadedProject in activeConfiguredProject.UnconfiguredProject.LoadedConfiguredProjects)
+            {
+                foreach (var configuredInput in configuredInputs)
+                {
+                    if (loadedProject.ProjectConfiguration.Equals(configuredInput.ProjectConfiguration) &&
+                        loadedProject.ProjectVersion.IsLaterThan(configuredInput.ConfiguredProjectVersion))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
     [Export(typeof(IPackageRestoreDataSource))]
     [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
     [AppliesTo(ProjectCapability.PackageReferences)]
-    internal class PackageRestoreDataSource : ChainedProjectValueDataSourceBase<RestoreData>, IPackageRestoreDataSource, IProjectDynamicLoadComponent
+    internal class PackageRestoreDataSource : ChainedProjectValueDataSourceBase<RestoreData>, IPackageRestoreDataSource, IProjectDynamicLoadComponent, IVsProjectRestoreInfoSource
     {
         // This class represents the last data source in the package restore chain, which is made up of the following:
         //  _________________________________________      _________________________________________
@@ -62,20 +62,44 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         private readonly IFileSystem _fileSystem;
         private readonly IProjectDiagnosticOutputService _logger;
         private readonly IProjectDependentFileChangeNotificationService _projectDependentFileChangeNotificationService;
-
+        private readonly IVsSolutionRestoreService4 _solutionRestoreService4;
         private byte[]? _latestHash;
         private bool _enabled;
+
+        /// <summary>
+        /// Re-usable task that completes when there is a new nomination
+        /// </summary>
+        private TaskCompletionSource<bool>? _whenNominatedTask;
+
+        private bool _restoreStarted;
+
+        private bool _wasSourceBlockContinuationSet;
+
+        /// <summary>
+        /// Save the configured project versions that might get nominations.
+        /// </summary>
+        private readonly Dictionary<ProjectConfiguration, IComparable> _savedNominatedConfiguredVersion = new();
+
+        /// <summary>
+        /// Project Unique Name used by Nuget Nomination.
+        /// </summary>
+        public string Name => _project.FullPath;
+
+        // True means the project system plans to call NominateProjectAsync in the future.
+        bool IVsProjectRestoreInfoSource.HasPendingNomination => CheckIfHasPendingNomination();
 
         [ImportingConstructor]
         public PackageRestoreDataSource(
             UnconfiguredProject project,
             IPackageRestoreUnconfiguredInputDataSource dataSource,
-            [Import(ExportContractNames.Scopes.UnconfiguredProject)]IProjectAsynchronousTasksService projectAsynchronousTasksService,
+            [Import(ExportContractNames.Scopes.UnconfiguredProject)] IProjectAsynchronousTasksService projectAsynchronousTasksService,
             IVsSolutionRestoreService3 solutionRestoreService,
             IFileSystem fileSystem,
             IProjectDiagnosticOutputService logger,
-            IProjectDependentFileChangeNotificationService projectDependentFileChangeNotificationService)
-            : base(project, synchronousDisposal : true, registerDataSource : false)
+            IProjectDependentFileChangeNotificationService projectDependentFileChangeNotificationService,
+            IVsSolutionRestoreService4 solutionRestoreService4,
+            PackageRestoreSharedJoinableTaskCollection sharedJoinableTaskCollection)
+            : base(project, sharedJoinableTaskCollection, synchronousDisposal: true, registerDataSource: false)
         {
             _project = project;
             _dataSource = dataSource;
@@ -84,10 +108,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             _fileSystem = fileSystem;
             _logger = logger;
             _projectDependentFileChangeNotificationService = projectDependentFileChangeNotificationService;
+            _solutionRestoreService4 = solutionRestoreService4;
         }
 
         protected override IDisposable? LinkExternalInput(ITargetBlock<IProjectVersionedValue<RestoreData>> targetBlock)
         {
+            // Register before this project receives any data flows containing possible nominations.
+            // This is needed because we need to register before any nuget restore or before the solution load.
+#pragma warning disable RS0030 // Do not used banned APIs
+            var registerRestoreInfoSourceTask = Task.Run(async () =>
+            {
+                try
+                {
+                    await _solutionRestoreService4.RegisterRestoreInfoSourceAsync(this, _projectAsynchronousTasksService.UnloadCancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    throw ex;
+                }
+            });
+#pragma warning restore RS0030 // Do not used banned APIs
+
+            _project.Services.FaultHandler.Forget(registerRestoreInfoSourceTask, _project, ProjectFaultSeverity.Recoverable);
+
             JoinUpstreamDataSources(_dataSource);
 
             // Take the unconfigured "restore inputs", send them to NuGet, and then return the result of that restore
@@ -101,11 +144,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 
         internal async Task<IEnumerable<IProjectVersionedValue<RestoreData>>> RestoreAsync(IProjectVersionedValue<PackageRestoreUnconfiguredInput> e)
         {
-            // No configurations - likely during project close
-            if (!_enabled || e.Value.RestoreInfo is null)
+            // No configurations - likely during project close.
+            // Check if out of date to prevent extra restore under some conditions.
+            if (!_enabled || e.Value.RestoreInfo is null || IsProjectConfigurationVersionOutOfDate(e.Value.ConfiguredInputs))
+            {
                 return Enumerable.Empty<IProjectVersionedValue<RestoreData>>();
+            }
 
-            bool succeeded = await RestoreCoreAsync(e.Value.RestoreInfo);
+            bool succeeded = await RestoreCoreAsync(e.Value);
 
             RestoreData restoreData = CreateRestoreData(e.Value.RestoreInfo, succeeded);
 
@@ -115,32 +161,76 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             };
         }
 
-        private async Task<bool> RestoreCoreAsync(ProjectRestoreInfo restoreInfo)
+        private async Task<bool> RestoreCoreAsync(PackageRestoreUnconfiguredInput value)
         {
-            // Restore service always does work regardless of whether the value we pass 
-            // them to actually contains changes, only nominate if there are any.
-            byte[] hash = RestoreHasher.CalculateHash(restoreInfo);
+            ProjectRestoreInfo? restoreInfo = value.RestoreInfo;
+            bool success = false;
 
-            if (_latestHash != null && Enumerable.SequenceEqual(hash, _latestHash))
-                return true;
+            Assumes.NotNull(restoreInfo);
 
-            _latestHash = hash;
-
-            JoinableTask<bool> joinableTask = JoinableFactory.RunAsync(() =>
+            try
             {
-                return NominateForRestoreAsync(restoreInfo, _projectAsynchronousTasksService.UnloadCancellationToken);
-            });
+                // Restore service always does work regardless of whether the value we pass 
+                // them to actually contains changes, only nominate if there are any.
+                byte[] hash = RestoreHasher.CalculateHash(restoreInfo);
 
-            _projectAsynchronousTasksService.RegisterAsyncTask(joinableTask,
-                                                               ProjectCriticalOperation.Build | ProjectCriticalOperation.Unload | ProjectCriticalOperation.Rename,
-                                                               registerFaultHandler: true);
+                if (_latestHash != null && hash.AsSpan().SequenceEqual(_latestHash))
+                {
+                    SaveNominatedConfiguredVersions(value.ConfiguredInputs);
+                    return true;
+                }
 
-            // Prevent overlap until Restore completes
-            bool success = await joinableTask;
+                _latestHash = hash;
 
-            HintProjectDependentFile(restoreInfo);
+                _restoreStarted = true;
+                JoinableTask<bool> joinableTask = JoinableFactory.RunAsync(() =>
+                {
+                    return NominateForRestoreAsync(restoreInfo!, _projectAsynchronousTasksService.UnloadCancellationToken);
+                });
+
+                SaveNominatedConfiguredVersions(value.ConfiguredInputs);
+
+                _projectAsynchronousTasksService.RegisterAsyncTask(joinableTask,
+                                                                   ProjectCriticalOperation.Build | ProjectCriticalOperation.Unload | ProjectCriticalOperation.Rename,
+                                                                   registerFaultHandler: true);
+
+                // Prevent overlap until Restore completes
+                success = await joinableTask;
+
+                lock (SyncObject)
+                {
+                    _restoreStarted = false;
+                }
+
+                HintProjectDependentFile(restoreInfo!);
+            }
+            finally
+            {
+                _restoreStarted = false;
+            }
 
             return success;
+        }
+
+        private void SaveNominatedConfiguredVersions(IReadOnlyCollection<PackageRestoreConfiguredInput> configuredInputs)
+        {
+            lock (SyncObject)
+            {
+                _savedNominatedConfiguredVersion.Clear();
+
+                foreach (var configuredInput in configuredInputs)
+                {
+                    _savedNominatedConfiguredVersion[configuredInput.ProjectConfiguration] = configuredInput.ConfiguredProjectVersion;
+                }
+
+                if (_whenNominatedTask is not null)
+                {
+                    if (_whenNominatedTask.TrySetResult(true))
+                    {
+                        _whenNominatedTask = null;
+                    }
+                }
+            }
         }
 
         private void HintProjectDependentFile(ProjectRestoreInfo restoreInfo)
@@ -202,9 +292,172 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 
         public Task UnloadAsync()
         {
-            _enabled = false;
+            lock (SyncObject)
+            {
+                _enabled = false;
+
+                _whenNominatedTask?.TrySetCanceled();
+            }
 
             return Task.CompletedTask;
+        }
+
+        // NuGet calls this method to wait project to nominate restoring.
+        // If the project has no pending restore data, it will return a completed task.
+        // Otherwise a task which will be completed once the project nominate the next restore
+        // the task will be cancelled, if the project system decide it no longer need restore (for example: the restore state has no change)
+        // the task will be failed, if the project system runs into a problem, so it cannot get correct data to nominate a restore (DT build failed)
+        public Task WhenNominated(CancellationToken cancellationToken)
+        {
+            lock (SyncObject)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                if (!CheckIfHasPendingNomination())
+                {
+                    return Task.CompletedTask;
+                }
+
+                _whenNominatedTask ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                if (!_wasSourceBlockContinuationSet)
+                {
+                    _wasSourceBlockContinuationSet = true;
+
+                    _ = SourceBlock.Completion.ContinueWith(t =>
+                    {
+                        lock (SyncObject)
+                        {
+                            if (_whenNominatedTask is not null)
+                            {
+                                if (t.IsFaulted)
+                                {
+                                    _whenNominatedTask.SetException(t.Exception);
+                                }
+                                else
+                                {
+                                    _whenNominatedTask.TrySetCanceled();
+                                }
+                            }
+                        }
+                    }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+                }
+            }
+
+            return _whenNominatedTask.Task.WithCancellation(cancellationToken);
+        }
+
+        private bool CheckIfHasPendingNomination()
+        {
+            lock (SyncObject)
+            {
+                Assumes.Present(_project.Services.ActiveConfiguredProjectProvider);
+                Assumes.Present(_project.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject);
+
+                // Nuget should not wait for projects that failed DTB
+                if (!_enabled || SourceBlock.Completion.IsFaulted || SourceBlock.Completion.IsCompleted)
+                {
+                    return false;
+                }
+
+                // Avoid possible deadlock.
+                // Because RestoreCoreAsync() is called inside a dataflow block it will not be called with new data
+                // until the old task finishes. So, if the project gets nominating restore, it will not get updated data.
+                if (IsPackageRestoreOnGoing())
+                {
+                    return false;
+                }
+
+                ConfiguredProject? activeConfiguredProject = _project.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject;
+
+                // After the first nomination, we should check the saved nominated version
+                return IsSavedNominationOutOfDate(activeConfiguredProject);
+            }
+        }
+
+        private bool IsPackageRestoreOnGoing()
+        {
+            // If NominateForRestoreAsync() has not finished, return false
+            return _restoreStarted;
+        }
+
+        protected virtual bool IsSavedNominationOutOfDate(ConfiguredProject activeConfiguredProject)
+        {
+            if (!_savedNominatedConfiguredVersion.TryGetValue(activeConfiguredProject.ProjectConfiguration,
+                    out IComparable latestSavedVersionForActiveConfiguredProject) ||
+                activeConfiguredProject.ProjectVersion.IsLaterThan(latestSavedVersionForActiveConfiguredProject))
+            {
+                return true;
+            }
+
+            if (_savedNominatedConfiguredVersion.Count == 1)
+            {
+                return false;
+            }
+
+            foreach (var loadedProject in activeConfiguredProject.UnconfiguredProject.LoadedConfiguredProjects)
+            {
+                if (_savedNominatedConfiguredVersion.TryGetValue(loadedProject.ProjectConfiguration, out IComparable savedProjectVersion))
+                {
+                    if (loadedProject.ProjectVersion.IsLaterThan(savedProjectVersion))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        protected virtual bool IsProjectConfigurationVersionOutOfDate(IReadOnlyCollection<PackageRestoreConfiguredInput> configuredInputs)
+        {
+            Assumes.Present(_project.Services.ActiveConfiguredProjectProvider);
+            Assumes.Present(_project.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject);
+
+            if (configuredInputs is null)
+            {
+                return false;
+            }
+
+            var activeConfiguredProject = _project.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject;
+
+            IComparable? activeProjectConfigurationVersionFromConfiguredInputs = null;
+            foreach (var configuredInput in configuredInputs)
+            {
+                if (configuredInput.ProjectConfiguration.Equals(activeConfiguredProject.ProjectConfiguration))
+                {
+                    activeProjectConfigurationVersionFromConfiguredInputs = configuredInput.ConfiguredProjectVersion;
+                }
+            }
+
+            if (activeProjectConfigurationVersionFromConfiguredInputs is null ||
+                activeConfiguredProject.ProjectVersion.IsLaterThan(
+                    activeProjectConfigurationVersionFromConfiguredInputs))
+            {
+                return true;
+            }
+
+            if (configuredInputs.Count == 1)
+            {
+                return false;
+            }
+
+            foreach (var loadedProject in activeConfiguredProject.UnconfiguredProject.LoadedConfiguredProjects)
+            {
+                foreach (var configuredInput in configuredInputs)
+                {
+                    if (loadedProject.ProjectConfiguration.Equals(configuredInput.ProjectConfiguration) &&
+                        loadedProject.ProjectVersion.IsLaterThan(configuredInput.ConfiguredProjectVersion))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
     [Export(typeof(IPackageRestoreDataSource))]
     [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
     [AppliesTo(ProjectCapability.PackageReferences)]
-    internal class PackageRestoreDataSource : ChainedProjectValueDataSourceBase<RestoreData>, IPackageRestoreDataSource, IProjectDynamicLoadComponent, IVsProjectRestoreInfoSource
+    internal partial class PackageRestoreDataSource : ChainedProjectValueDataSourceBase<RestoreData>, IPackageRestoreDataSource, IProjectDynamicLoadComponent
     {
         // This class represents the last data source in the package restore chain, which is made up of the following:
         //  _________________________________________      _________________________________________
@@ -66,28 +66,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         private byte[]? _latestHash;
         private bool _enabled;
 
-        /// <summary>
-        /// Re-usable task that completes when there is a new nomination
-        /// </summary>
-        private TaskCompletionSource<bool>? _whenNominatedTask;
-
-        private bool _restoreStarted;
-
-        private bool _wasSourceBlockContinuationSet;
-
-        /// <summary>
-        /// Save the configured project versions that might get nominations.
-        /// </summary>
-        private readonly Dictionary<ProjectConfiguration, IComparable> _savedNominatedConfiguredVersion = new();
-
-        /// <summary>
-        /// Project Unique Name used by Nuget Nomination.
-        /// </summary>
-        public string Name => _project.FullPath;
-
-        // True means the project system plans to call NominateProjectAsync in the future.
-        bool IVsProjectRestoreInfoSource.HasPendingNomination => CheckIfHasPendingNomination();
-
         [ImportingConstructor]
         public PackageRestoreDataSource(
             UnconfiguredProject project,
@@ -113,23 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 
         protected override IDisposable? LinkExternalInput(ITargetBlock<IProjectVersionedValue<RestoreData>> targetBlock)
         {
-            // Register before this project receives any data flows containing possible nominations.
-            // This is needed because we need to register before any nuget restore or before the solution load.
-#pragma warning disable RS0030 // Do not used banned APIs
-            var registerRestoreInfoSourceTask = Task.Run(async () =>
-            {
-                try
-                {
-                    await _solutionRestoreService4.RegisterRestoreInfoSourceAsync(this, _projectAsynchronousTasksService.UnloadCancellationToken);
-                }
-                catch (Exception ex)
-                {
-                    throw ex;
-                }
-            });
-#pragma warning restore RS0030 // Do not used banned APIs
-
-            _project.Services.FaultHandler.Forget(registerRestoreInfoSourceTask, _project, ProjectFaultSeverity.Recoverable);
+            RegisterProjectRestoreInfoSource();
 
             JoinUpstreamDataSources(_dataSource);
 
@@ -212,27 +174,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             return success;
         }
 
-        private void SaveNominatedConfiguredVersions(IReadOnlyCollection<PackageRestoreConfiguredInput> configuredInputs)
-        {
-            lock (SyncObject)
-            {
-                _savedNominatedConfiguredVersion.Clear();
-
-                foreach (var configuredInput in configuredInputs)
-                {
-                    _savedNominatedConfiguredVersion[configuredInput.ProjectConfiguration] = configuredInput.ConfiguredProjectVersion;
-                }
-
-                if (_whenNominatedTask is not null)
-                {
-                    if (_whenNominatedTask.TrySetResult(true))
-                    {
-                        _whenNominatedTask = null;
-                    }
-                }
-            }
-        }
-
         private void HintProjectDependentFile(ProjectRestoreInfo restoreInfo)
         {
             if (restoreInfo.ProjectAssetsFilePath.Length != 0)
@@ -300,164 +241,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             }
 
             return Task.CompletedTask;
-        }
-
-        // NuGet calls this method to wait project to nominate restoring.
-        // If the project has no pending restore data, it will return a completed task.
-        // Otherwise a task which will be completed once the project nominate the next restore
-        // the task will be cancelled, if the project system decide it no longer need restore (for example: the restore state has no change)
-        // the task will be failed, if the project system runs into a problem, so it cannot get correct data to nominate a restore (DT build failed)
-        public Task WhenNominated(CancellationToken cancellationToken)
-        {
-            lock (SyncObject)
-            {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                }
-
-                if (!CheckIfHasPendingNomination())
-                {
-                    return Task.CompletedTask;
-                }
-
-                _whenNominatedTask ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-                if (!_wasSourceBlockContinuationSet)
-                {
-                    _wasSourceBlockContinuationSet = true;
-
-                    _ = SourceBlock.Completion.ContinueWith(t =>
-                    {
-                        lock (SyncObject)
-                        {
-                            if (_whenNominatedTask is not null)
-                            {
-                                if (t.IsFaulted)
-                                {
-                                    _whenNominatedTask.SetException(t.Exception);
-                                }
-                                else
-                                {
-                                    _whenNominatedTask.TrySetCanceled();
-                                }
-                            }
-                        }
-                    }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-                }
-            }
-
-            return _whenNominatedTask.Task.WithCancellation(cancellationToken);
-        }
-
-        private bool CheckIfHasPendingNomination()
-        {
-            lock (SyncObject)
-            {
-                Assumes.Present(_project.Services.ActiveConfiguredProjectProvider);
-                Assumes.Present(_project.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject);
-
-                // Nuget should not wait for projects that failed DTB
-                if (!_enabled || SourceBlock.Completion.IsFaulted || SourceBlock.Completion.IsCompleted)
-                {
-                    return false;
-                }
-
-                // Avoid possible deadlock.
-                // Because RestoreCoreAsync() is called inside a dataflow block it will not be called with new data
-                // until the old task finishes. So, if the project gets nominating restore, it will not get updated data.
-                if (IsPackageRestoreOnGoing())
-                {
-                    return false;
-                }
-
-                ConfiguredProject? activeConfiguredProject = _project.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject;
-
-                // After the first nomination, we should check the saved nominated version
-                return IsSavedNominationOutOfDate(activeConfiguredProject);
-            }
-        }
-
-        private bool IsPackageRestoreOnGoing()
-        {
-            // If NominateForRestoreAsync() has not finished, return false
-            return _restoreStarted;
-        }
-
-        protected virtual bool IsSavedNominationOutOfDate(ConfiguredProject activeConfiguredProject)
-        {
-            if (!_savedNominatedConfiguredVersion.TryGetValue(activeConfiguredProject.ProjectConfiguration,
-                    out IComparable latestSavedVersionForActiveConfiguredProject) ||
-                activeConfiguredProject.ProjectVersion.IsLaterThan(latestSavedVersionForActiveConfiguredProject))
-            {
-                return true;
-            }
-
-            if (_savedNominatedConfiguredVersion.Count == 1)
-            {
-                return false;
-            }
-
-            foreach (var loadedProject in activeConfiguredProject.UnconfiguredProject.LoadedConfiguredProjects)
-            {
-                if (_savedNominatedConfiguredVersion.TryGetValue(loadedProject.ProjectConfiguration, out IComparable savedProjectVersion))
-                {
-                    if (loadedProject.ProjectVersion.IsLaterThan(savedProjectVersion))
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        protected virtual bool IsProjectConfigurationVersionOutOfDate(IReadOnlyCollection<PackageRestoreConfiguredInput> configuredInputs)
-        {
-            Assumes.Present(_project.Services.ActiveConfiguredProjectProvider);
-            Assumes.Present(_project.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject);
-
-            if (configuredInputs is null)
-            {
-                return false;
-            }
-
-            var activeConfiguredProject = _project.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject;
-
-            IComparable? activeProjectConfigurationVersionFromConfiguredInputs = null;
-            foreach (var configuredInput in configuredInputs)
-            {
-                if (configuredInput.ProjectConfiguration.Equals(activeConfiguredProject.ProjectConfiguration))
-                {
-                    activeProjectConfigurationVersionFromConfiguredInputs = configuredInput.ConfiguredProjectVersion;
-                }
-            }
-
-            if (activeProjectConfigurationVersionFromConfiguredInputs is null ||
-                activeConfiguredProject.ProjectVersion.IsLaterThan(
-                    activeProjectConfigurationVersionFromConfiguredInputs))
-            {
-                return true;
-            }
-
-            if (configuredInputs.Count == 1)
-            {
-                return false;
-            }
-
-            foreach (var loadedProject in activeConfiguredProject.UnconfiguredProject.LoadedConfiguredProjects)
-            {
-                foreach (var configuredInput in configuredInputs)
-                {
-                    if (loadedProject.ProjectConfiguration.Equals(configuredInput.ProjectConfiguration) &&
-                        loadedProject.ProjectVersion.IsLaterThan(configuredInput.ConfiguredProjectVersion))
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreSharedJoinableTaskCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreSharedJoinableTaskCollection.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Composition;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
+{
+    [Export(typeof(PackageRestoreSharedJoinableTaskCollection))]
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    internal class PackageRestoreSharedJoinableTaskCollection : IJoinableTaskScope
+    {
+        [ImportingConstructor]
+        public PackageRestoreSharedJoinableTaskCollection(IProjectThreadingService threadingService) 
+        {
+            JoinableTaskCollection = threadingService.JoinableTaskContext.CreateCollection();
+            JoinableTaskFactory = threadingService.JoinableTaskContext.CreateFactory(JoinableTaskCollection);
+        }
+
+        public JoinableTaskCollection JoinableTaskCollection { get; }
+
+        public JoinableTaskFactory JoinableTaskFactory { get; }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/PackageRestoreConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/PackageRestoreConfiguredInput.cs
@@ -1,5 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
+
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 {
     /// <summary>
@@ -7,10 +9,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
     /// </summary>
     internal class PackageRestoreConfiguredInput
     {
-        public PackageRestoreConfiguredInput(ProjectConfiguration projectConfiguration, ProjectRestoreInfo restoreInfo)
+        public PackageRestoreConfiguredInput(ProjectConfiguration projectConfiguration, ProjectRestoreInfo restoreInfo, IComparable configuredProjectVersion)
         {
             ProjectConfiguration = projectConfiguration;
             RestoreInfo = restoreInfo;
+            ConfiguredProjectVersion = configuredProjectVersion;
         }
 
         /// <summary>
@@ -22,5 +25,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         ///     Gets the restore information produced in this input.
         /// </summary>
         public ProjectRestoreInfo RestoreInfo { get; }
+
+        /// <summary>
+        ///     Get the project version produced in this input
+        /// </summary>
+        public IComparable ConfiguredProjectVersion { get; }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/UnconfiguredProjectFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/UnconfiguredProjectFactory.cs
@@ -23,6 +23,20 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return project.Object;
         }
 
+        public static UnconfiguredProject CreateWithActiveConfiguredProjectProvider(IProjectThreadingService threadingService)
+        {
+            var project = CreateDefault(threadingService);
+
+            var activeConfiguredProject = new Mock<IActiveConfiguredProjectProvider>().Object;
+            project.Setup(s => s.Services.ActiveConfiguredProjectProvider).Returns(activeConfiguredProject);
+
+            var configuredProject = new Mock<ConfiguredProject>();
+
+            project.Setup(s => s.Services.ActiveConfiguredProjectProvider!.ActiveConfiguredProject).Returns(configuredProject.Object);
+            project.Setup(s => s.Services.ActiveConfiguredProjectProvider!.ActiveConfiguredProject!.ProjectVersion).Returns(configuredProject.Object.ProjectVersion);
+            return project.Object;
+        }
+
         public static UnconfiguredProject Create(object? hostObject = null,
                                                  string? fullPath = null,
                                                  IProjectConfigurationsService? projectConfigurationsService = null,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionRestoreService4Factory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionRestoreService4Factory.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading;
+using Moq;
+
+namespace NuGet.SolutionRestoreManager
+{
+    internal static class IVsSolutionRestoreService4Factory
+    {
+        public static IVsSolutionRestoreService4 Create()
+        {
+            return Mock.Of<IVsSolutionRestoreService4>();
+        }
+
+        internal static IVsSolutionRestoreService4 ImplementRegisterRestoreInfoSourceAsync()
+        {
+            var mock = new Mock<IVsSolutionRestoreService4>();
+
+            mock.Setup(s => s.RegisterRestoreInfoSourceAsync(It.IsAny<IVsProjectRestoreInfoSource>(), It.IsAny<CancellationToken>()));
+
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/PackageRestoreConfiguredInputFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/PackageRestoreConfiguredInputFactory.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
+{
+    internal static class PackageRestoreConfiguredInputFactory
+    {
+        public static IReadOnlyCollection<PackageRestoreConfiguredInput>? Create(ProjectRestoreInfo restoreInfo)
+        {
+            ProjectConfiguration projectConfiguration = ProjectConfigurationFactory.Create("Debug|x64");
+            IComparable projectVersion = (IComparable)0;
+
+            return new PackageRestoreConfiguredInput[1]{new PackageRestoreConfiguredInput(projectConfiguration, restoreInfo, projectVersion)};
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/Snapshots/PackageRestoreDataSourceMocked.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/Snapshots/PackageRestoreDataSourceMocked.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.IO;
+using NuGet.SolutionRestoreManager;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore.Snapshots
+{
+    internal class PackageRestoreDataSourceMocked : PackageRestoreDataSource
+    {
+        public PackageRestoreDataSourceMocked(UnconfiguredProject project, 
+            IPackageRestoreUnconfiguredInputDataSource dataSource, 
+            IProjectAsynchronousTasksService projectAsynchronousTasksService, 
+            IVsSolutionRestoreService3 solutionRestoreService, 
+            IFileSystem fileSystem, 
+            IProjectDiagnosticOutputService logger, 
+            IProjectDependentFileChangeNotificationService projectDependentFileChangeNotificationService, 
+            IVsSolutionRestoreService4 solutionRestoreService4, 
+            PackageRestoreSharedJoinableTaskCollection sharedJoinableTaskCollection) 
+            : base(project, dataSource, projectAsynchronousTasksService, solutionRestoreService, fileSystem, logger, projectDependentFileChangeNotificationService, solutionRestoreService4, sharedJoinableTaskCollection)
+        {
+        }
+
+        protected override bool IsProjectConfigurationVersionOutOfDate(System.Collections.Generic.IReadOnlyCollection<PackageRestoreConfiguredInput>? configuredInputs)
+        {
+            return false;
+        }
+
+        protected override bool IsSavedNominationOutOfDate(ConfiguredProject activeConfiguredProject)
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
 This pr is a coordinated effort between NuGet and Project-system to [Add a contract for identifying a restore source, to help nuget better batch restores/branch switches](https://github.com/NuGet/Home/issues/10807) to fix #AB1283992


**The problem:**
Current implementation of NuGet Restore has some performance issues.
1) The excessive number of design time builds are largely coming from excessive number of NuGet restoring work. During that time frame, CPU is usage is very heavy, and it gets worse because the power usage throttling and thermal throttling of the laptop kicks in due to the excessive work, which makes it even worse.

2) NuGet uses a simple slide window to group projects for restoring. The time limitation is around 20s. If the gap to provide restore data between two projects are beyond that time, it starts to work.

i.e
Given a solution with 3 projects.
Proj A -> Proj B -> Proj C.

Say a Directory.Build.Props is edited that affect all projects.
Say the nominations come in the following order:

Proj B
Proj C
Proj A


1) When the nomination for B comes in, NuGet will trigger a restore that will affect projects B & A, given that A depends on B.
While that first restore runs, it possible that C & A nominations have arrived. When NuGet receives these nominations and the previous restore completes, which happens last, a new restore will be kicked off, with the nomination data for C & A.
This second restore will affect A, B & C. Project A & B have been restored twice, thus causing unnecessary work.
In the ideal scenario, only 1 restore for each 3 projects is done.

2) During solution loading time, it is possible that design time build of a project may fail. It will not notify NuGet, so if NuGet waits on all projects, it will never start to restore for all projects, when one project is in the bad state.
After loading the solution, it took 5+ minutes to get intellisense ready on a typical laptop. During that time, it runs 10 times more design time builds than the number of projects in the solution.


The current implementation is missing a handshake between project-system and NuGet to pass the required information about project nominations.

**The changes:**
Because `PackageRestoreDataSource` has all the information to decide if a project gets nominated or not, the implements the proposed api `IVsProjectRestoreInfoSource` (https://github.com/NuGet/NuGet.Client/pull/4058) should be here.

**How this changes fixes the problems:**
NuGet restoring a single project does not touch the project alone, it touches all projects transitively depend on it. If all projects are grouped together to do one restore, it is more like O(n) work, but if they are restored in very small groups, it can be close to O(n^2) times to update the project (mostly assert.json file, which contains the closure).

This API implementation coordinates solution restore when bulk operations to fix how NuGet group restoring work.

The goal of this implementation is to hold NuGet restore until all projects prepared the up to date data to NuGet.

At solution load, project-system runs DT builds and call the `IVsSolutionRestoreService` to nominate a project.
NuGet is aware of all projects that are supposed to nominate, so NuGet can wait for all projects to be nominated.

NuGet will be a polling `IVsProjectRestoreInfoSource`, so NuGet will call `HasPendingNomination` or `WhenNominated()` at any moment before it wants to start restoring process. It will hold the work, if any project is still preparing data. When the project sends data to NuGet, it will poll it again to make sure no other project is in that state in the new point of time.

Projects should only tell NuGet to hold restore, if it is working on computing the data, and plan to send it. If a project is in the error state, or it cannot pass a design time build, it should not hold NuGet restore to start.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7199)