### PR TITLE
Ensure only the VS layer uses VS packages

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -16,11 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Explicitly referenced to prevent upstream packages from bringing in old PIAs -->
-    <PackageReference Include="EnvDTE" Version="$(VSSDK_GeneralVersion)" Pack="false" ExcludeAssets="compile" PrivateAssets="all" />
-  </ItemGroup>
-
-  <ItemGroup>
     <!-- Toolset -->
     <PackageReference Update="Nerdbank.Streams"                                                       Version="2.6.81" />
     <PackageReference Update="System.IO.Pipelines"                                                    Version="5.0.1" />
@@ -40,6 +35,8 @@
     <PackageReference Update="Microsoft.DevDiv.Validation.MediaRecorder"                              Version="15.0.199" />
 
     <!-- VS SDK -->
+    <PackageReference Update="EnvDTE"                                                                 Version="$(VSSDK_GeneralVersion)" />
+    <PackageReference Update="Microsoft.Internal.VisualStudio.Interop"                                Version="17.0.0-previews-2-31423-289"/>
     <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="17.0.1056-Dev17PIAs-g9dffd635" />
     <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.0.154-preview"/>
     <PackageReference Update="Microsoft.VisualStudio.Composition"                                     Version="16.9.20"/>
@@ -50,6 +47,7 @@
     <PackageReference Update="Microsoft.VisualStudio.Debugger.Contracts"                              Version="17.2.0-beta.21278.1" />
     <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces"                             Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.0.0-previews-2-31421-281" />
+    <PackageReference Update="Microsoft.VisualStudio.Interop"                                         Version="17.0.0-previews-2-31423-289"/>
     <PackageReference Update="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50728" />
     <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="17.0.50-preview-0002-0002" />
     <PackageReference Update="Microsoft.VisualStudio.Telemetry"                                       Version="16.3.176" />
@@ -68,8 +66,6 @@
     <PackageReference Update="Microsoft.VisualStudio.XmlEditor"                                       Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VSDesigner"                                                   Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="VsWebSite.Interop"                                                      Version="16.8.30523.219"/>
-    <PackageReference Include="Microsoft.VisualStudio.Interop"                                        Version="17.0.0-previews-2-31423-289"/>
-    <PackageReference Include="Microsoft.Internal.VisualStudio.Interop"                               Version="17.0.0-previews-2-31423-289"/>
     
     <!-- https://github.com/dotnet/roslyn/issues/53877 -->
     <PackageReference Include="StreamJsonRpc"                                                         Version="2.8.21" />

--- a/build/import/VisualStudio.props
+++ b/build/import/VisualStudio.props
@@ -4,7 +4,6 @@
 
   <ItemGroup>
     <!-- Framework -->
-    
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
@@ -17,8 +16,10 @@
     <PackageReference Include="Microsoft.VSSDK.BuildTools" PrivateAssets="All" />
 
     <!-- VS SDK -->
+    <PackageReference Include="Microsoft.Internal.VisualStudio.Interop" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" />
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Contracts" />
+    <PackageReference Include="Microsoft.VisualStudio.Interop" />
     <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces" />
     <PackageReference Include="Microsoft.VisualStudio.RpcContracts" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" />    
@@ -27,7 +28,10 @@
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" />
     <PackageReference Include="NuGet.SolutionRestoreManager.Interop" />
-    <PackageReference Include="NuGet.VisualStudio" />    
+    <PackageReference Include="NuGet.VisualStudio" />
+
+    <!-- Explicitly referenced to prevent upstream packages from bringing in old PIAs -->
+    <PackageReference Include="EnvDTE" Pack="false" ExcludeAssets="compile" PrivateAssets="all" />
   </ItemGroup>
  
 </Project>


### PR DESCRIPTION
During work to integrate bits for Dev17, these packages were added to all projects in the solution.

The host-agnostic layer should not take a dependency upon any host-specific (i.e. VS) packages.

This change enforces that layering, so we don't accidentally take a dependency in future that we should not.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7388)