### PR TITLE
Support reading and writing properties directly to OtherSettings

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/LaunchProfileProjectProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/LaunchProfileProjectProperties.cs
@@ -162,6 +162,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 }
             }
 
+            if (profile.OtherSettings is not null)
+            {
+                foreach ((string propertyName, _) in profile.OtherSettings)
+                {
+                    builder.Add(propertyName);
+                }
+            }
+
             return builder.ToImmutable();
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchSettingsProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchSettingsProviderFactory.cs
@@ -27,6 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <param name="removeProfileCallback">An optional methods to call when a profile is removed.</param>
         /// <param name="tryUpdateProfileCallback">An optional method to call when a profile is updated.</param>
         /// <param name="updateGlobalSettingsCallback">An optional method to call when a global setting is updated.</param>
+        /// <param name="globalSettings">The initial set of global settings to expose through the provider.</param>
         public static ILaunchSettingsProvider3 Create(
             string? activeProfileName = null,
             IEnumerable<ILaunchProfile>? launchProfiles = null,
@@ -36,13 +37,16 @@ namespace Microsoft.VisualStudio.ProjectSystem
             Action<ILaunchProfile, bool>? addOrUpdateProfileCallback = null,
             Action<string>? removeProfileCallback = null,
             Action<string, Action<IWritableLaunchProfile>>? tryUpdateProfileCallback = null,
-            Func<ImmutableDictionary<string, object>, ImmutableDictionary<string, object?>>? updateGlobalSettingsCallback = null)
+            Func<ImmutableDictionary<string, object>, ImmutableDictionary<string, object?>>? updateGlobalSettingsCallback = null,
+            ImmutableDictionary<string, object>? globalSettings = null)
         {
             var launchSettingsMock = new Mock<ILaunchSettings>();
 
             var initialLaunchProfiles = launchProfiles is not null
                 ? launchProfiles.ToImmutableList()
                 : ImmutableList<ILaunchProfile>.Empty;
+
+            var initialGlobalSettings = globalSettings ?? ImmutableDictionary<string, object>.Empty;
 
             if (getProfilesCallback is not null)
             {
@@ -51,6 +55,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
             else
             {
                 launchSettingsMock.Setup(t => t.Profiles).Returns(initialLaunchProfiles);
+            }
+
+            if (initialGlobalSettings is not null)
+            {
+                launchSettingsMock.Setup(t => t.GlobalSettings).Returns(initialGlobalSettings);
             }
 
             if (activeProfileName != null)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectPropertiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectPropertiesTests.cs
@@ -535,6 +535,53 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             Assert.DoesNotContain("BetaProperty", names);
         }
 
+        [Fact]
+        public async Task WhenRetrievingPropertyNames_PropertiesInOtherSettingsAreIncluded()
+        {
+            var profile1 = new WritableLaunchProfile
+            {
+                Name = "Profile1",
+                OtherSettings = { { "alpha", 1 } }
+            };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile() });
+
+            var properties = new LaunchProfileProjectProperties(
+                DefaultTestProjectPath,
+                "Profile1",
+                launchSettingsProvider,
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
+
+            var names = await properties.GetPropertyNamesAsync();
+
+            Assert.Contains("alpha", names);
+        }
+
+        [Fact]
+        public async Task WhenRetrievingPropertyNames_PropertiesInGlobalSettingsAreNotIncluded()
+        {
+            var profile1 = new WritableLaunchProfile
+            {
+                Name = "Profile1",
+                OtherSettings = { { "alpha", 1 } }
+            };
+            var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
+                launchProfiles: new[] { profile1.ToLaunchProfile() },
+                globalSettings: ImmutableDictionary<string, object>.Empty.Add("beta", "value"));
+
+            var properties = new LaunchProfileProjectProperties(
+                DefaultTestProjectPath,
+                "Profile1",
+                launchSettingsProvider,
+                EmptyLaunchProfileExtensionValueProviders,
+                EmptyGlobalSettingExtensionValueProviders);
+
+            var names = await properties.GetPropertyNamesAsync();
+
+            Assert.DoesNotContain("beta", names);
+        }
+
         /// <summary>
         /// Creates an <see cref="ILaunchSettingsProvider"/> with two empty profiles named
         /// "Profile1" and "Profile2".


### PR DESCRIPTION
Fixes #7384.

Right now, if you want to create a .xaml file for a particular kind of launch profile you also need to create an implementation of `ILaunchProfileExtensionValueProvider` and/or `IGlobalSettingExtensionValueProvider` to handle reading and writing the property value. Most developers outside of the dotnet/project-system team who need to do this will just store their properties as-is in the `ILaunchProfiles.OtherSettings` dictionary; writing an extension value provider to do this isn't hard but does involve some amount of boilerplate.

Instead, in the absence of an extension value provider for a particular property we should just default reading and writing it to `ILaunchProfile.OtherSettings`. We do need to know the storage type of the property, but this can be determined based on the type information already in the .xaml `Rule` file.

There are a number of further improvements we could make, such as using default values from the `Rule` in cases where the property is being read but no value is found in `OtherSettings` or as a backup when attempting to set the value to an invalid value. However, this should be enough to unblock our partners.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7407)