### PR TITLE
Update environment helper

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -521,9 +521,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// </summary>
         private string? GetFullPathOfExeFromEnvironmentPath(string exeToSearchFor)
         {
-            string pathEnv = _environment.GetEnvironmentVariable("Path");
+            string? pathEnv = _environment.GetEnvironmentVariable("Path");
 
-            if (string.IsNullOrEmpty(pathEnv))
+            if (Strings.IsNullOrEmpty(pathEnv))
             {
                 return null;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/EnvironmentHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/EnvironmentHelper.cs
@@ -20,13 +20,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         {
             return Environment.ExpandEnvironmentVariables(name);
         }
-
-        public bool Is64BitOperatingSystem
-        {
-            get
-            {
-                return Environment.Is64BitOperatingSystem;
-            }
-        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/EnvironmentHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/EnvironmentHelper.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
     [Export(typeof(IEnvironmentHelper))]
     internal class EnvironmentHelper : IEnvironmentHelper
     {
-        public string GetEnvironmentVariable(string name)
+        public string? GetEnvironmentVariable(string name)
         {
             return Environment.GetEnvironmentVariable(name);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/IEnvironmentHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/IEnvironmentHelper.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
     [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IEnvironmentHelper
     {
-        string GetEnvironmentVariable(string name);
+        string? GetEnvironmentVariable(string name);
 
         string ExpandEnvironmentVariables(string name);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/IEnvironmentHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/IEnvironmentHelper.cs
@@ -13,7 +13,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         string? GetEnvironmentVariable(string name);
 
         string ExpandEnvironmentVariables(string name);
-
-        bool Is64BitOperatingSystem { get; }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IEnvironmentHelperFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IEnvironmentHelperFactory.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
 {
     internal static class IEnvironmentHelperFactory
     {
-        public static IEnvironmentHelper ImplementGetEnvironmentVariable(string result)
+        public static IEnvironmentHelper ImplementGetEnvironmentVariable(string? result)
         {
             var mock = new Mock<IEnvironmentHelper>();
 


### PR DESCRIPTION
- `IEnvironmentHelper.GetEnvironmentVariable` can return `null`
- `IEnvironmentHelper.Is64BitOperatingSystem` is unused

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7268)