### PR TITLE
Introduce AutoGenerateBindingRedirects property.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -190,6 +190,20 @@
     </BoolProperty.Metadata>
   </BoolProperty>
 
+  <BoolProperty Name="AutoGenerateBindingRedirects"
+                DisplayName="Auto-generate binding redirects"
+                Description="Enables binding redirection to be added automatically to the app configuration file to override assembly unification."
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2164379"
+                Category="General">
+    <BoolProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>
+        (has-net-framework)
+        </NameValuePair.Value>
+      </NameValuePair>
+    </BoolProperty.Metadata>
+  </BoolProperty>
+
   <DynamicEnumProperty Name="StartupObject"
                        DisplayName="Startup object"
                        Description="Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point."

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -192,7 +192,7 @@
 
   <BoolProperty Name="AutoGenerateBindingRedirects"
                 DisplayName="Auto-generate binding redirects"
-                Description="Enables binding redirection to be added automatically to the app configuration file to override assembly unification."
+                Description="Add binding redirects automatically to App.config."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2164379"
                 Category="General">
     <BoolProperty.Metadata>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.cs.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../ApplicationPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
+        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
+        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">
+        <source>Auto-generate binding redirects</source>
+        <target state="new">Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|IsPublishable|Description">
         <source>Allow publishing outside of Visual Studio, such as via "dotnet publish".</source>
         <target state="translated">Umožňuje publikovat mimo Visual Studio, například prostřednictvím „dotnet publish“.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.cs.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../ApplicationPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
-        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
-        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <source>Add binding redirects automatically to App.config.</source>
+        <target state="new">Add binding redirects automatically to App.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.de.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="de" original="../ApplicationPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
-        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
-        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <source>Add binding redirects automatically to App.config.</source>
+        <target state="new">Add binding redirects automatically to App.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.de.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../ApplicationPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
+        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
+        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">
+        <source>Auto-generate binding redirects</source>
+        <target state="new">Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|IsPublishable|Description">
         <source>Allow publishing outside of Visual Studio, such as via "dotnet publish".</source>
         <target state="translated">Hiermit wird die Veröffentlichung außerhalb von Visual Studio zugelassen, z. B. über "dotnet publish".</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.es.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../ApplicationPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
+        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
+        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">
+        <source>Auto-generate binding redirects</source>
+        <target state="new">Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|IsPublishable|Description">
         <source>Allow publishing outside of Visual Studio, such as via "dotnet publish".</source>
         <target state="translated">Permite publicaciones fuera de Visual Studio, como por ejemplo "dotnet publish".</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.es.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="es" original="../ApplicationPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
-        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
-        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <source>Add binding redirects automatically to App.config.</source>
+        <target state="new">Add binding redirects automatically to App.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.fr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../ApplicationPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
-        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
-        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <source>Add binding redirects automatically to App.config.</source>
+        <target state="new">Add binding redirects automatically to App.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.fr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../ApplicationPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
+        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
+        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">
+        <source>Auto-generate binding redirects</source>
+        <target state="new">Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|IsPublishable|Description">
         <source>Allow publishing outside of Visual Studio, such as via "dotnet publish".</source>
         <target state="translated">Autorisez la publication en dehors de Visual Studio, par exemple via « dotnet publish ».</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.it.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../ApplicationPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
+        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
+        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">
+        <source>Auto-generate binding redirects</source>
+        <target state="new">Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|IsPublishable|Description">
         <source>Allow publishing outside of Visual Studio, such as via "dotnet publish".</source>
         <target state="translated">Consentire la pubblicazione all'esterno di Visual Studio, ad esempio tramite "dotnet publish".</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.it.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="it" original="../ApplicationPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
-        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
-        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <source>Add binding redirects automatically to App.config.</source>
+        <target state="new">Add binding redirects automatically to App.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ja.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../ApplicationPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
-        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
-        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <source>Add binding redirects automatically to App.config.</source>
+        <target state="new">Add binding redirects automatically to App.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ja.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../ApplicationPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
+        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
+        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">
+        <source>Auto-generate binding redirects</source>
+        <target state="new">Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|IsPublishable|Description">
         <source>Allow publishing outside of Visual Studio, such as via "dotnet publish".</source>
         <target state="translated">"dotnet publish" を使用するなど、Visual Studio 外でのパブリッシュを許可します。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ko.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../ApplicationPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
-        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
-        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <source>Add binding redirects automatically to App.config.</source>
+        <target state="new">Add binding redirects automatically to App.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ko.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../ApplicationPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
+        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
+        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">
+        <source>Auto-generate binding redirects</source>
+        <target state="new">Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|IsPublishable|Description">
         <source>Allow publishing outside of Visual Studio, such as via "dotnet publish".</source>
         <target state="translated">"dotnet publish"와 같이 Visual Studio 외부에 게시할 수 있습니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pl.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../ApplicationPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
+        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
+        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">
+        <source>Auto-generate binding redirects</source>
+        <target state="new">Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|IsPublishable|Description">
         <source>Allow publishing outside of Visual Studio, such as via "dotnet publish".</source>
         <target state="translated">Zezwalaj na publikowanie poza programem Visual Studio, na przykład za pomocą polecenia „dotnet publish”.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pl.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../ApplicationPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
-        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
-        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <source>Add binding redirects automatically to App.config.</source>
+        <target state="new">Add binding redirects automatically to App.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pt-BR.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ApplicationPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
-        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
-        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <source>Add binding redirects automatically to App.config.</source>
+        <target state="new">Add binding redirects automatically to App.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pt-BR.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ApplicationPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
+        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
+        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">
+        <source>Auto-generate binding redirects</source>
+        <target state="new">Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|IsPublishable|Description">
         <source>Allow publishing outside of Visual Studio, such as via "dotnet publish".</source>
         <target state="translated">Permita a publicação fora do Visual Studio, como por meio do "dotnet publish".</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ru.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../ApplicationPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
-        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
-        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <source>Add binding redirects automatically to App.config.</source>
+        <target state="new">Add binding redirects automatically to App.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ru.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../ApplicationPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
+        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
+        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">
+        <source>Auto-generate binding redirects</source>
+        <target state="new">Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|IsPublishable|Description">
         <source>Allow publishing outside of Visual Studio, such as via "dotnet publish".</source>
         <target state="translated">Разрешить публикацию вне Visual Studio, например с помощью "dotnet publish".</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.tr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../ApplicationPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
-        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
-        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <source>Add binding redirects automatically to App.config.</source>
+        <target state="new">Add binding redirects automatically to App.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.tr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../ApplicationPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
+        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
+        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">
+        <source>Auto-generate binding redirects</source>
+        <target state="new">Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|IsPublishable|Description">
         <source>Allow publishing outside of Visual Studio, such as via "dotnet publish".</source>
         <target state="translated">"Dotnet publish" gibi Visual Studio dışında yayımlamaya izin ver.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hans.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ApplicationPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
-        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
-        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <source>Add binding redirects automatically to App.config.</source>
+        <target state="new">Add binding redirects automatically to App.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hans.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ApplicationPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
+        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
+        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">
+        <source>Auto-generate binding redirects</source>
+        <target state="new">Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|IsPublishable|Description">
         <source>Allow publishing outside of Visual Studio, such as via "dotnet publish".</source>
         <target state="translated">允许在 Visual Studio 外部发布，例如通过“dotnet 发布”。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hant.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ApplicationPropertyPage.xaml">
     <body>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
-        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
-        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <source>Add binding redirects automatically to App.config.</source>
+        <target state="new">Add binding redirects automatically to App.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hant.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ApplicationPropertyPage.xaml">
     <body>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|Description">
+        <source>Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</source>
+        <target state="new">Enables binding redirection to be added automatically to the app configuration file to override assembly unification.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|AutoGenerateBindingRedirects|DisplayName">
+        <source>Auto-generate binding redirects</source>
+        <target state="new">Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|IsPublishable|Description">
         <source>Allow publishing outside of Visual Studio, such as via "dotnet publish".</source>
         <target state="translated">允許在 Visual Studio 以外發佈，例如透過「dotnet publish」。</target>


### PR DESCRIPTION
Fixes #5940.

On .NET Framework projects, a user will now be able to enable or disable automatic binding redirection by setting the `AutoGenerateBindingRedirects` property in the Project Propeties UI. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7320)