### PR TITLE
Remove usage of the 'evaluated' visibility condition function

### DIFF
--- a/docs/repo/property-pages/property-specification.md
+++ b/docs/repo/property-pages/property-specification.md
@@ -101,7 +101,7 @@ Here is a complex example of a string property that demonstrates the majority of
   <StringProperty.Metadata>
     <NameValuePair Name="DependsOn" Value="OtherPage::OtherProperty;OtherPage::AnotherProperty" />
     <NameValuePair Name="VisibilityCondition">
-      <NameValuePair.Value>(eq "SomeValue" (evaluated "OtherPage" "OtherProperty"))</NameValuePair.Value>
+      <NameValuePair.Value>(has-evaluated-value "OtherPage" "OtherProperty" "SomeValue")</NameValuePair.Value>
     </NameValuePair>
   </StringProperty.Metadata>
 </StringProperty>

--- a/docs/repo/property-pages/visibility-conditions.md
+++ b/docs/repo/property-pages/visibility-conditions.md
@@ -16,7 +16,7 @@ In a XAML rule file, a visibility condition is specified as metadata on the prop
 <StringProperty ...>
   <StringProperty.Metadata>
     <NameValuePair Name="VisibilityCondition">
-      <NameValuePair.Value>(has-evaluated-evalue "MyPage" "MyProperty" "Foo")</NameValuePair.Value>
+      <NameValuePair.Value>(has-evaluated-value "MyPage" "MyProperty" "Foo")</NameValuePair.Value>
     </NameValuePair>
   </StringProperty.Metadata>
 </StringProperty>
@@ -96,7 +96,7 @@ The following table details the default set of visibility expression functions:
 
 These functions are defined in class `VisibilityConditionEvaluator`.
 
-Note that there is no `evaluated` function. A propery may have multiple evaluated values, and as such it's not possible to reliably return a single value. Use `has-evaluated-value` instead.
+Note that there is no `evaluated` function. A property may have multiple evaluated values, and as such it's not possible to reliably return a single value. Use `has-evaluated-value` instead.
 
 ## Adding Functions
 

--- a/docs/repo/property-pages/visibility-conditions.md
+++ b/docs/repo/property-pages/visibility-conditions.md
@@ -16,7 +16,7 @@ In a XAML rule file, a visibility condition is specified as metadata on the prop
 <StringProperty ...>
   <StringProperty.Metadata>
     <NameValuePair Name="VisibilityCondition">
-      <NameValuePair.Value>(eq "Foo" (evaluated "MyPage" "MyProperty"))</NameValuePair.Value>
+      <NameValuePair.Value>(has-evaluated-evalue "MyPage" "MyProperty" "Foo")</NameValuePair.Value>
     </NameValuePair>
   </StringProperty.Metadata>
 </StringProperty>
@@ -55,10 +55,10 @@ These expressions compose nicely. An expression may be an argument to another fu
 
 To be useful in the context of the Project Properties UI, these expressions must be able to query the state of properties directly. Functions are included for doing so.
 
-The following expression returns the evaluated value of _MyProperty_ on _MyPage_:
+The following expression returns the unevaluated value of _MyProperty_ on _MyPage_:
 
 ```lisp
-(evaluated "MyPage" "MyProperty")
+(unevaluated "MyPage" "MyProperty")
 ```
 
 If _MyProperty_ is a boolean property, then this expression stands alone as a visibility condition and will cause the targeted property to only be visible when _MyProperty_ is true. However if _MyProperty_ has non-boolean type then further comparison is required.
@@ -66,7 +66,7 @@ If _MyProperty_ is a boolean property, then this expression stands alone as a vi
 For example, if _MyProperty_ is an enum property, the following expression may be used:
 
 ```lisp
-(eq "MyEnumValue" (evaluated "MyPage" "MyProperty"))
+(eq "MyEnumValue" (unevaluated "MyPage" "MyProperty"))
 ```
 
 Now, the property will only be visible if _MyProperty_ has value _MyEnumValue_.
@@ -89,13 +89,14 @@ The following table details the default set of visibility expression functions:
 | `or`                     | Variadic | Computes logical OR of arguments                                                                |
 | `xor`                    | 2        | Computes exclusive logical OR of arguments                                                      |
 | `not`                    | 1        | Computes logical NOT of argument                                                                |
-| `evaluated`              | 2        | Returns the evaluated value of property on page `arg0` with name `arg1`                         |
 | `unevaluated`            | 2        | Returns the unevaluated value of property on page `arg0` with name `arg1`                       |
 | `has-evaluated-value`    | 3        | Returns true if property on page `arg0` with name `arg1` has an evaluated value matching `arg2` |
 | `is-codespaces-client`   | 0        | Returns true if the Project Properties UI is running in a Codespaces client                     |
 | `has-project-capability` | 1        | Returns true if the project has the specified capability.                                       |
 
 These functions are defined in class `VisibilityConditionEvaluator`.
+
+Note that there is no `evaluated` function. A propery may have multiple evaluated values, and as such it's not possible to reliably return a single value. Use `has-evaluated-value` instead.
 
 ## Adding Functions
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -62,7 +62,7 @@
                        MultipleValuesAllowed="False">
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(not (evaluated "Application" "TargetMultipleFrameworks"))</NameValuePair.Value>
+        <NameValuePair.Value>(not (has-evaluated-value "Application" "TargetMultipleFrameworks" true))</NameValuePair.Value>
       </NameValuePair>
       <NameValuePair Name="SearchTerms" Value="TFM" />
       <NameValuePair Name="DependsOn" Value="Application::TargetMultipleFrameworks" />
@@ -80,7 +80,7 @@
     </StringProperty.DataSource>
     <StringProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(evaluated "Application" "TargetMultipleFrameworks")</NameValuePair.Value>
+        <NameValuePair.Value>(has-evaluated-value "Application" "TargetMultipleFrameworks" true)</NameValuePair.Value>
       </NameValuePair>
       <NameValuePair Name="SearchTerms" Value="TFM" />
       <NameValuePair Name="DependsOn" Value="Application::TargetMultipleFrameworks" />
@@ -111,7 +111,7 @@
                        EnumProvider="StartupObjectsEnumProvider">
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(ne (evaluated "Application" "OutputType") "Library")</NameValuePair.Value>
+        <NameValuePair.Value>(not (has-evaluated-value "Application" "OutputType" "Library"))</NameValuePair.Value>
       </NameValuePair>
     </DynamicEnumProperty.Metadata>
     <DynamicEnumProperty.ProviderSettings>
@@ -154,7 +154,7 @@
     <StringProperty.Metadata>
       <NameValuePair Name="DependsOn" Value="Application::ResourceSpecificationKind" />
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(eq (evaluated "Application" "ResourceSpecificationKind") "IconAndManifest")</NameValuePair.Value>
+        <NameValuePair.Value>(has-evaluated-value "Application" "ResourceSpecificationKind" "IconAndManifest")</NameValuePair.Value>
       </NameValuePair>
     </StringProperty.Metadata>
   </StringProperty>
@@ -171,7 +171,7 @@
     <EnumProperty.Metadata>
       <NameValuePair Name="DependsOn" Value="Application::ResourceSpecificationKind" />
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(eq (evaluated "Application" "ResourceSpecificationKind") "IconAndManifest")</NameValuePair.Value>
+        <NameValuePair.Value>(has-evaluated-value "Application" "ResourceSpecificationKind" "IconAndManifest")</NameValuePair.Value>
       </NameValuePair>
     </EnumProperty.Metadata>
     <EnumValue Name="DefaultManifest"
@@ -197,8 +197,8 @@
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
           (and 
-            (eq (evaluated "Application" "ApplicationManifestKind") "CustomManifest")
-            (eq (evaluated "Application" "ResourceSpecificationKind") "IconAndManifest"))
+            (has-evaluated-value "Application" "ApplicationManifestKind" "CustomManifest")
+            (has-evaluated-value "Application" "ResourceSpecificationKind" "IconAndManifest"))
         </NameValuePair.Value>
       </NameValuePair>
     </StringProperty.Metadata>
@@ -213,7 +213,7 @@
     <StringProperty.Metadata>
       <NameValuePair Name="DependsOn" Value="Application::ResourceSpecificationKind" />
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(eq (evaluated "Application" "ResourceSpecificationKind") "ResourceFile")</NameValuePair.Value>
+        <NameValuePair.Value>(has-evaluated-value "Application" "ResourceSpecificationKind" "ResourceFile")</NameValuePair.Value>
       </NameValuePair>
     </StringProperty.Metadata>
   </StringProperty>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -301,7 +301,7 @@
     </StringProperty.DataSource>
     <StringProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(evaluated "Build" "GenerateDocumentationFile")</NameValuePair.Value>
+        <NameValuePair.Value>(has-evaluated-value "Build" "GenerateDocumentationFile" true)</NameValuePair.Value>
       </NameValuePair>
     </StringProperty.Metadata>
   </StringProperty>
@@ -381,7 +381,7 @@
                   Subtype="file">
     <StringProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(evaluated "Build" "SignAssembly")</NameValuePair.Value>
+        <NameValuePair.Value>(has-evaluated-value "Build" "SignAssembly" true)</NameValuePair.Value>
       </NameValuePair>
     </StringProperty.Metadata>
     <StringProperty.DataSource>
@@ -398,7 +398,7 @@
                 Category="StrongNaming">
     <BoolProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(evaluated "Build" "SignAssembly")</NameValuePair.Value>
+        <NameValuePair.Value>(has-evaluated-value "Build" "SignAssembly" true)</NameValuePair.Value>
       </NameValuePair>
     </BoolProperty.Metadata>
     <BoolProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ExecutableDebugPropertyPage.xaml
@@ -47,7 +47,7 @@
                   Description="The name and port number of the remote machine in 'name:port' format.">
     <StringProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(evaluated "Executable" "RemoteDebugEnabled")</NameValuePair.Value>
+        <NameValuePair.Value>(has-evaluated-value "Executable" "RemoteDebugEnabled" true)</NameValuePair.Value>
       </NameValuePair>
       <NameValuePair Name="DependsOn" Value="Executable::RemoteDebugMachine" />
     </StringProperty.Metadata>
@@ -59,7 +59,7 @@
                        EnumProvider="AuthenticationModeEnumProvider">
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(evaluated "Executable" "RemoteDebugEnabled")</NameValuePair.Value>
+        <NameValuePair.Value>(has-evaluated-value "Executable" "RemoteDebugEnabled" true)</NameValuePair.Value>
       </NameValuePair>
       <NameValuePair Name="DependsOn" Value="Executable::RemoteDebugMachine" />
     </DynamicEnumProperty.Metadata>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
@@ -165,7 +165,7 @@
     <StringProperty.Metadata>
       <NameValuePair Name="DependsOn" Value="Package::PackageLicenseKind" />
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(eq "Expression" (evaluated "Package" "PackageLicenseKind"))</NameValuePair.Value>
+        <NameValuePair.Value>(has-evaluated-value "Package" "PackageLicenseKind" "Expression")</NameValuePair.Value>
       </NameValuePair>
     </StringProperty.Metadata>
   </StringProperty>
@@ -189,7 +189,7 @@
     </StringProperty.ValueEditors>
     <StringProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(eq "Expression" (evaluated "Package" "PackageLicenseKind"))</NameValuePair.Value>
+        <NameValuePair.Value>(has-evaluated-value "Package" "PackageLicenseKind" "Expression")</NameValuePair.Value>
       </NameValuePair>
     </StringProperty.Metadata>
   </StringProperty>
@@ -202,7 +202,7 @@
     <StringProperty.Metadata>
       <NameValuePair Name="DependsOn" Value="Package::PackageLicenseKind" />
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(eq "File" (evaluated "Package" "PackageLicenseKind"))</NameValuePair.Value>
+        <NameValuePair.Value>(has-evaluated-value "Package" "PackageLicenseKind" "File")</NameValuePair.Value>
       </NameValuePair>
     </StringProperty.Metadata>
   </StringProperty>
@@ -214,7 +214,7 @@
     <BoolProperty.Metadata>
       <NameValuePair Name="DependsOn" Value="Package::PackageLicenseKind" />
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(ne "None" (evaluated "Package" "PackageLicenseKind"))</NameValuePair.Value>
+        <NameValuePair.Value>(not (has-evaluated-value "Package" "PackageLicenseKind" "None"))</NameValuePair.Value>
       </NameValuePair>
     </BoolProperty.Metadata>
   </BoolProperty>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
@@ -42,7 +42,7 @@
                   Description="The name and port number of the remote machine in 'name:port' format.">
     <StringProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(evaluated "Project" "RemoteDebugEnabled")</NameValuePair.Value>
+        <NameValuePair.Value>(has-evaluated-value "Project" "RemoteDebugEnabled" true)</NameValuePair.Value>
       </NameValuePair>
       <NameValuePair Name="DependsOn" Value="Project::RemoteDebugMachine" />
     </StringProperty.Metadata>
@@ -54,7 +54,7 @@
                        EnumProvider="AuthenticationModeEnumProvider">
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(evaluated "Project" "RemoteDebugEnabled")</NameValuePair.Value>
+        <NameValuePair.Value>(has-evaluated-value "Project" "RemoteDebugEnabled" true)</NameValuePair.Value>
       </NameValuePair>
       <NameValuePair Name="DependsOn" Value="Project::RemoteDebugMachine" />
     </DynamicEnumProperty.Metadata>


### PR DESCRIPTION
Fixes #7021

Currently we have a visibility condition function `evaluated` which returns a single evaluated value for a property.

However a project may produce different evaluated values per configuration. Currently, if that happens, the `evaluated` function throws an exception.

We also have an `has-evaluated-value` function which returns true if any of the evaluated value matches an argument. This will never throw the above exception.

The original idea was that we would use `evaluated` for properties which self-identify as non-configurable (and therefore would only have a single value).

The problem is that a project can still be manually constructed that produces different values across configurations for any property. If we use `evaluated` then there will always be a "valid" project that produces an exception in the UI.

This change removes usage of the `evaluated` function, and removes it from the documentation. Once this has merged and inserted, we can remove the definition of this function from CPS.

I have manually tested all the changed properties here to verify they still work as expected.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7225)