### PR TITLE
Allow Razor files to appear in any source item type

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         private ExportLifetimeContext<IWorkspaceContextHandler>[] _handlers = Array.Empty<ExportLifetimeContext<IWorkspaceContextHandler>>();
 
         [ImportingConstructor]
-        public ApplyChangesToWorkspaceContext(ConfiguredProject project, IProjectDiagnosticOutputService logger, [ImportMany]ExportFactory<IWorkspaceContextHandler>[] workspaceContextHandlerFactories)
+        public ApplyChangesToWorkspaceContext(ConfiguredProject project, IProjectDiagnosticOutputService logger, [ImportMany] ExportFactory<IWorkspaceContextHandler>[] workspaceContextHandlerFactories)
         {
             _project = project;
             _logger = logger;
@@ -58,9 +58,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             EnsureInitialized();
         }
 
-        public async Task ApplyProjectBuildAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, 
+        public async Task ApplyProjectBuildAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update,
             IProjectBuildSnapshot buildSnapshot,
-            ContextState state, 
+            ContextState state,
             CancellationToken cancellationToken)
         {
             Requires.NotNull(update, nameof(update));
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             }
 
             // We just need to pass all options to Roslyn
-            _context.SetOptions(options .MoveToImmutable());
+            _context.SetOptions(options.MoveToImmutable());
         }
 
         public Task ApplyProjectEvaluationAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, ContextState state, CancellationToken cancellationToken)
@@ -107,6 +107,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             IComparable version = GetConfiguredProjectVersion(update);
 
             return ProcessProjectEvaluationHandlersAsync(version, update, state, cancellationToken);
+        }
+
+        public Task ApplySourceItemsAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, ContextState state, CancellationToken cancellationToken)
+        {
+            Requires.NotNull(update, nameof(update));
+
+            VerifyInitializedAndNotDisposed();
+
+            IComparable version = GetConfiguredProjectVersion(update);
+
+            return ProcessSourceItemsHandlersAsync(version, update, state, cancellationToken);
         }
 
         public IEnumerable<string> GetProjectEvaluationRules()
@@ -211,6 +222,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                         continue;
 
                     evaluationHandler.Handle(version, projectChange, state, _logger);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private Task ProcessSourceItemsHandlersAsync(IComparable version, IProjectVersionedValue<IProjectSubscriptionUpdate> update, ContextState state, CancellationToken cancellationToken)
+        {
+            foreach (ExportLifetimeContext<IWorkspaceContextHandler> handler in _handlers)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (handler.Value is ISourceItemsHandler evaluationHandler)
+                {
+                    evaluationHandler.Handle(version, update.Value.ProjectChanges, state, _logger);
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
@@ -234,9 +234,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (handler.Value is ISourceItemsHandler evaluationHandler)
+                if (handler.Value is ISourceItemsHandler sourceItemsHandler)
                 {
-                    evaluationHandler.Handle(version, update.Value.ProjectChanges, state, _logger);
+                    sourceItemsHandler.Handle(version, update.Value.ProjectChanges, state, _logger);
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/DynamicItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/DynamicItemHandler.cs
@@ -36,6 +36,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             foreach (var (_, projectChange) in projectChanges)
             {
+                if (!projectChange.Difference.AnyChanges)
+                    continue;
+
                 IProjectChangeDiff difference = HandlerServices.NormalizeRenames(projectChange.Difference);
 
                 foreach (string includePath in difference.RemovedItems)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/DynamicItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/DynamicItemHandler.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     ///     Handles changes to dynamic items, such as Razor CSHTML files.
     /// </summary>
     [Export(typeof(IWorkspaceContextHandler))]
-    internal class DynamicItemHandler : AbstractWorkspaceContextHandler, IProjectEvaluationHandler
+    internal class DynamicItemHandler : AbstractWorkspaceContextHandler, ISourceItemsHandler
     {
         private const string RazorPagesExtension = ".cshtml";
         private const string RazorComponentsExtension = ".razor";
@@ -26,48 +26,46 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _project = project;
         }
 
-        public string ProjectEvaluationRule
-        {
-            get { return Content.SchemaName; }
-        }
-
-        public void Handle(IComparable version, IProjectChangeDescription projectChange, ContextState state, IProjectDiagnosticOutputService logger)
+        public void Handle(IComparable version, IImmutableDictionary<string, IProjectChangeDescription> projectChanges, ContextState state, IProjectDiagnosticOutputService logger)
         {
             Requires.NotNull(version, nameof(version));
-            Requires.NotNull(projectChange, nameof(projectChange));
+            Requires.NotNull(projectChanges, nameof(projectChanges));
             Requires.NotNull(logger, nameof(logger));
 
             VerifyInitialized();
 
-            IProjectChangeDiff difference = HandlerServices.NormalizeRenames(projectChange.Difference);
-
-            foreach (string includePath in difference.RemovedItems)
+            foreach (var (_, projectChange) in projectChanges)
             {
-                if (IsDynamicFile(includePath))
+                IProjectChangeDiff difference = HandlerServices.NormalizeRenames(projectChange.Difference);
+
+                foreach (string includePath in difference.RemovedItems)
                 {
-                    RemoveFromContextIfPresent(includePath, logger);
+                    if (IsDynamicFile(includePath))
+                    {
+                        RemoveFromContextIfPresent(includePath, logger);
+                    }
                 }
-            }
 
-            foreach (string includePath in difference.AddedItems)
-            {
-                if (IsDynamicFile(includePath))
+                foreach (string includePath in difference.AddedItems)
                 {
-                    IImmutableDictionary<string, string> metadata = projectChange.After.Items.GetValueOrDefault(includePath, ImmutableStringDictionary<string>.EmptyOrdinal);
+                    if (IsDynamicFile(includePath))
+                    {
+                        IImmutableDictionary<string, string> metadata = projectChange.After.Items.GetValueOrDefault(includePath, ImmutableStringDictionary<string>.EmptyOrdinal);
 
-                    AddToContextIfNotPresent(includePath, metadata, logger);
+                        AddToContextIfNotPresent(includePath, metadata, logger);
+                    }
                 }
-            }
 
-            // We Remove then Add changed items to pick up the Linked metadata
-            foreach (string includePath in difference.ChangedItems)
-            {
-                if (IsDynamicFile(includePath))
+                // We Remove then Add changed items to pick up the Linked metadata
+                foreach (string includePath in difference.ChangedItems)
                 {
-                    IImmutableDictionary<string, string> metadata = projectChange.After.Items.GetValueOrDefault(includePath, ImmutableStringDictionary<string>.EmptyOrdinal);
+                    if (IsDynamicFile(includePath))
+                    {
+                        IImmutableDictionary<string, string> metadata = projectChange.After.Items.GetValueOrDefault(includePath, ImmutableStringDictionary<string>.EmptyOrdinal);
 
-                    RemoveFromContextIfPresent(includePath, logger);
-                    AddToContextIfNotPresent(includePath, metadata, logger);
+                        RemoveFromContextIfPresent(includePath, logger);
+                        AddToContextIfNotPresent(includePath, metadata, logger);
+                    }
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
@@ -84,5 +84,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     intention that the <see cref="IWorkspaceProjectContext"/> will be immediately disposed.
         /// </remarks>
         Task ApplyProjectBuildAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, IProjectBuildSnapshot buildSnapshot, ContextState state, CancellationToken cancellationToken);
+
+        /// <summary>
+        ///     Applies source items changes to the underlying <see cref="IWorkspaceProjectContext"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="update"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///     <see cref="Initialize(IWorkspaceProjectContext)"/> has not been called.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///     The <see cref="IApplyChangesToWorkspaceContext"/> has been disposed of.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">
+        ///     The result is awaited and <paramref name="cancellationToken"/> is cancelled.
+        /// </exception>
+        /// <remarks>
+        ///     Note: Cancelling the <paramref name="cancellationToken"/> may result in the underlying
+        ///     <see cref="IWorkspaceProjectContext"/> to be left in an inconsistent state with respect
+        ///     to the project snapshot state. The cancellation token should only be cancelled with the
+        ///     intention that the <see cref="IWorkspaceProjectContext"/> will be immediately disposed.
+        /// </remarks>
+        Task ApplySourceItemsAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, ContextState state, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ISourceItemsHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ISourceItemsHandler.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS;
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
     /// <summary>
-    ///     Handles changes to project evaluation rule and applies them to a
+    ///     Handles changes to source items and applies them to a
     ///     <see cref="IWorkspaceProjectContext"/> instance.
     /// </summary>
     internal interface ISourceItemsHandler : IWorkspaceContextHandler

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ISourceItemsHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ISourceItemsHandler.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.VS;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    /// <summary>
+    ///     Handles changes to project evaluation rule and applies them to a
+    ///     <see cref="IWorkspaceProjectContext"/> instance.
+    /// </summary>
+    internal interface ISourceItemsHandler : IWorkspaceContextHandler
+    {
+        /// <summary>
+        ///     Handles the specified set of changes to source items, and applies them
+        ///     to the underlying <see cref="IWorkspaceProjectContext"/>.
+        /// </summary>
+        /// <param name="version">
+        ///     An <see cref="IComparable"/> representing the <see cref="ConfiguredProject.ProjectVersion"/> at
+        ///     the time the <see cref="IProjectChangeDescription"/> was produced.
+        /// </param>
+        /// <param name="projectChanges">
+        ///     A dictionary of <see cref="IProjectChangeDescription"/> representing the set of
+        ///     changes made to the project, keyed by their item type.
+        /// </param>
+        /// <param name="state">
+        ///     A <see cref="ContextState"/> describing the state of the <see cref="IWorkspaceProjectContext"/>.
+        /// </param>
+        /// <param name="logger">
+        ///     The <see cref="IProjectDiagnosticOutputService"/> for logging to the log.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="version"/> is <see langword="null"/>.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="projectChanges"/> is <see langword="null"/>.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="logger"/> is <see langword="null"/>.
+        /// </exception>
+        void Handle(IComparable version, IImmutableDictionary<string, IProjectChangeDescription> projectChanges, ContextState state, IProjectDiagnosticOutputService logger);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHandlerType.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHandlerType.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    internal enum WorkspaceContextHandlerType
+    {
+        Evaluation,
+        ProjectBuild,
+        SourceItems
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.ProjectChange.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.ProjectChange.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    internal partial class WorkspaceProjectContextHost
+    {
+        internal partial class WorkspaceProjectContextHostInstance
+        {
+            /// <summary>
+            /// Converts a dataflow update into a data structure that is easier to deal with
+            /// </summary>
+            internal class ProjectChange
+            {
+                public ConfiguredProject Project { get; }
+                public IProjectVersionedValue<IProjectSubscriptionUpdate> Subscription { get; }
+                public IProjectBuildSnapshot? BuildSnapshot { get; }
+                public IImmutableDictionary<NamedIdentity, IComparable> DataSourceVersions { get; }
+
+                public ProjectChange(IProjectVersionedValue<(ConfiguredProject project, IProjectSubscriptionUpdate subscription, IProjectBuildSnapshot buildSnapshot)> update)
+                {
+                    Project = update.Value.project;
+                    Subscription = update.Derive(u => u.subscription);
+                    BuildSnapshot = update.Value.buildSnapshot;
+                    DataSourceVersions = update.DataSourceVersions;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.ProjectChange.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.ProjectChange.cs
@@ -27,6 +27,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     BuildSnapshot = update.Value.buildSnapshot;
                     DataSourceVersions = update.DataSourceVersions;
                 }
+
+                public ProjectChange(IProjectVersionedValue<(ConfiguredProject project, IProjectSubscriptionUpdate subscription)> update)
+                {
+                    Project = update.Value.project;
+                    Subscription = update.Derive(u => u.subscription);
+                    DataSourceVersions = update.DataSourceVersions;
+                }
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
@@ -115,8 +115,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     ProjectDataSources.SyncLinkTo(
                         _activeConfiguredProjectProvider.ActiveConfiguredProjectBlock.SyncLinkOptions(),
                         _projectSubscriptionService.SourceItemsRuleSource.SourceBlock.SyncLinkOptions(),
-                        _projectBuildSnapshotService.SourceBlock.SyncLinkOptions(),
-                            target: DataflowBlockFactory.CreateActionBlock<IProjectVersionedValue<ValueTuple<ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot>>>(e =>
+                            target: DataflowBlockFactory.CreateActionBlock<IProjectVersionedValue<ValueTuple<ConfiguredProject, IProjectSubscriptionUpdate>>>(e =>
                                 OnProjectChangedAsync(new ProjectChange(e), WorkspaceContextHandlerType.SourceItems),
                                 _project.UnconfiguredProject,
                                 ProjectFaultSeverity.LimitedFunctionality),

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IApplyChangesToWorkspaceContextFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IApplyChangesToWorkspaceContextFactory.cs
@@ -34,5 +34,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             return mock.Object;
         }
+
+        public static IApplyChangesToWorkspaceContext ImplementApplySourceItemsAsync(Action<IProjectVersionedValue<IProjectSubscriptionUpdate>, ContextState, CancellationToken> action)
+        {
+            var mock = new Mock<IApplyChangesToWorkspaceContext>();
+            mock.Setup(c => c.ApplySourceItemsAsync(It.IsAny<IProjectVersionedValue<IProjectSubscriptionUpdate>>(), It.IsAny<ContextState>(), It.IsAny<CancellationToken>()))
+                .Callback(action)
+                .Returns(Task.CompletedTask);
+
+            return mock.Object;
+        }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/DynamicItemHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/DynamicItemHandlerTests.cs
@@ -1,12 +1,13 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
-    public class DynamicItemHandlerTests : EvaluationHandlerTestBase
+    public class DynamicItemHandlerTests : SourceItemsHandlerTestBase
     {
         [Fact]
         public void Handle_RazorAndCshtmlFiles_AddsToContext()
@@ -19,22 +20,91 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             var handler = CreateInstance(project, context);
 
-            var projectChange = IProjectChangeDescriptionFactory.FromJson(
+            var projectChanges = ImmutableDictionary<string, IProjectChangeDescription>.Empty.Add(
+                "None", IProjectChangeDescriptionFactory.FromJson(
 @"{
     ""Difference"": { 
         ""AnyChanges"": true,
         ""AddedItems"": [ ""File1.razor"", ""File1.cshtml"", ""File1.cs"" ]
     }
-}");
+}"));
 
-            Handle(handler, projectChange);
+            Handle(handler, projectChanges);
 
             Assert.Equal(2, dynamicFiles.Count);
             Assert.Contains(@"C:\File1.razor", dynamicFiles);
             Assert.Contains(@"C:\File1.cshtml", dynamicFiles);
         }
 
-        internal override IProjectEvaluationHandler CreateInstance()
+        [Fact]
+        public void Handle_RazorAndCshtmlFiles_InDifferentItemTypes_AddsToContext()
+        {
+            var dynamicFiles = new HashSet<string>(StringComparers.Paths);
+            void onDynamicFileAdded(string s) => Assert.True(dynamicFiles.Add(s));
+
+            var project = UnconfiguredProjectFactory.Create(fullPath: @"C:\Myproject.csproj");
+            var context = IWorkspaceProjectContextMockFactory.CreateForDynamicFiles(project, onDynamicFileAdded);
+
+            var handler = CreateInstance(project, context);
+
+            var projectChanges = ImmutableDictionary<string, IProjectChangeDescription>.Empty.Add(
+                "None", IProjectChangeDescriptionFactory.FromJson(
+@"{
+    ""Difference"": { 
+        ""AnyChanges"": true,
+        ""AddedItems"": [ ""File1.razor"", ""File1.cs"" ]
+    }
+}")).Add(
+                "Content", IProjectChangeDescriptionFactory.FromJson(
+@"{
+    ""Difference"": { 
+        ""AnyChanges"": true,
+        ""AddedItems"": [ ""File1.cshtml"", ""File2.cs"" ]
+    }
+}"));
+
+            Handle(handler, projectChanges);
+
+            Assert.Equal(2, dynamicFiles.Count);
+            Assert.Contains(@"C:\File1.razor", dynamicFiles);
+            Assert.Contains(@"C:\File1.cshtml", dynamicFiles);
+        }
+
+        [Fact]
+        public void Handle_RazorAndCshtmlFiles_InDifferentItemTypes_IgnoresDuplicates()
+        {
+            var dynamicFiles = new HashSet<string>(StringComparers.Paths);
+            void onDynamicFileAdded(string s) => Assert.True(dynamicFiles.Add(s));
+
+            var project = UnconfiguredProjectFactory.Create(fullPath: @"C:\Myproject.csproj");
+            var context = IWorkspaceProjectContextMockFactory.CreateForDynamicFiles(project, onDynamicFileAdded);
+
+            var handler = CreateInstance(project, context);
+
+            var projectChanges = ImmutableDictionary<string, IProjectChangeDescription>.Empty.Add(
+                "None", IProjectChangeDescriptionFactory.FromJson(
+@"{
+    ""Difference"": { 
+        ""AnyChanges"": true,
+        ""AddedItems"": [ ""File1.razor"", ""File1.cs"" ]
+    }
+}")).Add(
+                "Content", IProjectChangeDescriptionFactory.FromJson(
+@"{
+    ""Difference"": { 
+        ""AnyChanges"": true,
+        ""AddedItems"": [ ""File1.razor"", ""File1.cshtml"", ""File2.cs"" ]
+    }
+}"));
+
+            Handle(handler, projectChanges);
+
+            Assert.Equal(2, dynamicFiles.Count);
+            Assert.Contains(@"C:\File1.razor", dynamicFiles);
+            Assert.Contains(@"C:\File1.cshtml", dynamicFiles);
+        }
+
+        internal override ISourceItemsHandler CreateInstance()
         {
             return CreateInstance(null, null);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemsHandlerTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemsHandlerTestBase.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.VS;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
+{
+    public abstract class SourceItemsHandlerTestBase
+    {
+        [Fact]
+        public void Handle_NullAsVersion_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var projectChanges = ImmutableDictionary<string, IProjectChangeDescription>.Empty;
+            var logger = Mock.Of<IProjectDiagnosticOutputService>();
+
+            Assert.Throws<ArgumentNullException>("version", () =>
+            {
+                handler.Handle(null!, projectChanges, new ContextState(), logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsProjectChanges_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var logger = Mock.Of<IProjectDiagnosticOutputService>();
+
+            Assert.Throws<ArgumentNullException>("projectChanges", () =>
+            {
+                handler.Handle(10, null!, new ContextState(), logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsLogger_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var projectChanges = ImmutableDictionary<string, IProjectChangeDescription>.Empty;
+
+            Assert.Throws<ArgumentNullException>("logger", () =>
+            {
+                handler.Handle(10, projectChanges, new ContextState(), null!);
+            });
+        }
+
+        [Fact]
+        public void Handle_WhenNotInitialized_ThrowsInvalidOperation()
+        {
+            var handler = CreateInstance();
+            var projectChanges = ImmutableDictionary<string, IProjectChangeDescription>.Empty;
+            var logger = Mock.Of<IProjectDiagnosticOutputService>();
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Handle(10, projectChanges, new ContextState(), logger);
+            });
+        }
+
+        [Fact]
+        public void Initialize_WhenAlreadyInitialized_ThrowsInvalidOperation()
+        {
+            var handler = CreateInstance();
+
+            var workspaceContext = IWorkspaceProjectContextMockFactory.Create();
+
+            handler.Initialize(workspaceContext);
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Initialize(workspaceContext);
+            });
+        }
+
+        internal static void Handle(ISourceItemsHandler handler, IImmutableDictionary<string, IProjectChangeDescription> projectChanges)
+        {
+            handler.Handle(1, projectChanges, new ContextState(), IProjectDiagnosticOutputServiceFactory.Create());
+        }
+
+        internal abstract ISourceItemsHandler CreateInstance();
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
@@ -168,7 +168,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var instance = await CreateInitializedInstanceAsync(tasksService: tasksService, applyChangesToWorkspaceContext: applyChangesToWorkspaceContext);
 
-            var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>(default);
+            var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>((default!, default!, Mock.Of<IProjectBuildSnapshot>()));
             var change = new WorkspaceProjectContextHostInstance.ProjectChange(update);
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
             {
@@ -210,7 +210,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             instance = await CreateInitializedInstanceAsync(applyChangesToWorkspaceContext: applyChangesToWorkspaceContext);
 
-            var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>(default);
+            var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>((default!, default!, Mock.Of<IProjectBuildSnapshot>()));
             var change = new WorkspaceProjectContextHostInstance.ProjectChange(update);
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
             {
@@ -287,7 +287,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var instance = await CreateInitializedInstanceAsync(applyChangesToWorkspaceContext: applyChangesToWorkspaceContext, activeWorkspaceProjectContextTracker: activeWorkspaceProjectContextTracker);
 
-            var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>(default);
+            var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>((default!, default!, Mock.Of<IProjectBuildSnapshot>()));
             var change = new WorkspaceProjectContextHostInstance.ProjectChange(update);
             await instance.OnProjectChangedAsync(change, handlerType);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
@@ -134,9 +134,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Theory]
-        [InlineData(true)]      // Evaluation
-        [InlineData(false)]     // Project Build
-        public async Task OnProjectChangedAsync_WhenProjectUnloaded_TriggersCancellation(bool evaluation)
+        [InlineData(WorkspaceContextHandlerType.Evaluation)]
+        [InlineData(WorkspaceContextHandlerType.ProjectBuild)]
+        [InlineData(WorkspaceContextHandlerType.SourceItems)]
+        internal async Task OnProjectChangedAsync_WhenProjectUnloaded_TriggersCancellation(WorkspaceContextHandlerType handlerType)
         {
             var unloadSource = new CancellationTokenSource();
             var tasksService = IUnconfiguredProjectTasksServiceFactory.ImplementUnloadCancellationToken(unloadSource.Token);
@@ -157,21 +158,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 cancellationToken.ThrowIfCancellationRequested();
             }
 
-            var applyChangesToWorkspaceContext = evaluation ? IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectEvaluationAsync(ApplyProjectEvaluation) : IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectBuildAsync(ApplyProjectBuild);
+            var applyChangesToWorkspaceContext = handlerType switch
+            {
+                WorkspaceContextHandlerType.Evaluation => IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectEvaluationAsync(ApplyProjectEvaluation),
+                WorkspaceContextHandlerType.ProjectBuild => IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectBuildAsync(ApplyProjectBuild),
+                WorkspaceContextHandlerType.SourceItems => IApplyChangesToWorkspaceContextFactory.ImplementApplySourceItemsAsync(ApplyProjectEvaluation), // ApplyProjectEvaluation works for source items as they share a signature
+                _ => throw new NotImplementedException()
+            };
 
             var instance = await CreateInitializedInstanceAsync(tasksService: tasksService, applyChangesToWorkspaceContext: applyChangesToWorkspaceContext);
 
             var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>(default);
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
             {
-                return instance.OnProjectChangedAsync(update, evaluation);
+                return instance.OnProjectChangedAsync(update, handlerType);
             });
         }
 
         [Theory]
-        [InlineData(true)]      // Evaluation
-        [InlineData(false)]     // Project Build
-        public async Task OnProjectChangedAsync_WhenInstanceDisposed_TriggersCancellation(bool evaluation)
+        [InlineData(WorkspaceContextHandlerType.Evaluation)]
+        [InlineData(WorkspaceContextHandlerType.ProjectBuild)]
+        [InlineData(WorkspaceContextHandlerType.SourceItems)]
+        internal async Task OnProjectChangedAsync_WhenInstanceDisposed_TriggersCancellation(WorkspaceContextHandlerType handlerType)
         {
             WorkspaceProjectContextHostInstance? instance = null;
 
@@ -191,21 +199,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 cancellationToken.ThrowIfCancellationRequested();
             }
 
-            var applyChangesToWorkspaceContext = evaluation ? IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectEvaluationAsync(ApplyProjectEvaluation) : IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectBuildAsync(ApplyProjectBuild);
+            var applyChangesToWorkspaceContext = handlerType switch
+            {
+                WorkspaceContextHandlerType.Evaluation => IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectEvaluationAsync(ApplyProjectEvaluation),
+                WorkspaceContextHandlerType.ProjectBuild => IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectBuildAsync(ApplyProjectBuild),
+                WorkspaceContextHandlerType.SourceItems => IApplyChangesToWorkspaceContextFactory.ImplementApplySourceItemsAsync(ApplyProjectEvaluation), // ApplyProjectEvaluation works for source items as they share a signature
+                _ => throw new NotImplementedException()
+            };
 
             instance = await CreateInitializedInstanceAsync(applyChangesToWorkspaceContext: applyChangesToWorkspaceContext);
 
             var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>(default);
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
             {
-                return instance.OnProjectChangedAsync(update, evaluation);
+                return instance.OnProjectChangedAsync(update, handlerType);
             });
         }
 
         [Theory]
-        [InlineData(true)]      // Evaluation
-        [InlineData(false)]     // Project Build
-        public async Task OnProjectChangedAsync_PassesProjectUpdate(bool evaluation)
+        [InlineData(WorkspaceContextHandlerType.Evaluation)]
+        [InlineData(WorkspaceContextHandlerType.ProjectBuild)]
+        [InlineData(WorkspaceContextHandlerType.SourceItems)]
+        internal async Task OnProjectChangedAsync_PassesProjectUpdate(WorkspaceContextHandlerType handlerType)
         {
             IProjectVersionedValue<IProjectSubscriptionUpdate>? subscriptionResult = null;
 
@@ -219,24 +234,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 subscriptionResult = u;
             }
 
-            var applyChangesToWorkspaceContext = evaluation ? IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectEvaluationAsync(ApplyProjectEvaluation) : IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectBuildAsync(ApplyProjectBuild);
+            var applyChangesToWorkspaceContext = handlerType switch
+            {
+                WorkspaceContextHandlerType.Evaluation => IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectEvaluationAsync(ApplyProjectEvaluation),
+                WorkspaceContextHandlerType.ProjectBuild => IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectBuildAsync(ApplyProjectBuild),
+                WorkspaceContextHandlerType.SourceItems => IApplyChangesToWorkspaceContextFactory.ImplementApplySourceItemsAsync(ApplyProjectEvaluation), // ApplyProjectEvaluation works for source items as they share a signature
+                _ => throw new NotImplementedException()
+            };
 
             var instance = await CreateInitializedInstanceAsync(applyChangesToWorkspaceContext: applyChangesToWorkspaceContext);
 
             var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
             var subscription = IProjectSubscriptionUpdateFactory.CreateEmpty();
             var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>((null!, subscription, buildSnapshot));
-            await instance.OnProjectChangedAsync(update, evaluation);
+            await instance.OnProjectChangedAsync(update, handlerType);
 
             Assert.Same(subscriptionResult!.Value, subscription);
         }
 
         [Theory] // Evaluation/Project Build       IsActiveContext
-        [InlineData(true,                          true)]
-        [InlineData(true,                          false)]
-        [InlineData(false,                         true)]
-        [InlineData(false,                         false)]
-        public async Task OnProjectChangedAsync_RespectsIsActiveContext(bool evaluation, bool isActiveContext)
+        [InlineData(WorkspaceContextHandlerType.Evaluation, true)]
+        [InlineData(WorkspaceContextHandlerType.Evaluation, false)]
+        [InlineData(WorkspaceContextHandlerType.ProjectBuild, true)]
+        [InlineData(WorkspaceContextHandlerType.ProjectBuild, false)]
+        [InlineData(WorkspaceContextHandlerType.SourceItems, true)]
+        [InlineData(WorkspaceContextHandlerType.SourceItems, false)]
+        internal async Task OnProjectChangedAsync_RespectsIsActiveContext(WorkspaceContextHandlerType handlerType, bool isActiveContext)
         {
             bool? isActiveContextResult = null;
 
@@ -251,12 +274,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             }
 
             var activeWorkspaceProjectContextTracker = IActiveEditorContextTrackerFactory.ImplementIsActiveEditorContext(context => isActiveContext);
-            var applyChangesToWorkspaceContext = evaluation ? IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectEvaluationAsync(ApplyProjectEvaluation) : IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectBuildAsync(ApplyProjectBuild);
+            var applyChangesToWorkspaceContext = handlerType switch
+            {
+                WorkspaceContextHandlerType.Evaluation => IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectEvaluationAsync(ApplyProjectEvaluation),
+                WorkspaceContextHandlerType.ProjectBuild => IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectBuildAsync(ApplyProjectBuild),
+                WorkspaceContextHandlerType.SourceItems => IApplyChangesToWorkspaceContextFactory.ImplementApplySourceItemsAsync(ApplyProjectEvaluation), // ApplyProjectEvaluation works for source items as they share a signature
+                _ => throw new NotImplementedException()
+            };
 
             var instance = await CreateInitializedInstanceAsync(applyChangesToWorkspaceContext: applyChangesToWorkspaceContext, activeWorkspaceProjectContextTracker: activeWorkspaceProjectContextTracker);
 
             var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>(default);
-            await instance.OnProjectChangedAsync(update, evaluation);
+            await instance.OnProjectChangedAsync(update, handlerType);
 
             Assert.Equal(isActiveContext, isActiveContextResult);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
@@ -169,9 +169,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var instance = await CreateInitializedInstanceAsync(tasksService: tasksService, applyChangesToWorkspaceContext: applyChangesToWorkspaceContext);
 
             var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>(default);
+            var change = new WorkspaceProjectContextHostInstance.ProjectChange(update);
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
             {
-                return instance.OnProjectChangedAsync(update, handlerType);
+                return instance.OnProjectChangedAsync(change, handlerType);
             });
         }
 
@@ -210,9 +211,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             instance = await CreateInitializedInstanceAsync(applyChangesToWorkspaceContext: applyChangesToWorkspaceContext);
 
             var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>(default);
+            var change = new WorkspaceProjectContextHostInstance.ProjectChange(update);
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
             {
-                return instance.OnProjectChangedAsync(update, handlerType);
+                return instance.OnProjectChangedAsync(change, handlerType);
             });
         }
 
@@ -247,7 +249,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var buildSnapshot = Mock.Of<IProjectBuildSnapshot>();
             var subscription = IProjectSubscriptionUpdateFactory.CreateEmpty();
             var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>((null!, subscription, buildSnapshot));
-            await instance.OnProjectChangedAsync(update, handlerType);
+            var change = new WorkspaceProjectContextHostInstance.ProjectChange(update);
+            await instance.OnProjectChangedAsync(change, handlerType);
 
             Assert.Same(subscriptionResult!.Value, subscription);
         }
@@ -285,7 +288,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var instance = await CreateInitializedInstanceAsync(applyChangesToWorkspaceContext: applyChangesToWorkspaceContext, activeWorkspaceProjectContextTracker: activeWorkspaceProjectContextTracker);
 
             var update = IProjectVersionedValueFactory.Create<(ConfiguredProject, IProjectSubscriptionUpdate, IProjectBuildSnapshot)>(default);
-            await instance.OnProjectChangedAsync(update, handlerType);
+            var change = new WorkspaceProjectContextHostInstance.ProjectChange(update);
+            await instance.OnProjectChangedAsync(change, handlerType);
 
             Assert.Equal(isActiveContext, isActiveContextResult);
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/project-system/issues/7411
Fixes https://github.com/dotnet/aspnetcore/issues/34188

This changes the DynamicItemHandler for Razor so that instead of being hardcoded to the `Content` item type, it now uses CPSes SourceItemsService (via an ISourceItemsHandler) so that it can see all items in any type that is considered a source file. Essentially my understanding is that this will now see any file that is in the project tree. This solves various issues from enterprise solutions:

* OrchardCore includes Razor files in the `EmbeddedResource` item type
* Bing has Razor files in the `None` item type (ie, the default from the SDK) and uses custom build targets and tasks to process them at build time
* MAUI uses a custom item type added by `AvailableItemName`

I'm still doing manual validation, but want to get a real build so may as well put this up too.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7417)