### PR TITLE
Use new Project Properties UI by default in Dev17

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
@@ -178,7 +178,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Implements IVsEditorFactory.CreateEditorInstance
 
             ' If we're using the new project properties editor, delegate to its editor factory
-            Dim shouldUseNewEditor As Boolean = UseNewEditor(Hierarchy)
+            Dim shouldUseNewEditor As Boolean = Hierarchy.IsCapabilityMatch("ProjectPropertiesEditor")
 
             Common.TelemetryLogger.LogEditorCreation(shouldUseNewEditor, FileName, PhysicalView)
 
@@ -226,11 +226,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             End If
 
             Return hr
-        End Function
-
-        Private Shared Function UseNewEditor(vsHierarchy As IVsHierarchy) As Boolean
-            ' The new editor is only available for CPS-based C# projects
-            Return vsHierarchy.IsCapabilityMatch("CPS & CSharp")
         End Function
 
         Private Function GetNewEditorFactory() As IVsEditorFactory

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
@@ -2,7 +2,6 @@
 
 Imports System.Runtime.InteropServices
 
-Imports Microsoft.Internal.VisualStudio.Shell.Interop
 Imports Microsoft.VisualStudio.Designer.Interfaces
 Imports Microsoft.VisualStudio.Editors.AppDesInterop
 Imports Microsoft.VisualStudio.Shell
@@ -229,17 +228,9 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             Return hr
         End Function
 
-        Private Function UseNewEditor(vsHierarchy As IVsHierarchy) As Boolean
-            If Not vsHierarchy.IsCapabilityMatch("CPS & CSharp") Then
-                ' The new editor is only available for CPS-based C# projects
-                Return False
-            End If
-
-            Dim featureFlags = TryCast(_siteProvider.GetService(GetType(SVsFeatureFlags)), IVsFeatureFlags)
-
-            Return _
-                featureFlags IsNot Nothing AndAlso _
-                featureFlags.IsFeatureEnabled("CPS.UpdatedProjectPropertiesDesigner.Local", False)
+        Private Shared Function UseNewEditor(vsHierarchy As IVsHierarchy) As Boolean
+            ' The new editor is only available for CPS-based C# projects
+            Return vsHierarchy.IsCapabilityMatch("CPS & CSharp")
         End Function
 
         Private Function GetNewEditorFactory() As IVsEditorFactory

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.CSharp.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.CSharp.DesignTime.targets
@@ -33,7 +33,8 @@
                           CSharp;
                           Managed;
                           ClassDesigner;
-                          SharedProjectReferences;" />
+                          SharedProjectReferences;
+                          ProjectPropertiesEditor;" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DefineCommonManagedItemSchemas)' == 'true'">


### PR DESCRIPTION
Fixes #7171

In Dev16 we only enabled the new UI if a feature flag was enabled.

In Dev17 we will only support this new UI, so no longer need to check the feature flag. The flag will be removed once this change inserts.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7231)