### PR TITLE
Fixes System.OverflowException being thrown from old csproj.dll-based property pages

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerWindowPane.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerWindowPane.vb
@@ -51,7 +51,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
 
             Dim DesignerView As PropPageDesignerView = GetPropPageDesignerView()
             If DesignerView IsNot Nothing Then
-                Dim KeyCode As Keys = DirectCast(m.WParam.ToInt32(), Keys) And Keys.KeyCode
+                Dim KeyCode As Keys = DirectCast(CInt(m.WParam.ToInt64() And Keys.KeyCode), Keys)
                 'Is the message intended for a window or control in the property page?
                 If DesignerView.IsNativeHostedPropertyPageActivated AndAlso NativeMethods.IsChild(View.Handle, m.HWnd) Then
                     Common.Switches.TracePDMessageRouting(TraceLevel.Info, "  ... Message is for a child of the property page.  Calling MyBase.PreProcessMessage", m)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/7267

With the change to 64-bit, it seems this `WParam` value can be above Int32 now. Good news is that `Keys.KeyCode` is an enum set to `65535` in *System.Windows.Forms*, so that isn't changing... ever. Therefore, doing a *binary-and* against `65535` means the value will always be equal to or below `65535`, well within the range of Int32. Here, I just *binary-and* the Int64 with the enum, and do `CInt` so that the cast to `Keys` is aware the value produced an Int32. This no longer causes the System.OverflowException to occur.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7270)