### PR TITLE
Make XliffTasks and RoslynTools.SignTool have PrivateAssets=all

### DIFF
--- a/build/import/HostAgnostic.props
+++ b/build/import/HostAgnostic.props
@@ -22,8 +22,8 @@
     <PackageReference Include="MicroBuild.Core.Sentinel"            ExcludeAssets="All" />
     <PackageReference Include="MicroBuild.Plugins.SwixBuild"        ExcludeAssets="All"/>
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
-    <PackageReference Include="XliffTasks" />
-    <PackageReference Include="RoslynTools.SignTool" />
+    <PackageReference Include="XliffTasks"                          PrivateAssets="All" />
+    <PackageReference Include="RoslynTools.SignTool"                PrivateAssets="All" />
     <PackageReference Include="RoslynTools.RepoToolset"             ExcludeAssets="all" />
     <PackageReference Include="Codecov"                             ExcludeAssets="all" />
     <PackageReference Include="OpenCover"                           ExcludeAssets="all" />


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7228)