### PR TITLE
Include invisible properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
@@ -106,8 +106,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             if (requestedProperties.VisibilityCondition)
             {
-                string? visibilityCondition = property.GetMetadataValueOrNull("VisibilityCondition");
-                newUIProperty.VisibilityCondition = visibilityCondition ?? string.Empty;
+                if (!property.Visible)
+                {
+                    newUIProperty.VisibilityCondition = "false";
+                }
+                else
+                {
+                    string? visibilityCondition = property.GetMetadataValueOrNull("VisibilityCondition");
+                    newUIProperty.VisibilityCondition = visibilityCondition ?? string.Empty;
+                }
             }
 
             ((IEntityValueFromProvider)newUIProperty).ProviderState = new PropertyProviderState(cache, property.ContainingRule, propertiesContext, property.Name);
@@ -119,11 +126,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         {
             foreach ((int index, BaseProperty property) in rule.Properties.WithIndices())
             {
-                if (property.Visible)
-                {
-                    IEntityValue propertyValue = CreateUIPropertyValue(queryExecutionContext, parent, cache, propertiesContext, property, index, properties);
-                    yield return propertyValue;
-                }
+                IEntityValue propertyValue = CreateUIPropertyValue(queryExecutionContext, parent, cache, propertiesContext, property, index, properties);
+                yield return propertyValue;
             }
         }
 
@@ -143,8 +147,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
                 if (await project.GetProjectLevelPropertyPagesCatalogAsync() is IPropertyPagesCatalog projectCatalog
                     && projectCatalog.GetSchema(propertyPageName) is Rule rule
-                    && rule.TryGetPropertyAndIndex(propertyName, out BaseProperty? property, out int index)
-                    && property.Visible)
+                    && rule.TryGetPropertyAndIndex(propertyName, out BaseProperty? property, out int index))
                 {
                     IProjectState? projectState = null;
                     if (StringComparers.ItemTypes.Equals(propertiesContext.ItemType, "LaunchProfile"))

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             {
                 new TestProperty { Name = "Alpha" },
                 new TestProperty { Name = "Beta" },
-                new TestProperty { Name = "Gamma" },
+                new TestProperty { Name = "Gamma", Visible = false }, // We create properties even if they will be invisible
             });
             rule.EndInit();
 
@@ -280,6 +280,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(context, id, cache, QueryProjectPropertiesContext.ProjectFile, property, order: 42, requestedProperties: properties);
 
             Assert.Equal(expected: "true or false", actual: result.VisibilityCondition);
+        }
+
+        [Fact]
+        public void WhenAPropertyIsInvisible_TheVisibilityConditionIsIgnored()
+        {
+            var properties = PropertiesAvailableStatusFactory.CreateUIPropertyPropertiesAvailableStatus(includeVisibilityCondition: true);
+
+            var context = IQueryExecutionContextFactory.Create();
+            var id = new EntityIdentity(key: "PropertyName", value: "A");
+            var cache = IProjectStateFactory.Create();
+            var property = new TestProperty
+            {
+                Visible = false,
+                Metadata = new()
+                {
+                    new() { Name = "VisibilityCondition", Value = "true" }
+                }
+            };
+            InitializeFakeRuleForProperty(property);
+
+            var result = (UIPropertyValue)UIPropertyDataProducer.CreateUIPropertyValue(context, id, cache, QueryProjectPropertiesContext.ProjectFile, property, order: 42, requestedProperties: properties);
+
+            Assert.Equal(expected: "false", actual: result.VisibilityCondition);
         }
 
         /// <remarks>


### PR DESCRIPTION
Related to #7243.

On the properties pages back end, the `BaseProperty` type has a `Visible` property that can be `true` or `false` to indicate if the property should be shown in the UI. For the very first implementation of property pages in CodeSpaces (using the C++-style grid) we didn't have the ability to hide a property at the UI layer, so the back end simply filtered out hidden properties from the data it sent to the client. Even as we reworked the new Property Page UI in various ways this implementation detail persisted.

At the same time, we wanted the ability to _conditionally_ show or hide some properties based on the values of other properties; to support this we added the concept of `VisibilityCondition` metadata on the property. So if you wanted a property to be hidden but still available on the client to other properties, you would set the `VisibilityCondition` to `false`.

However, setting the `VisibilityCondition` is rather verbose, since it is stored in the `BaseProperty.Metadata` property bag rather than in a real member of the `BaseProperty` type. For properties that will be unconditionally hidden it would be much simpler to just set `Visible` to false.

In this commit we stop filtering properties based on `Visible`. However, if `Visible` is set to `false` we will force the `VisibilityCondition` of the created entity to `false`, ignoring whatever was in the metadata.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7266)