### PR TITLE
Make XliffTasks and RoslynTools.SignTool have PrivateAssets=all

### DIFF
--- a/build/import/HostAgnostic.props
+++ b/build/import/HostAgnostic.props
@@ -22,8 +22,8 @@
     <PackageReference Include="MicroBuild.Core.Sentinel"            ExcludeAssets="All" />
     <PackageReference Include="MicroBuild.Plugins.SwixBuild"        ExcludeAssets="All"/>
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
-    <PackageReference Include="XliffTasks" />
-    <PackageReference Include="RoslynTools.SignTool" />
+    <PackageReference Include="XliffTasks"                          PrivateAssets="All" />
+    <PackageReference Include="RoslynTools.SignTool"                PrivateAssets="All" />
     <PackageReference Include="RoslynTools.RepoToolset"             ExcludeAssets="all" />
     <PackageReference Include="Codecov"                             ExcludeAssets="all" />
     <PackageReference Include="OpenCover"                           ExcludeAssets="all" />

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -70,8 +70,8 @@
     <PackageReference Update="Microsoft.VisualStudio.XmlEditor"                                       Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VSDesigner"                                                   Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="VsWebSite.Interop"                                                      Version="16.8.30523.219"/>
-    <PackageReference Include="Microsoft.VisualStudio.Interop"                                        Version="17.0.0-preview-2-31223-026"/>
-    <PackageReference Include="Microsoft.Internal.VisualStudio.Interop"                               Version="17.0.0-preview-2-31223-026"/>
+    <PackageReference Include="Microsoft.VisualStudio.Interop"                                        Version="17.0.0-previews-1-31317-048"/>
+    <PackageReference Include="Microsoft.Internal.VisualStudio.Interop"                               Version="17.0.0-previews-1-31317-048"/>
     
 
     <!-- CPS -->

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerToolbarPanel.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerToolbarPanel.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         Public Sub Activate(h As IntPtr)
             ' It seems that designers don't set the active secondary toolbar when activated -
             ' this should take care of that!
-            _toolbarHost.ProcessMouseActivation(h, Win32Constant.WM_SETFOCUS, 0, 0)
+            _toolbarHost.ProcessMouseActivation(h, Win32Constant.WM_SETFOCUS, CType(0, IntPtr), CType(0, IntPtr))
         End Sub
 
         ''' <summary>


### PR DESCRIPTION
Updating to newest version of interop package. Also taking advantage of this PR to backport the changes in #7228

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7232)