### PR TITLE
Fix  wrong canonicalization for TargetPlatform

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetPlatformMonikersValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetPlatformMonikersValueProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
                 string? currentPlatformVersion = (string?)await configuration.TargetPlatformVersion.GetValueAsync();
 
                 Assumes.NotNull(currentPlatformMoniker);
-                builder.Add(currentPlatformMoniker + currentPlatformVersion);
+                builder.Add($"{ currentPlatformMoniker }, Version={ currentPlatformVersion }");
             }
 
             return string.Join(";", builder.ToArrayAndFree());


### PR DESCRIPTION
This is a code cleanup.

Currently this value is not used, so this change should not affect other teams using it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7397)