### PR TITLE
Ignore temporary WPF vbproj files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ $RECYCLE.BIN/
 TRXUnit.zip
 RoslynTools.VSIXExpInstaller.zip
 *_wpftmp.csproj
+*_wpftmp.vbproj


### PR DESCRIPTION
These files are created during build, and should never be committed to the repository. Add them to the .gitignore file so they will not be.

We had previously added temporary WPF csproj files.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7224)