### PR TITLE
Use Visible property over visibility condition

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -41,16 +41,12 @@
                 DisplayName="Target multiple frameworks"
                 Description="Build this project for multiple target frameworks."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147236"
-                Category="General">
+                Category="General"
+                Visible="False">
     <BoolProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception"
                   HasConfigurationCondition="False" />
     </BoolProperty.DataSource>
-    <BoolProperty.Metadata>
-      <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>false</NameValuePair.Value>
-      </NameValuePair>
-    </BoolProperty.Metadata>
   </BoolProperty>
 
   <DynamicEnumProperty Name="TargetFramework"


### PR DESCRIPTION
Relates to https://github.com/dotnet/project-system/issues/7251

Items backed by a visibility condition have non-visible UI elements allocated to them. Setting `Visible="False"` makes them permanently non-visible, which is more optimal.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7280)