### PR TITLE
[16.11] Pass evaluated AssemblyName during Roslyn workspace construction

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -100,7 +100,7 @@
     <PackageReference Update="Microsoft.CSharp"                                                       Version="4.7.0" />
 
     <!-- Analyzers -->
-    <PackageReference Update="Microsoft.CodeAnalysis.Analyzers"                                       Version="3.3.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis.Analyzers"                                       Version="3.3.2" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle"                                Version="3.8.0-4.final" />
     <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"                           Version="3.8.0-4.final" />
     <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers"                                  Version="3.3.0" />

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -47,7 +47,7 @@
     <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces"                             Version="1.1.4323" />
     <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="16.9.30701-preview-2-30710-200" />
     <PackageReference Update="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50728" />
-    <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="16.9.67" />
+    <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="16.10.23" />
     <PackageReference Update="Microsoft.VisualStudio.Telemetry"                                       Version="16.3.104" />
     <PackageReference Update="Microsoft.VisualStudio.Settings.15.0"                                   Version="16.8.30406.155-pre" />
     <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="2.3.2262-g94fae01e" />
@@ -88,14 +88,17 @@
     <PackageReference Update="EnvDTE80"                                                               Version="16.8.30523.219" />
     <PackageReference Update="EnvDTE90"                                                               Version="16.8.30523.219" />
 
+    <!-- https://github.com/dotnet/roslyn/issues/53877 -->
+    <PackageReference Include="StreamJsonRpc"                                                         Version="2.8.21" />
+
     <!-- CPS -->
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="16.10.137-pre" />
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="16.10.137-pre" />
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="16.10.337-pre" />
 
     <!-- Roslyn -->
-    <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.0.0-2.21302.13" />
-    <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="4.0.0-2.21302.13" />
+    <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="3.11.0-2.21310.17" />
+    <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="3.11.0-2.21310.17" />
     <PackageReference Update="Microsoft.VisualStudio.IntegrationTest.Utilities"                       Version="2.6.0-beta1-62113-02" />
     <PackageReference Update="Microsoft.CSharp"                                                       Version="4.7.0" />
 

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -94,8 +94,8 @@
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="16.10.337-pre" />
 
     <!-- Roslyn -->
-    <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="3.10.0-2.21121.14" />
-    <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="3.10.0-2.21121.14" />
+    <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.0.0-2.21302.13" />
+    <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="4.0.0-2.21302.13" />
     <PackageReference Update="Microsoft.VisualStudio.IntegrationTest.Utilities"                       Version="2.6.0-beta1-62113-02" />
     <PackageReference Update="Microsoft.CSharp"                                                       Version="4.7.0" />
 

--- a/build/import/VisualStudio.props
+++ b/build/import/VisualStudio.props
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" />
     <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" />
     <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces" />
+    <PackageReference Include="Microsoft.VisualStudio.RpcContracts" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" />    
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -23,6 +23,11 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Needed to break assembly conflict on StreamJsonRpc between microsoft.visualstudio.projectsystem.query and microsoft.visualstudio.languageservices -->
+    <PackageReference Include="Microsoft.VisualStudio.RpcContracts" />
+  </ItemGroup>
+
   <!-- Dependencies -->
   <ItemGroup>
     <!-- Analyzer Reference -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.ProjectContextInitData.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.ProjectContextInitData.cs
@@ -16,6 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             public string LanguageName;
             public string BinOutputPath;
             public string ProjectFilePath;
+            public string AssemblyName;
             public Guid ProjectGuid;
             public string WorkspaceProjectContextId;
 
@@ -38,6 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 snapshot.Properties.TryGetValue(ConfigurationGeneral.LanguageServiceNameProperty, out data.LanguageName);
                 snapshot.Properties.TryGetValue(ConfigurationGeneral.TargetPathProperty, out data.BinOutputPath);
                 snapshot.Properties.TryGetValue(ConfigurationGeneral.MSBuildProjectFullPathProperty, out data.ProjectFilePath);
+                snapshot.Properties.TryGetValue(ConfigurationGeneral.AssemblyNameProperty, out data.AssemblyName);
 
                 data.ProjectGuid = projectGuid;
                 data.WorkspaceProjectContextId = GetWorkspaceProjectContextId(data.ProjectFilePath, projectGuid, configuration);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.cs
@@ -82,7 +82,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                                                                     data.ProjectFilePath,
                                                                                     data.ProjectGuid,
                                                                                     hostObject,
-                                                                                    data.BinOutputPath);
+                                                                                    data.BinOutputPath,
+                                                                                    data.AssemblyName);
 #pragma warning restore 612,618
 
                 context.LastDesignTimeBuildSucceeded = false;  // By default, turn off diagnostics until the first design time build succeeds for this project.

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextFactoryFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextFactoryFactory.cs
@@ -12,12 +12,12 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
             return Mock.Of<IWorkspaceProjectContextFactory>();
         }
 
-        public static IWorkspaceProjectContextFactory ImplementCreateProjectContext(Func<string, string, string, Guid, object, string, IWorkspaceProjectContext?> action)
+        public static IWorkspaceProjectContextFactory ImplementCreateProjectContext(Func<string, string, string, Guid, object, string, string, IWorkspaceProjectContext?> action)
         {
             var mock = new Mock<IWorkspaceProjectContextFactory>();
 
 #pragma warning disable 612,618
-            mock.Setup(c => c.CreateProjectContext(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<object>(), It.IsAny<string>()))
+            mock.Setup(c => c.CreateProjectContext(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<object>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(action!);
 #pragma warning restore 612,618
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextProviderTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var snapshot = IProjectRuleSnapshotFactory.FromJson(json);
 
             int callCount = 0;
-            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, _, _, _, _, _) => { callCount++; return null; });
+            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, _, _, _, _, _, _) => { callCount++; return null; });
             var provider = CreateInstance(workspaceProjectContextFactory: workspaceProjectContextFactory, projectRuleSnapshot: snapshot);
 
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration("Debug|AnyCPU");
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var projectGuidService = ISafeProjectGuidServiceFactory.ImplementGetProjectGuidAsync(new Guid(guid));
 
             string? result = null;
-            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, id, _, _, _, _) => { result = id; return null; });
+            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, id, _, _, _, _, _) => { result = id; return null; });
             var provider = CreateInstance(workspaceProjectContextFactory: workspaceProjectContextFactory, projectGuidService: projectGuidService);
 
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration(configuration);
@@ -128,13 +128,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             string? languageNameResult = null, projectFilePathResult = null, binOutputPathResult = null;
             Guid? projectGuidResult = null;
             object? hierarchyResult = null;
-            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((languageName, _, projectFilePath, guid, hierarchy, binOutputPath) =>
+            string? assemblyNameResult = null;
+            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((languageName, _, projectFilePath, guid, hierarchy, binOutputPath, assemblyName) =>
             {
                 languageNameResult = languageName;
                 projectFilePathResult = projectFilePath;
                 projectGuidResult = guid;
                 hierarchyResult = hierarchy;
                 binOutputPathResult = binOutputPath;
+                assemblyNameResult = assemblyName;
                 return null;
             });
 
@@ -146,6 +148,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             Assert.Equal("CSharp", languageNameResult);
             Assert.Equal("C:\\Project\\Project.csproj", projectFilePathResult);
             Assert.Equal("C:\\Target.dll", binOutputPathResult);
+            Assert.Equal("Project", assemblyNameResult);
             Assert.Equal(projectGuid, projectGuidResult!.Value);
             Assert.Equal(hostObject, hierarchyResult);
         }
@@ -154,7 +157,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         public async Task CreateProjectContextAsync_ReturnsContextWithLastDesignTimeBuildSucceededSetToFalse()
         {
             var context = IWorkspaceProjectContextMockFactory.Create();
-            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, _, _, _, _, _) => context);
+            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, _, _, _, _, _, _) => context);
             var provider = CreateInstance(workspaceProjectContextFactory: workspaceProjectContextFactory);
 
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration("Debug|AnyCPU");
@@ -168,7 +171,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         [Fact]
         public async Task CreateProjectContextAsync_WhenCreateProjectContextThrows_ReturnsNull()
         {
-            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, _, _, _, _, _) => { throw new Exception(); });
+            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, _, _, _, _, _, _) => { throw new Exception(); });
             var provider = CreateInstance(workspaceProjectContextFactory: workspaceProjectContextFactory);
 
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration("Debug|AnyCPU");
@@ -210,7 +213,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     ""Properties"": {
         ""MSBuildProjectFullPath"": ""C:\\Project\\Project.csproj"",
         ""LanguageServiceName"": ""CSharp"",
-        ""TargetPath"": ""C:\\Target.dll""
+        ""TargetPath"": ""C:\\Target.dll"",
+        ""AssemblyName"": ""Project""
     }
 }");
 


### PR DESCRIPTION
Cherry-pick of #7216 for 16.11.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7295)