### PR TITLE
Support multiple Hot Reload sessions

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.ProjectSystem.VS.HotReload;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Threading;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Task = System.Threading.Tasks.Task;
@@ -104,6 +105,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
         public async Task OnAfterLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile, IReadOnlyList<VsDebugTargetProcessInfo> processInfos)
         {
+            await TaskScheduler.Default;
+
             await _hotReloadSessionManager.Value.ActivateSessionAsync((int)processInfos[0].dwProcessId);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSession.cs
@@ -6,14 +6,36 @@ using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 {
+    /// <summary>
+    /// Represents a Hot Reload session within the project system.
+    /// </summary>
     public interface IProjectHotReloadSession
     {
+        /// <summary>
+        /// A name used to identify the session in diagnostic messages. Not guaranteed to be
+        /// unique.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Starts the Hot Reload Session.
+        /// </summary>
         Task StartSessionAsync(CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Stops the Hot Reload Session.
+        /// </summary>
         Task StopSessionAsync(CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Applies any pending changes to the Hot Reload session.
+        /// </summary>
         Task ApplyChangesAsync(CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Updates the environment variables in <paramref name="envVars"/> to include
+        /// settings needed by a process using Hot Reload.
+        /// </summary>
         Task<bool> ApplyLaunchVariablesAsync(IDictionary<string, string> envVars, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionManager.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
+{
+    /// <summary>
+    /// Tracks and manages the pending and active Hot Reload sessions for the project.
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private, Cardinality = Composition.ImportCardinality.ExactlyOne)]
+    internal interface IProjectHotReloadSessionManager
+    {
+        /// <summary>
+        /// Creates a pending Hot Reload session for the project as possible, and updates
+        /// the given <paramref name="environmentVariables"/> accordingly.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true"/> if the session was created; <see langword="false"/>
+        /// otherwise.
+        /// </returns>
+        Task<bool> TryCreatePendingSessionAsync(IDictionary<string, string> environmentVariables);
+        
+        /// <summary>
+        /// Activates the pending Hot Reload session and associates it with the specified
+        /// process.
+        /// </summary>
+        Task ActivateSessionAsync(int processId);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
@@ -12,7 +12,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 {
     internal class ProjectHotReloadSession : IManagedHotReloadAgent, IProjectHotReloadSession
     {
-        private readonly string _id;
         private readonly string _runtimeVersion;
         private readonly Lazy<IHotReloadAgentManagerClient> _hotReloadAgentManagerClient;
         private readonly Lazy<IHotReloadDiagnosticOutputService> _hotReloadOutputService;
@@ -23,14 +22,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
         private IDeltaApplier? _deltaApplier;
 
         public ProjectHotReloadSession(
-            string id,
+            string name,
             string runtimeVersion,
             Lazy<IHotReloadAgentManagerClient> hotReloadAgentManagerClient,
             Lazy<IHotReloadDiagnosticOutputService> hotReloadOutputService,
             Lazy<IManagedDeltaApplierCreator> deltaApplierCreator,
             IProjectHotReloadSessionCallback callback)
         {
-            _id = id;
+            Name = name;
             _runtimeVersion = runtimeVersion;
             _hotReloadAgentManagerClient = hotReloadAgentManagerClient;
             _hotReloadOutputService = hotReloadOutputService;
@@ -39,6 +38,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
         }
 
         // IProjectHotReloadSession
+
+        public string Name { get; }
 
         public async Task ApplyChangesAsync(CancellationToken cancellationToken)
         {
@@ -185,7 +186,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 
         private Task WriteToOutputWindowAsync(string message)
         {
-            return _hotReloadOutputService.Value.WriteLineAsync($"{_id}: {message}");
+            return _hotReloadOutputService.Value.WriteLineAsync($"{Name}: {message}");
         }
 
         private void EnsureDeltaApplierforSession()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
@@ -1,0 +1,233 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.HotReload.Components.DeltaApplier;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
+{
+    [Export(typeof(IProjectHotReloadSessionManager))]
+    internal class ProjectHotReloadSessionManager : IProjectHotReloadSessionManager
+    {
+        private readonly UnconfiguredProject _project;
+        private readonly IActiveDebugFrameworkServices _activeDebugFrameworkServices;
+        private readonly Lazy<IProjectHotReloadAgent> _projectHotReloadAgent;
+        private readonly Lazy<IHotReloadDiagnosticOutputService> _hotReloadDiagnosticOutputService;
+
+        private HotReloadState? _pendingSessionState = null;
+
+        private ImmutableDictionary<int, HotReloadState> _activeSessions = ImmutableDictionary<int, HotReloadState>.Empty;
+
+        private int _nextUniqueId = 1;
+
+        [ImportingConstructor]
+        public ProjectHotReloadSessionManager(
+            UnconfiguredProject project,
+            IActiveDebugFrameworkServices activeDebugFrameworkServices,
+            Lazy<IProjectHotReloadAgent> projectHotReloadAgent,
+            Lazy<IHotReloadDiagnosticOutputService> hotReloadDiagnosticOutputService)
+        {
+            _project = project;
+            _activeDebugFrameworkServices = activeDebugFrameworkServices;
+            _projectHotReloadAgent = projectHotReloadAgent;
+            _hotReloadDiagnosticOutputService = hotReloadDiagnosticOutputService;
+        }
+
+        public async Task ActivateSessionAsync(int processId)
+        {
+            if (_pendingSessionState is not null)
+            {
+                Assumes.NotNull(_pendingSessionState.Session);
+
+                try
+                {
+                    Process? process = Process.GetProcessById(processId);
+
+                    await _hotReloadDiagnosticOutputService.Value.WriteLineAsync($"{_pendingSessionState.Session.Name}: Attaching to process '{processId}'.");
+
+                    process.Exited += _pendingSessionState.OnProcessExited;
+                    process.EnableRaisingEvents = true;
+
+                    if (process.HasExited)
+                    {
+                        await _hotReloadDiagnosticOutputService.Value.WriteLineAsync($"{_pendingSessionState.Session.Name}: The process has already exited.");
+                        process.Exited -= _pendingSessionState.OnProcessExited;
+                        process = null;
+                    }
+
+                    _pendingSessionState.Process = process;
+                }
+                catch (Exception ex)
+                {
+                    await _hotReloadDiagnosticOutputService.Value.WriteLineAsync($"{_pendingSessionState.Session.Name}: Error while attaching to process '{processId}':\r\n{ex.GetType()}\r\n{ex.Message}");
+                }
+
+                if (_pendingSessionState.Process is null)
+                {
+                    await _hotReloadDiagnosticOutputService.Value.WriteLineAsync($"{_pendingSessionState.Session.Name}: Unable to start Hot Reload session: no active process.");
+                }
+                else
+                {
+                    _ = _pendingSessionState.Session.StartSessionAsync(default);
+                    ImmutableInterlocked.TryAdd(ref _activeSessions, processId, _pendingSessionState);
+                }
+
+                _pendingSessionState = null;
+            }
+        }
+
+        public async Task<bool> TryCreatePendingSessionAsync(IDictionary<string, string> environmentVariables)
+        {
+            if (await DebugFrameworkSupportsHotReloadAsync()
+                && await GetDebugFrameworkVersionAsync() is string frameworkVersion)
+            {
+                string name = $"{Path.GetFileNameWithoutExtension(_project.FullPath)}:{_nextUniqueId++}";
+                HotReloadState state = new(this);
+                IProjectHotReloadSession? projectHotReloadSession = _projectHotReloadAgent.Value.CreateHotReloadSession(name, frameworkVersion, state);
+
+                if (projectHotReloadSession is not null)
+                {
+                    state.Session = projectHotReloadSession;
+                    await projectHotReloadSession.ApplyLaunchVariablesAsync(environmentVariables, default);
+                    _pendingSessionState = state;
+
+                    return true;
+                }
+            }
+
+            _pendingSessionState = null;
+            return false;
+        }
+
+        private async Task<bool> DebugFrameworkSupportsHotReloadAsync()
+        {
+            ConfiguredProject? configuredProjectForDebug = await GetConfiguredProjectForDebugAsync();
+            if (configuredProjectForDebug is null)
+            {
+                return false;
+            }
+
+            return configuredProjectForDebug.Capabilities.AppliesTo("SupportsHotReload");
+        }
+
+        private Task<ConfiguredProject?> GetConfiguredProjectForDebugAsync() =>
+            _activeDebugFrameworkServices.GetConfiguredProjectForActiveFrameworkAsync();
+
+        private async Task<string?> GetDebugFrameworkVersionAsync()
+        {
+            ConfiguredProject? configuredProjectForDebug = await GetConfiguredProjectForDebugAsync();
+            if (configuredProjectForDebug is null)
+            {
+                return null;
+            }
+
+            Assumes.Present(configuredProjectForDebug.Services.ProjectPropertiesProvider);
+            IProjectProperties commonProperties = configuredProjectForDebug.Services.ProjectPropertiesProvider.GetCommonProperties();
+            string targetFrameworkVersion = await commonProperties.GetEvaluatedPropertyValueAsync(ConfigurationGeneral.TargetFrameworkVersionProperty);
+
+            if (targetFrameworkVersion.StartsWith("v", StringComparison.OrdinalIgnoreCase))
+            {
+                targetFrameworkVersion = targetFrameworkVersion.Substring(startIndex: 1);
+            }
+
+            return targetFrameworkVersion;
+        }
+
+        private async Task ProcessExitedAsync(HotReloadState hotReloadState)
+        {
+            Assumes.NotNull(hotReloadState.Session);
+            Assumes.NotNull(hotReloadState.Process);
+
+            await _hotReloadDiagnosticOutputService.Value.WriteLineAsync($"{hotReloadState.Session.Name}: The process has exited.");
+
+            await StopProjectAsync(hotReloadState, default);
+        }
+
+        private IDeltaApplier? GetDeltaApplier(HotReloadState hotReloadState)
+        {
+            return null;
+        }
+
+        private Task<bool> RestartProjectAsync(HotReloadState hotReloadState, CancellationToken cancellationToken)
+        {
+            // TODO: Support restarting the project.
+            return TaskResult.False;
+        }
+
+        private Task OnAfterChangesAppliedAsync(HotReloadState hotReloadState, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        private async Task<bool> StopProjectAsync(HotReloadState hotReloadState, CancellationToken cancellationToken)
+        {
+            Assumes.NotNull(hotReloadState.Session);
+            Assumes.NotNull(hotReloadState.Process);
+
+            try
+            {
+                await hotReloadState.Session.StopSessionAsync(default);
+
+                ImmutableInterlocked.TryRemove(ref _activeSessions, hotReloadState.Process.Id, out _);
+            }
+            catch (Exception ex)
+            {
+                await _hotReloadDiagnosticOutputService.Value.WriteLineAsync($"{hotReloadState.Session.Name}: Error while stopping the session:\r\n{ex.GetType()}\r\n{ex.Message}");
+            }
+
+            return true;
+        }
+
+        private class HotReloadState : IProjectHotReloadSessionCallback
+        {
+            private readonly ProjectHotReloadSessionManager _sessionManager;
+
+            public Process? Process { get; set; }
+            public IProjectHotReloadSession? Session { get; set; }
+
+            // TODO: Support restarting the session.
+            public bool SupportsRestart => false;
+
+            public HotReloadState(ProjectHotReloadSessionManager sessionManager)
+            {
+                _sessionManager = sessionManager;
+            }
+
+#pragma warning disable VSTHRD100 // Avoid async void methods
+            internal async void OnProcessExited(object sender, EventArgs e)
+#pragma warning restore VSTHRD100 // Avoid async void methods
+            {
+                await _sessionManager.ProcessExitedAsync(this);
+            }
+
+            public Task OnAfterChangesAppliedAsync(CancellationToken cancellationToken)
+            {
+                return _sessionManager.OnAfterChangesAppliedAsync(this, cancellationToken);
+            }
+
+            public Task<bool> StopProjectAsync(CancellationToken cancellationToken)
+            {
+                return _sessionManager.StopProjectAsync(this, cancellationToken);
+            }
+
+            public Task<bool> RestartProjectAsync(CancellationToken cancellationToken)
+            {
+                return _sessionManager.RestartProjectAsync(this, cancellationToken);
+            }
+
+            public IDeltaApplier? GetDeltaApplier()
+            {
+                return _sessionManager.GetDeltaApplier(this);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -8,6 +8,7 @@ Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadAgent.CreateH
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.ApplyChangesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.ApplyLaunchVariablesAsync(System.Collections.Generic.IDictionary<string!, string!>! envVars, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.Name.get -> string!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.StartSessionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.StopSessionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectHotReloadSessionManagerFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectHotReloadSessionManagerFactory.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.VS.HotReload;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal static class IProjectHotReloadSessionManagerFactory
+    {
+        public static IProjectHotReloadSessionManager Create()
+        {
+            var mock = new Mock<IProjectHotReloadSessionManager>();
+
+            mock.Setup(manager => manager.TryCreatePendingSessionAsync(It.IsAny<IDictionary<string, string>>()))
+                .ReturnsAsync(true);
+
+            mock.Setup(manager => manager.ActivateSessionAsync(It.IsAny<int>()))
+                .Returns(Task.CompletedTask);
+
+            return mock.Object;
+        }
+    }
+
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -731,17 +731,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             IActiveDebugFrameworkServices? activeDebugFramework = null,
             ProjectProperties? properties = null,
             IProjectThreadingService? threadingService = null,
-            IVsDebugger10? debugger = null,
-            IProjectHotReloadAgent? projectHotReloadAgent = null,
-            IHotReloadDiagnosticOutputService? hotReloadDiagnosticOutputService = null)
+            IVsDebugger10? debugger = null)
         {
             environment ??= Mock.Of<IEnvironmentHelper>();
             tokenReplacer ??= IDebugTokenReplacerFactory.Create();
             activeDebugFramework ??= IActiveDebugFrameworkServicesFactory.ImplementGetConfiguredProjectForActiveFrameworkAsync(configuredProject);
             threadingService ??= IProjectThreadingServiceFactory.Create();
             debugger ??= IVsDebugger10Factory.ImplementIsIntegratedConsoleEnabled(enabled: false);
-            projectHotReloadAgent ??= IProjectHotReloadAgentFactory.Create();
-            hotReloadDiagnosticOutputService ??= IHotReloadDiagnosticOutputServiceFactory.Create();
 
             IUnconfiguredProjectVsServices unconfiguredProjectVsServices = IUnconfiguredProjectVsServicesFactory.Implement(() => IVsHierarchyFactory.Create());
 
@@ -758,8 +754,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 threadingService,
                 IVsUIServiceFactory.Create<SVsShellDebugger, IVsDebugger10>(debugger),
                 remoteDebuggerAuthenticationService,
-                projectHotReloadAgent,
-                new Lazy<IHotReloadDiagnosticOutputService>(() => hotReloadDiagnosticOutputService));
+                new Lazy<IProjectHotReloadSessionManager>(() => IProjectHotReloadSessionManagerFactory.Create()));
         }
     }
 }


### PR DESCRIPTION
1. Extract the logic for creating and tracking Hot Reload sessions to a new type, `IProjectHotReloadSessionManager`. The `ProjectLaunchTargetsProvider`'s role in Hot Reload to now reduced to requesting that a pending session be created, and informing the manager of when the pending session should be activated. Inside the manager, `HotReloadState` serves as to associate a session with a `Process` and also implements `IProjectHotReloadSessionCallback`. In general it redirects all operations to the manager for actual handling, though.
2. Support multiple sessions. Currently, If a Hot Reload session is active for a project and the user runs the project again with Ctrl+F5 we kill the previous process and session, and then run the new one. This is deviation from the previous (non-Hot-Reload) behavior where running with Ctrl+F5 multiple times will start multiple processes. Bringing support for this to Hot Reload is mostly a matter of never killing a process and maintaining a set of all the active sessions/processes.

In future the manager will likely have more responsibility. For example, if the user makes an edit that cannot be applied we would like to automate the process of killing the processes, building, and restarting.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7418)