### PR TITLE
Add a project property provider for Target Platform Monikers

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetPlatformMonikersValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetPlatformMonikersValueProvider.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties
+{
+    [ExportInterceptingPropertyValueProvider("TargetPlatformMonikers", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    internal class TargetPlatformMonikersValueProvider : InterceptingPropertyValueProviderBase
+    {
+        private readonly IActiveConfiguredProjectsProvider _projectProvider;
+
+        [ImportingConstructor]
+        public TargetPlatformMonikersValueProvider(IActiveConfiguredProjectsProvider projectProvider)
+        {
+            _projectProvider = projectProvider;
+        }
+
+        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        {
+            ActiveConfiguredObjects<ConfiguredProject>? configuredProjects = await _projectProvider.GetActiveConfiguredProjectsAsync();
+
+            if (configuredProjects == null)
+            {
+                return "";
+            }
+
+            var builder = PooledArray<string>.GetInstance(capacity: configuredProjects.Objects.Length);
+
+            foreach (ConfiguredProject configuredProject in configuredProjects.Objects)
+            {
+                ProjectProperties projectProperties = configuredProject.Services.ExportProvider.GetExportedValue<ProjectProperties>();
+                ConfigurationGeneral configuration = await projectProperties.GetConfigurationGeneralPropertiesAsync();
+                string? currentPlatformMoniker = (string?)await configuration.TargetPlatformIdentifier.GetValueAsync();
+                Assumes.NotNull(currentPlatformMoniker);
+                builder.Add(currentPlatformMoniker);
+            }
+
+            return string.Join(";", builder.ToArrayAndFree());
+        }
+    }
+}


### PR DESCRIPTION
Fix [AB#1332261](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1332261)

Target Platform Monikers suffix is used primarily in MAUI projects to enable targeting of the the project to different app platforms
and currently there is no provider for this value.

This implementation will intercept the project property  `"TargetPlatformMonikers"` and to a generate a string with all suffixes as requested by the Maui team i.e `vs.solution.project.targetplatformmonikers="ios;android;windows10.0.19041.0"`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7383)