### PR TITLE
Condition platform properties to .NET 5 or greater.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -115,6 +115,9 @@
     </DynamicEnumProperty.DataSource>
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="SearchTerms" Value="platform" />
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-net-core-app-version-or-greater "5.0")</NameValuePair.Value>
+      </NameValuePair>
     </DynamicEnumProperty.Metadata>
   </DynamicEnumProperty>
 
@@ -129,7 +132,11 @@
     </DynamicEnumProperty.DataSource>
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(ne (unevaluated "Application" "TargetPlatformIdentifier") "")</NameValuePair.Value>
+        <NameValuePair.Value>
+          (and
+            (has-net-core-app-version-or-greater "5.0")
+            (ne (unevaluated "Application" "TargetPlatformIdentifier") ""))
+        </NameValuePair.Value>
       </NameValuePair>
       <NameValuePair Name="SearchTerms" Value="platform" />
       <NameValuePair Name="DependsOn" Value="Application::TargetPlatformIdentifier" />
@@ -147,7 +154,11 @@
     </DynamicEnumProperty.DataSource>
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(ne (unevaluated "Application" "TargetPlatformIdentifier") "")</NameValuePair.Value>
+        <NameValuePair.Value>
+          (and
+            (has-net-core-app-version-or-greater "5.0")
+            (ne (unevaluated "Application" "TargetPlatformIdentifier") ""))
+        </NameValuePair.Value>
       </NameValuePair>
       <NameValuePair Name="SearchTerms" Value="platform" />
       <NameValuePair Name="DependsOn" Value="Application::TargetPlatformIdentifier" />


### PR DESCRIPTION
Fixes #7227.

We want to show the new platform properties on .NET 5 (or greater) projects, which can be easily achieved with the conditional visibility metadata.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7322)