### PR TITLE
Added new IDefaultLaunchProfileProvider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DefaultLaunchProfileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DefaultLaunchProfileProvider.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.IO;
+using System.ComponentModel.Composition;
+using ExportOrder = Microsoft.VisualStudio.ProjectSystem.OrderAttribute;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    [Export(typeof(IDefaultLaunchProfileProvider))]
+    [AppliesTo(ProjectCapability.LaunchProfiles)]
+    [ExportOrder(int.MinValue)] 
+    internal class DefaultLaunchProfileProvider : IDefaultLaunchProfileProvider
+    {
+        private readonly UnconfiguredProject _project;
+
+        [ImportingConstructor]
+        public DefaultLaunchProfileProvider(UnconfiguredProject project)
+        {
+            _project = project;
+        }
+
+        public ILaunchProfile? CreateDefaultProfile()
+        {
+            return new LaunchProfile { Name = Path.GetFileNameWithoutExtension(_project.FullPath), CommandName = LaunchSettingsProvider.RunProjectCommandName };
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DefaultLaunchProfileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DefaultLaunchProfileProvider.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     [Export(typeof(IDefaultLaunchProfileProvider))]
     [AppliesTo(ProjectCapability.LaunchProfiles)]
-    [ExportOrder(int.MinValue)] 
+    [ExportOrder(Order.Default)] 
     internal class DefaultLaunchProfileProvider : IDefaultLaunchProfileProvider
     {
         private readonly UnconfiguredProject _project;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IDefaultLaunchProfileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IDefaultLaunchProfileProvider.cs
@@ -4,9 +4,15 @@ using Microsoft.VisualStudio.Composition;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
+    /// <summary>
+    /// Provides a default <see cref="ILaunchProfile"/> to be displayed when no profiles are provided.
+    /// </summary>
     [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Extension, Cardinality = ImportCardinality.ZeroOrMore)]
     public interface IDefaultLaunchProfileProvider
     {
+        /// <summary>
+        /// Gets the default <see cref="ILaunchProfile"/>. Return null to remove the default profile.
+        /// </summary>
         ILaunchProfile? CreateDefaultProfile();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IDefaultLaunchProfileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IDefaultLaunchProfileProvider.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Extension, Cardinality = ImportCardinality.ZeroOrMore)]
+    public interface IDefaultLaunchProfileProvider
+    {
+        ILaunchProfile? CreateDefaultProfile();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -76,10 +76,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                                                                                                                     project);
             SourceControlIntegrations = new OrderPrecedenceImportCollection<ISourceCodeControlIntegration>(projectCapabilityCheckProvider: project);
 
+            DefaultLaunchProfileProviders = new OrderPrecedenceImportCollection<IDefaultLaunchProfileProvider>(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst, project);
+
             _projectSubscriptionService = projectSubscriptionService;
             _appDesignerSpecialFileProvider = appDesignerSpecialFileProvider;
             _projectFaultHandler = projectFaultHandler;
             _launchSettingsFilePath = new AsyncLazy<string>(GetLaunchSettingsFilePathNoCacheAsync, commonProjectServices.ThreadingService.JoinableTaskFactory);
+
+            _defaultLaunchProfile = new Lazy<ILaunchProfile?> (() => {
+                    return DefaultLaunchProfileProviders?.First()?.Value?.CreateDefaultProfile();
+                }
+            );
 
             _nextVersion = 1;
         }
@@ -89,6 +96,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         [ImportMany]
         protected OrderPrecedenceImportCollection<ISourceCodeControlIntegration> SourceControlIntegrations { get; set; }
+
+        [ImportMany]
+        protected OrderPrecedenceImportCollection<IDefaultLaunchProfileProvider> DefaultLaunchProfileProviders { get; set; }
+
+        private readonly Lazy<ILaunchProfile?> _defaultLaunchProfile;
 
         protected SimpleFileWatcher? FileWatcher { get; set; }
 
@@ -252,7 +264,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 // won't be called on F5 and the user will see a poor error message
                 if (launchSettingData.Profiles.Count == 0)
                 {
-                    launchSettingData.Profiles.Add(new LaunchProfileData() { Name = Path.GetFileNameWithoutExtension(_commonProjectServices.Project.FullPath), CommandName = RunProjectCommandName });
+                    var defaultLaunchProfile = _defaultLaunchProfile.Value;
+                    if (defaultLaunchProfile != null)
+                        launchSettingData.Profiles.Add(new LaunchProfileData() { Name = defaultLaunchProfile.Name, CommandName = defaultLaunchProfile.CommandName});
                 }
 
                 // If we have a previous snapshot merge in in-memory profiles

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
+Microsoft.VisualStudio.ProjectSystem.Debug.IDefaultLaunchProfileProvider
+Microsoft.VisualStudio.ProjectSystem.Debug.IDefaultLaunchProfileProvider.CreateDefaultProfile() -> Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile?
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider3
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider3.TryUpdateProfileAsync(string! profileName, System.Action<Microsoft.VisualStudio.ProjectSystem.Debug.IWritableLaunchProfile!>! updateAction) -> System.Threading.Tasks.Task<bool>!
 Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchSettingsProvider3.UpdateGlobalSettingsAsync(System.Func<System.Collections.Immutable.ImmutableDictionary<string!, object!>!, System.Collections.Immutable.ImmutableDictionary<string!, object?>!>! updateFunction) -> System.Threading.Tasks.Task!

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(project, IProjectThreadingServiceFactory.Create(), null, properties);
             var projectServices = IUnconfiguredProjectServicesFactory.Create(IProjectAsynchronousTasksServiceFactory.Create());
             var projectFaultHandlerService = IProjectFaultHandlerServiceFactory.Create();
-            var provider = new LaunchSettingsUnderTest(project, projectServices, fileSystem ?? new IFileSystemMock(), commonServices, null, specialFilesManager, projectFaultHandlerService);
+            var provider = new LaunchSettingsUnderTest(project, projectServices, fileSystem ?? new IFileSystemMock(), commonServices, null, specialFilesManager, projectFaultHandlerService, new DefaultLaunchProfileProvider(project));
             return provider;
         }
 
@@ -1028,7 +1028,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             IUnconfiguredProjectCommonServices commonProjectServices,
             IActiveConfiguredProjectSubscriptionService? projectSubscriptionService,
             IActiveConfiguredValue<IAppDesignerFolderSpecialFileProvider?> appDesignerFolderSpecialFileProvider,
-            IProjectFaultHandlerService projectFaultHandler)
+            IProjectFaultHandlerService projectFaultHandler,
+            IDefaultLaunchProfileProvider defaultLaunchProfileProvider)
           : base(project, projectServices, fileSystem, commonProjectServices, projectSubscriptionService, appDesignerFolderSpecialFileProvider, projectFaultHandler)
         {
             // Block the code from setting up one on the real file system. Since we block, it we need to set up the fileChange scheduler manually
@@ -1037,6 +1038,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             FileChangeProcessingDelay = TimeSpan.FromMilliseconds(50);
             FileChangeScheduler = new TaskDelayScheduler(FileChangeProcessingDelay, commonProjectServices.ThreadingService,
                     CancellationToken.None);
+            DefaultLaunchProfileProviders.Add(defaultLaunchProfileProvider);
         }
 
         // Wrappers to call protected members


### PR DESCRIPTION
As specified in https://github.com/dotnet/project-system/issues/7327, we
need a way to remove de default launch profile for project systems
where it doesn't represent a valid option. This commit adds an extension
point for providing a new provider that lets extensions proide a
different default that will make more sense for their projects, or no
provider at all.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7329)