### PR TITLE
Restrict 'Nullable' property to C# 8+

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -61,6 +61,11 @@
     <EnumProperty.DataSource>
       <DataSource HasConfigurationCondition="False" />
     </EnumProperty.DataSource>
+    <EnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-csharp-lang-version-or-greater "8.0")</NameValuePair.Value>
+      </NameValuePair>
+    </EnumProperty.Metadata>
     <EnumValue Name="disable"
                DisplayName="Disable" />
     <EnumValue Name="enable"


### PR DESCRIPTION
Contributes to #6989.

Nullable reference types were introduced in C# 8.

This change uses a newly introduced visibility condition function to hide the `Nullable` property from the UI when `LangVersion` is less than 8.0.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7285)