### PR TITLE
Expose process information

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider.cs
@@ -29,11 +29,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// <summary>
         /// Called just prior to launch to allow the provider to do additional work.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso cref="IDebugProfileLaunchTargetsProvider4.OnBeforeLaunchAsync(DebugLaunchOptions, ILaunchProfile, IReadOnlyList{IDebugLaunchSettings})"/>
+        /// </remarks>
         Task OnBeforeLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile);
 
         /// <summary>
         /// Called right after launch to allow the provider to do additional work.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso cref="IDebugProfileLaunchTargetsProvider4.OnAfterLaunchAsync(DebugLaunchOptions, ILaunchProfile, IReadOnlyList{Shell.Interop.VsDebugTargetProcessInfo})"/>
+        /// </remarks>
         Task OnAfterLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider.cs
@@ -30,7 +30,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// Called just prior to launch to allow the provider to do additional work.
         /// </summary>
         /// <remarks>
-        /// See also: <seealso cref="IDebugProfileLaunchTargetsProvider4.OnBeforeLaunchAsync(DebugLaunchOptions, ILaunchProfile, IReadOnlyList{IDebugLaunchSettings})"/>
+        /// Note that if <see cref="IDebugProfileLaunchTargetsProvider4"/> is also implemented, <see cref="IDebugProfileLaunchTargetsProvider4.OnBeforeLaunchAsync(DebugLaunchOptions, ILaunchProfile, IReadOnlyList{IDebugLaunchSettings})"/>
+        /// will be called instead of this.
         /// </remarks>
         Task OnBeforeLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile);
 
@@ -38,7 +39,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// Called right after launch to allow the provider to do additional work.
         /// </summary>
         /// <remarks>
-        /// See also: <seealso cref="IDebugProfileLaunchTargetsProvider4.OnAfterLaunchAsync(DebugLaunchOptions, ILaunchProfile, IReadOnlyList{Shell.Interop.VsDebugTargetProcessInfo})"/>
+        /// Note that if <see cref="IDebugProfileLaunchTargetsProvider4"/> is also implemented, <see cref="IDebugProfileLaunchTargetsProvider4.OnAfterLaunchAsync(DebugLaunchOptions, ILaunchProfile, IReadOnlyList{Shell.Interop.VsDebugTargetProcessInfo})"/>
+        /// will be called instead of this.
         /// </remarks>
         Task OnAfterLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider4.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider4.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// Called just prior to launch to allow the provider to do additional work.
         /// </summary>
         /// <remarks>
-        /// See also: <seealso cref="IDebugProfileLaunchTargetsProvider.OnBeforeLaunchAsync(DebugLaunchOptions, ILaunchProfile)"/>.
+        /// Note this will be called instead of <see cref="IDebugProfileLaunchTargetsProvider.OnBeforeLaunchAsync(DebugLaunchOptions, ILaunchProfile)"/>.
         /// </remarks>
         Task OnBeforeLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile, IReadOnlyList<IDebugLaunchSettings> debugLaunchSettings);
 
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// Called right after launch to allow the provider to do additional work.
         /// </summary>
         /// <remarks>
-        /// See also: <seealso cref="IDebugProfileLaunchTargetsProvider.OnAfterLaunchAsync(DebugLaunchOptions, ILaunchProfile)"/>.
+        /// Note this will be called instead of <see cref="IDebugProfileLaunchTargetsProvider.OnAfterLaunchAsync(DebugLaunchOptions, ILaunchProfile)"/>.
         /// </remarks>
         Task OnAfterLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile, IReadOnlyList<VsDebugTargetProcessInfo> processInfos);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider4.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider4.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
+{
+    /// <summary>
+    /// Optional interface that allows the provider to receive more information about
+    /// launch settings and started processes.
+    /// </summary>
+    public interface IDebugProfileLaunchTargetsProvider4
+    {
+        /// <summary>
+        /// Called just prior to launch to allow the provider to do additional work.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso cref="IDebugProfileLaunchTargetsProvider.OnBeforeLaunchAsync(DebugLaunchOptions, ILaunchProfile)"/>.
+        /// </remarks>
+        Task OnBeforeLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile, IReadOnlyList<IDebugLaunchSettings> debugLaunchSettings);
+
+        /// <summary>
+        /// Called right after launch to allow the provider to do additional work.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso cref="IDebugProfileLaunchTargetsProvider.OnAfterLaunchAsync(DebugLaunchOptions, ILaunchProfile)"/>.
+        /// </remarks>
+        Task OnAfterLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile, IReadOnlyList<VsDebugTargetProcessInfo> processInfos);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
@@ -158,7 +158,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 {
                     _threadingService.ExecuteSynchronously(() => targetsProvider4.OnAfterLaunchAsync(_launchOptions, _activeProfile, processInfoArray));
                 }
-                if (_targetProfile != null)
+                else if (_targetProfile is not null)
                 {
                     _threadingService.ExecuteSynchronously(() => _targetProfile.OnAfterLaunchAsync(_launchOptions, _activeProfile));
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
@@ -140,27 +140,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         private class LaunchCompleteCallback : IVsDebuggerLaunchCompletionCallback
         {
             private readonly DebugLaunchOptions _launchOptions;
-            private readonly IDebugProfileLaunchTargetsProvider? _targetProfile;
+            private readonly IDebugProfileLaunchTargetsProvider? _targetsProvider;
             private readonly ILaunchProfile _activeProfile;
             private readonly IProjectThreadingService _threadingService;
 
-            public LaunchCompleteCallback(IProjectThreadingService threadingService, DebugLaunchOptions launchOptions, IDebugProfileLaunchTargetsProvider? targetProfile, ILaunchProfile activeProfile)
+            public LaunchCompleteCallback(IProjectThreadingService threadingService, DebugLaunchOptions launchOptions, IDebugProfileLaunchTargetsProvider? targetsProvider, ILaunchProfile activeProfile)
             {
                 _threadingService = threadingService;
                 _launchOptions = launchOptions;
-                _targetProfile = targetProfile;
+                _targetsProvider = targetsProvider;
                 _activeProfile = activeProfile;
             }
 
             public void OnComplete(int hr, uint debugTargetCount, VsDebugTargetProcessInfo[] processInfoArray)
             {
-                if (_targetProfile is IDebugProfileLaunchTargetsProvider4 targetsProvider4)
+                if (_targetsProvider is IDebugProfileLaunchTargetsProvider4 targetsProvider4)
                 {
                     _threadingService.ExecuteSynchronously(() => targetsProvider4.OnAfterLaunchAsync(_launchOptions, _activeProfile, processInfoArray));
                 }
-                else if (_targetProfile is not null)
+                else if (_targetsProvider is not null)
                 {
-                    _threadingService.ExecuteSynchronously(() => _targetProfile.OnAfterLaunchAsync(_launchOptions, _activeProfile));
+                    _threadingService.ExecuteSynchronously(() => _targetsProvider.OnAfterLaunchAsync(_launchOptions, _activeProfile));
                 }
             }
         };

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -27,7 +27,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     [Export(typeof(IDebugProfileLaunchTargetsProvider))]
     [AppliesTo(ProjectCapability.LaunchProfiles)]
     [Order(Order.Default)] // The higher the number the higher priority and we want this one last
-    internal class ProjectLaunchTargetsProvider : IDebugProfileLaunchTargetsProvider, IDebugProfileLaunchTargetsProvider2, IDebugProfileLaunchTargetsProvider3
+    internal class ProjectLaunchTargetsProvider :
+        IDebugProfileLaunchTargetsProvider,
+        IDebugProfileLaunchTargetsProvider2,
+        IDebugProfileLaunchTargetsProvider3,
+        IDebugProfileLaunchTargetsProvider4
     {
         private static readonly char[] s_escapedChars = new[] { '^', '<', '>', '&' };
         private readonly ConfiguredProject _project;
@@ -78,12 +82,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// <summary>
         /// Called just prior to launch to do additional work (put up ui, do special configuration etc).
         /// </summary>
-        public Task OnBeforeLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile) => Task.CompletedTask;
+        public Task OnBeforeLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile)
+        {
+            throw new InvalidOperationException($"Wrong overload of {nameof(OnBeforeLaunchAsync)} called.");
+        }
+
+        public Task OnBeforeLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile, IReadOnlyList<IDebugLaunchSettings> debugLaunchSettings) => Task.CompletedTask;
 
         /// <summary>
         /// Called just after the launch to do additional work (put up ui, do special configuration etc).
         /// </summary>
-        public Task OnAfterLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile) => Task.CompletedTask;
+        public Task OnAfterLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile)
+        {
+            throw new InvalidOperationException($"Wrong overload of {nameof(OnAfterLaunchAsync)} called.");
+        }
+
+        public Task OnAfterLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile, IReadOnlyList<VsDebugTargetProcessInfo> processInfos) => Task.CompletedTask;
 
         private Task<bool> IsClassLibraryAsync() => IsOutputTypeAsync(ConfigurationGeneral.OutputTypeValues.Library);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugProfileLaunchTargetsProvider3
 Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugProfileLaunchTargetsProvider3.CanBeStartupProjectAsync(Microsoft.VisualStudio.ProjectSystem.Debug.DebugLaunchOptions launchOptions, Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile! profile) -> System.Threading.Tasks.Task<bool>!
+Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugProfileLaunchTargetsProvider4
+Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugProfileLaunchTargetsProvider4.OnAfterLaunchAsync(Microsoft.VisualStudio.ProjectSystem.Debug.DebugLaunchOptions launchOptions, Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile! profile, System.Collections.Generic.IReadOnlyList<Microsoft.VisualStudio.Shell.Interop.VsDebugTargetProcessInfo>! processInfos) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugProfileLaunchTargetsProvider4.OnBeforeLaunchAsync(Microsoft.VisualStudio.ProjectSystem.Debug.DebugLaunchOptions launchOptions, Microsoft.VisualStudio.ProjectSystem.Debug.ILaunchProfile! profile, System.Collections.Generic.IReadOnlyList<Microsoft.VisualStudio.ProjectSystem.VS.Debug.IDebugLaunchSettings!>! debugLaunchSettings) -> System.Threading.Tasks.Task!
 ~static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.JSWebView2DebuggingAdditionalText.get -> string
 ~static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.chkJSWebView2DebuggingText.get -> string


### PR DESCRIPTION
Currently, the `LaunchProfilesDebugLaunchProvider` calls `IDebugProfileLaunchTargetsProvider.OnBeforeLaunchAsync` right before launching processes, and `IDebugProfileLaunchTargetsProvider.OnAfterLaunchAsync` right after. The idea is that, in addition to creating the launch settings for the processes, the launch targets provider may want to do something special right before or right after processes launch like turn on some logging or show some UI.

There is some information available that isn't currently passed to the launch targets provider. One is the set of `IDebugLaunchSettings` objects that is actually going to be passed to CPS (and then on to the debugger) to start the processes, and the other is the set of `VsDebugTargetProcessInfo`s providing info about the started processes. We're going to need these, especially the latter, for Hot Reload scenarios. For example, when we start a process with Hot Reload enabled we need to know when it exits so that we can end the Hot Reload session. To do this, we need the process ID from the `VsDebugTargetProcessInfo`.

This change introduces `IDebugProfileLaunchTargetsProvider4` which provides replacements for `IDebugProfileLaunchTargetsProvider.OnBeforeLaunchAsync` and `IDebugProfileLaunchTargetsProvider.OnAfterLaunchAsync` that pass along the relevant information.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7341)