### PR TITLE
Update cps packages

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -12,6 +12,7 @@
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
 
@@ -49,7 +50,7 @@
     <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.0.0-previews-2-31421-281" />
     <PackageReference Update="Microsoft.VisualStudio.Interop"                                         Version="17.0.0-previews-2-31423-289"/>
     <PackageReference Update="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50728" />
-    <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="17.0.50-preview-0002-0002" />
+    <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="17.0.50-preview-0002-0010" />
     <PackageReference Update="Microsoft.VisualStudio.Telemetry"                                       Version="16.3.176" />
     <PackageReference Update="Microsoft.VisualStudio.Settings.15.0"                                   Version="16.8.30406.155-pre" />
     <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="2.3.2262-g94fae01e" />
@@ -58,23 +59,23 @@
     <PackageReference Update="Microsoft.VisualStudio.Shell.Design"                                    Version="17.0.0-previews-2-31421-281" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.0.0-previews-2-31421-281" />
     <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.0.0-preview-2-31223-026" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="17.0.21-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.0.21-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="17.0.26-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.0.26-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="17.0.0-previews-2-31421-281" />
     <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="17.0.12-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.XmlEditor"                                       Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VSDesigner"                                                   Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="VsWebSite.Interop"                                                      Version="16.8.30523.219"/>
-    
+
     <!-- https://github.com/dotnet/roslyn/issues/53877 -->
     <PackageReference Include="StreamJsonRpc"                                                         Version="2.8.21" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.0.610-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.0.610-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.0.610-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.0.610-pre" />
-    
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.0.788-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.0.788-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.0.788-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.0.788-pre" />
+
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.0.0-2.21302.13" />
     <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="4.0.0-2.21302.13" />
@@ -88,15 +89,15 @@
     <PackageReference Update="Roslyn.Diagnostics.Analyzers"                                           Version="3.3.2" />
 
     <!-- NuGet -->
-    <PackageReference Update="NuGet.SolutionRestoreManager.Interop"                                   Version="5.8.0-preview.2.6776" />
-    <PackageReference Update="NuGet.VisualStudio"                                                     Version="6.0.0-preview.0.2" />
+    <PackageReference Update="NuGet.SolutionRestoreManager.Interop"                                   Version="6.0.0-preview.1.89" />
+    <PackageReference Update="NuGet.VisualStudio"                                                     Version="6.0.0-preview.1.89" />
 
     <!-- Framework packages -->
     <PackageReference Update="Microsoft.IO.Redist"                                                    Version="4.7.1" />
-    
+
     <!-- Hot Reload -->
     <PackageReference Update="Microsoft.VisualStudio.HotReload.Components"                            Version="6.0.0-preview.6.21330.17" />
-    
+
     <!-- 3rd party -->
     <PackageReference Update="Newtonsoft.Json"                                                        Version="12.0.2"/>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
@@ -44,7 +44,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
         protected override Task<int> OnApplyAsync()
         {
+#pragma warning disable VSTHRD110 // Observe result of async calls
             return _control?.ApplyAsync() ?? Task.FromResult((int)HResult.Fail);
+#pragma warning restore VSTHRD110 // Observe result of async calls
         }
 
         protected override Task OnDeactivateAsync()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
@@ -64,7 +64,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public Task SolutionLoadedInHost
         {
+#pragma warning disable VSTHRD110 // Observe result of async calls
             get { return _solutionService?.LoadedInHost.WithCancellation(_tasksService.UnloadCancellationToken) ?? throw new NotSupportedException(); }
+#pragma warning restore VSTHRD110 // Observe result of async calls
         }
 
         public CancellationToken UnloadCancellationToken


### PR DESCRIPTION
The update is needed in order to use the new constructor in `ChainedProjectValueDataSourceBase `that will be used in the implementation of `IVsProjectRestoreInfoSource`.

The two warnings [VSTHRD110 ](https://github.com/microsoft/vs-threading/issues/233) detected were suppressed.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7424)