### PR TITLE
Create fwlink URLs for properties with HelpUrls.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -174,7 +174,7 @@
   <BoolProperty Name="UseWPF"
                 DisplayName="Windows Presentation Foundation"
                 Description="Enable WPF for this project."
-                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2165974"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2166131"
                 Category="General">
     <BoolProperty.Metadata>
       <NameValuePair Name="DependsOn" Value="Application::OutputType" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -154,11 +154,10 @@
     </DynamicEnumProperty.Metadata>
   </DynamicEnumProperty>
 
-  <!-- TODO use fwlink for HelpUrl -->
   <BoolProperty Name="UseWindowsForms"
                 DisplayName="Windows Forms"
                 Description="Enable Windows Forms for this project."
-                HelpUrl="https://docs.microsoft.com/dotnet/core/project-sdk/msbuild-props-desktop"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2165974"
                 Category="General">
     <BoolProperty.Metadata>
       <NameValuePair Name="DependsOn" Value="Application::OutputType" />
@@ -172,11 +171,10 @@
     </BoolProperty.Metadata>
   </BoolProperty>
 
-  <!-- TODO use fwlink for HelpUrl -->
   <BoolProperty Name="UseWPF"
                 DisplayName="Windows Presentation Foundation"
                 Description="Enable WPF for this project."
-                HelpUrl="https://docs.microsoft.com/dotnet/core/project-sdk/msbuild-props-desktop"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2165974"
                 Category="General">
     <BoolProperty.Metadata>
       <NameValuePair Name="DependsOn" Value="Application::OutputType" />
@@ -304,9 +302,9 @@
     </StringProperty.Metadata>
   </StringProperty>
 
-  <!-- TODO Documentation issue for this property: https://github.com/MicrosoftDocs/visualstudio-docs/issues/6643 -->
   <BoolProperty Name="IsPublishable"
                 DisplayName="Publishing"
                 Description="Allow publishing outside of Visual Studio, such as via &quot;dotnet publish&quot;."
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2165975"
                 Category="Packaging" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -142,29 +142,26 @@
     </StringProperty.ValueEditors>
   </StringProperty>
 
-  <!-- TODO create fwlink for this HelpUrl -->
   <BoolProperty Name="CheckForOverflowUnderflow"
                 DisplayName="Check for arithmetic overflow"
                 Description="Specifies whether integer arithmetic that results in a value outside the range of the data type, and that is not in the scope of a checked or unchecked keyword, causes a run-time exception."
-                HelpUrl="https://docs.microsoft.com/dotnet/csharp/language-reference/compiler-options/checked-compiler-option"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2166113"
                 Category="General">
     <BoolProperty.Metadata>
       <NameValuePair Name="SearchTerms" Value="checked;unchecked" />
     </BoolProperty.Metadata>
   </BoolProperty>
 
-  <!-- TODO create fwlink for this HelpUrl -->
   <BoolProperty Name="Deterministic"
                 DisplayName="Deterministic"
                 Description="Indicates whether the compiler should produce identical assemblies for identical inputs."
-                HelpUrl="https://docs.microsoft.com/dotnet/csharp/language-reference/compiler-options/deterministic-compiler-option"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2165770"
                 Category="General" />
-  
-  <!-- TODO create fwlink for this HelpUrl -->
+ 
   <EnumProperty Name="ErrorReport"
                 DisplayName="Internal compiler error reporting"
                 Description="Controls when internal compiler error (ICE) reports are sent to Microsoft."
-                HelpUrl="https://docs.microsoft.com/dotnet/csharp/language-reference/compiler-options/errorreport-compiler-option"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2165771"
                 Category="General">
     <EnumProperty.DataSource>
       <DataSource HasConfigurationCondition="False" />
@@ -178,12 +175,11 @@
     <EnumValue Name="send"
                DisplayName="Send" />
   </EnumProperty>
-  
-  <!-- TODO create fwlink for this HelpUrl -->
+ 
   <EnumProperty Name="FileAlignment"
                 DisplayName="File alignment"
                 Description="Specifies, in bytes, where to align the sections of the output file."
-                HelpUrl="https://docs.microsoft.com/dotnet/csharp/language-reference/compiler-options/filealign-compiler-option"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2166114"
                 Category="General">
     <EnumValue Name="512"
                DisplayName="512" />
@@ -278,22 +274,20 @@
     </StringProperty.DataSource>
   </StringProperty>
 
-  <!-- TODO create fwlink for this HelpUrl -->
   <BoolProperty Name="ProduceReferenceAssembly"
                 DisplayName="Reference assembly"
                 Description="Produce a reference assembly containing the public API of the project."
-                HelpUrl="https://docs.microsoft.com/dotnet/standard/assembly/reference-assemblies"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2166115"
                 Category="Output">
     <BoolProperty.DataSource>
       <DataSource HasConfigurationCondition="False" />
     </BoolProperty.DataSource>
   </BoolProperty>
 
-  <!-- TODO create fwlink for this HelpUrl -->
   <BoolProperty Name="GenerateDocumentationFile"
                 DisplayName="Documentation file"
                 Description="Generate a file containing API documentation."
-                HelpUrl="https://docs.microsoft.com/dotnet/csharp/codedoc"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2165772"
                 Category="Output">
     <BoolProperty.DataSource>
       <DataSource HasConfigurationCondition="False" />
@@ -322,11 +316,10 @@
     </StringProperty.Metadata>
   </StringProperty>
 
-  <!-- TODO create fwlink -->
   <StringProperty Name="PreBuildEvent"
                   DisplayName="Pre-build event"
                   Description="Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs."
-                  HelpUrl="https://docs.microsoft.com/visualstudio/ide/how-to-specify-build-events-csharp?view=vs-2019"
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2165773"
                   Category="Events">
     <StringProperty.DataSource>
       <DataSource HasConfigurationCondition="False"
@@ -342,11 +335,10 @@
     </StringProperty.ValueEditors>
   </StringProperty>
 
-  <!-- TODO create fwlink -->
   <StringProperty Name="PostBuildEvent"
                   DisplayName="Post-build event"
                   Description="Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build."
-                  HelpUrl="https://docs.microsoft.com/visualstudio/ide/how-to-specify-build-events-csharp?view=vs-2019"
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2165773"
                   Category="Events">
     <StringProperty.DataSource>
       <DataSource HasConfigurationCondition="False"
@@ -362,11 +354,10 @@
     </StringProperty.ValueEditors>
   </StringProperty>
 
-  <!-- TODO create fwlink -->
   <EnumProperty Name="RunPostBuildEvent"
                 DisplayName="When to run the post-build event"
                 Description="Specifies under which condition the post-build event will be executed."
-                HelpUrl="https://docs.microsoft.com/visualstudio/ide/how-to-specify-build-events-csharp?view=vs-2019"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2165773"
                 Category="Events">
     <EnumProperty.DataSource>
       <DataSource HasConfigurationCondition="False"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
@@ -183,7 +183,7 @@
       <ValueEditor EditorType="LinkAction">
         <ValueEditor.Metadata>
           <NameValuePair Name="Action" Value="URL" />
-          <NameValuePair Name="URL" Value="https://spdx.org/licenses/" />
+          <NameValuePair Name="URL" Value="https://go.microsoft.com/fwlink/?linkid=2166116" />
         </ValueEditor.Metadata>
       </ValueEditor>
     </StringProperty.ValueEditors>


### PR DESCRIPTION
Fixes #7262.

I went through our rule files to 
1. Create a fwlink URL if needed.
2. Verify that the URL doesn't reference a particular cutlure (i.e. `en-us`) in our link manager website.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7324)