### PR TITLE
Use Scaled Set Pool in servicing branches

### DIFF
--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -10,7 +10,7 @@ resources:
 - repo: self
   clean: true
 queue:
-  name: VSEng-MicroBuildVS2019
+  name: VSEngSS-MicroBuild2019
   demands: Cmd
   timeoutInMinutes: 90
 variables:
@@ -93,19 +93,12 @@ steps:
     ArtifactName: symbols
     publishLocation: Container
   displayName: 'Publish Artifact: symbols'
-
-- task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
-  displayName: Publish Symbols to Artifact Services (symweb)
-  inputs:
-    symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
-    requestName: '$(system.teamProject)/$(Build.DefinitionName)/$(Build.BuildNumber)/$(Build.BuildId)'
-    sourcePath: $(Build.ArtifactStagingDirectory)/symbols
-    usePat: false
         
-- task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
+- task: MicroBuildUploadVstsDropFolder@1
   displayName: Upload VSTS Drop
   inputs:
     DropFolder: 'artifacts\$(BuildConfiguration)\VSSetup\Insertion'
+    AccessToken: $(System.AccessToken)
 
 - task: CopyFiles@2
   inputs:


### PR DESCRIPTION
If we need to update a servicing branch to build using the Scaled Set pools this is the change that needs to be done in this repo.

Additionally you'll have to change the matching release pipeline and add the Publish Symbols stage (look at the release pipeline for main as reference). 
It's *very* important that you make sure the Agent Pool here is set to VSEng-ReleasePool
![image](https://user-images.githubusercontent.com/3288375/124185335-b2261f80-da6f-11eb-937a-b130b9ac5116.png)

You will then add the task for MicroBuild Archive Symbols
![image](https://user-images.githubusercontent.com/3288375/124185163-768b5580-da6f-11eb-813f-5b804cdb4728.png)

and you'll also have to add the Project System Symbols variable group
![image](https://user-images.githubusercontent.com/3288375/124185905-69229b00-da70-11eb-8cea-4f2d6e69d6d9.png)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7381)