### PR TITLE
Implement Hot Reload Support

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -47,6 +47,7 @@
     <PackageReference Update="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.0.0-preview-2-31223-026"/>
     <PackageReference Update="Microsoft.VisualStudio.Data.Services"                                   Version="9.0.21023" />
     <PackageReference Update="Microsoft.VisualStudio.DataTools.Interop"                               Version="17.0.0-preview-2-31223-026" />
+    <PackageReference Update="Microsoft.VisualStudio.Debugger.Contracts"                              Version="17.2.0-beta.21278.1" />
     <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces"                             Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.0.0-previews-1-31321-016" />
     <PackageReference Update="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50728" />

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -44,9 +44,9 @@
     <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="17.0.1056-Dev17PIAs-g9dffd635" />
     <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.0.154-preview"/>
     <PackageReference Update="Microsoft.VisualStudio.Composition"                                     Version="16.9.20"/>
-    <PackageReference Update="Microsoft.VisualStudio.Data.Core"                                       Version="9.0.21023" />
+    <PackageReference Update="Microsoft.VisualStudio.Data.Core"                                       Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.0.0-preview-2-31223-026"/>
-    <PackageReference Update="Microsoft.VisualStudio.Data.Services"                                   Version="9.0.21023" />
+    <PackageReference Update="Microsoft.VisualStudio.Data.Services"                                   Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.DataTools.Interop"                               Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.Debugger.Contracts"                              Version="17.2.0-beta.21278.1" />
     <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces"                             Version="17.0.0-preview-2-31223-026" />
@@ -69,8 +69,8 @@
     <PackageReference Update="Microsoft.VisualStudio.XmlEditor"                                       Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VSDesigner"                                                   Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="VsWebSite.Interop"                                                      Version="16.8.30523.219"/>
-    <PackageReference Include="Microsoft.VisualStudio.Interop"                                        Version="17.0.0-previews-2-31421-281"/>
-    <PackageReference Include="Microsoft.Internal.VisualStudio.Interop"                               Version="17.0.0-previews-1-31321-016"/>
+    <PackageReference Include="Microsoft.VisualStudio.Interop"                                        Version="17.0.0-previews-2-31423-289"/>
+    <PackageReference Include="Microsoft.Internal.VisualStudio.Interop"                               Version="17.0.0-previews-2-31423-289"/>
     
     <!-- https://github.com/dotnet/roslyn/issues/53877 -->
     <PackageReference Include="StreamJsonRpc"                                                         Version="2.8.21" />

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -12,6 +12,7 @@
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal/nuget/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
 
@@ -41,7 +42,7 @@
 
     <!-- VS SDK -->
     <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="17.0.1056-Dev17PIAs-g9dffd635" />
-    <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.0.67-g9e37b637e6"/>
+    <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.0.154-preview"/>
     <PackageReference Update="Microsoft.VisualStudio.Composition"                                     Version="16.9.20"/>
     <PackageReference Update="Microsoft.VisualStudio.Data.Core"                                       Version="9.0.21023" />
     <PackageReference Update="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.0.0-preview-2-31223-026"/>
@@ -49,26 +50,26 @@
     <PackageReference Update="Microsoft.VisualStudio.DataTools.Interop"                               Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.Debugger.Contracts"                              Version="17.2.0-beta.21278.1" />
     <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces"                             Version="17.0.0-preview-2-31223-026" />
-    <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.0.0-previews-1-31321-016" />
+    <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.0.0-previews-2-31421-281" />
     <PackageReference Update="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50728" />
-    <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="17.0.50-preview-0001-0001" />
+    <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="17.0.50-preview-0002-0002" />
     <PackageReference Update="Microsoft.VisualStudio.Telemetry"                                       Version="16.3.176" />
     <PackageReference Update="Microsoft.VisualStudio.Settings.15.0"                                   Version="16.8.30406.155-pre" />
     <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="2.3.2262-g94fae01e" />
     <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes"                           Version="15.0.34" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.15.0"                                      Version="17.0.0-previews-1-31321-016" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Design"                                    Version="17.0.0-previews-1-31321-016" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.0.0-previews-1-31321-016" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.15.0"                                      Version="17.0.0-previews-2-31421-281" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Design"                                    Version="17.0.0-previews-2-31421-281" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.0.0-previews-2-31421-281" />
     <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.0.0-preview-2-31223-026" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="17.0.15-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.0.15-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="17.0.0-previews-1-31321-016" />
-    <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="17.0.1-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="17.0.21-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.0.21-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="17.0.0-previews-2-31421-281" />
+    <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="17.0.12-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Workspace.VSIntegration"                         Version="16.7.47-preview-0001" />
     <PackageReference Update="Microsoft.VisualStudio.XmlEditor"                                       Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VSDesigner"                                                   Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="VsWebSite.Interop"                                                      Version="16.8.30523.219"/>
-    <PackageReference Include="Microsoft.VisualStudio.Interop"                                        Version="17.0.0-previews-1-31321-016"/>
+    <PackageReference Include="Microsoft.VisualStudio.Interop"                                        Version="17.0.0-previews-2-31421-281"/>
     <PackageReference Include="Microsoft.Internal.VisualStudio.Interop"                               Version="17.0.0-previews-1-31321-016"/>
     
     <!-- https://github.com/dotnet/roslyn/issues/53877 -->
@@ -98,6 +99,9 @@
 
     <!-- Framework packages -->
     <PackageReference Update="Microsoft.IO.Redist"                                                    Version="4.7.1" />
+    
+    <!-- Hot Reload -->
+    <PackageReference Update="Microsoft.VisualStudio.HotReload.Components"                            Version="6.0.0-preview.6.21328.2" />
     
     <!-- 3rd party -->
     <PackageReference Update="Newtonsoft.Json"                                                        Version="12.0.2"/>

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -12,7 +12,6 @@
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
-      https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal/nuget/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
 
@@ -101,7 +100,7 @@
     <PackageReference Update="Microsoft.IO.Redist"                                                    Version="4.7.1" />
     
     <!-- Hot Reload -->
-    <PackageReference Update="Microsoft.VisualStudio.HotReload.Components"                            Version="6.0.0-preview.6.21328.2" />
+    <PackageReference Update="Microsoft.VisualStudio.HotReload.Components"                            Version="6.0.0-preview.6.21330.17" />
     
     <!-- 3rd party -->
     <PackageReference Update="Newtonsoft.Json"                                                        Version="12.0.2"/>

--- a/build/import/VisualStudio.props
+++ b/build/import/VisualStudio.props
@@ -18,6 +18,7 @@
 
     <!-- VS SDK -->
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" />
+    <PackageReference Include="Microsoft.VisualStudio.Debugger.Contracts" />
     <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" />    
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -19,6 +19,9 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.HotReload.Components" />
+  </ItemGroup>
+  <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Buffers.PooledObjects;
+using Microsoft.VisualStudio.HotReload.Components.DeltaApplier;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
@@ -791,7 +792,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             return TaskResult.False;
         }
 
-        public object? GetDeltaApplier()
+        public IDeltaApplier? GetDeltaApplier()
         {
             return null;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -456,6 +456,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             }
 
             if (IsRunProjectCommand(resolvedProfile)
+                && resolvedProfile.IsHotReloadEnabled()
                 && await DebugFrameworkSupportsHotReloadAsync()
                 && await GetDebugFrameworkVersionAsync() is string frameworkVersion)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -457,6 +457,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             if (IsRunProjectCommand(resolvedProfile)
                 && resolvedProfile.IsHotReloadEnabled()
+                && (launchOptions & DebugLaunchOptions.NoDebug) == DebugLaunchOptions.NoDebug
                 && await DebugFrameworkSupportsHotReloadAsync()
                 && await GetDebugFrameworkVersionAsync() is string frameworkVersion)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/HotReloadDiagnosticOutputService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/HotReloadDiagnosticOutputService.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
+{
+    [Export(typeof(IHotReloadDiagnosticOutputService))]
+    internal class HotReloadOutputWindowPaneProvider : IHotReloadDiagnosticOutputService
+    {
+        // This is the well-known GUID for the Hot Reload output window pane.
+        private static readonly Guid s_hotReloadOutputWindowPaneGuid = new("{7BD3920C-C53C-40ED-8D79-4D2F601BEFB0}");
+
+        private readonly IProjectThreadingService _threadingService;
+        private readonly IVsUIService<IVsOutputWindow?> _outputWindow;
+        private readonly AsyncLazy<IVsOutputWindowPane?> _outputWindowPane;
+
+        [ImportingConstructor]
+        public HotReloadOutputWindowPaneProvider(IProjectThreadingService threadingService, IVsUIService<SVsOutputWindow, IVsOutputWindow?> outputWindow)
+        {
+            _threadingService = threadingService;
+            _outputWindow = outputWindow;
+            _outputWindowPane = new AsyncLazy<IVsOutputWindowPane?>(CreateOutputWindowPaneAsync, threadingService.JoinableTaskFactory);
+        }
+
+        private async Task<IVsOutputWindowPane?> CreateOutputWindowPaneAsync()
+        {
+            await _threadingService.SwitchToUIThread();
+
+            IVsOutputWindow? outputWindow = _outputWindow.Value;
+            if (outputWindow is null)
+            {
+                return null;    // Command-line build
+            }
+
+            Guid activePane = outputWindow.GetActivePane();
+
+            IVsOutputWindowPane pane = CreateProjectOutputWindowPane(outputWindow);
+
+            // Creating a pane causes it to be "active", reset the active pane back to the previously active pane
+            if (activePane != Guid.Empty)
+            {
+                outputWindow.ActivatePane(activePane);
+            }
+
+            return pane;
+        }
+
+        private static IVsOutputWindowPane CreateProjectOutputWindowPane(IVsOutputWindow outputWindow)
+        {
+            Guid paneGuid = s_hotReloadOutputWindowPaneGuid;
+
+            Verify.HResult(outputWindow.CreatePane(ref paneGuid, VSResources.HotReloadOutputWindowPaneName, fInitVisible: 1, fClearWithSolution: 0));
+
+            Verify.HResult(outputWindow.GetPane(ref paneGuid, out IVsOutputWindowPane pane));
+
+            return pane;
+        }
+
+        public async Task WriteLineAsync(string outputMessage)
+        {
+            await _threadingService.SwitchToUIThread();
+
+            IVsOutputWindowPane? pane = await _outputWindowPane.GetValueAsync();
+            if (pane is not null)
+            {
+                pane.OutputString(outputMessage + Environment.NewLine);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IHotReloadDiagnosticOutputService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IHotReloadDiagnosticOutputService.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
+{
+    /// <summary>
+    /// Defines a service to print out messages to the Hot Reload output window pane.
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.System, Cardinality = Composition.ImportCardinality.OneOrZero)]
+    internal interface IHotReloadDiagnosticOutputService
+    {
+        /// <summary>
+        /// Writes a message to the Hot Reload diagnostic output window.
+        /// </summary>
+        /// <param name="outputMessage">The message to write.</param>
+        Task WriteLineAsync(string outputMessage);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadAgent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadAgent.cs
@@ -2,8 +2,9 @@
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 {
+    [ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.System, Cardinality = Composition.ImportCardinality.ExactlyOne)]
     public interface IProjectHotReloadAgent
     {
-        IProjectHotReloadSession? CreateHotReloadSession(string runtimeVersion, IProjectHotReloadSessionCallback callback);
+        IProjectHotReloadSession? CreateHotReloadSession(string id, string runtimeVersion, IProjectHotReloadSessionCallback callback);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadAgent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadAgent.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
+{
+    public interface IProjectHotReloadAgent
+    {
+        IProjectHotReloadSession? CreateHotReloadSession(string runtimeVersion, IProjectHotReloadSessionCallback callback);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSession.cs
@@ -8,15 +8,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 {
     public interface IProjectHotReloadSession
     {
-        bool IsSupported { get; }
-
         Task StartSessionAsync(CancellationToken cancellationToken);
 
         Task StopSessionAsync(CancellationToken cancellationToken);
 
         Task ApplyChangesAsync(CancellationToken cancellationToken);
 
-        Task<bool> ApplyLaunchVariablesAsync(IDictionary<string, string> envVars, string configuration, CancellationToken cancellationToken);
-
+        Task<bool> ApplyLaunchVariablesAsync(IDictionary<string, string> envVars, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSession.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
+{
+    public interface IProjectHotReloadSession
+    {
+        bool IsSupported { get; }
+
+        Task StartSessionAsync(CancellationToken cancellationToken);
+
+        Task StopSessionAsync(CancellationToken cancellationToken);
+
+        Task ApplyChangesAsync(CancellationToken cancellationToken);
+
+        Task<bool> ApplyLaunchVariablesAsync(IDictionary<string, string> envVars, string configuration, CancellationToken cancellationToken);
+
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionCallback.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionCallback.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
+{
+    public interface IProjectHotReloadSessionCallback
+    {
+        bool IsSupported { get; }
+
+        bool SupportsRestart { get; }
+
+        Task OnAfterChangesAppliedAsync(CancellationToken cancellationToken);
+
+        Task<bool> StopProjectAsync(CancellationToken cancellationToken);
+
+        Task<bool> RestartProjectAsync(CancellationToken cancellationToken);
+
+        // TODO: IDeltaApplier will be defined elsewhere. Add this back in once we
+        // can reference it in the final location.
+        // IDeltaApplier GetDeltaApplier();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionCallback.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionCallback.cs
@@ -2,6 +2,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.HotReload.Components.DeltaApplier;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 {
@@ -15,8 +16,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 
         Task<bool> RestartProjectAsync(CancellationToken cancellationToken);
 
-        // TODO: IDeltaApplier will be defined elsewhere. Add this back in once we
-        // can reference it in the final location.
-        object? GetDeltaApplier();
+        IDeltaApplier? GetDeltaApplier();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionCallback.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionCallback.cs
@@ -17,6 +17,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 
         // TODO: IDeltaApplier will be defined elsewhere. Add this back in once we
         // can reference it in the final location.
-        object GetDeltaApplier();
+        object? GetDeltaApplier();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionCallback.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionCallback.cs
@@ -19,6 +19,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 
         // TODO: IDeltaApplier will be defined elsewhere. Add this back in once we
         // can reference it in the final location.
-        // IDeltaApplier GetDeltaApplier();
+        object GetDeltaApplier();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionCallback.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionCallback.cs
@@ -7,8 +7,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 {
     public interface IProjectHotReloadSessionCallback
     {
-        bool IsSupported { get; }
-
         bool SupportsRestart { get; }
 
         Task OnAfterChangesAppliedAsync(CancellationToken cancellationToken);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadAgent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadAgent.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Debugger.Contracts.HotReload;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
+{
+    [Export(typeof(IProjectHotReloadAgent))]
+    internal class ProjectHotReloadAgent : IProjectHotReloadAgent
+    {
+        private readonly Lazy<IHotReloadAgentManagerClient> _hotReloadAgentManagerClient;
+        private readonly Lazy<IHotReloadDiagnosticOutputService> _hotReloadDiagnosticOutputService;
+        private readonly Lazy<IManagedDeltaApplierCreator> _managedDeltaApplierCreator;
+
+        [ImportingConstructor]
+        public ProjectHotReloadAgent(
+            Lazy<IHotReloadAgentManagerClient> hotReloadAgentManagerClient,
+            Lazy<IHotReloadDiagnosticOutputService> hotReloadDiagnosticOutputService,
+            Lazy<IManagedDeltaApplierCreator> managedDeltaApplierCreator)
+        {
+            _hotReloadAgentManagerClient = hotReloadAgentManagerClient;
+            _hotReloadDiagnosticOutputService = hotReloadDiagnosticOutputService;
+            _managedDeltaApplierCreator = managedDeltaApplierCreator;
+        }
+
+        public IProjectHotReloadSession? CreateHotReloadSession(string id, string runtimeVersion, IProjectHotReloadSessionCallback callback)
+        {
+            return new ProjectHotReloadSession(
+                id,
+                runtimeVersion,
+                _hotReloadAgentManagerClient,
+                _hotReloadDiagnosticOutputService,
+                _managedDeltaApplierCreator,
+                callback);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadAgent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadAgent.cs
@@ -3,6 +3,7 @@
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Debugger.Contracts.HotReload;
+using Microsoft.VisualStudio.HotReload.Components.DeltaApplier;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
@@ -1,0 +1,178 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Debugger.Contracts.HotReload;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
+{
+    internal class ProjectHotReloadSession : IManagedHotReloadAgent, IProjectHotReloadSession
+    {
+        private readonly string _id;
+        private readonly string _runtimeVersion;
+        private readonly Lazy<IHotReloadAgentManagerClient> _hotReloadAgentManagerClient;
+        private readonly Lazy<IHotReloadDiagnosticOutputService> _hotReloadOutputService;
+        private readonly Lazy<IManagedDeltaApplierCreator> _deltaApplierCreator;
+        private readonly IProjectHotReloadSessionCallback _callback;
+
+        private bool _sessionActive;
+        private IDeltaApplier? _deltaApplier;
+
+        public ProjectHotReloadSession(
+            string id,
+            string runtimeVersion,
+            Lazy<IHotReloadAgentManagerClient> hotReloadAgentManagerClient,
+            Lazy<IHotReloadDiagnosticOutputService> hotReloadOutputService,
+            Lazy<IManagedDeltaApplierCreator> deltaApplierCreator,
+            IProjectHotReloadSessionCallback callback)
+        {
+            _id = id;
+            _runtimeVersion = runtimeVersion;
+            _hotReloadAgentManagerClient = hotReloadAgentManagerClient;
+            _hotReloadOutputService = hotReloadOutputService;
+            _deltaApplierCreator = deltaApplierCreator;
+            _callback = callback;
+        }
+
+        public bool IsSupported => throw new NotImplementedException();
+
+        // IProjectHotReloadSession
+
+        public async Task ApplyChangesAsync(CancellationToken cancellationToken)
+        {
+            if (_sessionActive)
+            {
+                await _hotReloadAgentManagerClient.Value.ApplyUpdatesAsync(cancellationToken);
+            }
+        }
+
+        public async Task<bool> ApplyLaunchVariablesAsync(IDictionary<string, string> envVars, string configuration, CancellationToken cancellationToken)
+        {
+            if (string.Equals(configuration, "Debug", StringComparison.OrdinalIgnoreCase) && IsSupported)
+            {
+                EnsureDeltaApplierforSession();
+                if (_deltaApplier is not null)
+                {
+                    return await _deltaApplier.ApplyProcessEnvironmentVariablesAsync(envVars, cancellationToken);
+                }
+            }
+
+            return false;
+        }
+
+        public async Task StartSessionAsync(CancellationToken cancellationToken)
+        {
+            if (!_sessionActive)
+            {
+                await WriteToOutputWindowAsync(VSResources.HotReloadStartSession);
+                await _hotReloadAgentManagerClient.Value.AgentStartedAsync(this, cancellationToken);
+                _sessionActive = true;
+                EnsureDeltaApplierforSession();
+            }
+        }
+
+        public async Task StopSessionAsync(CancellationToken cancellationToken)
+        {
+            if (_sessionActive)
+            {
+                await WriteToOutputWindowAsync(VSResources.HotReloadStopSession);
+                _sessionActive = false;
+
+                await _hotReloadAgentManagerClient.Value.AgentTerminatedAsync(this, cancellationToken);
+            }
+        }
+
+        // IManagedHotReloadAgent
+
+        public async ValueTask ApplyUpdatesAsync(ImmutableArray<ManagedHotReloadUpdate> updates, CancellationToken cancellationToken)
+        {
+            if (!_sessionActive || _deltaApplier is null)
+            {
+                return;
+            }
+
+            try
+            {
+                await WriteToOutputWindowAsync(VSResources.HotReloadSendingUpdates);
+
+                ApplyResult result = await _deltaApplier.ApplyUpdatesAsync(updates, cancellationToken);
+                if (result == ApplyResult.Success || result == ApplyResult.SuccessRefreshUI)
+                {
+                    await WriteToOutputWindowAsync(VSResources.HotReloadApplyUpdatesSuccessful);
+                    if (_callback is not null)
+                    {
+                        await _callback.OnAfterChangesAppliedAsync(cancellationToken);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                string message = $"{ex.GetType()}: {ex.Message}";
+
+                await WriteToOutputWindowAsync(string.Format(VSResources.HotReloadApplyUpdatesFailure, message));
+                throw;
+            }
+        }
+
+        public async ValueTask<ImmutableArray<string>> GetCapabilitiesAsync(CancellationToken cancellationToken)
+        {
+            // Delegate to the delta applier for the session
+            if (_deltaApplier is not null)
+            {
+                return await _deltaApplier.GetCapabilitiesAsync(cancellationToken);
+            }
+            return ImmutableArray<string>.Empty;
+        }
+
+        public async ValueTask ReportDiagnosticsAsync(ImmutableArray<ManagedHotReloadDiagnostic> diagnostics, CancellationToken cancellationToken)
+        {
+            await WriteToOutputWindowAsync(VSResources.HotReloadErrorsInApplication);
+
+            foreach (ManagedHotReloadDiagnostic diagnostic in diagnostics)
+            {
+                await WriteToOutputWindowAsync($"{diagnostic.FilePath}({diagnostic.Span.StartLine},{diagnostic.Span.StartColumn},{diagnostic.Span.EndLine},{diagnostic.Span.EndColumn}): {diagnostic.Message}");
+            }
+        }
+
+        public async ValueTask RestartAsync(CancellationToken cancellationToken)
+        {
+            await WriteToOutputWindowAsync(VSResources.HotReloadRestartInProgress);
+
+            await _callback.RestartProjectAsync(cancellationToken);
+
+            // TODO: Should we stop the session here? Or does someone else do it?
+            // TODO: Should we handle rebuilding here? Or do we expect the callback to handle it?
+        }
+
+        public async ValueTask StopAsync(CancellationToken cancellationToken)
+        {
+            await WriteToOutputWindowAsync(VSResources.HotReloadStoppingApplication);
+
+            await _callback.StopProjectAsync(cancellationToken);
+
+            // TODO: Should we stop the session here? Or does someone else do it?
+        }
+
+        public ValueTask<bool> SupportsRestartAsync(CancellationToken cancellationToken)
+        {
+            return new ValueTask<bool>(_callback.SupportsRestart);
+        }
+
+        private Task WriteToOutputWindowAsync(string message)
+        {
+            return _hotReloadOutputService.Value.WriteLineAsync($"{_id}: {message}");
+        }
+
+        private void EnsureDeltaApplierforSession()
+        {
+            if (_deltaApplier is null)
+            {
+                _deltaApplier = (IDeltaApplier)(_callback.GetDeltaApplier()
+                    ?? _deltaApplierCreator.Value.CreateManagedDeltaApplier(_runtimeVersion));
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
@@ -37,8 +37,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             _callback = callback;
         }
 
-        public bool IsSupported => throw new NotImplementedException();
-
         // IProjectHotReloadSession
 
         public async Task ApplyChangesAsync(CancellationToken cancellationToken)
@@ -49,15 +47,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             }
         }
 
-        public async Task<bool> ApplyLaunchVariablesAsync(IDictionary<string, string> envVars, string configuration, CancellationToken cancellationToken)
+        public async Task<bool> ApplyLaunchVariablesAsync(IDictionary<string, string> envVars, CancellationToken cancellationToken)
         {
-            if (string.Equals(configuration, "Debug", StringComparison.OrdinalIgnoreCase) && IsSupported)
+            EnsureDeltaApplierforSession();
+            if (_deltaApplier is not null)
             {
-                EnsureDeltaApplierforSession();
-                if (_deltaApplier is not null)
-                {
-                    return await _deltaApplier.ApplyProcessEnvironmentVariablesAsync(envVars, cancellationToken);
-                }
+                return await _deltaApplier.ApplyProcessEnvironmentVariablesAsync(envVars, cancellationToken);
             }
 
             return false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
@@ -62,8 +62,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
         {
             if (!_sessionActive)
             {
-                await WriteToOutputWindowAsync(VSResources.HotReloadStartSession);
                 await _hotReloadAgentManagerClient.Value.AgentStartedAsync(this, cancellationToken);
+                await WriteToOutputWindowAsync(VSResources.HotReloadStartSession);
                 _sessionActive = true;
                 EnsureDeltaApplierforSession();
             }
@@ -73,10 +73,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
         {
             if (_sessionActive)
             {
-                await WriteToOutputWindowAsync(VSResources.HotReloadStopSession);
                 _sessionActive = false;
 
                 await _hotReloadAgentManagerClient.Value.AgentTerminatedAsync(this, cancellationToken);
+                await WriteToOutputWindowAsync(VSResources.HotReloadStopSession);
             }
         }
 
@@ -84,6 +84,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 
         public async ValueTask ApplyUpdatesAsync(ImmutableArray<ManagedHotReloadUpdate> updates, CancellationToken cancellationToken)
         {
+            if (!_sessionActive)
+            {
+                await WriteToOutputWindowAsync($"ApplyUpdatesAsync called but the session is not active.");
+                return;
+            }
+
+            if (_deltaApplier is null)
+            {
+                await WriteToOutputWindowAsync($"ApplyUpdatesAsync called but we have no delta applier.");
+            }
+
             if (!_sessionActive || _deltaApplier is null)
             {
                 return;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -11,7 +11,7 @@ Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.Apply
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.StartSessionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.StopSessionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback
-Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.GetDeltaApplier() -> object!
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.GetDeltaApplier() -> object?
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.OnAfterChangesAppliedAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.RestartProjectAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.StopProjectAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -4,7 +4,7 @@ Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugProfileLaunchTargetsProvider
 Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugProfileLaunchTargetsProvider4.OnAfterLaunchAsync(Microsoft.VisualStudio.ProjectSystem.Debug.DebugLaunchOptions launchOptions, Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile! profile, System.Collections.Generic.IReadOnlyList<Microsoft.VisualStudio.Shell.Interop.VsDebugTargetProcessInfo>! processInfos) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugProfileLaunchTargetsProvider4.OnBeforeLaunchAsync(Microsoft.VisualStudio.ProjectSystem.Debug.DebugLaunchOptions launchOptions, Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile! profile, System.Collections.Generic.IReadOnlyList<Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugLaunchSettings!>! debugLaunchSettings) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadAgent
-Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadAgent.CreateHotReloadSession(string! runtimeVersion, Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback! callback) -> Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession?
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadAgent.CreateHotReloadSession(string! id, string! runtimeVersion, Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback! callback) -> Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession?
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.ApplyChangesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.ApplyLaunchVariablesAsync(System.Collections.Generic.IDictionary<string!, string!>! envVars, string! configuration, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
@@ -12,6 +12,7 @@ Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.IsSup
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.StartSessionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.StopSessionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.GetDeltaApplier() -> object!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.IsSupported.get -> bool
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.OnAfterChangesAppliedAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.RestartProjectAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -3,5 +3,19 @@ Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugProfileLaunchTargetsProvider
 Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugProfileLaunchTargetsProvider4
 Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugProfileLaunchTargetsProvider4.OnAfterLaunchAsync(Microsoft.VisualStudio.ProjectSystem.Debug.DebugLaunchOptions launchOptions, Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile! profile, System.Collections.Generic.IReadOnlyList<Microsoft.VisualStudio.Shell.Interop.VsDebugTargetProcessInfo>! processInfos) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugProfileLaunchTargetsProvider4.OnBeforeLaunchAsync(Microsoft.VisualStudio.ProjectSystem.Debug.DebugLaunchOptions launchOptions, Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile! profile, System.Collections.Generic.IReadOnlyList<Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugLaunchSettings!>! debugLaunchSettings) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadAgent
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadAgent.CreateHotReloadSession(string! runtimeVersion, Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback! callback) -> Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession?
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.ApplyChangesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.ApplyLaunchVariablesAsync(System.Collections.Generic.IDictionary<string!, string!>! envVars, string! configuration, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.IsSupported.get -> bool
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.StartSessionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.StopSessionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.IsSupported.get -> bool
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.OnAfterChangesAppliedAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.RestartProjectAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.StopProjectAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.SupportsRestart.get -> bool
 ~static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.JSWebView2DebuggingAdditionalText.get -> string
 ~static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.chkJSWebView2DebuggingText.get -> string

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -7,13 +7,11 @@ Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadAgent
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadAgent.CreateHotReloadSession(string! id, string! runtimeVersion, Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback! callback) -> Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession?
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.ApplyChangesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
-Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.ApplyLaunchVariablesAsync(System.Collections.Generic.IDictionary<string!, string!>! envVars, string! configuration, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
-Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.IsSupported.get -> bool
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.ApplyLaunchVariablesAsync(System.Collections.Generic.IDictionary<string!, string!>! envVars, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.StartSessionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.StopSessionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.GetDeltaApplier() -> object!
-Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.IsSupported.get -> bool
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.OnAfterChangesAppliedAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.RestartProjectAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.StopProjectAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -11,7 +11,7 @@ Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.Apply
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.StartSessionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.StopSessionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback
-Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.GetDeltaApplier() -> object?
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.GetDeltaApplier() -> Microsoft.VisualStudio.HotReload.Components.DeltaApplier.IDeltaApplier?
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.OnAfterChangesAppliedAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.RestartProjectAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback.StopProjectAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsOutputWindowExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsOutputWindowExtensions.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using Microsoft.VisualStudio.ProjectSystem.VS;
+
+namespace Microsoft.VisualStudio.Shell.Interop
+{
+    /// <summary>
+    ///     Provides extension methods for <see cref="IVsOutputWindow"/>.
+    /// </summary>
+    internal static class IVsOutputWindowExtensions
+    {
+        /// <summary>
+        ///     Actives the output window pane associated with the specified GUID. Does nothing if the pane cannot be found.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="outputWindow"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="paneGuid"/> is empty.
+        /// </exception>
+        public static void ActivatePane(this IVsOutputWindow outputWindow, Guid paneGuid)
+        {
+            Requires.NotNull(outputWindow, nameof(outputWindow));
+            Requires.NotEmpty(paneGuid, nameof(paneGuid));
+
+            HResult hr = outputWindow.GetPane(ref paneGuid, out IVsOutputWindowPane pane);
+            if (hr.IsOK) // Pane found
+            {
+                Verify.HResult(pane.Activate());
+            }
+        }
+
+        /// <summary>
+        ///     Returns the GUID associated with the active window pane, or <see cref="Guid.Empty"/> if no
+        ///     active pane or the active pane is unknown.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="outputWindow"/> is <see langword="null"/>.
+        /// </exception>
+        public static Guid GetActivePane(this IVsOutputWindow outputWindow)
+        {
+            Requires.NotNull(outputWindow, nameof(outputWindow));
+
+            if (outputWindow is IVsOutputWindow2 outputWindow2)
+            {
+                Verify.HResult(outputWindow2.GetActivePaneGUID(out Guid activePaneGuid));
+
+                return activePaneGuid;
+            }
+
+            return Guid.Empty;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -232,6 +232,15 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hot Reload.
+        /// </summary>
+        internal static string HotReloadOutputWindowPaneName {
+            get {
+                return ResourceManager.GetString("HotReloadOutputWindowPaneName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} - Import comes fom target file. This import cannot be removed..
         /// </summary>
         internal static string ImportsFromTargetCannotBeDeleted {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -232,11 +232,83 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Applying updates failed: {0}.
+        /// </summary>
+        internal static string HotReloadApplyUpdatesFailure {
+            get {
+                return ResourceManager.GetString("HotReloadApplyUpdatesFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Updates applied successfully.
+        /// </summary>
+        internal static string HotReloadApplyUpdatesSuccessful {
+            get {
+                return ResourceManager.GetString("HotReloadApplyUpdatesSuccessful", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Errors found in application: .
+        /// </summary>
+        internal static string HotReloadErrorsInApplication {
+            get {
+                return ResourceManager.GetString("HotReloadErrorsInApplication", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hot Reload.
         /// </summary>
         internal static string HotReloadOutputWindowPaneName {
             get {
                 return ResourceManager.GetString("HotReloadOutputWindowPaneName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rebuilding and restarting the application since the edits can&apos;t be applied dynamically..
+        /// </summary>
+        internal static string HotReloadRestartInProgress {
+            get {
+                return ResourceManager.GetString("HotReloadRestartInProgress", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sending updates to running application.
+        /// </summary>
+        internal static string HotReloadSendingUpdates {
+            get {
+                return ResourceManager.GetString("HotReloadSendingUpdates", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hot Reload session started.
+        /// </summary>
+        internal static string HotReloadStartSession {
+            get {
+                return ResourceManager.GetString("HotReloadStartSession", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stopping application.
+        /// </summary>
+        internal static string HotReloadStoppingApplication {
+            get {
+                return ResourceManager.GetString("HotReloadStoppingApplication", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hot Reload session complete.
+        /// </summary>
+        internal static string HotReloadStopSession {
+            get {
+                return ResourceManager.GetString("HotReloadStopSession", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -253,4 +253,8 @@ In order to debug this project, add an executable project to this solution which
     <value>Profile {0}</value>
     <comment>Default name for new launch profiles. The {0} is a decimal number chosen to guarantee the name is unique.</comment>
   </data>
+  <data name="HotReloadOutputWindowPaneName" xml:space="preserve">
+    <value>Hot Reload</value>
+    <comment>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</comment>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -257,4 +257,28 @@ In order to debug this project, add an executable project to this solution which
     <value>Hot Reload</value>
     <comment>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</comment>
   </data>
+  <data name="HotReloadApplyUpdatesSuccessful" xml:space="preserve">
+    <value>Updates applied successfully</value>
+  </data>
+  <data name="HotReloadApplyUpdatesFailure" xml:space="preserve">
+    <value>Applying updates failed: {0}</value>
+  </data>
+  <data name="HotReloadErrorsInApplication" xml:space="preserve">
+    <value>Errors found in application: </value>
+  </data>
+  <data name="HotReloadRestartInProgress" xml:space="preserve">
+    <value>Rebuilding and restarting the application since the edits can't be applied dynamically.</value>
+  </data>
+  <data name="HotReloadStoppingApplication" xml:space="preserve">
+    <value>Stopping application</value>
+  </data>
+  <data name="HotReloadStartSession" xml:space="preserve">
+    <value>Hot Reload session started</value>
+  </data>
+  <data name="HotReloadStopSession" xml:space="preserve">
+    <value>Hot Reload session complete</value>
+  </data>
+  <data name="HotReloadSendingUpdates" xml:space="preserve">
+    <value>Sending updates to running application</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Cesta</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadOutputWindowPaneName">
+        <source>Hot Reload</source>
+        <target state="new">Hot Reload</target>
+        <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} – import pochází z cílového souboru. Tento import nelze odebrat.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -52,10 +52,50 @@
         <target state="translated">Cesta</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesFailure">
+        <source>Applying updates failed: {0}</source>
+        <target state="new">Applying updates failed: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesSuccessful">
+        <source>Updates applied successfully</source>
+        <target state="new">Updates applied successfully</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadErrorsInApplication">
+        <source>Errors found in application: </source>
+        <target state="new">Errors found in application: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="HotReloadOutputWindowPaneName">
         <source>Hot Reload</source>
         <target state="new">Hot Reload</target>
         <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
+      <trans-unit id="HotReloadRestartInProgress">
+        <source>Rebuilding and restarting the application since the edits can't be applied dynamically.</source>
+        <target state="new">Rebuilding and restarting the application since the edits can't be applied dynamically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadSendingUpdates">
+        <source>Sending updates to running application</source>
+        <target state="new">Sending updates to running application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStartSession">
+        <source>Hot Reload session started</source>
+        <target state="new">Hot Reload session started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStopSession">
+        <source>Hot Reload session complete</source>
+        <target state="new">Hot Reload session complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStoppingApplication">
+        <source>Stopping application</source>
+        <target state="new">Stopping application</target>
+        <note />
       </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Pfad</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadOutputWindowPaneName">
+        <source>Hot Reload</source>
+        <target state="new">Hot Reload</target>
+        <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} – Import kommt von der Zieldatei. Dieser Import kann nicht entfernt werden.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -52,10 +52,50 @@
         <target state="translated">Pfad</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesFailure">
+        <source>Applying updates failed: {0}</source>
+        <target state="new">Applying updates failed: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesSuccessful">
+        <source>Updates applied successfully</source>
+        <target state="new">Updates applied successfully</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadErrorsInApplication">
+        <source>Errors found in application: </source>
+        <target state="new">Errors found in application: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="HotReloadOutputWindowPaneName">
         <source>Hot Reload</source>
         <target state="new">Hot Reload</target>
         <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
+      <trans-unit id="HotReloadRestartInProgress">
+        <source>Rebuilding and restarting the application since the edits can't be applied dynamically.</source>
+        <target state="new">Rebuilding and restarting the application since the edits can't be applied dynamically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadSendingUpdates">
+        <source>Sending updates to running application</source>
+        <target state="new">Sending updates to running application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStartSession">
+        <source>Hot Reload session started</source>
+        <target state="new">Hot Reload session started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStopSession">
+        <source>Hot Reload session complete</source>
+        <target state="new">Hot Reload session complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStoppingApplication">
+        <source>Stopping application</source>
+        <target state="new">Stopping application</target>
+        <note />
       </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Ruta de acceso</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadOutputWindowPaneName">
+        <source>Hot Reload</source>
+        <target state="new">Hot Reload</target>
+        <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0}: la importación procede del archivo de destino. Esta importación no se puede quitar.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -52,10 +52,50 @@
         <target state="translated">Ruta de acceso</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesFailure">
+        <source>Applying updates failed: {0}</source>
+        <target state="new">Applying updates failed: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesSuccessful">
+        <source>Updates applied successfully</source>
+        <target state="new">Updates applied successfully</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadErrorsInApplication">
+        <source>Errors found in application: </source>
+        <target state="new">Errors found in application: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="HotReloadOutputWindowPaneName">
         <source>Hot Reload</source>
         <target state="new">Hot Reload</target>
         <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
+      <trans-unit id="HotReloadRestartInProgress">
+        <source>Rebuilding and restarting the application since the edits can't be applied dynamically.</source>
+        <target state="new">Rebuilding and restarting the application since the edits can't be applied dynamically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadSendingUpdates">
+        <source>Sending updates to running application</source>
+        <target state="new">Sending updates to running application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStartSession">
+        <source>Hot Reload session started</source>
+        <target state="new">Hot Reload session started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStopSession">
+        <source>Hot Reload session complete</source>
+        <target state="new">Hot Reload session complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStoppingApplication">
+        <source>Stopping application</source>
+        <target state="new">Stopping application</target>
+        <note />
       </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -52,10 +52,50 @@
         <target state="translated">Chemin</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesFailure">
+        <source>Applying updates failed: {0}</source>
+        <target state="new">Applying updates failed: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesSuccessful">
+        <source>Updates applied successfully</source>
+        <target state="new">Updates applied successfully</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadErrorsInApplication">
+        <source>Errors found in application: </source>
+        <target state="new">Errors found in application: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="HotReloadOutputWindowPaneName">
         <source>Hot Reload</source>
         <target state="new">Hot Reload</target>
         <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
+      <trans-unit id="HotReloadRestartInProgress">
+        <source>Rebuilding and restarting the application since the edits can't be applied dynamically.</source>
+        <target state="new">Rebuilding and restarting the application since the edits can't be applied dynamically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadSendingUpdates">
+        <source>Sending updates to running application</source>
+        <target state="new">Sending updates to running application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStartSession">
+        <source>Hot Reload session started</source>
+        <target state="new">Hot Reload session started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStopSession">
+        <source>Hot Reload session complete</source>
+        <target state="new">Hot Reload session complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStoppingApplication">
+        <source>Stopping application</source>
+        <target state="new">Stopping application</target>
+        <note />
       </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Chemin</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadOutputWindowPaneName">
+        <source>Hot Reload</source>
+        <target state="new">Hot Reload</target>
+        <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} - L'importation provient du fichier cible. Impossible de supprimer cette importation.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -52,10 +52,50 @@
         <target state="translated">Percorso</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesFailure">
+        <source>Applying updates failed: {0}</source>
+        <target state="new">Applying updates failed: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesSuccessful">
+        <source>Updates applied successfully</source>
+        <target state="new">Updates applied successfully</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadErrorsInApplication">
+        <source>Errors found in application: </source>
+        <target state="new">Errors found in application: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="HotReloadOutputWindowPaneName">
         <source>Hot Reload</source>
         <target state="new">Hot Reload</target>
         <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
+      <trans-unit id="HotReloadRestartInProgress">
+        <source>Rebuilding and restarting the application since the edits can't be applied dynamically.</source>
+        <target state="new">Rebuilding and restarting the application since the edits can't be applied dynamically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadSendingUpdates">
+        <source>Sending updates to running application</source>
+        <target state="new">Sending updates to running application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStartSession">
+        <source>Hot Reload session started</source>
+        <target state="new">Hot Reload session started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStopSession">
+        <source>Hot Reload session complete</source>
+        <target state="new">Hot Reload session complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStoppingApplication">
+        <source>Stopping application</source>
+        <target state="new">Stopping application</target>
+        <note />
       </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Percorso</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadOutputWindowPaneName">
+        <source>Hot Reload</source>
+        <target state="new">Hot Reload</target>
+        <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} - L'importazione proviene dal file di destinazione e non può essere rimossa.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -52,6 +52,11 @@
         <target state="translated">パス</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadOutputWindowPaneName">
+        <source>Hot Reload</source>
+        <target state="new">Hot Reload</target>
+        <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} - インポートは、ターゲット ファイルからのものです。このインポートは削除できません。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -52,10 +52,50 @@
         <target state="translated">パス</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesFailure">
+        <source>Applying updates failed: {0}</source>
+        <target state="new">Applying updates failed: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesSuccessful">
+        <source>Updates applied successfully</source>
+        <target state="new">Updates applied successfully</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadErrorsInApplication">
+        <source>Errors found in application: </source>
+        <target state="new">Errors found in application: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="HotReloadOutputWindowPaneName">
         <source>Hot Reload</source>
         <target state="new">Hot Reload</target>
         <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
+      <trans-unit id="HotReloadRestartInProgress">
+        <source>Rebuilding and restarting the application since the edits can't be applied dynamically.</source>
+        <target state="new">Rebuilding and restarting the application since the edits can't be applied dynamically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadSendingUpdates">
+        <source>Sending updates to running application</source>
+        <target state="new">Sending updates to running application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStartSession">
+        <source>Hot Reload session started</source>
+        <target state="new">Hot Reload session started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStopSession">
+        <source>Hot Reload session complete</source>
+        <target state="new">Hot Reload session complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStoppingApplication">
+        <source>Stopping application</source>
+        <target state="new">Stopping application</target>
+        <note />
       </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -52,10 +52,50 @@
         <target state="translated">경로</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesFailure">
+        <source>Applying updates failed: {0}</source>
+        <target state="new">Applying updates failed: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesSuccessful">
+        <source>Updates applied successfully</source>
+        <target state="new">Updates applied successfully</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadErrorsInApplication">
+        <source>Errors found in application: </source>
+        <target state="new">Errors found in application: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="HotReloadOutputWindowPaneName">
         <source>Hot Reload</source>
         <target state="new">Hot Reload</target>
         <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
+      <trans-unit id="HotReloadRestartInProgress">
+        <source>Rebuilding and restarting the application since the edits can't be applied dynamically.</source>
+        <target state="new">Rebuilding and restarting the application since the edits can't be applied dynamically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadSendingUpdates">
+        <source>Sending updates to running application</source>
+        <target state="new">Sending updates to running application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStartSession">
+        <source>Hot Reload session started</source>
+        <target state="new">Hot Reload session started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStopSession">
+        <source>Hot Reload session complete</source>
+        <target state="new">Hot Reload session complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStoppingApplication">
+        <source>Stopping application</source>
+        <target state="new">Stopping application</target>
+        <note />
       </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -52,6 +52,11 @@
         <target state="translated">경로</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadOutputWindowPaneName">
+        <source>Hot Reload</source>
+        <target state="new">Hot Reload</target>
+        <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} - 대상 파일에서 가져옵니다. 이 가져오기는 제거할 수 없습니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Ścieżka</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadOutputWindowPaneName">
+        <source>Hot Reload</source>
+        <target state="new">Hot Reload</target>
+        <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} — import pochodzi z pliku docelowego. Nie można usunąć importu.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -52,10 +52,50 @@
         <target state="translated">Ścieżka</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesFailure">
+        <source>Applying updates failed: {0}</source>
+        <target state="new">Applying updates failed: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesSuccessful">
+        <source>Updates applied successfully</source>
+        <target state="new">Updates applied successfully</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadErrorsInApplication">
+        <source>Errors found in application: </source>
+        <target state="new">Errors found in application: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="HotReloadOutputWindowPaneName">
         <source>Hot Reload</source>
         <target state="new">Hot Reload</target>
         <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
+      <trans-unit id="HotReloadRestartInProgress">
+        <source>Rebuilding and restarting the application since the edits can't be applied dynamically.</source>
+        <target state="new">Rebuilding and restarting the application since the edits can't be applied dynamically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadSendingUpdates">
+        <source>Sending updates to running application</source>
+        <target state="new">Sending updates to running application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStartSession">
+        <source>Hot Reload session started</source>
+        <target state="new">Hot Reload session started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStopSession">
+        <source>Hot Reload session complete</source>
+        <target state="new">Hot Reload session complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStoppingApplication">
+        <source>Stopping application</source>
+        <target state="new">Stopping application</target>
+        <note />
       </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Caminho</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadOutputWindowPaneName">
+        <source>Hot Reload</source>
+        <target state="new">Hot Reload</target>
+        <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} – a importação é proveniente do arquivo de destino. Essa importação não pode ser removida.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -52,10 +52,50 @@
         <target state="translated">Caminho</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesFailure">
+        <source>Applying updates failed: {0}</source>
+        <target state="new">Applying updates failed: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesSuccessful">
+        <source>Updates applied successfully</source>
+        <target state="new">Updates applied successfully</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadErrorsInApplication">
+        <source>Errors found in application: </source>
+        <target state="new">Errors found in application: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="HotReloadOutputWindowPaneName">
         <source>Hot Reload</source>
         <target state="new">Hot Reload</target>
         <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
+      <trans-unit id="HotReloadRestartInProgress">
+        <source>Rebuilding and restarting the application since the edits can't be applied dynamically.</source>
+        <target state="new">Rebuilding and restarting the application since the edits can't be applied dynamically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadSendingUpdates">
+        <source>Sending updates to running application</source>
+        <target state="new">Sending updates to running application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStartSession">
+        <source>Hot Reload session started</source>
+        <target state="new">Hot Reload session started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStopSession">
+        <source>Hot Reload session complete</source>
+        <target state="new">Hot Reload session complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStoppingApplication">
+        <source>Stopping application</source>
+        <target state="new">Stopping application</target>
+        <note />
       </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -52,10 +52,50 @@
         <target state="translated">Путь</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesFailure">
+        <source>Applying updates failed: {0}</source>
+        <target state="new">Applying updates failed: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesSuccessful">
+        <source>Updates applied successfully</source>
+        <target state="new">Updates applied successfully</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadErrorsInApplication">
+        <source>Errors found in application: </source>
+        <target state="new">Errors found in application: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="HotReloadOutputWindowPaneName">
         <source>Hot Reload</source>
         <target state="new">Hot Reload</target>
         <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
+      <trans-unit id="HotReloadRestartInProgress">
+        <source>Rebuilding and restarting the application since the edits can't be applied dynamically.</source>
+        <target state="new">Rebuilding and restarting the application since the edits can't be applied dynamically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadSendingUpdates">
+        <source>Sending updates to running application</source>
+        <target state="new">Sending updates to running application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStartSession">
+        <source>Hot Reload session started</source>
+        <target state="new">Hot Reload session started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStopSession">
+        <source>Hot Reload session complete</source>
+        <target state="new">Hot Reload session complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStoppingApplication">
+        <source>Stopping application</source>
+        <target state="new">Stopping application</target>
+        <note />
       </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Путь</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadOutputWindowPaneName">
+        <source>Hot Reload</source>
+        <target state="new">Hot Reload</target>
+        <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} — источником импорта является целевой файл. Удалить этот импорт невозможно.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Yol</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadOutputWindowPaneName">
+        <source>Hot Reload</source>
+        <target state="new">Hot Reload</target>
+        <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} - İçeri aktarım hedef dosyadan geliyor. Bu içeri aktarım kaldırılamaz.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -52,10 +52,50 @@
         <target state="translated">Yol</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesFailure">
+        <source>Applying updates failed: {0}</source>
+        <target state="new">Applying updates failed: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesSuccessful">
+        <source>Updates applied successfully</source>
+        <target state="new">Updates applied successfully</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadErrorsInApplication">
+        <source>Errors found in application: </source>
+        <target state="new">Errors found in application: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="HotReloadOutputWindowPaneName">
         <source>Hot Reload</source>
         <target state="new">Hot Reload</target>
         <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
+      <trans-unit id="HotReloadRestartInProgress">
+        <source>Rebuilding and restarting the application since the edits can't be applied dynamically.</source>
+        <target state="new">Rebuilding and restarting the application since the edits can't be applied dynamically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadSendingUpdates">
+        <source>Sending updates to running application</source>
+        <target state="new">Sending updates to running application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStartSession">
+        <source>Hot Reload session started</source>
+        <target state="new">Hot Reload session started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStopSession">
+        <source>Hot Reload session complete</source>
+        <target state="new">Hot Reload session complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStoppingApplication">
+        <source>Stopping application</source>
+        <target state="new">Stopping application</target>
+        <note />
       </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -52,10 +52,50 @@
         <target state="translated">路径</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesFailure">
+        <source>Applying updates failed: {0}</source>
+        <target state="new">Applying updates failed: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesSuccessful">
+        <source>Updates applied successfully</source>
+        <target state="new">Updates applied successfully</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadErrorsInApplication">
+        <source>Errors found in application: </source>
+        <target state="new">Errors found in application: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="HotReloadOutputWindowPaneName">
         <source>Hot Reload</source>
         <target state="new">Hot Reload</target>
         <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
+      <trans-unit id="HotReloadRestartInProgress">
+        <source>Rebuilding and restarting the application since the edits can't be applied dynamically.</source>
+        <target state="new">Rebuilding and restarting the application since the edits can't be applied dynamically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadSendingUpdates">
+        <source>Sending updates to running application</source>
+        <target state="new">Sending updates to running application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStartSession">
+        <source>Hot Reload session started</source>
+        <target state="new">Hot Reload session started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStopSession">
+        <source>Hot Reload session complete</source>
+        <target state="new">Hot Reload session complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStoppingApplication">
+        <source>Stopping application</source>
+        <target state="new">Stopping application</target>
+        <note />
       </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -52,6 +52,11 @@
         <target state="translated">路径</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadOutputWindowPaneName">
+        <source>Hot Reload</source>
+        <target state="new">Hot Reload</target>
+        <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} - 导入项来自目标文件。无法删除此导入。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -52,10 +52,50 @@
         <target state="translated">路徑</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesFailure">
+        <source>Applying updates failed: {0}</source>
+        <target state="new">Applying updates failed: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadApplyUpdatesSuccessful">
+        <source>Updates applied successfully</source>
+        <target state="new">Updates applied successfully</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadErrorsInApplication">
+        <source>Errors found in application: </source>
+        <target state="new">Errors found in application: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="HotReloadOutputWindowPaneName">
         <source>Hot Reload</source>
         <target state="new">Hot Reload</target>
         <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
+      <trans-unit id="HotReloadRestartInProgress">
+        <source>Rebuilding and restarting the application since the edits can't be applied dynamically.</source>
+        <target state="new">Rebuilding and restarting the application since the edits can't be applied dynamically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadSendingUpdates">
+        <source>Sending updates to running application</source>
+        <target state="new">Sending updates to running application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStartSession">
+        <source>Hot Reload session started</source>
+        <target state="new">Hot Reload session started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStopSession">
+        <source>Hot Reload session complete</source>
+        <target state="new">Hot Reload session complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HotReloadStoppingApplication">
+        <source>Stopping application</source>
+        <target state="new">Stopping application</target>
+        <note />
       </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -52,6 +52,11 @@
         <target state="translated">路徑</target>
         <note />
       </trans-unit>
+      <trans-unit id="HotReloadOutputWindowPaneName">
+        <source>Hot Reload</source>
+        <target state="new">Hot Reload</target>
+        <note>This is the name given to the Output Window pane responsible for displaying messages related to Hot Reload operations.</note>
+      </trans-unit>
       <trans-unit id="ImportsFromTargetCannotBeDeleted">
         <source>{0} - Import comes fom target file. This import cannot be removed.</source>
         <target state="translated">{0} - 匯入來自目標檔案。此項匯入無法移除。</target>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IHotReloadDiagnosticOutputServiceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IHotReloadDiagnosticOutputServiceFactory.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.VS.HotReload;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal static class IHotReloadDiagnosticOutputServiceFactory
+    {
+        public static IHotReloadDiagnosticOutputService Create()
+        {
+            var mock = new Mock<IHotReloadDiagnosticOutputService>();
+
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectHotReloadAgentFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectHotReloadAgentFactory.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.VS.HotReload;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal static class IProjectHotReloadAgentFactory
+    {
+        public static IProjectHotReloadAgent Create()
+        {
+            var mock = new Mock<IProjectHotReloadAgent>();
+
+            mock.Setup(agent => agent.CreateHotReloadSession(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IProjectHotReloadSessionCallback>()))
+                .Returns((IProjectHotReloadSession)null!);
+
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -732,7 +732,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             ProjectProperties? properties = null,
             IProjectThreadingService? threadingService = null,
             IVsDebugger10? debugger = null,
-            IProjectHotReloadAgent? projectHotReloadAgent = null)
+            IProjectHotReloadAgent? projectHotReloadAgent = null,
+            IHotReloadDiagnosticOutputService? hotReloadDiagnosticOutputService = null)
         {
             environment ??= Mock.Of<IEnvironmentHelper>();
             tokenReplacer ??= IDebugTokenReplacerFactory.Create();
@@ -740,12 +741,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             threadingService ??= IProjectThreadingServiceFactory.Create();
             debugger ??= IVsDebugger10Factory.ImplementIsIntegratedConsoleEnabled(enabled: false);
             projectHotReloadAgent ??= IProjectHotReloadAgentFactory.Create();
+            hotReloadDiagnosticOutputService ??= IHotReloadDiagnosticOutputServiceFactory.Create();
 
             IUnconfiguredProjectVsServices unconfiguredProjectVsServices = IUnconfiguredProjectVsServicesFactory.Implement(() => IVsHierarchyFactory.Create());
 
             IRemoteDebuggerAuthenticationService remoteDebuggerAuthenticationService = Mock.Of<IRemoteDebuggerAuthenticationService>();
 
-            return new ProjectLaunchTargetsProvider(unconfiguredProjectVsServices, configuredProject!, tokenReplacer, fileSystem!, environment, activeDebugFramework, properties!, threadingService, IVsUIServiceFactory.Create<SVsShellDebugger, IVsDebugger10>(debugger), remoteDebuggerAuthenticationService, projectHotReloadAgent);
+            return new ProjectLaunchTargetsProvider(
+                unconfiguredProjectVsServices,
+                configuredProject!,
+                tokenReplacer,
+                fileSystem!,
+                environment,
+                activeDebugFramework,
+                properties!,
+                threadingService,
+                IVsUIServiceFactory.Create<SVsShellDebugger, IVsDebugger10>(debugger),
+                remoteDebuggerAuthenticationService,
+                projectHotReloadAgent,
+                new Lazy<IHotReloadDiagnosticOutputService>(() => hotReloadDiagnosticOutputService));
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
+using Microsoft.VisualStudio.ProjectSystem.VS.HotReload;
 using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
 using Xunit;
@@ -730,19 +731,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             IActiveDebugFrameworkServices? activeDebugFramework = null,
             ProjectProperties? properties = null,
             IProjectThreadingService? threadingService = null,
-            IVsDebugger10? debugger = null)
+            IVsDebugger10? debugger = null,
+            IProjectHotReloadAgent? projectHotReloadAgent = null)
         {
             environment ??= Mock.Of<IEnvironmentHelper>();
             tokenReplacer ??= IDebugTokenReplacerFactory.Create();
             activeDebugFramework ??= IActiveDebugFrameworkServicesFactory.ImplementGetConfiguredProjectForActiveFrameworkAsync(configuredProject);
             threadingService ??= IProjectThreadingServiceFactory.Create();
             debugger ??= IVsDebugger10Factory.ImplementIsIntegratedConsoleEnabled(enabled: false);
+            projectHotReloadAgent ??= IProjectHotReloadAgentFactory.Create();
 
             IUnconfiguredProjectVsServices unconfiguredProjectVsServices = IUnconfiguredProjectVsServicesFactory.Implement(() => IVsHierarchyFactory.Create());
 
             IRemoteDebuggerAuthenticationService remoteDebuggerAuthenticationService = Mock.Of<IRemoteDebuggerAuthenticationService>();
 
-            return new ProjectLaunchTargetsProvider(unconfiguredProjectVsServices, configuredProject!, tokenReplacer, fileSystem!, environment, activeDebugFramework, properties!, threadingService, IVsUIServiceFactory.Create<SVsShellDebugger, IVsDebugger10>(debugger), remoteDebuggerAuthenticationService);
+            return new ProjectLaunchTargetsProvider(unconfiguredProjectVsServices, configuredProject!, tokenReplacer, fileSystem!, environment, activeDebugFramework, properties!, threadingService, IVsUIServiceFactory.Create<SVsShellDebugger, IVsDebugger10>(debugger), remoteDebuggerAuthenticationService, projectHotReloadAgent);
         }
     }
 }


### PR DESCRIPTION
Implement Hot Reload support for Console, WinForms, and WPF apps in Ctrl+F5 scenarios.

When Hot Reload is enabled, the project system is responsible for implementing the following functionality:

1. Configuring the application for Hot Reload. This involves checking that the application supports Hot Reload (e.g., targets .NET 6 or higher; is built with the correct code gen settings, etc.) and setting various environment variables that will cause the CLR to load the "delta applier" assembly when the app runs.
2. Managing the Hot Reload session lifetime. The project system creates the Hot Reload session, tells it to start once the app has launched, and tells it to stop if/when the app exits.
3. Managing the process lifetime. There are situations where we will want to stop and restart the application. For example, if the process is running and the user invokes Ctrl+F5 again we want to stop the current process and start it again. A similar situation arises if the user tries to make edits that aren't supported by Hot Reload. In this case we want to stop the process, rebuild, and launch it again.

So really the project system is only involved at the beginning and end of the Hot Reload scenario. Everything that happens in the middle (watching for changes to source files, applying code changes to the running process, etc.) is handled elsewhere.

This change includes several base components that will be used both by dotnet/project-system as well as other project systems that build on top of us (e.g. WinUI, web tooling):

1. `IProjectHotReloadSession` - Represents the Hot Reload session within the project system, and is responsible for communicating with the other parts of the feature. This includes methods for setting up environment variables prior to process launch (`ApplyLaunchVariablesAsync`), starting and stopping the Hot Reload session, and a method to signal that any pending changes should be applied to the application (`ApplyChangesAsync`).
2. `IProjectHotReloadSessionCallback` - Handles communication from the other parts of the Hot Reload feature back to the project system and allows the session creator to customize the experience in various ways.
3. `IProjectHotReloadAgent` - A singleton service responsible for creating an `IProjectHotReloadSession` for a given version of the runtime and callback. Returns `null` if a session cannot be created.

The implementations of these three interfaces largely abstract away the underlying Hot Reload machinery.

For our internal use, we also define and implement the `IHotReloadDiagnosticOutputService`. This abstracts away and simplifies our interaction with the Hot Reload output window pane shared by all Hot Reload components for diagnostic messages.

We use these base components to implement Hot Reload support for console, WinForms, and WPF apps via a number of changes to the `ProjectLaunchTargetsProvider`.

1. Update `GetConsoleTargetForProfileAsync` to perform various checks for Hot Reload support and create a new _pending_ Hot Reload session.
2. Update `OnBeforeLaunchAsync` to stop the _active_ Hot Reload session (if any) so that we can start a new one. This will cause the running process to exit as well as ending the session.
3. Update `OnAfterLaunchAsync` to "attach" the pending Hot Reload session to the just-launched app (which is mostly a matter of hooking up an event handler to watch for it exiting), start the session, and make the pending session the active session.
4. Implement a bare-bones version of the `IProjectHotReloadSessionCallback` interface.

There's a fair bit of clean-up that could be done, as well as a number of improvements that will come on later. However, we would like to get the basic implementation in as soon as possible.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7323)