### PR TITLE
Telemetry property/event names in lower case

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
@@ -676,8 +676,8 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
                 TelemetryService.DefaultSession.PostEvent(userTask)
             End Sub
 
-            Private Const EditorCreationEventName As String = ProjectSystemEventNamePrefix + "propertiespages/createEditor"
-            Private Const EditorCreationPropertyNamePrefix As String = ProjectSystemPropertyNamePrefix + "propertiespages.createEditor."
+            Private Const EditorCreationEventName As String = ProjectSystemEventNamePrefix + "propertiespages/createeditor"
+            Private Const EditorCreationPropertyNamePrefix As String = ProjectSystemPropertyNamePrefix + "propertiespages.createeditor."
 
             Public Shared Sub LogEditorCreation(useNewEditor As Boolean, fileName As String, physicalView As String)
                 Dim telemetryEvent As TelemetryEvent = New TelemetryEvent(EditorCreationEventName)


### PR DESCRIPTION
Telemetry property/event names are converted to lower case during publishing. By using a string which is not already lowercase, we trigger allocation of new strings.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7222)