### PR TITLE
Remove most usages of synchronous disposal

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworkAliasEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworkAliasEnumProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
         public SupportedTargetFrameworkAliasEnumProvider(
             ConfiguredProject project,
             IProjectSubscriptionService subscriptionService)
-            : base(project, synchronousDisposal: true, registerDataSource: false)
+            : base(project, synchronousDisposal: false, registerDataSource: false)
         {
             _subscriptionService = subscriptionService;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedValuesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedValuesProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
             ConfiguredProject project,
             IProjectSubscriptionService subscriptionService,
             bool useNoneValue = false)
-            : base(project, synchronousDisposal: true, registerDataSource: false)
+            : base(project, synchronousDisposal: false, registerDataSource: false)
         {
             SubscriptionService = subscriptionService;
             _useNoneValue = useNoneValue;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreConfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreConfiguredInputDataSource.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 
         [ImportingConstructor]
         public PackageRestoreConfiguredInputDataSource(ConfiguredProject project, IProjectSubscriptionService projectSubscriptionService)
-            : base(project, synchronousDisposal: true, registerDataSource: false)
+            : base(project, synchronousDisposal: false, registerDataSource: false)
         {
             _containingProject = project.UnconfiguredProject;
             _projectSubscriptionService = projectSubscriptionService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreUnconfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreUnconfiguredInputDataSource.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 
         [ImportingConstructor]
         public PackageRestoreUnconfiguredInputDataSource(UnconfiguredProject project, IActiveConfigurationGroupService activeConfigurationGroupService)
-            : base(project, synchronousDisposal: true, registerDataSource: false)
+            : base(project, synchronousDisposal: false, registerDataSource: false)
         {
             _project = project;
             _activeConfigurationGroupService = activeConfigurationGroupService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                                              IActiveConfiguredProjectSubscriptionService projectSubscriptionService,
                                              IDesignTimeInputsDataSource inputsDataSource,
                                              IDesignTimeInputsFileWatcher fileWatcher)
-            : base(unconfiguredProjectServices, synchronousDisposal: true, registerDataSource: false)
+            : base(unconfiguredProjectServices, synchronousDisposal: false, registerDataSource: false)
         {
             _project = project;
             _projectSubscriptionService = projectSubscriptionService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsDataSource.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         public DesignTimeInputsDataSource(UnconfiguredProject project,
                                           IUnconfiguredProjectServices unconfiguredProjectServices,
                                           IActiveConfiguredProjectSubscriptionService projectSubscriptionService)
-            : base(project, synchronousDisposal: true, registerDataSource: false)
+            : base(project, synchronousDisposal: false, registerDataSource: false)
         {
             _project = project;
             _projectSubscriptionService = projectSubscriptionService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         [ImportingConstructor]
         public ActiveConfiguredProjectsLoader(UnconfiguredProject project, IActiveConfigurationGroupService activeConfigurationGroupService, IUnconfiguredProjectTasksService tasksService)
-            : base(synchronousDisposal: true)
+            : base(synchronousDisposal: false)
         {
             _project = project;
             _activeConfigurationGroupService = activeConfigurationGroupService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DropConfiguredProjectVersionDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DropConfiguredProjectVersionDataSource.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private readonly IProjectValueDataSource<T> _dataSource;
 
         public DropConfiguredProjectVersionDataSource(UnconfiguredProject project, IProjectValueDataSource<T> dataSource)
-            : base(project, synchronousDisposal: true, registerDataSource: false)
+            : base(project, synchronousDisposal: false, registerDataSource: false)
         {
             _dataSource = dataSource;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckConfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckConfiguredInputDataSource.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         public UpToDateCheckConfiguredInputDataSource(
             ConfiguredProject containingProject,
             IActiveConfigurationGroupService activeConfigurationGroupService)
-            : base(containingProject, synchronousDisposal: true, registerDataSource: false)
+            : base(containingProject, synchronousDisposal: false, registerDataSource: false)
         {
             _configuredProject = containingProject;
             _activeConfigurationGroupService = activeConfigurationGroupService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         public UpToDateCheckImplicitConfiguredInputDataSource(
             ConfiguredProject containingProject,
             IProjectItemSchemaService projectItemSchemaService)
-            : base(containingProject, synchronousDisposal: true, registerDataSource: false)
+            : base(containingProject, synchronousDisposal: false, registerDataSource: false)
         {
             _configuredProject = containingProject;
             _projectItemSchemaService = projectItemSchemaService;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
@@ -84,12 +84,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Fact]
-        public void Dispose_WhenNotInitialized_DoesNotThrow()
+        public async Task Dispose_WhenNotInitialized_DoesNotThrow()
         {
             var project = UnconfiguredProjectFactory.Create();
 
             var loader = CreateInstance(project, out _);
-            loader.Dispose();
+
+            await loader.DisposeAsync();
 
             Assert.True(loader.IsDisposed);
         }
@@ -108,7 +109,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             var loader = CreateInstance(project, out ProjectValueDataSource<IConfigurationGroup<ProjectConfiguration>> source);
             await loader.InitializeAsync();
-            loader.Dispose();
+            await loader.DisposeAsync();
 
             var configurationGroups = IConfigurationGroupFactory.CreateFromConfigurationNames("Debug|AnyCPU");
 


### PR DESCRIPTION
Fixes #7409

These types derive from `OnceInitializedOnceDisposed` which supports both sync and async disposal. If async disposal is requested, the dispose call is made via `Task.Run`, causing it to occur on a background (thread pool) thread.

Async disposal can free up the UI thread during solution close.

Looking through these usages of synchronous disposal, it seems they can all be made async.

cc @lifengl @davkean for your expertise on whether this may be an unsafe change. I've verified that all these changes result in some actual disposal occurring, and left instances where the dispose operation was a no-op, which will be faster to do sync.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7414)