### PR TITLE
Fix up VB code

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/Common/ShellUtil.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/ShellUtil.vb
@@ -187,7 +187,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             Const ProjectsAndSolution As String = "ProjectsandSolution"
 
             Try
-                ProjAndSolutionProperties = DTE.get_Properties(EnvironmentCategory, ProjectsAndSolution)
+                ProjAndSolutionProperties = DTE.Properties(EnvironmentCategory, ProjectsAndSolution)
                 If ProjAndSolutionProperties IsNot Nothing Then
                     ShowValue = CBool(ProjAndSolutionProperties.Item("ShowAdvancedBuildConfigurations").Value)
                 Else

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/ShellUtil.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/ShellUtil.vb
@@ -1,6 +1,5 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-Option Strict Off
 Imports System.Drawing
 Imports System.Windows.Forms
 Imports System.Windows.Forms.Design

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -2836,7 +2836,7 @@ NextControl:
             'First see if it is already in the project
             For Each ProjectItem As EnvDTE.ProjectItem In ProjectItems
 #Disable Warning BC42025 ' Access of shared member, constant member, enum member or nested type through an instance
-                If ProjectItem.get_FileNames(1).Equals(FileName, StringComparison.OrdinalIgnoreCase) Then
+                If ProjectItem.FileNames(1).Equals(FileName, StringComparison.OrdinalIgnoreCase) Then
 #Enable Warning BC42025 ' Access of shared member, constant member, enum member or nested type through an instance
                     Return ProjectItem
                 End If

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -1,7 +1,5 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-Option Strict Off
-
 Imports System.Collections.Specialized
 Imports System.ComponentModel
 Imports System.ComponentModel.Design

--- a/src/Microsoft.VisualStudio.Editors/Common/CodeModelUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/CodeModelUtils.vb
@@ -1,7 +1,5 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-Option Strict Off
-
 Imports EnvDTE
 
 Namespace Microsoft.VisualStudio.Editors.Common

--- a/src/Microsoft.VisualStudio.Editors/Common/CodeModelUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/CodeModelUtils.vb
@@ -123,7 +123,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             Try
                 'Ensure the document is activated
                 If Func.ProjectItem IsNot Nothing Then
-                    If Not Func.ProjectItem.get_IsOpen Then
+                    If Not Func.ProjectItem.IsOpen Then
                         Func.ProjectItem.Open()
                     End If
                     Func.ProjectItem.Document.Activate()

--- a/src/Microsoft.VisualStudio.Editors/Common/DTEUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/DTEUtils.vb
@@ -78,7 +78,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
         Public Shared Function FindAllFilesWithExtension(ProjectItems As ProjectItems, Extension As String, SearchChildren As Boolean) As List(Of ProjectItem)
             Dim ResXFiles As New List(Of ProjectItem)
             For Each Item As ProjectItem In ProjectItems
-                If Path.GetExtension(Item.get_FileNames(1)).Equals(Extension, StringComparison.OrdinalIgnoreCase) Then
+                If Path.GetExtension(Item.FileNames(1)).Equals(Extension, StringComparison.OrdinalIgnoreCase) Then
                     ResXFiles.Add(Item)
                 End If
 
@@ -107,7 +107,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             End If
 
             ' The ProjectItem.FileNames collection is 1 based...
-            Return ProjectItem.get_FileNames(1)
+            Return ProjectItem.FileNames(1)
         End Function
 
         ''' <summary>
@@ -214,7 +214,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                     EnvDTE.Constants.vsProjectItemKindPhysicalFile, StringComparison.OrdinalIgnoreCase) AndAlso
                     projectItem.FileCount > 0 Then
 
-                    Dim itemFileName As String = Path.GetFileName(projectItem.get_FileNames(1))
+                    Dim itemFileName As String = Path.GetFileName(projectItem.FileNames(1))
                     If String.Equals(fileName, itemFileName, StringComparison.OrdinalIgnoreCase) Then
                         Return projectItem
                     End If
@@ -230,7 +230,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         Public Shared Function ItemIdOfProjectItem(Hierarchy As IVsHierarchy, ProjectItem As ProjectItem) As UInteger
             Dim FoundItemId As UInteger
-            VSErrorHandler.ThrowOnFailure(Hierarchy.ParseCanonicalName(ProjectItem.get_FileNames(1), FoundItemId))
+            VSErrorHandler.ThrowOnFailure(Hierarchy.ParseCanonicalName(ProjectItem.FileNames(1), FoundItemId))
             Return FoundItemId
         End Function
 

--- a/src/Microsoft.VisualStudio.Editors/Common/DTEUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/DTEUtils.vb
@@ -1,7 +1,5 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-Option Strict Off
-
 Imports System.IO
 
 Imports EnvDTE

--- a/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
@@ -1,7 +1,5 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-Option Strict Off
-
 Imports System.Drawing
 Imports System.Windows.Forms
 Imports System.Windows.Forms.Design

--- a/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
@@ -165,7 +165,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             Const ProjectsAndSolution As String = "ProjectsandSolution"
 
             Try
-                ProjAndSolutionProperties = DTE.get_Properties(EnvironmentCategory, ProjectsAndSolution)
+                ProjAndSolutionProperties = DTE.Properties(EnvironmentCategory, ProjectsAndSolution)
                 If ProjAndSolutionProperties IsNot Nothing Then
                     ShowValue = CBool(ProjAndSolutionProperties.Item("ShowAdvancedBuildConfigurations").Value)
                 Else

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
@@ -448,7 +448,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             _punkDocData = punkDocData
 
             'Get the WindowEvents object
-            m_WindowEvents = ProjectItem.DTE.Events.get_WindowEvents
+            m_WindowEvents = ProjectItem.DTE.Events.WindowEvents
             Debug.Assert(m_WindowEvents IsNot Nothing)
 
             ' If a random editor opens the file and locks it using an incompatible buffer, we need 

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
@@ -1,6 +1,6 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-Option Strict Off
+Option Strict On
 Option Explicit On
 
 Imports System.ComponentModel.Design

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
@@ -1,7 +1,5 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-Option Strict Off
-
 Imports System.CodeDom
 Imports System.CodeDom.Compiler
 Imports System.ComponentModel

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
@@ -521,7 +521,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             Dim designerPrjItem As ProjectItem = GetDesignerProjectItem(phier, itemId)
             If designerPrjItem IsNot Nothing Then
                 Dim applicationData As MyApplicationData = Nothing
-                Using dd As New Design.Serialization.DocData(Common.ServiceProviderFromHierarchy(phier), designerPrjItem.get_FileNames(1))
+                Using dd As New Design.Serialization.DocData(Common.ServiceProviderFromHierarchy(phier), designerPrjItem.FileNames(1))
                     applicationData = GetApplicationData(dd)
                 End Using
                 If applicationData IsNot Nothing Then
@@ -574,7 +574,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             Dim designerPrjItem As ProjectItem = GetDesignerProjectItem(phier, itemId)
             If designerPrjItem IsNot Nothing Then
                 Try
-                    Using dd As New Design.Serialization.DocData(Common.ServiceProviderFromHierarchy(phier), designerPrjItem.get_FileNames(1))
+                    Using dd As New Design.Serialization.DocData(Common.ServiceProviderFromHierarchy(phier), designerPrjItem.FileNames(1))
                         Dim data As MyApplicationData = GetApplicationData(dd)
                         If data IsNot Nothing Then
                             Dim oldSymbolName As String = GetSymbolNameNoRootNamespace(rglpszRQName(0), designerPrjItem.ContainingProject)

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
@@ -1,7 +1,5 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-Option Strict Off
-
 Imports System.ComponentModel
 Imports System.IO
 Imports System.Runtime.InteropServices

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
@@ -261,7 +261,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
 
             'BEGIN Beta 1 Backwards compatibility
             If Not File.Exists(MyAppFileNameWithPath) Then
-                Dim FileNameCompat As String = Path.Combine(ProjectDesignerProjectItem.get_FileNames(1), Const_MyApplicationFileName_B1Compat)
+                Dim FileNameCompat As String = Path.Combine(ProjectDesignerProjectItem.FileNames(1), Const_MyApplicationFileName_B1Compat)
                 If File.Exists(FileNameCompat) Then
                     'The new version of the filename does not exist, but the old one does - use it instead
                     _myAppFileName = Const_MyApplicationFileName_B1Compat
@@ -650,7 +650,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             'Create the DocData for the file
             If _myAppDocData Is Nothing Then
                 Debug.Assert(_docDataService Is Nothing)
-                _myAppDocData = New DocData(ServiceProvider, Item.get_FileNames(1))
+                _myAppDocData = New DocData(ServiceProvider, Item.FileNames(1))
 
                 Dim ItemId As UInteger = ItemIdOfProjectItem(_projectHierarchy, Item)
                 _docDataService = New DesignerDocDataService(ServiceProvider, _projectHierarchy, ItemId, MyAppDocData)
@@ -661,7 +661,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' Returns the full path/filename of the .myapp file
         ''' </summary>
         Private Function MyAppFileNameWithPath() As String
-            Return Path.Combine(ProjectDesignerProjectItem.get_FileNames(1), _myAppFileName)
+            Return Path.Combine(ProjectDesignerProjectItem.FileNames(1), _myAppFileName)
         End Function
 
         ''' <summary>
@@ -672,7 +672,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                 'First see if it is already in the project
                 For Each ProjectItem As ProjectItem In ProjectDesignerProjectItem.ProjectItems
 #Disable Warning BC42025 ' Access of shared member, constant member, enum member or nested type through an instance
-                    If ProjectItem.get_FileNames(1).Equals(MyAppFileNameWithPath, StringComparison.OrdinalIgnoreCase) Then
+                    If ProjectItem.FileNames(1).Equals(MyAppFileNameWithPath, StringComparison.OrdinalIgnoreCase) Then
 #Enable Warning BC42025 ' Access of shared member, constant member, enum member or nested type through an instance
                         Return ProjectItem
                     End If
@@ -919,7 +919,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
 
             'Add or navigate to the default event handler
             Dim DefaultEventHandler As CodeFunction
-            If MyEventsProjectItem.get_IsOpen AndAlso MyEventsProjectItem.Document IsNot Nothing Then
+            If MyEventsProjectItem.IsOpen AndAlso MyEventsProjectItem.Document IsNot Nothing Then
                 'Document is already open.  Don't change anything and don't do any navigation.  Just activate it.
                 Debug.Assert(Not FileIsNew)
                 MyEventsProjectItem.Document.Activate()

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectSettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectSettings.vb
@@ -583,7 +583,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
 
             Dim itemPath As String = Nothing
             Try
-                itemPath = projectItem.get_FileNames(1)
+                itemPath = projectItem.FileNames(1)
             Catch ex As Exception When ReportWithoutCrash(ex, NameOf(GetProjectItemPath), NameOf(MyExtensibilityProjectSettings))
             End Try
             If itemPath IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectSettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectSettings.vb
@@ -1,6 +1,6 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-Option Strict Off
+Option Strict On
 Option Explicit On
 Imports System.IO
 Imports System.Windows.Forms

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageBase.vb
@@ -1,7 +1,5 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-Option Strict Off
-
 Imports System.ComponentModel
 Imports System.Drawing
 Imports System.Drawing.Drawing2D

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageBase.vb
@@ -200,7 +200,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         'Could not copy
                         ApplicationIconCombobox.SelectedItem = _lastIconImage
                     Else
-                        Dim sRelativePath As String = GetProjectRelativeFilePath(ProjectItem.get_FileNames(1))
+                        Dim sRelativePath As String = GetProjectRelativeFilePath(ProjectItem.FileNames(1))
 
                         'Find the item in the list and select it
                         ApplicationIconCombobox.SelectedIndex = -1
@@ -214,7 +214,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         If ApplicationIconCombobox.SelectedIndex = -1 Then
                             'Icon is not in the list, so add it to the list
                             'Now get the new path of copied file
-                            sRelativePath = GetProjectRelativeFilePath(ProjectItem.get_FileNames(1))
+                            sRelativePath = GetProjectRelativeFilePath(ProjectItem.FileNames(1))
                             AddIconEntryToCombobox(ApplicationIconCombobox, sRelativePath)
                             ApplicationIconCombobox.SelectedItem = sRelativePath
                         End If
@@ -335,7 +335,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         End Try
 
                         'Now get the new path of copied file
-                        sRelativePath = GetProjectRelativeFilePath(ProjectItem.get_FileNames(1))
+                        sRelativePath = GetProjectRelativeFilePath(ProjectItem.FileNames(1))
 
                     End If
 
@@ -394,7 +394,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="ProjectItem"></param>
         Protected Sub AddIconsFromProjectItem(ProjectItem As ProjectItem, ApplicationIconCombobox As ComboBox)
             For Index As Short = 1 To ProjectItem.FileCount
-                Dim FileName As String = ProjectItem.get_FileNames(Index)
+                Dim FileName As String = ProjectItem.FileNames(Index)
                 Dim ext As String = IO.Path.GetExtension(FileName)
                 If ext.Equals(".ico", StringComparison.OrdinalIgnoreCase) Then
                     ApplicationIconCombobox.Items.Add(GetProjectRelativeFilePath(FileName))
@@ -499,7 +499,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="ProjectItem"></param>
         Protected Sub AddManifestsFromProjectItem(ProjectItem As ProjectItem, ApplicationManifestCombobox As ComboBox)
             For Index As Short = 1 To ProjectItem.FileCount
-                Dim FileName As String = ProjectItem.get_FileNames(Index)
+                Dim FileName As String = ProjectItem.FileNames(Index)
                 Dim ext As String = IO.Path.GetExtension(FileName)
                 If ext.Equals(".manifest", StringComparison.OrdinalIgnoreCase) Then
                     ApplicationManifestCombobox.Items.Add(GetProjectRelativeFilePath(FileName))

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
@@ -773,7 +773,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             If _applicationXamlDocData Is Nothing Then
                 Dim applicationXamlProjectItem As ProjectItem = FindApplicationXamlProjectItem(createAppXamlIfDoesNotExist)
                 If applicationXamlProjectItem IsNot Nothing Then
-                    _applicationXamlDocData = New DocData(ServiceProvider, applicationXamlProjectItem.get_FileNames(1))
+                    _applicationXamlDocData = New DocData(ServiceProvider, applicationXamlProjectItem.FileNames(1))
                 End If
             End If
 
@@ -1257,7 +1257,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         Private Sub FindXamlPageFiles(projectItems As ProjectItems, list As List(Of ProjectItem))
             For Each projectItem As ProjectItem In projectItems
 #Disable Warning BC42025 ' Access of shared member, constant member, enum member or nested type through an instance
-                If IO.Path.GetExtension(projectItem.get_FileNames(1)).Equals(".xaml", StringComparison.OrdinalIgnoreCase) Then
+                If IO.Path.GetExtension(projectItem.FileNames(1)).Equals(".xaml", StringComparison.OrdinalIgnoreCase) Then
 #Enable Warning BC42025 ' Access of shared member, constant member, enum member or nested type through an instance
                     'We only want .xaml files with BuildAction="Page"
                     Dim CurrentBuildAction As String = DTEUtils.GetBuildActionAsString(projectItem)
@@ -1265,7 +1265,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                         'Build action is correct.
 
                         'Is the item inside the project folders (instead of, say, a link to an external file)?
-                        If IsFileRelativeToProjectPath(projectItem.get_FileNames(1)) Then
+                        If IsFileRelativeToProjectPath(projectItem.FileNames(1)) Then
                             'Okay, we want this one
                             list.Add(projectItem)
                         End If
@@ -1298,7 +1298,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                     FindXamlPageFiles(DTEProject.ProjectItems, xamlFiles)
 
                     For Each projectItem As ProjectItem In xamlFiles
-                        startupObjects.Add(New StartupUri(GetProjectRelativeFilePath(projectItem.get_FileNames(1))))
+                        startupObjects.Add(New StartupUri(GetProjectRelativeFilePath(projectItem.FileNames(1))))
                     Next
                 End Using
             End If
@@ -1589,7 +1589,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <param name="extension"></param>
         Private Shared Function FindDependentFile(projectItem As ProjectItem, extension As String) As ProjectItem
             For Each dependentItem As ProjectItem In projectItem.ProjectItems
-                If dependentItem.get_FileNames(1) IsNot Nothing _
+                If dependentItem.FileNames(1) IsNot Nothing _
                         AndAlso IO.Path.GetExtension(dependentItem.Name).Equals(extension, StringComparison.OrdinalIgnoreCase) Then
                     Return dependentItem
                 End If
@@ -1720,7 +1720,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             Try
                 Dim appXaml As ProjectItem = FindApplicationXamlProjectItem(False)
                 If appXaml IsNot Nothing Then
-                    Return appXaml.get_FileNames(1)
+                    Return appXaml.FileNames(1)
                 End If
             Catch ex As Exception
             End Try

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
@@ -1,5 +1,4 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
-Option Strict Off
 
 Imports System.ComponentModel
 Imports System.Runtime.InteropServices

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -1,7 +1,7 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 Option Explicit On
-Option Strict Off
+Option Strict On
 Option Compare Binary
 Imports System.CodeDom.Compiler
 Imports System.ComponentModel

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
@@ -298,7 +298,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Dim ProjectItem As EnvDTE.ProjectItem = TryCast(GetService(GetType(EnvDTE.ProjectItem)), EnvDTE.ProjectItem)
                 If ProjectItem IsNot Nothing Then
                     'FileNames is 1-indexed
-                    Return ProjectItem.get_FileNames(1)
+                    Return ProjectItem.FileNames(1)
                 Else
                     Debug.Fail("Couldn't find ExtensibilityObject as service (should have been added by ResourceEditorDesignerLoader")
                 End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
@@ -1,7 +1,7 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 Option Explicit On
-Option Strict Off
+Option Strict On
 Option Compare Binary
 
 Imports System.ComponentModel

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcesFolderService.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcesFolderService.vb
@@ -1,7 +1,7 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-Option Explicit Off
-Option Strict Off
+Option Explicit On
+Option Strict On
 Option Compare Binary
 
 Imports System.IO

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcesFolderService.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcesFolderService.vb
@@ -788,14 +788,14 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             'Look for a FileName with the expected extension.  It's unclear whether we can assume it will always be the
             '  first one.  (There can be multiple files for a ProjectItem for such cases as code behind, etc.)
             For i As Short = 1 To ProjectItem.FileCount 'this collection is 1-indexed
-                Dim FileName As String = ProjectItem.get_FileNames(i)
+                Dim FileName As String = ProjectItem.FileNames(i)
                 If Path.GetExtension(FileName).Equals(ExpectedExtension, StringComparison.OrdinalIgnoreCase) Then
                     Return FileName
                 End If
             Next
 
             Debug.Fail("Didn't find a ProjectItem.FileName with the expected extension")
-            Return ProjectItem.get_FileNames(1)
+            Return ProjectItem.FileNames(1)
         End Function
 
         ''' <summary>
@@ -808,7 +808,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 'The FileNames property represents the actual full path of the directory if the folder
                 '  is an actual physical folder on disk.
                 Debug.Assert(ProjectItem.FileCount = 1, "Didn't expect multiple filenames for a folder ProjectItem")
-                Return ProjectItem.get_FileNames(1) 'this collection is 1-indexed
+                Return ProjectItem.FileNames(1) 'this collection is 1-indexed
             Else
                 Debug.Fail("Trying to get filename of a non-physical folder in the project")
                 Return ""

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResxItemWizard.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResxItemWizard.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Debug.Assert(projectItem IsNot Nothing, "Null projectItem?")
             If projectItem IsNot Nothing AndAlso _propertiesToSet IsNot Nothing Then
 
-                Dim fileName As String = projectItem.get_FileNames(1)
+                Dim fileName As String = projectItem.FileNames(1)
                 Debug.Assert(fileName IsNot Nothing AndAlso fileName.Length > 0, "bogus ProjectItem.FileNames(1) value?")
 
                 Dim isLocalizedResxFile As Boolean = ResourceEditorView.IsLocalizedResXFile(fileName)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResxItemWizard.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResxItemWizard.vb
@@ -1,6 +1,6 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-Option Strict Off
+Option Strict On
 Option Explicit On
 Option Compare Binary
 Imports System.Collections.Specialized

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
@@ -1,7 +1,5 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-Option Strict Off
-
 Imports System.CodeDom
 Imports System.CodeDom.Compiler
 Imports System.IO

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
             End If
 
             ' The ProjectItem.FileNames collection is 1 based...
-            Return ProjectItem.get_FileNames(1)
+            Return ProjectItem.FileNames(1)
         End Function
 
         ''' <summary>
@@ -248,7 +248,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
             Debug.Assert(ExtendingItem IsNot Nothing, "Couldn't find/create a class that extends the generated settings class")
 
             If ExtendingItem IsNot Nothing Then
-                If ExtendingItem.get_IsOpen AndAlso ExtendingItem.Document IsNot Nothing Then
+                If ExtendingItem.IsOpen AndAlso ExtendingItem.Document IsNot Nothing Then
                     ExtendingItem.Document.Activate()
                 Else
                     Dim Win As EnvDTE.Window = ExtendingItem.Open()

--- a/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
@@ -307,7 +307,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             Dim fileName As String
 
             If item.FileCount > 0 Then
-                fileName = item.get_FileNames(1) 'Index is 1-based
+                fileName = item.FileNames(1) 'Index is 1-based
             Else
                 fileName = item.Name
             End If

--- a/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
@@ -1,7 +1,5 @@
 ﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-Option Strict Off
-
 Imports System.CodeDom
 Imports System.ComponentModel
 Imports System.ComponentModel.Design


### PR DESCRIPTION
While the Dev17 interop work was ongoing we needed to make some adjustments to the VB code to make progress, notably referring to some interop methods and properties with different names and making use of `Option Strict Off`. Now that the interop work has settled a bit these are no longer needed and should be backed out.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1327354/.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7235)