### PR TITLE
Add feature flag to disable sending build diagnostics to roslyn when the new LSP pull diagnostics system is enabled

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.cs
@@ -4,6 +4,7 @@ using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
+using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
@@ -19,17 +20,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
     [Order(Order.Default)]
     internal partial class LanguageServiceErrorListProvider : IVsErrorListProvider
     {
+        internal const string LspPullDiagnosticsFeatureFlagName = "Lsp.PullDiagnostics";
+
         private readonly UnconfiguredProject _project;
         private readonly IActiveWorkspaceProjectContextHost _projectContextHost;
+
+        private readonly AsyncLazy<bool> _isLspPullDiagnosticsEnabled;
 
         /// <remarks>
         /// <see cref="UnconfiguredProject"/> must be imported in the constructor in order for scope of this class' export to be correct.
         /// </remarks>
         [ImportingConstructor]
-        public LanguageServiceErrorListProvider(UnconfiguredProject project, IActiveWorkspaceProjectContextHost projectContextHost)
+        public LanguageServiceErrorListProvider(
+            UnconfiguredProject project,
+            IActiveWorkspaceProjectContextHost projectContextHost,
+            IVsService<SVsFeatureFlags, IVsFeatureFlags> featureFlagsService,
+            JoinableTaskContext joinableTaskContext)
         {
             _project = project;
             _projectContextHost = projectContextHost;
+
+            _isLspPullDiagnosticsEnabled = new AsyncLazy<bool>(async () =>
+            {
+                IVsFeatureFlags? service = await featureFlagsService.GetValueAsync();
+                return service.IsFeatureEnabled(LspPullDiagnosticsFeatureFlagName, defaultValue: false);
+            }, joinableTaskContext.Factory);
         }
 
         public void SuspendRefresh()
@@ -53,6 +68,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             // service, so we skip tasks that do not have a code
             if (!TryExtractErrorListDetails(error.BuildEventArgs, out ErrorListDetails details) || string.IsNullOrEmpty(details.Code))
                 return AddMessageResult.NotHandled;
+
+            // When this feature flag is enabled, build diagnostics will be published by CPS and should not be passed to roslyn.
+            bool isLspPullDiagnosticsEnabled = await _isLspPullDiagnosticsEnabled.GetValueAsync();
+            if (isLspPullDiagnosticsEnabled)
+            {
+                return AddMessageResult.NotHandled;
+            }
 
             bool? handled = await _projectContextHost.OpenContextForWriteAsync(accessor =>
             {


### PR DESCRIPTION
In d17, we will be starting an experiment to switch away from direct Roslyn integration with the error list / tagger and over to an LSP based implementation.  In the new LSP based implementation, Roslyn will no longer be publishing build diagnostics and instead they will be published by CPS.  Once the feature flag fully roles out, this provider can be deleted.

To allow the CPS IVsErrorListProvider to take over, we check the appropriate feature flag and return NotHandled (as the CPS provider has Order(1) but this provider has Order(10)).

I considered implementing the check in roslyn, but there is no way to report NotHandled via the IVsLanguageServiceBuildErrorReporter2 interface.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7328)