### PR TITLE
Send telemetry on a thread pool thread

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
     /// </remarks>
     [Export(typeof(IDependencyTreeTelemetryService))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
-    internal sealed class DependencyTreeTelemetryService : IDependencyTreeTelemetryService, IDisposable
+    internal sealed class DependencyTreeTelemetryService : OnceInitializedOnceDisposed, IDependencyTreeTelemetryService
     {
         private const int MaxEventCount = 10;
 
@@ -58,6 +58,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 _telemetryService = telemetryService;
                 _stateByFramework = new Dictionary<TargetFramework, TelemetryState>();
             }
+        }
+
+        protected override void Initialize()
+        {
         }
 
         public void InitializeTargetFrameworkRules(ImmutableArray<TargetFramework> targetFrameworks, IReadOnlyCollection<string> rules)
@@ -167,9 +171,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             _dependenciesSnapshot = dependenciesSnapshot;
         }
 
-        public void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            if (_telemetryService != null && _dependenciesSnapshot != null && _projectId != null)
+            if (disposing && _telemetryService != null && _dependenciesSnapshot != null && _projectId != null)
             {
                 var data = new List<TargetData>();
                 int totalDependencyCount = 0;


### PR DESCRIPTION
Fixes #7412 

During shutdown we compute and publish telemetry about project dependencies. Previously this code would run on the UI thread, although that is not necessary.

This change uses the `OnceInitializedOnceDisposed` base class which uses async disposal by default, running that work on the thread pool.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7419)