### PR TITLE
Populate IsVisible and return non-visible properties

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -72,10 +72,10 @@
     
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.0.89-pre-geec7dc0def" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.10.127-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.0.89-pre-geec7dc0def" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="16.10.127-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.0.596-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.0.596-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.0.596-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.0.596-pre" />
     
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.0.0-1.21181.18" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/AbstractProjectState.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/AbstractProjectState.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         private readonly AsyncLazy<IImmutableSet<ProjectConfiguration>?> _knownProjectConfigurations;
         private readonly AsyncLazy<ProjectConfiguration?> _defaultProjectConfiguration;
 
-        public AbstractProjectState(UnconfiguredProject project)
+        protected AbstractProjectState(UnconfiguredProject project)
         {
             Project = project;
             JoinableTaskFactory joinableTaskFactory = project.Services.ThreadingPolicy.JoinableTaskFactory;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryByIdDataProducer.cs
@@ -25,9 +25,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext queryExecutionContext, EntityIdentity id)
         {
             if (id.KeysCount == 3
-                && id.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string projectPath)
-                && id.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName)
-                && id.TryGetValue(ProjectModelIdentityKeys.CategoryName, out string categoryName))
+                && id.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string? projectPath)
+                && id.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string? propertyPageName)
+                && id.TryGetValue(ProjectModelIdentityKeys.CategoryName, out string? categoryName))
             {
                 return CategoryDataProducer.CreateCategoryValueAsync(
                     queryExecutionContext,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageByIdDataProducer.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext queryExecutionContext, EntityIdentity id)
         {
             if (QueryProjectPropertiesContext.TryCreateFromEntityId(id, out QueryProjectPropertiesContext? propertiesContext)
-                && id.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName))
+                && id.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string? propertyPageName))
             {
                 return PropertyPageDataProducer.CreatePropertyPageValueAsync(
                     queryExecutionContext,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryProjectPropertiesContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryProjectPropertiesContext.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         /// </summary>
         public static bool TryCreateFromEntityId(EntityIdentity id, [NotNullWhen(true)] out QueryProjectPropertiesContext? propertiesContext)
         {
-            if (id.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string projectPath))
+            if (id.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string? projectPath))
             {
                 id.TryGetValue(ProjectModelIdentityKeys.SourceItemType, out string? itemType);
                 id.TryGetValue(ProjectModelIdentityKeys.SourceItemName, out string? itemName);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyByIdProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyByIdProducer.cs
@@ -27,8 +27,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext queryExecutionContext, EntityIdentity id)
         {
             if (QueryProjectPropertiesContext.TryCreateFromEntityId(id, out QueryProjectPropertiesContext? propertiesContext)
-                && id.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName)
-                && id.TryGetValue(ProjectModelIdentityKeys.UIPropertyName, out string propertyName))
+                && id.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string? propertyPageName)
+                && id.TryGetValue(ProjectModelIdentityKeys.UIPropertyName, out string? propertyName))
             {
                 return UIPropertyDataProducer.CreateUIPropertyValueAsync(
                     queryExecutionContext,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyByIdProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyByIdProducer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     /// Handles retrieving an <see cref="IUIProperty"/> based on an ID.
     /// </summary>
     internal class UIPropertyByIdProducer : QueryDataByIdProducerBase
-    { 
+    {
         private readonly IUIPropertyPropertiesAvailableStatus _properties;
         private readonly IProjectService2 _projectService;
 
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     _properties);
             }
 
-            return NullEntityValue;   
+            return NullEntityValue;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
@@ -64,6 +64,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 newUIProperty.IsReadOnly = property.ReadOnly;
             }
 
+            if (requestedProperties.IsVisible)
+            {
+                newUIProperty.IsVisible = property.Visible;
+            }
+
             if (requestedProperties.HelpUrl)
             {
                 newUIProperty.HelpUrl = property.HelpUrl;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
@@ -119,11 +119,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         {
             foreach ((int index, BaseProperty property) in rule.Properties.WithIndices())
             {
-                if (property.Visible)
-                {
-                    IEntityValue propertyValue = CreateUIPropertyValue(queryExecutionContext, parent, cache, propertiesContext, property, index, properties);
-                    yield return propertyValue;
-                }
+                IEntityValue propertyValue = CreateUIPropertyValue(queryExecutionContext, parent, cache, propertiesContext, property, index, properties);
+                yield return propertyValue;
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorByIdDataProducer.cs
@@ -27,10 +27,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         protected override Task<IEntityValue?> TryCreateEntityOrNullAsync(IQueryExecutionContext queryExecutionContext, EntityIdentity id)
         {
             if (id.KeysCount == 4
-                && id.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string projectPath)
-                && id.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string propertyPageName)
-                && id.TryGetValue(ProjectModelIdentityKeys.UIPropertyName, out string propertyName)
-                && id.TryGetValue(ProjectModelIdentityKeys.EditorName, out string editorName))
+                && id.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string? projectPath)
+                && id.TryGetValue(ProjectModelIdentityKeys.PropertyPageName, out string? propertyPageName)
+                && id.TryGetValue(ProjectModelIdentityKeys.UIPropertyName, out string? propertyName)
+                && id.TryGetValue(ProjectModelIdentityKeys.EditorName, out string? editorName))
             {
                 return UIPropertyEditorDataProducer.CreateEditorValueAsync(
                     queryExecutionContext,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/QueryDataByIdProducerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/QueryDataByIdProducerBase.cs
@@ -18,19 +18,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public async Task SendRequestAsync(QueryProcessRequest<IReadOnlyCollection<EntityIdentity>> request)
         {
-            foreach (EntityIdentity requestId in request.RequestData)
+            if (request.RequestData is not null)
             {
-                try
+                foreach (EntityIdentity requestId in request.RequestData)
                 {
-                    IEntityValue? entityValue = await TryCreateEntityOrNullAsync(request.QueryExecutionContext, requestId);
-                    if (entityValue is not null)
+                    try
                     {
-                        await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(entityValue, request, ProjectModelZones.Cps));
+                        IEntityValue? entityValue = await TryCreateEntityOrNullAsync(request.QueryExecutionContext, requestId);
+                        if (entityValue is not null)
+                        {
+                            await ResultReceiver.ReceiveResultAsync(new QueryProcessResult<IEntityValue>(entityValue, request, ProjectModelZones.Cps));
+                        }
                     }
-                }
-                catch (Exception ex)
-                {
-                    request.QueryExecutionContext.ReportError(ex);
+                    catch (Exception ex)
+                    {
+                        request.QueryExecutionContext.ReportError(ex);
+                    }
                 }
             }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/PropertiesAvailableStatusFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/PropertiesAvailableStatusFactory.cs
@@ -28,6 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             bool? includeConfigurationIndependent = null,
             bool? includeHelpUrl = null,
             bool? includeCategoryName = null,
+            bool? includeIsVisible = null,
             bool? includeOrder = null,
             bool? includeType = null,
             bool? includeSearchTerms = null,
@@ -42,6 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             mock.SetupGet(m => m.ConfigurationIndependent).Returns(includeConfigurationIndependent ?? includeAllProperties);
             mock.SetupGet(m => m.HelpUrl).Returns(includeHelpUrl ?? includeAllProperties);
             mock.SetupGet(m => m.CategoryName).Returns(includeCategoryName ?? includeAllProperties);
+            mock.SetupGet(m => m.IsVisible).Returns(includeIsVisible ?? includeAllProperties);
             mock.SetupGet(m => m.Order).Returns(includeOrder ?? includeAllProperties);
             mock.SetupGet(m => m.Type).Returns(includeType ?? includeAllProperties);
             mock.SetupGet(m => m.SearchTerms).Returns(includeSearchTerms ?? includeAllProperties);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducerTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             var result = (CategoryValue)CategoryDataProducer.CreateCategoryValue(context, parentEntity, rule, category, order, properties);
 
-            Assert.True(result.Id.TryGetValue(ProjectModelIdentityKeys.CategoryName, out string name));
+            Assert.True(result.Id.TryGetValue(ProjectModelIdentityKeys.CategoryName, out string? name));
             Assert.Equal(expected: "MyCategoryName", actual: name);
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 Description = "This is the description for Page A",
                 HelpUrl = "https://mypage",
                 Category = "general",
+                Visible = false,
                 DataSource = new DataSource { HasConfigurationCondition = false }
             };
             InitializeFakeRuleForProperty(property);
@@ -55,6 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             Assert.Equal(expected: "This is the description for Page A", actual: result.Description);
             Assert.True(result.ConfigurationIndependent);
             Assert.Equal(expected: "general", actual: result.CategoryName);
+            Assert.False(result.IsVisible);
             Assert.Equal(expected: 42, actual: result.Order);
             Assert.Equal(expected: "string", actual: result.Type);
         }


### PR DESCRIPTION
Part of #7251. Alternative to #7266.

In order to show/hide properties based on project-level metadata such as `TargetPlatformIdentifier` or `LangVersion`, we need to plumb that data through to the UI for use in visibility condition expressions. Our approach for this is to have non-visible properties in the UI whose data is available to the visibility condition evaluator.

CPS PR https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/325905 added an `IsVisible` property to the Project Query API's project model.

This PR populates that property when queried.

It also changes the query provider to return non-visible properties.

Future work will be to add non-visible properties (probably in a new well-known `ConfigurationGeneralPropertyPage.xaml` in which all properties are non-visible), and then convenient visibility expressions to access them.

---

This PR bumps the CPS package version, which brings in newly annotated APIs. The bulk of the diff here is reacting to those annotations. Each step is pulled out into its own commit, in case that makes review easier.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7271)