### PR TITLE
Add more search aliases to the debug property

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/DebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/DebugPropertyPage.xaml
@@ -5,8 +5,6 @@
       DisplayName="Debug"
       PageTemplate="generic"
       Order="500"
-      xmlns:sys="clr-namespace:System;assembly=mscorlib"
-      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns="http://schemas.microsoft.com/build/2009/properties">
 
   <Rule.DataSource>
@@ -22,7 +20,7 @@
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>(has-project-capability "LaunchProfiles")</NameValuePair.Value>
       </NameValuePair>
-      <NameValuePair Name="SearchTerms" Value="arguments;command line;working directory;environment variables" />
+      <NameValuePair Name="SearchTerms" Value="arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote" />
     </StringProperty.Metadata>
     <StringProperty.ValueEditors>
       <ValueEditor EditorType="Description" />
@@ -35,7 +33,7 @@
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>(has-project-capability "LaunchProfiles")</NameValuePair.Value>
       </NameValuePair>
-      <NameValuePair Name="SearchTerms" Value="arguments;command line;working directory;environment variables" />
+      <NameValuePair Name="SearchTerms" Value="arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote" />
     </StringProperty.Metadata>
     <StringProperty.ValueEditors>
       <ValueEditor EditorType="LinkAction">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.cs.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">argumenty; příkazový řádek; pracovní adresář; proměnné prostředí</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">argumenty; příkazový řádek; pracovní adresář; proměnné prostředí</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">argumenty; příkazový řádek; pracovní adresář; proměnné prostředí</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">argumenty; příkazový řádek; pracovní adresář; proměnné prostředí</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.de.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">Argumente;Befehlszeile;Arbeitsverzeichnis;Umgebungsvariablen</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">Argumente;Befehlszeile;Arbeitsverzeichnis;Umgebungsvariablen</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">Argumente;Befehlszeile;Arbeitsverzeichnis;Umgebungsvariablen</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">Argumente;Befehlszeile;Arbeitsverzeichnis;Umgebungsvariablen</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.es.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">argumentos, línea de comandos, directorio de trabajo, variables de entorno</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">argumentos, línea de comandos, directorio de trabajo, variables de entorno</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">argumentos, línea de comandos, directorio de trabajo, variables de entorno</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">argumentos, línea de comandos, directorio de trabajo, variables de entorno</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.fr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">arguments ; ligne de commande ; répertoire de travail ; variables d’environnement</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">arguments ; ligne de commande ; répertoire de travail ; variables d’environnement</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">arguments ; ligne de commande ; répertoire de travail ; variables d’environnement</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">arguments ; ligne de commande ; répertoire de travail ; variables d’environnement</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.it.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">argomenti;riga di comando;directory di lavoro;variabili di ambiente</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">argomenti;riga di comando;directory di lavoro;variabili di ambiente</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">argomenti;riga di comando;directory di lavoro;variabili di ambiente</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">argomenti;riga di comando;directory di lavoro;variabili di ambiente</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ja.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">引数;コマンド ライン;作業ディレクトリ;環境変数</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">引数;コマンド ライン;作業ディレクトリ;環境変数</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">引数;コマンド ライン;作業ディレクトリ;環境変数</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">引数;コマンド ライン;作業ディレクトリ;環境変数</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ko.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">인수;명령줄;작업 디렉터리;환경 변수</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">인수;명령줄;작업 디렉터리;환경 변수</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">인수;명령줄;작업 디렉터리;환경 변수</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">인수;명령줄;작업 디렉터리;환경 변수</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.pl.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">argumenty; wiersz polecenia; katalog roboczy; zmienne środowiskowe</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">argumenty; wiersz polecenia; katalog roboczy; zmienne środowiskowe</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">argumenty; wiersz polecenia; katalog roboczy; zmienne środowiskowe</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">argumenty; wiersz polecenia; katalog roboczy; zmienne środowiskowe</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.pt-BR.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">argumentos; linha de comando; diretório de trabalho; variáveis de ambiente</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">argumentos; linha de comando; diretório de trabalho; variáveis de ambiente</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">argumentos; linha de comando; diretório de trabalho; variáveis de ambiente</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">argumentos; linha de comando; diretório de trabalho; variáveis de ambiente</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.ru.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">аргументы;командная строка;рабочая папка;переменные среды</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">аргументы;командная строка;рабочая папка;переменные среды</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">аргументы;командная строка;рабочая папка;переменные среды</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">аргументы;командная строка;рабочая папка;переменные среды</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.tr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">bağımsız değişkenler; komut satırı; çalışma dizini; ortam değişkenleri</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">bağımsız değişkenler; komut satırı; çalışma dizini; ortam değişkenleri</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">bağımsız değişkenler; komut satırı; çalışma dizini; ortam değişkenleri</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">bağımsız değişkenler; komut satırı; çalışma dizini; ortam değişkenleri</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.zh-Hans.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">参数；命令行；工作目录；环境变量</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">参数；命令行；工作目录；环境变量</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">参数；命令行；工作目录；环境变量</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">参数；命令行；工作目录；环境变量</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/DebugPropertyPage.xaml.zh-Hant.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugPagePlaceholderDescription|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">引數;命令列;工作目錄;環境變數</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">引數;命令列;工作目錄;環境變數</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OpenLaunchProfilesEditor|Metadata|SearchTerms">
-        <source>arguments;command line;working directory;environment variables</source>
-        <target state="translated">引數;命令列;工作目錄;環境變數</target>
+        <source>arguments;command line;working directory;environment variables;IIS;browser;URL;authentication;remote</source>
+        <target state="needs-review-translation">引數;命令列;工作目錄;環境變數</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
This makes it easier for people to find the new Launch Profile UI when searching for common launch profile operations in the Project Property UI.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7338)