### PR TITLE
Treat 'folder' as an alias of 'directory'

### DIFF
--- a/docs/repo/property-pages/property-specification.md
+++ b/docs/repo/property-pages/property-specification.md
@@ -350,7 +350,7 @@ internal sealed class MyCommandActionHandler : ILinkActionHandler
 
 ## File and Directory Properties
 
-When a property's value represents a file or directory path, it should be modelled as a `StringProperty` with its `Subtype` attribute set to `file` or `directory` respectively.
+When a property's value represents a file or directory path, it should be modelled as a `StringProperty` with its `Subtype` attribute set to `file` or `directory` respectively. `folder` is an equivalent alternative to `directory`.
 
 ```xml
 <StringProperty Subtype="file"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -68,11 +69,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
                 if (property is StringProperty stringProperty)
                 {
-                    if (stringProperty.Subtype == "file")
+                    if (string.Equals(stringProperty.Subtype, "file", StringComparison.OrdinalIgnoreCase))
                     {
                         yield return CreateEditorValue(queryExecutionContext, parent, new ValueEditor { EditorType = "FilePath" }, properties);
                     }
-                    else if (stringProperty.Subtype == "folder" || stringProperty.Subtype == "directory")
+                    else if (
+                        string.Equals(stringProperty.Subtype, "folder", StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(stringProperty.Subtype, "directory", StringComparison.OrdinalIgnoreCase))
                     {
                         yield return CreateEditorValue(queryExecutionContext, parent, new ValueEditor { EditorType = "DirectoryPath" }, properties);
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     {
                         yield return CreateEditorValue(queryExecutionContext, parent, new ValueEditor { EditorType = "FilePath" }, properties);
                     }
-                    else if (stringProperty.Subtype == "directory")
+                    else if (stringProperty.Subtype == "folder" || stringProperty.Subtype == "directory")
                     {
                         yield return CreateEditorValue(queryExecutionContext, parent, new ValueEditor { EditorType = "DirectoryPath" }, properties);
                     }


### PR DESCRIPTION
Fixes #7331

`StringProperty` may specify a `SubType`, which modifies how it is displayed in the UI. It turns out that rule files commonly use both `path` and `directory`, and these appear to be equivalent in semantics.

This is the root cause of the failure to show a "browse" button alongside the "working directory" property's editor.

Previously a value of `folder` would be ignored. This commit makes it equivalent to `directory`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7336)