### PR TITLE
Merge environment variables

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -405,11 +405,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 settings.AdditionalDebugEngines.Add(DebuggerEngines.SqlEngine);
             }
 
-            if (settings.Environment.Count > 0)
-            {
-                settings.LaunchOptions |= DebugLaunchOptions.MergeEnvironment;
-            }
-
             bool useCmdShell = false;
             if (await IsConsoleAppAsync())
             {
@@ -478,6 +473,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             else
             {
                 _pendingHotReloadSession = null;
+            }
+
+            if (settings.Environment.Count > 0)
+            {
+                settings.LaunchOptions |= DebugLaunchOptions.MergeEnvironment;
             }
 
             return settings;


### PR DESCRIPTION
When creating the `DebugLaunchSettings` that control how an app starts up, we set the `DebugLaunchOptions.MergeEnvironment` flag to indicate that we want to merge the environment variables in `DebugLaunchSettings.Environment` with whatever environment variables would be inherited from the system and/or VS (as the parent process). If we do not, the set of environment variables in `DebugLaunchSettings.Environment` will instead _replace_ the system/VS environment variables.

However, we only set this flag if at least one environment variable is specified, and we set the flag rather early in the method.

The Hot Reload support adds several environment variables, but that support was added near the _end_ of the method. So in practice, if Hot Reload is enabled the launched app will see _only_ the Hot Reload environment variables. This doesn't seem to be a problem for console or WinForms apps (at least, not that I can see in limited testing) but it does cause problems for WPF apps that depend on certain environment variables. When those are not found, exceptions are thrown while initializing the WPF stack and the process exits before it can even bring up a window.

The fix here is to set the flag near the end of the method. Note that I am not sure why we only set the flag when we have environment variables to add, rather than just setting it all the time. To avoid introducing other regressions I've left the check in place.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7386)