### PR TITLE
Add steps for using embedded XAML property pages

### DIFF
--- a/docs/repo/property-pages/how-to-add-a-new-launch-profile-kind.md
+++ b/docs/repo/property-pages/how-to-add-a-new-launch-profile-kind.md
@@ -181,3 +181,5 @@ public sealed class MyPackage : AsyncPackage
     ...
 }
 ```
+
+And you're done. This Launch Profile UI will be available in any project with matching capabilities.


### PR DESCRIPTION
Adds steps for using embedded XAML property pages when defining new launch profile types. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7402)