### PR TITLE
Don't assume en-US culture for customer-facing URLs

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class VSResources {
@@ -450,7 +450,7 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/..
+        ///   Looks up a localized string similar to Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/..
         /// </summary>
         internal static string XprojNotSupported {
             get {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -201,7 +201,7 @@ In order to debug this project, add an executable project to this solution which
     <value>The value of the 'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '{0}' configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</value>
   </data>
   <data name="XprojNotSupported" xml:space="preserve">
-    <value>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.</value>
+    <value>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.</value>
   </data>
   <data name="WindowsFormEditor_DisplayName" xml:space="preserve">
     <value>Form (Windows Forms) Designer</value>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -197,8 +197,8 @@ Pokud chcete projekt ladit, přidejte do řešení spustitelný projekt, který 
         <note />
       </trans-unit>
       <trans-unit id="XprojNotSupported">
-        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.</source>
-        <target state="translated">Soubory projektu xproj už nejsou podporované. Podrobnosti o migraci na csproj najdete na adrese https://docs.microsoft.com/en-us/dotnet/core/migration/.</target>
+        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.</source>
+        <target state="translated">Soubory projektu xproj už nejsou podporované. Podrobnosti o migraci na csproj najdete na adrese https://docs.microsoft.com/dotnet/core/migration/.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsFormEditor_DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -197,7 +197,7 @@ Um das Projekt zu debuggen, fügen Sie dieser Projektmappe ein ausführbares Pro
         <note />
       </trans-unit>
       <trans-unit id="XprojNotSupported">
-        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.</source>
+        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.</source>
         <target state="translated">Xproj-Projektdateien werden nicht mehr unterstützt. Informationen zur Migration zu "csproj" finden Sie unter "https://docs.microsoft.com/de-de/dotnet/core/migration/".</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -197,8 +197,8 @@ Para depurar este proyecto, agregue un proyecto ejecutable a esta solución con 
         <note />
       </trans-unit>
       <trans-unit id="XprojNotSupported">
-        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.</source>
-        <target state="translated">Ya no se admiten los archivos del proyecto xproj. Para obtener más información sobre cómo migrar a csproj, consulte https://docs.microsoft.com/en-us/dotnet/core/migration/.</target>
+        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.</source>
+        <target state="translated">Ya no se admiten los archivos del proyecto xproj. Para obtener más información sobre cómo migrar a csproj, consulte https://docs.microsoft.com/dotnet/core/migration/.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsFormEditor_DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -197,7 +197,7 @@ Pour déboguer ce projet, ajoutez à cette solution un projet exécutable qui fa
         <note />
       </trans-unit>
       <trans-unit id="XprojNotSupported">
-        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.</source>
+        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.</source>
         <target state="translated">Les fichiers projet Xproj ne sont plus pris en charge. Pour plus d'informations sur la migration vers csproj, consultez https://docs.microsoft.com/fr-fr/dotnet/core/migration/.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -197,7 +197,7 @@ Per eseguire il debug del progetto, aggiungere a questa soluzione un progetto es
         <note />
       </trans-unit>
       <trans-unit id="XprojNotSupported">
-        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.</source>
+        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.</source>
         <target state="translated">I file di progetto xproj non sono più supportati. Per informazioni dettagliate sulla migrazione a csproj, vedere https://docs.microsoft.com/it-it/dotnet/core/migration/.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -197,7 +197,7 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="XprojNotSupported">
-        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.</source>
+        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.</source>
         <target state="translated">Xproj プロジェクト ファイルはサポートされなくなりました。csproj への移行の詳細は、https://docs.microsoft.com/ja-jp/dotnet/core/migration/ を参照してください。</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -197,8 +197,8 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="XprojNotSupported">
-        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.</source>
-        <target state="translated">Xproj 프로젝트 파일은 더 이상 지원되지 않습니다. csproj로 마이그레이션에 대한 자세한 내용은 https://docs.microsoft.com/en-us/dotnet/core/migration/을 참조하세요.</target>
+        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.</source>
+        <target state="translated">Xproj 프로젝트 파일은 더 이상 지원되지 않습니다. csproj로 마이그레이션에 대한 자세한 내용은 https://docs.microsoft.com/dotnet/core/migration/을 참조하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsFormEditor_DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -197,7 +197,7 @@ Aby debugować ten projekt, dodaj projekt wykonywalny do tego rozwiązania, któ
         <note />
       </trans-unit>
       <trans-unit id="XprojNotSupported">
-        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.</source>
+        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.</source>
         <target state="translated">Pliki projektu xproj nie są już obsługiwane. Szczegółowe informacje na temat migrowania do plików csproj można znaleźć na stronie https://docs.microsoft.com/pl-pl/dotnet/core/migration/.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -197,7 +197,7 @@ Para depurar esse projeto, adicione um projeto executável a essa solução que 
         <note />
       </trans-unit>
       <trans-unit id="XprojNotSupported">
-        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.</source>
+        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.</source>
         <target state="translated">Não há mais suporte para arquivos de projeto Xproj. Para obter detalhes sobre migração para csproj, consulte https://docs.microsoft.com/pt-br/dotnet/core/migration/.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -197,7 +197,7 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="XprojNotSupported">
-        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.</source>
+        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.</source>
         <target state="translated">Файлы проектов Xproj больше не поддерживаются. Дополнительные сведения о переходе на csproj см. на странице https://docs.microsoft.com/ru-ru/dotnet/core/migration/.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -197,8 +197,8 @@ Bu projede hata ayıklamak için bu çözüme, kitaplık projesine başvuran bir
         <note />
       </trans-unit>
       <trans-unit id="XprojNotSupported">
-        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.</source>
-        <target state="translated">Xproj proje dosyaları artık desteklenmiyor. Csproj'a geçiş hakkında ayrıntılar için bkz. https://docs.microsoft.com/en-us/dotnet/core/migration/.</target>
+        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.</source>
+        <target state="translated">Xproj proje dosyaları artık desteklenmiyor. Csproj'a geçiş hakkında ayrıntılar için bkz. https://docs.microsoft.com/dotnet/core/migration/.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsFormEditor_DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -197,7 +197,7 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="XprojNotSupported">
-        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.</source>
+        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.</source>
         <target state="translated">不再支持 Xproj 项目文件。要详细了解如何迁移到 csproj，请参阅 https://docs.microsoft.com/zh-cn/dotnet/core/migration/。</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -197,7 +197,7 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="XprojNotSupported">
-        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.</source>
+        <source>Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.</source>
         <target state="translated">已不再支援 .xproj 專案檔。如需移轉到 csproj 的詳細資料，請參閱 https://docs.microsoft.com/zh-tw/dotnet/core/migration/。</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/cs/VSResources.xlf.lcl
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/cs/VSResources.xlf.lcl
@@ -393,9 +393,9 @@
       </Item>
       <Item ItemId=";XprojNotSupported" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.]]></Val>
+          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Soubory projektu xproj už nejsou podporované. Podrobnosti o migraci na csproj najdete na adrese https://docs.microsoft.com/en-us/dotnet/core/migration/.]]></Val>
+            <Val><![CDATA[Soubory projektu xproj už nejsou podporované. Podrobnosti o migraci na csproj najdete na adrese https://docs.microsoft.com/dotnet/core/migration/.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/de/VSResources.xlf.lcl
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/de/VSResources.xlf.lcl
@@ -393,7 +393,7 @@
       </Item>
       <Item ItemId=";XprojNotSupported" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.]]></Val>
+          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
             <Val><![CDATA[Xproj-Projektdateien werden nicht mehr unterstützt. Informationen zur Migration zu "csproj" finden Sie unter "https://docs.microsoft.com/de-de/dotnet/core/migration/".]]></Val>
           </Tgt>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/es/VSResources.xlf.lcl
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/es/VSResources.xlf.lcl
@@ -393,9 +393,9 @@
       </Item>
       <Item ItemId=";XprojNotSupported" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.]]></Val>
+          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Ya no se admiten los archivos del proyecto xproj. Para obtener más información sobre cómo migrar a csproj, consulte https://docs.microsoft.com/en-us/dotnet/core/migration/.]]></Val>
+            <Val><![CDATA[Ya no se admiten los archivos del proyecto xproj. Para obtener más información sobre cómo migrar a csproj, consulte https://docs.microsoft.com/dotnet/core/migration/.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/fr/VSResources.xlf.lcl
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/fr/VSResources.xlf.lcl
@@ -393,7 +393,7 @@
       </Item>
       <Item ItemId=";XprojNotSupported" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.]]></Val>
+          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
             <Val><![CDATA[Les fichiers projet Xproj ne sont plus pris en charge. Pour plus d'informations sur la migration vers csproj, consultez https://docs.microsoft.com/fr-fr/dotnet/core/migration/.]]></Val>
           </Tgt>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/it/VSResources.xlf.lcl
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/it/VSResources.xlf.lcl
@@ -393,7 +393,7 @@
       </Item>
       <Item ItemId=";XprojNotSupported" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.]]></Val>
+          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
             <Val><![CDATA[I file di progetto xproj non sono più supportati. Per informazioni dettagliate sulla migrazione a csproj, vedere https://docs.microsoft.com/it-it/dotnet/core/migration/.]]></Val>
           </Tgt>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/ja/VSResources.xlf.lcl
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/ja/VSResources.xlf.lcl
@@ -393,7 +393,7 @@
       </Item>
       <Item ItemId=";XprojNotSupported" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.]]></Val>
+          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
             <Val><![CDATA[Xproj プロジェクト ファイルはサポートされなくなりました。csproj への移行の詳細は、https://docs.microsoft.com/ja-jp/dotnet/core/migration/ を参照してください。]]></Val>
           </Tgt>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/ko/VSResources.xlf.lcl
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/ko/VSResources.xlf.lcl
@@ -393,9 +393,9 @@
       </Item>
       <Item ItemId=";XprojNotSupported" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.]]></Val>
+          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Xproj 프로젝트 파일은 더 이상 지원되지 않습니다. csproj로 마이그레이션에 대한 자세한 내용은 https://docs.microsoft.com/en-us/dotnet/core/migration/을 참조하세요.]]></Val>
+            <Val><![CDATA[Xproj 프로젝트 파일은 더 이상 지원되지 않습니다. csproj로 마이그레이션에 대한 자세한 내용은 https://docs.microsoft.com/dotnet/core/migration/을 참조하세요.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/pl/VSResources.xlf.lcl
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/pl/VSResources.xlf.lcl
@@ -393,7 +393,7 @@
       </Item>
       <Item ItemId=";XprojNotSupported" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.]]></Val>
+          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
             <Val><![CDATA[Pliki projektu xproj nie są już obsługiwane. Szczegółowe informacje na temat migrowania do plików csproj można znaleźć na stronie https://docs.microsoft.com/pl-pl/dotnet/core/migration/.]]></Val>
           </Tgt>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/pt-BR/VSResources.xlf.lcl
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/pt-BR/VSResources.xlf.lcl
@@ -393,7 +393,7 @@
       </Item>
       <Item ItemId=";XprojNotSupported" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.]]></Val>
+          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
             <Val><![CDATA[Não há mais suporte para arquivos de projeto Xproj. Para obter detalhes sobre migração para csproj, consulte https://docs.microsoft.com/pt-br/dotnet/core/migration/.]]></Val>
           </Tgt>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/ru/VSResources.xlf.lcl
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/ru/VSResources.xlf.lcl
@@ -393,7 +393,7 @@
       </Item>
       <Item ItemId=";XprojNotSupported" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.]]></Val>
+          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
             <Val><![CDATA[Файлы проектов Xproj больше не поддерживаются. Дополнительные сведения о переходе на csproj см. на странице https://docs.microsoft.com/ru-ru/dotnet/core/migration/.]]></Val>
           </Tgt>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/tr/VSResources.xlf.lcl
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/tr/VSResources.xlf.lcl
@@ -393,9 +393,9 @@
       </Item>
       <Item ItemId=";XprojNotSupported" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.]]></Val>
+          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Xproj proje dosyaları artık desteklenmiyor. Csproj'a geçiş hakkında ayrıntılar için bkz. https://docs.microsoft.com/en-us/dotnet/core/migration/.]]></Val>
+            <Val><![CDATA[Xproj proje dosyaları artık desteklenmiyor. Csproj'a geçiş hakkında ayrıntılar için bkz. https://docs.microsoft.com/dotnet/core/migration/.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/zh-Hans/VSResources.xlf.lcl
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/zh-Hans/VSResources.xlf.lcl
@@ -393,7 +393,7 @@
       </Item>
       <Item ItemId=";XprojNotSupported" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.]]></Val>
+          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
             <Val><![CDATA[不再支持 Xproj 项目文件。要详细了解如何迁移到 csproj，请参阅 https://docs.microsoft.com/zh-cn/dotnet/core/migration/。]]></Val>
           </Tgt>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/zh-Hant/VSResources.xlf.lcl
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/zh-Hant/VSResources.xlf.lcl
@@ -393,7 +393,7 @@
       </Item>
       <Item ItemId=";XprojNotSupported" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/en-us/dotnet/core/migration/.]]></Val>
+          <Val><![CDATA[Xproj project files are no longer supported. For details on migrating to csproj see https://docs.microsoft.com/dotnet/core/migration/.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
             <Val><![CDATA[已不再支援 .xproj 專案檔。如需移轉到 csproj 的詳細資料，請參閱 https://docs.microsoft.com/zh-tw/dotnet/core/migration/。]]></Val>
           </Tgt>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -141,7 +141,7 @@
   <BoolProperty Name="CheckForOverflowUnderflow"
                 DisplayName="Check for arithmetic overflow"
                 Description="Specifies whether integer arithmetic that results in a value outside the range of the data type, and that is not in the scope of a checked or unchecked keyword, causes a run-time exception."
-                HelpUrl="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/checked-compiler-option"
+                HelpUrl="https://docs.microsoft.com/dotnet/csharp/language-reference/compiler-options/checked-compiler-option"
                 Category="General">
     <BoolProperty.Metadata>
       <NameValuePair Name="SearchTerms" Value="checked;unchecked" />
@@ -152,14 +152,14 @@
   <BoolProperty Name="Deterministic"
                 DisplayName="Deterministic"
                 Description="Indicates whether the compiler should produce identical assemblies for identical inputs."
-                HelpUrl="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/deterministic-compiler-option"
+                HelpUrl="https://docs.microsoft.com/dotnet/csharp/language-reference/compiler-options/deterministic-compiler-option"
                 Category="General" />
   
   <!-- TODO create fwlink for this HelpUrl -->
   <EnumProperty Name="ErrorReport"
                 DisplayName="Internal compiler error reporting"
                 Description="Controls when internal compiler error (ICE) reports are sent to Microsoft."
-                HelpUrl="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/errorreport-compiler-option"
+                HelpUrl="https://docs.microsoft.com/dotnet/csharp/language-reference/compiler-options/errorreport-compiler-option"
                 Category="General">
     <EnumProperty.DataSource>
       <DataSource HasConfigurationCondition="False" />
@@ -178,7 +178,7 @@
   <EnumProperty Name="FileAlignment"
                 DisplayName="File alignment"
                 Description="Specifies, in bytes, where to align the sections of the output file."
-                HelpUrl="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/filealign-compiler-option"
+                HelpUrl="https://docs.microsoft.com/dotnet/csharp/language-reference/compiler-options/filealign-compiler-option"
                 Category="General">
     <EnumValue Name="512"
                DisplayName="512" />
@@ -277,7 +277,7 @@
   <BoolProperty Name="ProduceReferenceAssembly"
                 DisplayName="Reference assembly"
                 Description="Produce a reference assembly containing the public API of the project."
-                HelpUrl="https://docs.microsoft.com/en-us/dotnet/standard/assembly/reference-assemblies"
+                HelpUrl="https://docs.microsoft.com/dotnet/standard/assembly/reference-assemblies"
                 Category="Output">
     <BoolProperty.DataSource>
       <DataSource HasConfigurationCondition="False" />
@@ -288,7 +288,7 @@
   <BoolProperty Name="GenerateDocumentationFile"
                 DisplayName="Documentation file"
                 Description="Generate a file containing API documentation."
-                HelpUrl="https://docs.microsoft.com/en-us/dotnet/csharp/codedoc"
+                HelpUrl="https://docs.microsoft.com/dotnet/csharp/codedoc"
                 Category="Output">
     <BoolProperty.DataSource>
       <DataSource HasConfigurationCondition="False" />
@@ -321,7 +321,7 @@
   <StringProperty Name="PreBuildEvent"
                   DisplayName="Pre-build event"
                   Description="Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs."
-                  HelpUrl="https://docs.microsoft.com/en-us/visualstudio/ide/how-to-specify-build-events-csharp?view=vs-2019"
+                  HelpUrl="https://docs.microsoft.com/visualstudio/ide/how-to-specify-build-events-csharp?view=vs-2019"
                   Category="Events">
     <StringProperty.DataSource>
       <DataSource HasConfigurationCondition="False"
@@ -341,7 +341,7 @@
   <StringProperty Name="PostBuildEvent"
                   DisplayName="Post-build event"
                   Description="Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build."
-                  HelpUrl="https://docs.microsoft.com/en-us/visualstudio/ide/how-to-specify-build-events-csharp?view=vs-2019"
+                  HelpUrl="https://docs.microsoft.com/visualstudio/ide/how-to-specify-build-events-csharp?view=vs-2019"
                   Category="Events">
     <StringProperty.DataSource>
       <DataSource HasConfigurationCondition="False"
@@ -361,7 +361,7 @@
   <EnumProperty Name="RunPostBuildEvent"
                 DisplayName="When to run the post-build event"
                 Description="Specifies under which condition the post-build event will be executed."
-                HelpUrl="https://docs.microsoft.com/en-us/visualstudio/ide/how-to-specify-build-events-csharp?view=vs-2019"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/how-to-specify-build-events-csharp?view=vs-2019"
                 Category="Events">
     <EnumProperty.DataSource>
       <DataSource HasConfigurationCondition="False"


### PR DESCRIPTION
When a customer clicks a link to documentation, they expect to see it in their own language (where applicable).

This commit removes the assumption on en-US culture from the URLs we allow customers to navigate to.

More information at https://review.docs.microsoft.com/help/contribute/links-how-to?branch=master#locale-codes-in-external-links

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7283)