### PR TITLE
Rename "contexts"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/SetLaunchProfilePropertyAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/SetLaunchProfilePropertyAction.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             {
                 var cache = state.Cache;
                 if (await cache.GetSuggestedConfigurationAsync() is ProjectConfiguration configuration
-                    && await cache.BindToRule(configuration, state.Rule.Name, state.Context) is IRule boundRule
+                    && await cache.BindToRule(configuration, state.Rule.Name, state.PropertiesContext) is IRule boundRule
                     && boundRule.GetProperty(_executableStep.PropertyName) is IProperty property)
                 {
                     await property.SetValueAsync(_executableStep.Value);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryByIdDataProducer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _projectService = projectService;
         }
 
-        protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext executionContext, EntityIdentity id)
+        protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext queryExecutionContext, EntityIdentity id)
         {
             if (id.KeysCount == 3
                 && id.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string projectPath)
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 && id.TryGetValue(ProjectModelIdentityKeys.CategoryName, out string categoryName))
             {
                 return CategoryDataProducer.CreateCategoryValueAsync(
-                    executionContext,
+                    queryExecutionContext,
                     id,
                     _projectService,
                     projectPath,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal static class CategoryDataProducer
     {
-        public static IEntityValue CreateCategoryValue(IQueryExecutionContext executionContext, IEntityValue parent, Rule rule, Category category, int order, ICategoryPropertiesAvailableStatus requestedProperties)
+        public static IEntityValue CreateCategoryValue(IQueryExecutionContext queryExecutionContext, IEntityValue parent, Rule rule, Category category, int order, ICategoryPropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(parent, nameof(parent));
             Requires.NotNull(category, nameof(category));
@@ -30,13 +30,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     new(ProjectModelIdentityKeys.CategoryName, category.Name)
                 });
 
-            return CreateCategoryValue(executionContext, identity, rule, category, order, requestedProperties);
+            return CreateCategoryValue(queryExecutionContext, identity, rule, category, order, requestedProperties);
         }
 
-        public static IEntityValue CreateCategoryValue(IQueryExecutionContext executionContext, EntityIdentity id, Rule rule, Category category, int order, ICategoryPropertiesAvailableStatus requestedProperties)
+        public static IEntityValue CreateCategoryValue(IQueryExecutionContext queryExecutionContext, EntityIdentity id, Rule rule, Category category, int order, ICategoryPropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(category, nameof(category));
-            var newCategory = new CategoryValue(executionContext.EntityRuntime, id, new CategoryPropertiesAvailableStatus());
+            var newCategory = new CategoryValue(queryExecutionContext.EntityRuntime, id, new CategoryPropertiesAvailableStatus());
 
             if (requestedProperties.DisplayName)
             {
@@ -58,19 +58,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             return newCategory;
         }
 
-        public static IEnumerable<IEntityValue> CreateCategoryValues(IQueryExecutionContext executionContext, IEntityValue parent, Rule rule, ICategoryPropertiesAvailableStatus requestedProperties)
+        public static IEnumerable<IEntityValue> CreateCategoryValues(IQueryExecutionContext queryExecutionContext, IEntityValue parent, Rule rule, ICategoryPropertiesAvailableStatus requestedProperties)
         {
             int index = 0;
             foreach (Category category in rule.EvaluatedCategories)
             {
-                IEntityValue categoryValue = CreateCategoryValue(executionContext, parent, rule, category, index, requestedProperties);
+                IEntityValue categoryValue = CreateCategoryValue(queryExecutionContext, parent, rule, category, index, requestedProperties);
                 yield return categoryValue;
                 index++;
             }
         }
 
         public static async Task<IEntityValue?> CreateCategoryValueAsync(
-            IQueryExecutionContext executionContext,
+            IQueryExecutionContext queryExecutionContext,
             EntityIdentity id,
             IProjectService2 projectService,
             string projectPath,
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         {
             if (projectService.GetLoadedProject(projectPath) is UnconfiguredProject project)
             {
-                executionContext.ReportProjectVersion(project);
+                queryExecutionContext.ReportProjectVersion(project);
 
                 if (await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
                     && projectCatalog.GetSchema(propertyPageName) is Rule rule)
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     {
                         if (StringComparers.CategoryNames.Equals(category.Name, categoryName))
                         {
-                            IEntityValue categoryValue = CreateCategoryValue(executionContext, id, rule, category, index, requestedProperties);
+                            IEntityValue categoryValue = CreateCategoryValue(queryExecutionContext, id, rule, category, index, requestedProperties);
                             return categoryValue;
                         }
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryFromRuleDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryFromRuleDataProducer.cs
@@ -22,12 +22,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _properties = properties;
         }
 
-        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext executionContext, IEntityValue parent, ContextAndRuleProviderState providerState)
+        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext queryExecutionContext, IEntityValue parent, ContextAndRuleProviderState providerState)
         {
             (string versionKey, long versionNumber) = providerState.Cache.GetUnconfiguredProjectVersion();
-            executionContext.ReportInputDataVersion(versionKey, versionNumber);
+            queryExecutionContext.ReportInputDataVersion(versionKey, versionNumber);
 
-            return Task.FromResult(CategoryDataProducer.CreateCategoryValues(executionContext, parent, providerState.Rule, _properties));
+            return Task.FromResult(CategoryDataProducer.CreateCategoryValues(queryExecutionContext, parent, providerState.Rule, _properties));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionFromPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ConfigurationDimensionFromPropertyDataProducer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _properties = properties;
         }
 
-        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext executionContext, IEntityValue parent, PropertyValueProviderState providerState)
+        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext queryExecutionContext, IEntityValue parent, PropertyValueProviderState providerState)
         {
             return Task.FromResult(ConfigurationDimensionDataProducer.CreateProjectConfigurationDimensions(
                 parent,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ContextAndRuleProviderState.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ContextAndRuleProviderState.cs
@@ -12,15 +12,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal sealed class ContextAndRuleProviderState
     {
-        public ContextAndRuleProviderState(IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, Rule rule)
+        public ContextAndRuleProviderState(IPropertyPageQueryCache cache, QueryProjectPropertiesContext propertiesContext, Rule rule)
         {
             Cache = cache;
-            Context = context;
+            PropertiesContext = propertiesContext;
             Rule = rule;
         }
 
         public IPropertyPageQueryCache Cache { get; }
-        public QueryProjectPropertiesContext Context { get; }
+        public QueryProjectPropertiesContext PropertiesContext { get; }
         public Rule Rule { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/IPropertyPageQueryCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/IPropertyPageQueryCache.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         /// <summary>
         /// Binds the specified schema to a particular context within the given project configuration.
         /// </summary>
-        Task<IRule?> BindToRule(ProjectConfiguration projectConfiguration, string schemaName, QueryProjectPropertiesContext context);
+        Task<IRule?> BindToRule(ProjectConfiguration projectConfiguration, string schemaName, QueryProjectPropertiesContext propertiesContext);
         Task<IImmutableSet<ProjectConfiguration>?> GetKnownConfigurationsAsync();
         Task<ProjectConfiguration?> GetSuggestedConfigurationAsync();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileByIdDataProducer.cs
@@ -25,18 +25,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _queryCacheProvider = queryCacheProvider;
         }
 
-        protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext executionContext, EntityIdentity id)
+        protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext queryExecutionContext, EntityIdentity id)
         {
             if (QueryProjectPropertiesContext.TryCreateFromEntityId(id, out QueryProjectPropertiesContext? context)
                 && StringComparers.ItemTypes.Equals(context.ItemType, "LaunchProfile"))
             {
-                return CreateLaunchProfileValueAsync(executionContext, id, context);
+                return CreateLaunchProfileValueAsync(queryExecutionContext, id, context);
             }
 
             return NullEntityValue;
         }
 
-        private async Task<IEntityValue?> CreateLaunchProfileValueAsync(IQueryExecutionContext executionContext, EntityIdentity id, QueryProjectPropertiesContext context)
+        private async Task<IEntityValue?> CreateLaunchProfileValueAsync(IQueryExecutionContext queryExecutionContext, EntityIdentity id, QueryProjectPropertiesContext context)
         {
             if (_projectService.GetLoadedProject(context.File) is UnconfiguredProject project
                 && project.Services.ExportProvider.GetExportedValueOrDefault<ILaunchSettingsProvider>() is ILaunchSettingsProvider launchSettingsProvider
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                                 IPropertyPageQueryCache? queryCache = _queryCacheProvider.CreateCache(project);
 
                                 IEntityValue launchProfileValue = LaunchProfileDataProducer.CreateLaunchProfileValue(
-                                    executionContext,
+                                    queryExecutionContext,
                                     id,
                                     context,
                                     rule,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileDataProducer.cs
@@ -11,9 +11,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {
     internal static class LaunchProfileDataProducer
     {
-        public static IEntityValue CreateLaunchProfileValue(IQueryExecutionContext executionContext, EntityIdentity id, QueryProjectPropertiesContext context, Rule rule, int order, IPropertyPageQueryCache cache, ILaunchProfilePropertiesAvailableStatus properties)
+        public static IEntityValue CreateLaunchProfileValue(IQueryExecutionContext queryExecutionContext, EntityIdentity id, QueryProjectPropertiesContext context, Rule rule, int order, IPropertyPageQueryCache cache, ILaunchProfilePropertiesAvailableStatus properties)
         {
-            LaunchProfileValue newLaunchProfile = new(executionContext.EntityRuntime, id, new LaunchProfilePropertiesAvailableStatus());
+            LaunchProfileValue newLaunchProfile = new(queryExecutionContext.EntityRuntime, id, new LaunchProfilePropertiesAvailableStatus());
 
             if (properties.Name)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileDataProducer.cs
@@ -11,13 +11,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {
     internal static class LaunchProfileDataProducer
     {
-        public static IEntityValue CreateLaunchProfileValue(IQueryExecutionContext queryExecutionContext, EntityIdentity id, QueryProjectPropertiesContext context, Rule rule, int order, IPropertyPageQueryCache cache, ILaunchProfilePropertiesAvailableStatus properties)
+        public static IEntityValue CreateLaunchProfileValue(IQueryExecutionContext queryExecutionContext, EntityIdentity id, QueryProjectPropertiesContext propertiesContext, Rule rule, int order, IPropertyPageQueryCache cache, ILaunchProfilePropertiesAvailableStatus properties)
         {
             LaunchProfileValue newLaunchProfile = new(queryExecutionContext.EntityRuntime, id, new LaunchProfilePropertiesAvailableStatus());
 
             if (properties.Name)
             {
-                newLaunchProfile.Name = context.ItemName;
+                newLaunchProfile.Name = propertiesContext.ItemName;
             }
 
             if (properties.CommandName)
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 newLaunchProfile.Order = order;
             }
 
-            ((IEntityValueFromProvider)newLaunchProfile).ProviderState = new ContextAndRuleProviderState(cache, context, rule);
+            ((IEntityValueFromProvider)newLaunchProfile).ProviderState = new ContextAndRuleProviderState(cache, propertiesContext, rule);
 
             return newLaunchProfile;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileFromProjectDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileFromProjectDataProducer.cs
@@ -26,12 +26,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _queryCacheProvider = queryCacheProvider;
         }
 
-        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext executionContext, IEntityValue parent, UnconfiguredProject providerState)
+        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext queryExecutionContext, IEntityValue parent, UnconfiguredProject providerState)
         {
-            return CreateLaunchProfileValuesAsync(executionContext, parent, providerState);
+            return CreateLaunchProfileValuesAsync(queryExecutionContext, parent, providerState);
         }
 
-        private async Task<IEnumerable<IEntityValue>> CreateLaunchProfileValuesAsync(IQueryExecutionContext executionContext, IEntityValue parent, UnconfiguredProject project)
+        private async Task<IEnumerable<IEntityValue>> CreateLaunchProfileValuesAsync(IQueryExecutionContext queryExecutionContext, IEntityValue parent, UnconfiguredProject project)
         {
             if (project.Services.ExportProvider.GetExportedValueOrDefault<ILaunchSettingsProvider>() is ILaunchSettingsProvider launchSettingsProvider
                 && await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
@@ -68,14 +68,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                             itemType: LaunchProfileProjectItemProvider.ItemType,
                             itemName: profile.Name);
 
-                        IEntityValue launchProfileValue = CreateLaunchProfileValue(executionContext, parent, context, rule, index, propertyPageQueryCache);
+                        IEntityValue launchProfileValue = CreateLaunchProfileValue(queryExecutionContext, parent, context, rule, index, propertyPageQueryCache);
                         yield return launchProfileValue;
                     }
                 }
             }
         }
 
-        private IEntityValue CreateLaunchProfileValue(IQueryExecutionContext executionContext, IEntityValue parent, QueryProjectPropertiesContext context, Rule rule, int order, IPropertyPageQueryCache propertyPageQueryCache)
+        private IEntityValue CreateLaunchProfileValue(IQueryExecutionContext queryExecutionContext, IEntityValue parent, QueryProjectPropertiesContext context, Rule rule, int order, IPropertyPageQueryCache propertyPageQueryCache)
         {
             EntityIdentity identity = new(
                 ((IEntityWithId)parent).Id,
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     { ProjectModelIdentityKeys.SourceItemName, context.ItemName! }
                 });
 
-            return LaunchProfileDataProducer.CreateLaunchProfileValue(executionContext, identity, context, rule, order, propertyPageQueryCache, _properties);
+            return LaunchProfileDataProducer.CreateLaunchProfileValue(queryExecutionContext, identity, context, rule, order, propertyPageQueryCache, _properties);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileFromProjectDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileFromProjectDataProducer.cs
@@ -62,30 +62,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                         && !Strings.IsNullOrEmpty(profile.CommandName)
                         && debugRules.TryGetValue(profile.CommandName, out Rule rule))
                     {
-                        QueryProjectPropertiesContext context = new(
+                        QueryProjectPropertiesContext propertiesContext = new(
                             isProjectFile: true,
                             file: project.FullPath,
                             itemType: LaunchProfileProjectItemProvider.ItemType,
                             itemName: profile.Name);
 
-                        IEntityValue launchProfileValue = CreateLaunchProfileValue(queryExecutionContext, parent, context, rule, index, propertyPageQueryCache);
+                        IEntityValue launchProfileValue = CreateLaunchProfileValue(queryExecutionContext, parent, propertiesContext, rule, index, propertyPageQueryCache);
                         yield return launchProfileValue;
                     }
                 }
             }
         }
 
-        private IEntityValue CreateLaunchProfileValue(IQueryExecutionContext queryExecutionContext, IEntityValue parent, QueryProjectPropertiesContext context, Rule rule, int order, IPropertyPageQueryCache propertyPageQueryCache)
+        private IEntityValue CreateLaunchProfileValue(IQueryExecutionContext queryExecutionContext, IEntityValue parent, QueryProjectPropertiesContext propertiesContext, Rule rule, int order, IPropertyPageQueryCache propertyPageQueryCache)
         {
             EntityIdentity identity = new(
                 ((IEntityWithId)parent).Id,
                 new Dictionary<string, string>
                 {
-                    { ProjectModelIdentityKeys.SourceItemType, context.ItemType! },
-                    { ProjectModelIdentityKeys.SourceItemName, context.ItemName! }
+                    { ProjectModelIdentityKeys.SourceItemType, propertiesContext.ItemType! },
+                    { ProjectModelIdentityKeys.SourceItemName, propertiesContext.ItemName! }
                 });
 
-            return LaunchProfileDataProducer.CreateLaunchProfileValue(queryExecutionContext, identity, context, rule, order, propertyPageQueryCache, _properties);
+            return LaunchProfileDataProducer.CreateLaunchProfileValue(queryExecutionContext, identity, propertiesContext, rule, order, propertyPageQueryCache, _properties);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileTypeDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileTypeDataProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
             _properties = properties;
         }
 
-        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext executionContext, IEntityValue parent, UnconfiguredProject providerState)
+        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext queryExecutionContext, IEntityValue parent, UnconfiguredProject providerState)
         {
             return CreateLaunchProfileTypeValuesAsync(parent, providerState);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageByIdDataProducer.cs
@@ -28,13 +28,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _queryCacheProvider = queryCacheProvider;
         }
 
-        protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext executionContext, EntityIdentity id)
+        protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext queryExecutionContext, EntityIdentity id)
         {
             if (QueryProjectPropertiesContext.TryCreateFromEntityId(id, out QueryProjectPropertiesContext? context)
                 && id.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName))
             {
                 return PropertyPageDataProducer.CreatePropertyPageValueAsync(
-                    executionContext,
+                    queryExecutionContext,
                     id,
                     _projectService,
                     _queryCacheProvider,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageByIdDataProducer.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext queryExecutionContext, EntityIdentity id)
         {
-            if (QueryProjectPropertiesContext.TryCreateFromEntityId(id, out QueryProjectPropertiesContext? context)
+            if (QueryProjectPropertiesContext.TryCreateFromEntityId(id, out QueryProjectPropertiesContext? propertiesContext)
                 && id.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName))
             {
                 return PropertyPageDataProducer.CreatePropertyPageValueAsync(
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     id,
                     _projectService,
                     _queryCacheProvider,
-                    context,
+                    propertiesContext,
                     propertyPageName,
                     _properties);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal static class PropertyPageDataProducer
     {
-        public static IEntityValue CreatePropertyPageValue(IQueryExecutionContext executionContext, IEntityValue parent, IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, Rule rule, IPropertyPagePropertiesAvailableStatus requestedProperties)
+        public static IEntityValue CreatePropertyPageValue(IQueryExecutionContext queryExecutionContext, IEntityValue parent, IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, Rule rule, IPropertyPagePropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(parent, nameof(parent));
             Requires.NotNull(rule, nameof(rule));
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 ((IEntityWithId)parent).Id,
                 createKeys());
 
-            return CreatePropertyPageValue(executionContext, identity, cache, context, rule, requestedProperties);
+            return CreatePropertyPageValue(queryExecutionContext, identity, cache, context, rule, requestedProperties);
 
             IEnumerable<KeyValuePair<string, string>> createKeys()
             {
@@ -45,10 +45,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             }
         }
 
-        public static IEntityValue CreatePropertyPageValue(IQueryExecutionContext executionContext, EntityIdentity id, IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, Rule rule, IPropertyPagePropertiesAvailableStatus requestedProperties)
+        public static IEntityValue CreatePropertyPageValue(IQueryExecutionContext queryExecutionContext, EntityIdentity id, IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, Rule rule, IPropertyPagePropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(rule, nameof(rule));
-            var newPropertyPage = new PropertyPageValue(executionContext.EntityRuntime, id, new PropertyPagePropertiesAvailableStatus());
+            var newPropertyPage = new PropertyPageValue(queryExecutionContext.EntityRuntime, id, new PropertyPagePropertiesAvailableStatus());
 
             if (requestedProperties.Name)
             {
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         }
 
         public static async Task<IEntityValue?> CreatePropertyPageValueAsync(
-            IQueryExecutionContext executionContext,
+            IQueryExecutionContext queryExecutionContext,
             EntityIdentity id,
             IProjectService2 projectService,
             IPropertyPageQueryCacheProvider queryCacheProvider,
@@ -87,14 +87,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             if (projectService.GetLoadedProject(context.File) is UnconfiguredProject project)
             {
                 project.GetQueryDataVersion(out string versionKey, out long versionNumber);
-                executionContext.ReportInputDataVersion(versionKey, versionNumber);
+                queryExecutionContext.ReportInputDataVersion(versionKey, versionNumber);
 
                 if (await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
                     && projectCatalog.GetSchema(propertyPageName) is Rule rule
                     && !rule.PropertyPagesHidden)
                 {
                     IPropertyPageQueryCache propertyPageQueryCache = queryCacheProvider.CreateCache(project);
-                    IEntityValue propertyPageValue = CreatePropertyPageValue(executionContext, id, propertyPageQueryCache, context, rule, requestedProperties);
+                    IEntityValue propertyPageValue = CreatePropertyPageValue(queryExecutionContext, id, propertyPageQueryCache, context, rule, requestedProperties);
                     return propertyPageValue;
                 }
             }
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         }
 
         public static async Task<IEnumerable<IEntityValue>> CreatePropertyPageValuesAsync(
-            IQueryExecutionContext executionContext,
+            IQueryExecutionContext queryExecutionContext,
             IEntityValue parent,
             UnconfiguredProject project,
             IPropertyPageQueryCacheProvider queryCacheProvider,
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     if (projectCatalog.GetSchema(schemaName) is Rule rule
                         && !rule.PropertyPagesHidden)
                     {
-                        IEntityValue propertyPageValue = CreatePropertyPageValue(executionContext, parent, propertyPageQueryCache, context, rule, requestedProperties: requestedProperties);
+                        IEntityValue propertyPageValue = CreatePropertyPageValue(queryExecutionContext, parent, propertyPageQueryCache, context, rule, requestedProperties: requestedProperties);
                         yield return propertyPageValue;
                     }
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageFromProjectDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageFromProjectDataProducer.cs
@@ -22,11 +22,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _queryCacheProvider = queryCacheProvider;
         }
 
-        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext executionContext, IEntityValue parent, UnconfiguredProject providerState)
+        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext queryExecutionContext, IEntityValue parent, UnconfiguredProject providerState)
         {
-            executionContext.ReportProjectVersion(providerState);
+            queryExecutionContext.ReportProjectVersion(providerState);
 
-            return PropertyPageDataProducer.CreatePropertyPageValuesAsync(executionContext, parent, providerState, _queryCacheProvider, _properties);
+            return PropertyPageDataProducer.CreatePropertyPageValuesAsync(queryExecutionContext, parent, providerState, _queryCacheProvider, _properties);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageQueryCache.cs
@@ -87,11 +87,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         /// <summary>
         /// Retrieves the <see cref="IRule"/> with name "<paramref name="schemaName"/>" within the given <paramref
-        /// name="projectConfiguration"/> and <paramref name="context"/>.
+        /// name="projectConfiguration"/> and <paramref name="propertiesContext"/>.
         /// </summary>
-        public async Task<IRule?> BindToRule(ProjectConfiguration projectConfiguration, string schemaName, QueryProjectPropertiesContext context)
+        public async Task<IRule?> BindToRule(ProjectConfiguration projectConfiguration, string schemaName, QueryProjectPropertiesContext propertiesContext)
         {
-            if (_ruleCache.TryGetValue((projectConfiguration, schemaName, context), out IRule? cachedRule))
+            if (_ruleCache.TryGetValue((projectConfiguration, schemaName, propertiesContext), out IRule? cachedRule))
             {
                 return cachedRule;
             }
@@ -99,10 +99,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             IRule? rule = null;
             if (await GetProjectLevelPropertyPagesCatalogAsync(projectConfiguration) is IPropertyPagesCatalog catalog)
             {
-                rule = catalog.BindToContext(schemaName, context);
+                rule = catalog.BindToContext(schemaName, propertiesContext);
             }
 
-            _ruleCache.Add((projectConfiguration, schemaName, context), rule);
+            _ruleCache.Add((projectConfiguration, schemaName, propertiesContext), rule);
             return rule;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyProviderState.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyProviderState.cs
@@ -11,17 +11,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal sealed class PropertyProviderState
     {
-        public PropertyProviderState(IPropertyPageQueryCache cache, Rule containingRule, QueryProjectPropertiesContext context, string propertyName)
+        public PropertyProviderState(IPropertyPageQueryCache cache, Rule containingRule, QueryProjectPropertiesContext propertiesContext, string propertyName)
         {
             Cache = cache;
             ContainingRule = containingRule;
-            Context = context;
+            PropertiesContext = propertiesContext;
             PropertyName = propertyName;
         }
 
         public IPropertyPageQueryCache Cache { get; }
         public Rule ContainingRule { get; }
-        public QueryProjectPropertiesContext Context { get; }
+        public QueryProjectPropertiesContext PropertiesContext { get; }
         public string PropertyName { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryProjectPropertiesContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryProjectPropertiesContext.cs
@@ -85,17 +85,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         /// Creates a <see cref="QueryProjectPropertiesContext"/> from a Project Query API
         /// <see cref="EntityIdentity"/>.
         /// </summary>
-        public static bool TryCreateFromEntityId(EntityIdentity id, [NotNullWhen(true)] out QueryProjectPropertiesContext? context)
+        public static bool TryCreateFromEntityId(EntityIdentity id, [NotNullWhen(true)] out QueryProjectPropertiesContext? propertiesContext)
         {
             if (id.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string projectPath))
             {
                 id.TryGetValue(ProjectModelIdentityKeys.SourceItemType, out string? itemType);
                 id.TryGetValue(ProjectModelIdentityKeys.SourceItemName, out string? itemName);
-                context = new QueryProjectPropertiesContext(isProjectFile: true, projectPath, itemType, itemName);
+                propertiesContext = new QueryProjectPropertiesContext(isProjectFile: true, projectPath, itemType, itemName);
                 return true;
             }
 
-            context = null;
+            propertiesContext = null;
             return false;
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueFromPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueFromPropertyDataProducer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _properties = properties;
         }
 
-        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext executionContext, IEntityValue parent, PropertyValueProviderState providerState)
+        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext queryExecutionContext, IEntityValue parent, PropertyValueProviderState providerState)
         {
             return SupportedValueDataProducer.CreateSupportedValuesAsync(parent, providerState.Property, _properties);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataFromValueEditorProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIEditorMetadataFromValueEditorProducer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _properties = properties;
         }
 
-        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext executionContext, IEntityValue parent, ValueEditor providerState)
+        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext queryExecutionContext, IEntityValue parent, ValueEditor providerState)
         {
             return Task.FromResult(UIEditorMetadataProducer.CreateMetadataValues(parent, providerState, _properties));
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyByIdProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyByIdProducer.cs
@@ -26,14 +26,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _queryCacheProvider = queryCacheProvider;
         }
 
-        protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext executionContext, EntityIdentity id)
+        protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext queryExecutionContext, EntityIdentity id)
         {
             if (QueryProjectPropertiesContext.TryCreateFromEntityId(id, out QueryProjectPropertiesContext? context)
                 && id.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName)
                 && id.TryGetValue(ProjectModelIdentityKeys.UIPropertyName, out string propertyName))
             {
                 return UIPropertyDataProducer.CreateUIPropertyValueAsync(
-                    executionContext,
+                    queryExecutionContext,
                     id,
                     _projectService,
                     _queryCacheProvider,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyByIdProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyByIdProducer.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext queryExecutionContext, EntityIdentity id)
         {
-            if (QueryProjectPropertiesContext.TryCreateFromEntityId(id, out QueryProjectPropertiesContext? context)
+            if (QueryProjectPropertiesContext.TryCreateFromEntityId(id, out QueryProjectPropertiesContext? propertiesContext)
                 && id.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName)
                 && id.TryGetValue(ProjectModelIdentityKeys.UIPropertyName, out string propertyName))
             {
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     id,
                     _projectService,
                     _queryCacheProvider,
-                    context,
+                    propertiesContext,
                     propertyPageName,
                     propertyName,
                     _properties);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal static class UIPropertyDataProducer
     {
-        public static IEntityValue CreateUIPropertyValue(IQueryExecutionContext executionContext, IEntityValue parent, IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, BaseProperty property, int order, IUIPropertyPropertiesAvailableStatus requestedProperties)
+        public static IEntityValue CreateUIPropertyValue(IQueryExecutionContext queryExecutionContext, IEntityValue parent, IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, BaseProperty property, int order, IUIPropertyPropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(parent, nameof(parent));
             Requires.NotNull(property, nameof(property));
@@ -30,13 +30,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     new(ProjectModelIdentityKeys.UIPropertyName, property.Name)
                 });
 
-            return CreateUIPropertyValue(executionContext, identity, cache, context, property, order, requestedProperties);
+            return CreateUIPropertyValue(queryExecutionContext, identity, cache, context, property, order, requestedProperties);
         }
 
-        public static IEntityValue CreateUIPropertyValue(IQueryExecutionContext executionContext, EntityIdentity id, IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, BaseProperty property, int order, IUIPropertyPropertiesAvailableStatus requestedProperties)
+        public static IEntityValue CreateUIPropertyValue(IQueryExecutionContext queryExecutionContext, EntityIdentity id, IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, BaseProperty property, int order, IUIPropertyPropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(property, nameof(property));
-            var newUIProperty = new UIPropertyValue(executionContext.EntityRuntime, id, new UIPropertyPropertiesAvailableStatus());
+            var newUIProperty = new UIPropertyValue(queryExecutionContext.EntityRuntime, id, new UIPropertyPropertiesAvailableStatus());
 
             if (requestedProperties.Name)
             {
@@ -114,20 +114,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             return newUIProperty;
         }
 
-        public static IEnumerable<IEntityValue> CreateUIPropertyValues(IQueryExecutionContext executionContext, IEntityValue parent, IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, Rule rule, IUIPropertyPropertiesAvailableStatus properties)
+        public static IEnumerable<IEntityValue> CreateUIPropertyValues(IQueryExecutionContext queryExecutionContext, IEntityValue parent, IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, Rule rule, IUIPropertyPropertiesAvailableStatus properties)
         {
             foreach ((int index, BaseProperty property) in rule.Properties.WithIndices())
             {
                 if (property.Visible)
                 {
-                    IEntityValue propertyValue = CreateUIPropertyValue(executionContext, parent, cache, context, property, index, properties);
+                    IEntityValue propertyValue = CreateUIPropertyValue(queryExecutionContext, parent, cache, context, property, index, properties);
                     yield return propertyValue;
                 }
             }
         }
 
         public static async Task<IEntityValue?> CreateUIPropertyValueAsync(
-            IQueryExecutionContext executionContext,
+            IQueryExecutionContext queryExecutionContext,
             EntityIdentity requestId,
             IProjectService2 projectService,
             IPropertyPageQueryCacheProvider queryCacheProvider,
@@ -139,7 +139,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             if (projectService.GetLoadedProject(context.File) is UnconfiguredProject project)
             {
                 project.GetQueryDataVersion(out string versionKey, out long versionNumber);
-                executionContext.ReportInputDataVersion(versionKey, versionNumber);
+                queryExecutionContext.ReportInputDataVersion(versionKey, versionNumber);
 
                 if (await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
                     && projectCatalog.GetSchema(propertyPageName) is Rule rule
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     && property.Visible)
                 {
                     IPropertyPageQueryCache cache = queryCacheProvider.CreateCache(project);
-                    IEntityValue propertyValue = CreateUIPropertyValue(executionContext, requestId, cache, context, property, index, requestedProperties);
+                    IEntityValue propertyValue = CreateUIPropertyValue(queryExecutionContext, requestId, cache, context, property, index, requestedProperties);
                     return propertyValue;
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal static class UIPropertyDataProducer
     {
-        public static IEntityValue CreateUIPropertyValue(IQueryExecutionContext queryExecutionContext, IEntityValue parent, IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, BaseProperty property, int order, IUIPropertyPropertiesAvailableStatus requestedProperties)
+        public static IEntityValue CreateUIPropertyValue(IQueryExecutionContext queryExecutionContext, IEntityValue parent, IPropertyPageQueryCache cache, QueryProjectPropertiesContext propertiesContext, BaseProperty property, int order, IUIPropertyPropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(parent, nameof(parent));
             Requires.NotNull(property, nameof(property));
@@ -30,10 +30,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     new(ProjectModelIdentityKeys.UIPropertyName, property.Name)
                 });
 
-            return CreateUIPropertyValue(queryExecutionContext, identity, cache, context, property, order, requestedProperties);
+            return CreateUIPropertyValue(queryExecutionContext, identity, cache, propertiesContext, property, order, requestedProperties);
         }
 
-        public static IEntityValue CreateUIPropertyValue(IQueryExecutionContext queryExecutionContext, EntityIdentity id, IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, BaseProperty property, int order, IUIPropertyPropertiesAvailableStatus requestedProperties)
+        public static IEntityValue CreateUIPropertyValue(IQueryExecutionContext queryExecutionContext, EntityIdentity id, IPropertyPageQueryCache cache, QueryProjectPropertiesContext propertiesContext, BaseProperty property, int order, IUIPropertyPropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(property, nameof(property));
             var newUIProperty = new UIPropertyValue(queryExecutionContext.EntityRuntime, id, new UIPropertyPropertiesAvailableStatus());
@@ -109,18 +109,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 newUIProperty.VisibilityCondition = visibilityCondition ?? string.Empty;
             }
 
-            ((IEntityValueFromProvider)newUIProperty).ProviderState = new PropertyProviderState(cache, property.ContainingRule, context, property.Name);
+            ((IEntityValueFromProvider)newUIProperty).ProviderState = new PropertyProviderState(cache, property.ContainingRule, propertiesContext, property.Name);
 
             return newUIProperty;
         }
 
-        public static IEnumerable<IEntityValue> CreateUIPropertyValues(IQueryExecutionContext queryExecutionContext, IEntityValue parent, IPropertyPageQueryCache cache, QueryProjectPropertiesContext context, Rule rule, IUIPropertyPropertiesAvailableStatus properties)
+        public static IEnumerable<IEntityValue> CreateUIPropertyValues(IQueryExecutionContext queryExecutionContext, IEntityValue parent, IPropertyPageQueryCache cache, QueryProjectPropertiesContext propertiesContext, Rule rule, IUIPropertyPropertiesAvailableStatus properties)
         {
             foreach ((int index, BaseProperty property) in rule.Properties.WithIndices())
             {
                 if (property.Visible)
                 {
-                    IEntityValue propertyValue = CreateUIPropertyValue(queryExecutionContext, parent, cache, context, property, index, properties);
+                    IEntityValue propertyValue = CreateUIPropertyValue(queryExecutionContext, parent, cache, propertiesContext, property, index, properties);
                     yield return propertyValue;
                 }
             }
@@ -131,12 +131,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             EntityIdentity requestId,
             IProjectService2 projectService,
             IPropertyPageQueryCacheProvider queryCacheProvider,
-            QueryProjectPropertiesContext context,
+            QueryProjectPropertiesContext propertiesContext,
             string propertyPageName,
             string propertyName,
             IUIPropertyPropertiesAvailableStatus requestedProperties)
         {
-            if (projectService.GetLoadedProject(context.File) is UnconfiguredProject project)
+            if (projectService.GetLoadedProject(propertiesContext.File) is UnconfiguredProject project)
             {
                 project.GetQueryDataVersion(out string versionKey, out long versionNumber);
                 queryExecutionContext.ReportInputDataVersion(versionKey, versionNumber);
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     && property.Visible)
                 {
                     IPropertyPageQueryCache cache = queryCacheProvider.CreateCache(project);
-                    IEntityValue propertyValue = CreateUIPropertyValue(queryExecutionContext, requestId, cache, context, property, index, requestedProperties);
+                    IEntityValue propertyValue = CreateUIPropertyValue(queryExecutionContext, requestId, cache, propertiesContext, property, index, requestedProperties);
                     return propertyValue;
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorByIdDataProducer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _projectService = projectService;
         }
 
-        protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext executionContext, EntityIdentity id)
+        protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext queryExecutionContext, EntityIdentity id)
         {
             if (id.KeysCount == 4
                 && id.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string projectPath)
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 && id.TryGetValue(ProjectModelIdentityKeys.EditorName, out string editorName))
             {
                 return UIPropertyEditorDataProducer.CreateEditorValueAsync(
-                    executionContext,
+                    queryExecutionContext,
                     id,
                     _projectService,
                     projectPath,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// </summary>
     internal static class UIPropertyEditorDataProducer
     {
-        public static IEntityValue CreateEditorValue(IQueryExecutionContext executionContext, IEntityValue parent, ValueEditor editor, IUIPropertyEditorPropertiesAvailableStatus requestedProperties)
+        public static IEntityValue CreateEditorValue(IQueryExecutionContext queryExecutionContext, IEntityValue parent, ValueEditor editor, IUIPropertyEditorPropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(parent, nameof(parent));
             Requires.NotNull(editor, nameof(editor));
@@ -30,13 +30,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     new(ProjectModelIdentityKeys.EditorName, editor.EditorType)
                 });
 
-            return CreateEditorValue(executionContext, identity, editor, requestedProperties);
+            return CreateEditorValue(queryExecutionContext, identity, editor, requestedProperties);
         }
 
-        public static IEntityValue CreateEditorValue(IQueryExecutionContext executionContext, EntityIdentity identity, ValueEditor editor, IUIPropertyEditorPropertiesAvailableStatus requestedProperties)
+        public static IEntityValue CreateEditorValue(IQueryExecutionContext queryExecutionContext, EntityIdentity identity, ValueEditor editor, IUIPropertyEditorPropertiesAvailableStatus requestedProperties)
         {
             Requires.NotNull(editor, nameof(editor));
-            var newEditorValue = new UIPropertyEditorValue(executionContext.EntityRuntime, identity, new UIPropertyEditorPropertiesAvailableStatus());
+            var newEditorValue = new UIPropertyEditorValue(queryExecutionContext.EntityRuntime, identity, new UIPropertyEditorPropertiesAvailableStatus());
 
             if (requestedProperties.Name)
             {
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             return newEditorValue;
         }
 
-        public static IEnumerable<IEntityValue> CreateEditorValues(IQueryExecutionContext executionContext, IEntityValue parent, Rule schema, string propertyName, IUIPropertyEditorPropertiesAvailableStatus properties)
+        public static IEnumerable<IEntityValue> CreateEditorValues(IQueryExecutionContext queryExecutionContext, IEntityValue parent, Rule schema, string propertyName, IUIPropertyEditorPropertiesAvailableStatus properties)
         {
             BaseProperty? property = schema.GetProperty(propertyName);
             if (property is not null)
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             {
                 foreach (ValueEditor editor in property.ValueEditors)
                 {
-                    IEntityValue editorValue = CreateEditorValue(executionContext, parent, editor, properties);
+                    IEntityValue editorValue = CreateEditorValue(queryExecutionContext, parent, editor, properties);
                     yield return editorValue;
                 }
 
@@ -70,18 +70,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 {
                     if (stringProperty.Subtype == "file")
                     {
-                        yield return CreateEditorValue(executionContext, parent, new ValueEditor { EditorType = "FilePath" }, properties);
+                        yield return CreateEditorValue(queryExecutionContext, parent, new ValueEditor { EditorType = "FilePath" }, properties);
                     }
                     else if (stringProperty.Subtype == "directory")
                     {
-                        yield return CreateEditorValue(executionContext, parent, new ValueEditor { EditorType = "DirectoryPath" }, properties);
+                        yield return CreateEditorValue(queryExecutionContext, parent, new ValueEditor { EditorType = "DirectoryPath" }, properties);
                     }
                 }
             }
         }
 
         public static async Task<IEntityValue?> CreateEditorValueAsync(
-            IQueryExecutionContext executionContext,
+            IQueryExecutionContext queryExecutionContext,
             EntityIdentity requestId,
             IProjectService2 projectService,
             string projectPath,
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 && rule.GetProperty(propertyName) is BaseProperty property
                 && property.ValueEditors.FirstOrDefault(ed => string.Equals(ed.EditorType, editorName)) is ValueEditor editor)
             {
-                IEntityValue editorValue = CreateEditorValue(executionContext, requestId, editor, properties);
+                IEntityValue editorValue = CreateEditorValue(queryExecutionContext, requestId, editor, properties);
             }
 
             return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorFromUIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorFromUIPropertyDataProducer.cs
@@ -20,9 +20,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _properties = properties;
         }
 
-        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext executionContext, IEntityValue parent, PropertyProviderState providerState)
+        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext queryExecutionContext, IEntityValue parent, PropertyProviderState providerState)
         {
-            return Task.FromResult(UIPropertyEditorDataProducer.CreateEditorValues(executionContext, parent, providerState.ContainingRule, providerState.PropertyName, _properties));
+            return Task.FromResult(UIPropertyEditorDataProducer.CreateEditorValues(queryExecutionContext, parent, providerState.ContainingRule, providerState.PropertyName, _properties));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromRuleDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromRuleDataProducer.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             (string versionKey, long versionNumber) = providerState.Cache.GetUnconfiguredProjectVersion();
             queryExecutionContext.ReportInputDataVersion(versionKey, versionNumber);
 
-            return Task.FromResult(UIPropertyDataProducer.CreateUIPropertyValues(queryExecutionContext, parent, providerState.Cache, providerState.Context, providerState.Rule, _properties));
+            return Task.FromResult(UIPropertyDataProducer.CreateUIPropertyValues(queryExecutionContext, parent, providerState.Cache, providerState.PropertiesContext, providerState.Rule, _properties));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromRuleDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromRuleDataProducer.cs
@@ -21,12 +21,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _properties = properties;
         }
 
-        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext executionContext, IEntityValue parent, ContextAndRuleProviderState providerState)
+        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext queryExecutionContext, IEntityValue parent, ContextAndRuleProviderState providerState)
         {
             (string versionKey, long versionNumber) = providerState.Cache.GetUnconfiguredProjectVersion();
-            executionContext.ReportInputDataVersion(versionKey, versionNumber);
+            queryExecutionContext.ReportInputDataVersion(versionKey, versionNumber);
 
-            return Task.FromResult(UIPropertyDataProducer.CreateUIPropertyValues(executionContext, parent, providerState.Cache, providerState.Context, providerState.Rule, _properties));
+            return Task.FromResult(UIPropertyDataProducer.CreateUIPropertyValues(queryExecutionContext, parent, providerState.Cache, providerState.Context, providerState.Rule, _properties));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             IEntityValue parent,
             IPropertyPageQueryCache cache,
             Rule schema,
-            QueryProjectPropertiesContext context,
+            QueryProjectPropertiesContext propertiesContext,
             string propertyName,
             IUIPropertyValuePropertiesAvailableStatus requestedProperties)
         {
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 (string versionKey, long versionNumber) = await cache.GetConfiguredProjectVersionAsync(configuration);
                 queryExecutionContext.ReportInputDataVersion(versionKey, versionNumber);
 
-                if (await cache.BindToRule(configuration, schema.Name, context) is IRule rule
+                if (await cache.BindToRule(configuration, schema.Name, propertiesContext) is IRule rule
                     && rule.GetProperty(propertyName) is ProjectSystem.Properties.IProperty property)
                 {
                     IEntityValue propertyValue = await CreateUIPropertyValueValueAsync(parent, configuration, property, requestedProperties);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         }
 
         public static async Task<IEnumerable<IEntityValue>> CreateUIPropertyValueValuesAsync(
-            IQueryExecutionContext executionContext,
+            IQueryExecutionContext queryExecutionContext,
             IEntityValue parent,
             IPropertyPageQueryCache cache,
             Rule schema,
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             foreach (ProjectConfiguration configuration in configurations)
             {
                 (string versionKey, long versionNumber) = await cache.GetConfiguredProjectVersionAsync(configuration);
-                executionContext.ReportInputDataVersion(versionKey, versionNumber);
+                queryExecutionContext.ReportInputDataVersion(versionKey, versionNumber);
 
                 if (await cache.BindToRule(configuration, schema.Name, context) is IRule rule
                     && rule.GetProperty(propertyName) is ProjectSystem.Properties.IProperty property)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueFromUIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueFromUIPropertyDataProducer.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 parent,
                 providerState.Cache,
                 providerState.ContainingRule,
-                providerState.Context,
+                providerState.PropertiesContext,
                 providerState.PropertyName,
                 _properties);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueFromUIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueFromUIPropertyDataProducer.cs
@@ -20,13 +20,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             _properties = properties;
         }
 
-        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext executionContext, IEntityValue parent, PropertyProviderState providerState)
+        protected override Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext queryExecutionContext, IEntityValue parent, PropertyProviderState providerState)
         {
             (string versionKey, long versionNumber) = providerState.Cache.GetUnconfiguredProjectVersion();
-            executionContext.ReportInputDataVersion(versionKey, versionNumber);
+            queryExecutionContext.ReportInputDataVersion(versionKey, versionNumber);
 
             return UIPropertyValueDataProducer.CreateUIPropertyValueValuesAsync(
-                executionContext,
+                queryExecutionContext,
                 parent,
                 providerState.Cache,
                 providerState.ContainingRule,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/QueryDataByIdProducerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/QueryDataByIdProducerBase.cs
@@ -37,6 +37,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             await ResultReceiver.OnRequestProcessFinishedAsync(request);
         }
 
-        protected abstract Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext executionContext, EntityIdentity id);
+        protected abstract Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext queryExecutionContext, EntityIdentity id);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/QueryDataFromProviderStateProducerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/QueryDataFromProviderStateProducerBase.cs
@@ -40,6 +40,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         /// Given the <paramref name="parent"/> entity and the associated <paramref name="providerState"/>,
         /// returns a set of child entities.
         /// </summary>
-        protected abstract Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext executionContext, IEntityValue parent, T providerState);
+        protected abstract Task<IEnumerable<IEntityValue>> CreateValuesAsync(IQueryExecutionContext queryExecutionContext, IEntityValue parent, T providerState);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/QueryVersionExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/QueryVersionExtensions.cs
@@ -6,16 +6,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 {
     internal static class QueryVersionExtensions
     {
-        public static void ReportProjectVersion(this IQueryExecutionContext executionContext, UnconfiguredProject unconfiguredProject)
+        public static void ReportProjectVersion(this IQueryExecutionContext queryExecutionContext, UnconfiguredProject unconfiguredProject)
         {
             unconfiguredProject.GetQueryDataVersion(out string versionKey, out long versionNumber);
-            executionContext.ReportInputDataVersion(versionKey, versionNumber);
+            queryExecutionContext.ReportInputDataVersion(versionKey, versionNumber);
         }
 
-        public static void ReportProjectUpdate(this IQueryExecutionContext executionContext, UnconfiguredProject unconfiguredProject)
+        public static void ReportProjectUpdate(this IQueryExecutionContext queryExecutionContext, UnconfiguredProject unconfiguredProject)
         {
             unconfiguredProject.GetQueryDataVersion(out string versionKey, out long versionNumber);
-            executionContext.ReportUpdatedDataVersion(versionKey, versionNumber);
+            queryExecutionContext.ReportUpdatedDataVersion(versionKey, versionNumber);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducerTests.cs
@@ -159,7 +159,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 parent,
                 cache,
                 schema,
-                context: QueryProjectPropertiesContext.ProjectFile,
+                propertiesContext: QueryProjectPropertiesContext.ProjectFile,
                 propertyName,
                 requestedProperties);
 


### PR DESCRIPTION
The Project Query API implementation has various kinds of "context" types. This change renames a number of parameters, locals, and fields to be clear about which kind of context they refer to.

This is a straight rename with no semantic changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7200)