### PR TITLE
Remove unnecessary package

### DIFF
--- a/build/import/HostAgnostic.props
+++ b/build/import/HostAgnostic.props
@@ -98,7 +98,6 @@
            or '%(FileName)' == 'Microsoft.VisualStudio.ProjectSystem.Interop'
            or '%(FileName)' == 'stdole'
            or '%(FileName)' == 'Microsoft.VisualStudio.CommandBars'
-           or '%(FileName)' == 'NuGet.SolutionRestoreManager.Interop'
            or '%(FileName)' == 'NuGet.VisualStudio'
            or '%(FileName)' == 'VSLangProj110'
            or '%(FileName)' == 'VSLangProj165'

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -58,7 +58,7 @@
     <PackageReference Update="Microsoft.VisualStudio.Shell.15.0"                                      Version="17.0.0-previews-2-31421-281" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Design"                                    Version="17.0.0-previews-2-31421-281" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.0.0-previews-2-31421-281" />
-    <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.0.0-preview-2-31223-026" />
+    <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.0.0-previews-1-31321-016" />
     <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="17.0.39-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.0.39-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="17.0.0-previews-2-31421-281" />
@@ -89,8 +89,7 @@
     <PackageReference Update="Roslyn.Diagnostics.Analyzers"                                           Version="3.3.2" />
 
     <!-- NuGet -->
-    <PackageReference Update="NuGet.SolutionRestoreManager.Interop"                                   Version="6.0.0-preview.1.89" />
-    <PackageReference Update="NuGet.VisualStudio"                                                     Version="6.0.0-preview.1.89" />
+    <PackageReference Update="NuGet.VisualStudio"                                                     Version="6.0.0-preview.3.158" />
 
     <!-- Framework packages -->
     <PackageReference Update="Microsoft.IO.Redist"                                                    Version="4.7.1" />

--- a/build/import/VisualStudio.props
+++ b/build/import/VisualStudio.props
@@ -27,7 +27,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" />
-    <PackageReference Include="NuGet.SolutionRestoreManager.Interop" />
     <PackageReference Include="NuGet.VisualStudio" />
 
     <!-- Explicitly referenced to prevent upstream packages from bringing in old PIAs -->


### PR DESCRIPTION
Code cleanup

NuGet merged `NuGet.SolutionRestoreManager.Interop` into `NuGet.VisualStudio`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7398)