### PR TITLE
Simplify CanBeStartupProjectAsync

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -628,6 +628,60 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             Assert.Equal(DebuggerEngines.ManagedOnlyEngine, ProjectLaunchTargetsProvider.GetManagedDebugEngineForFramework(".NETFramework"));
         }
 
+        [Fact]
+        public async Task CanBeStartupProject_WhenUsingExecutableCommand_AlwaysTrue()
+        {
+            var provider = GetDebugTargetsProvider(
+                outputType: "dll",
+                properties: new Dictionary<string, string?>(),
+                debugger: null,
+                scope: null);
+
+            var activeProfile = new LaunchProfile { Name = "Name", CommandName = "Executable" };
+            bool canBeStartupProject = await provider.CanBeStartupProjectAsync(DebugLaunchOptions.NoDebug, activeProfile);
+
+            Assert.True(canBeStartupProject);
+        }
+
+        [Fact]
+        public async Task CanBeStartupProject_WhenUsingProjectCommand_TrueIfRunCommandPropertySpecified()
+        {
+            var provider = GetDebugTargetsProvider(
+                properties: new Dictionary<string, string?>() { { "RunCommand", @"C:\alpha\beta\gamma.exe" } });
+
+            var activeProfile = new LaunchProfile { Name = "Name", CommandName = "Project" };
+            bool canBeStartupProject = await provider.CanBeStartupProjectAsync(DebugLaunchOptions.NoDebug, activeProfile);
+
+            Assert.True(canBeStartupProject);
+        }
+
+        [Fact]
+        public async Task CanBeStartupProject_WhenUsingProjectCommand_TrueIfTargetPathPropertySpecified()
+        {
+            var provider = GetDebugTargetsProvider(
+                properties: new Dictionary<string, string?>() { { "TargetPath", @"C:\alpha\beta\gamma.exe" } });
+
+            var activeProfile = new LaunchProfile { Name = "Name", CommandName = "Project" };
+            bool canBeStartupProject = await provider.CanBeStartupProjectAsync(DebugLaunchOptions.NoDebug, activeProfile);
+
+            Assert.True(canBeStartupProject);
+        }
+
+        [Fact]
+        public async Task CanBeStartupProject_WhenUsingProjectCommand_FalseIfRunCommandAndTargetPathNotSpecified()
+        {
+            var provider = GetDebugTargetsProvider(
+                outputType: "dll",
+                properties: new Dictionary<string, string?>(),
+                debugger: null,
+                scope: null);
+
+            var activeProfile = new LaunchProfile { Name = "Name", CommandName = "Project" };
+            bool canBeStartupProject = await provider.CanBeStartupProjectAsync(DebugLaunchOptions.NoDebug, activeProfile);
+
+            Assert.False(canBeStartupProject);
+        }
+
         private ProjectLaunchTargetsProvider GetDebugTargetsProvider(string outputType = "exe", Dictionary<string, string?>? properties = null, IVsDebugger10? debugger = null, IProjectCapabilitiesScope? scope = null)
         {
             _mockFS.WriteAllText(@"c:\test\Project\someapp.exe", "");


### PR DESCRIPTION
Currently, `ProjectLaunchTargetsProvider.CanBeStartupProjectAsync` works by querying for the set of debug settings as though we were, in fact, about to start the project. If we can create the debug settings the project is startable, but if we get back `null` the project is not.

This is very straightforward, but there are downside. First, we end up doing a fair bit of work figuring out the debug settings, and most of those settings have no impact on whether or not the project is startable. Second, this approach obscures our intent. That is, you should be able to read the code and figure out when we _intend_ a project to be startable. Right now that isn't possible.

Supporting Hot Reload on Ctrl+F5 requires that we do even more work to setup debug settings and prepare other parts of the Hot Reload settings for a possible run. We can't avoid that on an actual F5 or Ctrl+F5, but we definitely don't need (or want) to do it every time we check if a project is startable.

In this change, I've gone through and figured out which parts of creating the debug settings are actually relevant to a project being a startup project and extracted those into the `CanBeStartupProjectAsync` method. It basically comes down to these rules:

1. If the launch profile is using the "Executable" command it is always startable (even if no executable has been specified!).
2. Otherwise, if the launch profile is using the "Project" command:
    1. If the "RunCommand" property is specified, it is startable, or,
    2. If the "TargetPath" property is specified, it is startable.
3. Otherwise, it is not startable.

Whether or not those are the right set of rules is a different question, but that is what the current checks boil down to.

Unit tests have been added to cover the current behavior.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7340)