### PR TITLE
Fast up-to-date check uses latest data

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckHost.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.UpToDate;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
+{
+    [Export(typeof(IUpToDateCheckHost))]
+    internal sealed class UpToDateCheckHost : IUpToDateCheckHost
+    {
+        private readonly IVsUIService<SVsShell, IVsShell> _vsShell;
+        private readonly JoinableTaskContext _joinableTaskContext;
+
+        private bool? _hasDesignTimeBuild;
+
+        [ImportingConstructor]
+        public UpToDateCheckHost(IVsUIService<SVsShell, IVsShell> vsShell, JoinableTaskContext joinableTaskContext)
+        {
+            _vsShell = vsShell;
+            _joinableTaskContext = joinableTaskContext;
+        }
+
+        public async ValueTask<bool> HasDesignTimeBuildsAsync(CancellationToken cancellationToken)
+        {
+            if (_hasDesignTimeBuild is null)
+            {
+                await _joinableTaskContext.Factory.SwitchToMainThreadAsync(cancellationToken);
+
+                // If VS is running in command line mode, design-time builds do not occur
+                if (ErrorHandler.Succeeded(_vsShell.Value.GetProperty((int)__VSSPROPID.VSSPROPID_IsInCommandLineMode, out object resultObj)) && resultObj is bool result)
+                {
+                    _hasDesignTimeBuild = !result;
+                }
+                else
+                {
+                    _hasDesignTimeBuild = false;
+                }
+            }
+
+            return _hasDesignTimeBuild.Value;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Subscription.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Subscription.cs
@@ -26,26 +26,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// Destruction of the Dataflow subscription happens when the parent component is disposed or unloaded.
         /// </para>
         /// </remarks>
-        private sealed class Subscription : IDisposable
+        private sealed class Subscription : ISubscription
         {
             private readonly IUpToDateCheckConfiguredInputDataSource _inputDataSource;
 
             private readonly ConfiguredProject _configuredProject;
 
             /// <summary>
-            /// Used to synchronise updates to <see cref="_link"/> and <see cref="State"/>.
+            /// Used to synchronise updates to <see cref="_link"/> and <see cref="_disposeTokenSource"/>.
             /// </summary>
             private readonly object _lock = new();
+
+            private readonly IUpToDateCheckHost _host;
 
             /// <summary>
             /// Prevent overlapping requests.
             /// </summary>
             private readonly AsyncSemaphore _semaphore = new(1);
 
-            /// <summary>
-            /// Internal for testing purposes only.
-            /// </summary>
-            internal UpToDateCheckConfiguredInput? State { get; private set; }
+            private int _disposed;
 
             /// <summary>
             /// Gets the time at which the last up-to-date check was made.
@@ -59,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             /// in that compilation. We use this property as a proxy for compilation start time, whereas
             /// the outputs represent compilation end time.
             /// </remarks>
-            internal DateTime LastCheckedAtUtc { get; set; } = DateTime.MinValue;
+            private DateTime _lastCheckedAtUtc = DateTime.MinValue;
 
             /// <summary>
             /// Lazily constructed Dataflow subscription. Set back to <see langword="null"/> in <see cref="Dispose"/>.
@@ -71,13 +70,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             /// </summary>
             private readonly CancellationTokenSource _disposeTokenSource = new();
 
-            public Subscription(IUpToDateCheckConfiguredInputDataSource inputDataSource, ConfiguredProject configuredProject)
+            public Subscription(IUpToDateCheckConfiguredInputDataSource inputDataSource, ConfiguredProject configuredProject, IUpToDateCheckHost host)
             {
                 Requires.NotNull(inputDataSource, nameof(inputDataSource));
                 Requires.NotNull(configuredProject, nameof(configuredProject));
 
                 _inputDataSource = inputDataSource;
                 _configuredProject = configuredProject;
+                _host = host;
             }
 
             public async Task<bool> RunAsync(Func<UpToDateCheckConfiguredInput, DateTime, CancellationToken, Task<bool>> func, CancellationToken cancellationToken)
@@ -89,77 +89,71 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 // Throws if the subscription has been disposed, or the caller's token cancelled.
                 token.ThrowIfCancellationRequested();
 
-                // Note that we defer subscription until an actual request is made in order to
-                // prevent redundant work/allocation for inactive project configurations.
-                // https://github.com/dotnet/project-system/issues/6327
-                //
-                // We don't pass the cancellation token here as initialization must be atomic.
-                EnsureInitialized();
-
-                token.ThrowIfCancellationRequested();
-
-                // TODO wait for our state to be up to date with that of the project (https://github.com/dotnet/project-system/issues/6185)
-
-                if (State == null)
+                if (!await _host.HasDesignTimeBuildsAsync(token))
                 {
-                    // We have either haven't received data yet, or have been disposed.
+                    // Design time builds aren't available in the host. This can happen when running in command line mode, for example.
+                    // In such a case we will not have the data we need. Presume the project is not up-to-date.
                     return false;
                 }
+
+                EnsureInitialized();
+
+                if (_disposed != 0)
+                {
+                    // We have been disposed
+                    return false;
+                }
+
+                Assumes.NotNull(_link);
 
                 // Prevent overlapping requests
                 using AsyncSemaphore.Releaser _ = await _semaphore.EnterAsync(token);
 
-                bool result = await func(State, LastCheckedAtUtc, token);
+                token.ThrowIfCancellationRequested();
 
-                lock (_lock)
-                {
-                    LastCheckedAtUtc = DateTime.UtcNow;
-                }
+                // Wait for our state to be up to date with that of the project
+                IProjectVersionedValue<UpToDateCheckConfiguredInput> state = await _inputDataSource.SourceBlock.GetLatestVersionAsync(
+                    _configuredProject,
+                    cancellationToken: token);
+
+                bool result = await func(state.Value, _lastCheckedAtUtc, token);
+
+                _lastCheckedAtUtc = DateTime.UtcNow;
 
                 return result;
             }
 
             public void EnsureInitialized()
             {
-                if (_link != null)
+                if (_link != null || _disposed != 0)
                 {
-                    // Already initialized (or disposed)
+                    // Already initialized or disposed
                     return;
                 }
 
+                // Double check within lock
                 lock (_lock)
                 {
-                    // Double check within lock
-                    if (_link == null)
+                    if (_link == null && _disposed == 0)
                     {
-                        ITargetBlock<IProjectVersionedValue<UpToDateCheckConfiguredInput>> actionBlock
-                            = DataflowBlockFactory.CreateActionBlock<IProjectVersionedValue<UpToDateCheckConfiguredInput>>(OnChanged, _configuredProject.UnconfiguredProject);
+                        // Link to a null target so that data will flow. The null target drops all values.
+                        // When we need a value we use GetLatestVersionAsync to ensure the UpToDateCheckConfiguredInput
+                        // is in sync with the current configured project.
 
-                        _link = _inputDataSource.SourceBlock.LinkTo(actionBlock, DataflowOption.PropagateCompletion);
+                        ITargetBlock<IProjectVersionedValue<UpToDateCheckConfiguredInput>> target
+                            = DataflowBlock.NullTarget<IProjectVersionedValue<UpToDateCheckConfiguredInput>>();
+
+                        _link = _inputDataSource.SourceBlock.LinkTo(target, DataflowOption.PropagateCompletion);
                     }
-                }
-            }
-
-            internal void OnChanged(IProjectVersionedValue<UpToDateCheckConfiguredInput> e)
-            {
-                lock (_lock)
-                {
-                    if (_disposeTokenSource.IsCancellationRequested)
-                    {
-                        // We've been disposed, so don't update State (which will be null)
-                        return;
-                    }
-
-                    State = e.Value;
                 }
             }
 
             /// <summary>
-            /// Tear down any Dataflow subscription and cancel any ongoing query.
+            /// Cancel any ongoing query and release Dataflow subscription.
             /// </summary>
             public void Dispose()
             {
-                if (_disposeTokenSource.IsCancellationRequested)
+                if (Interlocked.CompareExchange(ref _disposed, 1, 0) != 0)
                 {
                     // Already disposed
                     return;
@@ -170,12 +164,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     _link?.Dispose();
                     _link = null;
 
-                    State = null;
-
                     _disposeTokenSource.Cancel();
                     _disposeTokenSource.Dispose();
                 }
             }
+        }
+
+        internal interface ISubscription : IDisposable
+        {
+            void EnsureInitialized();
+
+            Task<bool> RunAsync(
+                Func<UpToDateCheckConfiguredInput, DateTime, CancellationToken, Task<bool>> func,
+                CancellationToken cancellationToken);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/IUpToDateCheckHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/IUpToDateCheckHost.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
+{
+    /// <summary>
+    /// Allows the fast up-to-date check to query the host for relevant information.
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    internal interface IUpToDateCheckHost
+    {
+        /// <summary>
+        /// Identifies whether design-time builds are available in the host.
+        /// </summary>
+        /// <remarks>
+        /// For example, when Visual Studio runs in "command line" mode, design-time builds do not occur.
+        /// </remarks>
+        /// <param name="cancellationToken">A token via which the operation may be cancelled.</param>
+        /// <returns>A task that, when completed, indicates whether design time builds are available in the host.</returns>
+        ValueTask<bool> HasDesignTimeBuildsAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -34,8 +34,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// </summary>
         public string? NewestImportInput { get; }
 
-        public IComparable? LastVersionSeen { get; }
-
         public bool IsDisabled { get; }
 
         /// <summary>
@@ -145,7 +143,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             string? copyUpToDateMarkerItem,
             string? outputRelativeOrFullPath,
             string? newestImportInput,
-            IComparable? lastVersionSeen,
             bool isDisabled,
             ImmutableArray<string> itemTypes,
             ImmutableDictionary<string, ImmutableArray<(string, string?, BuildUpToDateCheck.CopyType)>> itemsByItemType,
@@ -166,7 +163,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             CopyUpToDateMarkerItem = copyUpToDateMarkerItem;
             OutputRelativeOrFullPath = outputRelativeOrFullPath;
             NewestImportInput = newestImportInput;
-            LastVersionSeen = lastVersionSeen;
             IsDisabled = isDisabled;
             ItemTypes = itemTypes;
             ItemsByItemType = itemsByItemType;
@@ -203,8 +199,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             IProjectSubscriptionUpdate sourceItemsUpdate,
             IProjectSnapshot2 projectSnapshot,
             IProjectItemSchema projectItemSchema,
-            IProjectCatalogSnapshot projectCatalogSnapshot,
-            IComparable configuredProjectVersion)
+            IProjectCatalogSnapshot projectCatalogSnapshot)
         {
             bool isDisabled = jointRuleUpdate.CurrentState.IsPropertyTrue(ConfigurationGeneral.SchemaName, ConfigurationGeneral.DisableFastUpToDateCheckProperty, defaultValue: false);
 
@@ -449,7 +444,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 copyUpToDateMarkerItem,
                 outputRelativeOrFullPath,
                 newestImportInput,
-                lastVersionSeen: configuredProjectVersion,
                 isDisabled: isDisabled,
                 itemTypes: itemTypes.ToImmutableArray(),
                 itemsByItemType: itemsByItemTypeBuilder.ToImmutable(),
@@ -560,7 +554,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 CopyUpToDateMarkerItem,
                 OutputRelativeOrFullPath,
                 NewestImportInput,
-                LastVersionSeen,
                 IsDisabled,
                 ItemTypes,
                 ItemsByItemType,
@@ -588,7 +581,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 CopyUpToDateMarkerItem,
                 OutputRelativeOrFullPath,
                 NewestImportInput,
-                LastVersionSeen,
                 IsDisabled,
                 ItemTypes,
                 ItemsByItemType,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
@@ -90,8 +90,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     sourceItemsUpdate: e.Value.Item2,
                     projectSnapshot: snapshot,
                     projectItemSchema: e.Value.Item4,
-                    projectCatalogSnapshot: e.Value.Item5,
-                    configuredProjectVersion: e.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion]);
+                    projectCatalogSnapshot: e.Value.Item5);
 
                 return new ProjectVersionedValue<UpToDateCheckImplicitConfiguredInput>(state, e.DataSourceVersions);
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTestBase.cs
@@ -1,0 +1,103 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
+{
+    public abstract class BuildUpToDateCheckTestBase
+    {
+        private static readonly IImmutableList<IItemType> _itemTypes = ImmutableList<IItemType>.Empty
+            .Add(new ItemType("None", true))
+            .Add(new ItemType("Content", true))
+            .Add(new ItemType("Compile", true))
+            .Add(new ItemType("Resource", true));
+
+        private protected static IProjectRuleSnapshotModel SimpleItems(params string[] items)
+        {
+            return new IProjectRuleSnapshotModel
+            {
+                Items = items.Aggregate(
+                    ImmutableStringDictionary<IImmutableDictionary<string, string>>.EmptyOrdinal,
+                    (current, item) => current.Add(item, ImmutableStringDictionary<string>.EmptyOrdinal))
+            };
+        }
+
+        private protected static IProjectRuleSnapshotModel ItemWithMetadata(string itemSpec, string metadataName, string metadataValue)
+        {
+            return new IProjectRuleSnapshotModel
+            {
+                Items = ImmutableStringDictionary<IImmutableDictionary<string, string>>.EmptyOrdinal.Add(
+                    itemSpec,
+                    ImmutableStringDictionary<string>.EmptyOrdinal.Add(metadataName, metadataValue))
+            };
+        }
+
+        private protected static IProjectRuleSnapshotModel ItemsWithMetadata(params (string itemSpec, string metadataName, string metadataValue)[] items)
+        {
+            return new IProjectRuleSnapshotModel
+            {
+                Items = ImmutableStringDictionary<IImmutableDictionary<string, string>>.EmptyOrdinal.AddRange(
+                    items.Select(
+                        item => new KeyValuePair<string, IImmutableDictionary<string, string>>(
+                            item.itemSpec,
+                            ImmutableStringDictionary<string>.EmptyOrdinal.Add(item.metadataName, item.metadataValue))))
+            };
+        }
+
+        private protected static IProjectRuleSnapshotModel Union(params IProjectRuleSnapshotModel[] models)
+        {
+            var items = ImmutableDictionary<string, IImmutableDictionary<string, string>>.Empty;
+
+            foreach (var model in models)
+            {
+                foreach ((string key, IImmutableDictionary<string, string> value) in model.Items)
+                {
+                    items = items.Add(key, value);
+                }
+            }
+
+            return new IProjectRuleSnapshotModel { Items = items };
+        }
+
+        private protected static UpToDateCheckImplicitConfiguredInput UpdateState(
+            UpToDateCheckImplicitConfiguredInput priorState,
+            Dictionary<string, IProjectRuleSnapshotModel>? projectRuleSnapshot = null,
+            Dictionary<string, IProjectRuleSnapshotModel>? sourceRuleSnapshot = null,
+            IImmutableDictionary<string, DateTime>? dependentFileTimes = null)
+        {
+            return priorState.Update(
+                CreateUpdate(projectRuleSnapshot),
+                CreateUpdate(sourceRuleSnapshot),
+                IProjectSnapshot2Factory.Create(dependentFileTimes),
+                IProjectItemSchemaFactory.Create(_itemTypes),
+                IProjectCatalogSnapshotFactory.CreateWithDefaultMapping(_itemTypes));
+
+            static IProjectSubscriptionUpdate CreateUpdate(Dictionary<string, IProjectRuleSnapshotModel>? snapshotBySchemaName)
+            {
+                var snapshots = ImmutableStringDictionary<IProjectRuleSnapshot>.EmptyOrdinal;
+                var changes = ImmutableStringDictionary<IProjectChangeDescription>.EmptyOrdinal;
+
+                if (snapshotBySchemaName != null)
+                {
+                    foreach ((string schemaName, IProjectRuleSnapshotModel model) in snapshotBySchemaName)
+                    {
+                        var change = new IProjectChangeDescriptionModel
+                        {
+                            After = model,
+                            Difference = new IProjectChangeDiffModel { AnyChanges = true }
+                        };
+
+                        snapshots = snapshots.Add(schemaName, model.ToActualModel());
+                        changes = changes.Add(schemaName, change.ToActualModel());
+                    }
+                }
+
+                return IProjectSubscriptionUpdateFactory.Implement(snapshots, changes);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputTests.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
+{
+    public sealed class UpToDateCheckImplicitConfiguredInputTests : BuildUpToDateCheckTestBase
+    {
+        [Fact]
+        public void Update_InitialItemDataDoesNotUpdateLastItemsChangedAtUtc()
+        {
+            // This test covers a false negative described in https://github.com/dotnet/project-system/issues/5386
+            // where the initial snapshot of items sets LastItemsChangedAtUtc, so if a project is up to date when
+            // it is loaded, then the items are considered changed *after* the last build, but MSBuild's up-to-date
+            // check will determine the project doesn't require a rebuild and so the output timestamps won't update.
+            // This previously left the project in a state where it would be considered out of date endlessly.
+
+            var projectSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>()
+            {
+                [UpToDateCheckBuilt.SchemaName] = SimpleItems("BuiltOutputPath1")
+            };
+
+            var sourceSnapshot1 = new Dictionary<string, IProjectRuleSnapshotModel>()
+            {
+                [Compile.SchemaName] = SimpleItems("ItemPath1")
+            };
+
+            var sourceSnapshot2 = new Dictionary<string, IProjectRuleSnapshotModel>()
+            {
+                [Compile.SchemaName] = SimpleItems("ItemPath1", "ItemPath2")
+            };
+
+            var state = UpToDateCheckImplicitConfiguredInput.Empty;
+
+            Assert.Equal(DateTime.MinValue, state.LastItemsChangedAtUtc);
+
+            // Initial change does NOT set LastItemsChangedAtUtc
+            state = UpdateState(
+                state,
+                projectSnapshot,
+                sourceSnapshot1);
+
+            Assert.Equal(DateTime.MinValue, state.LastItemsChangedAtUtc);
+
+            // Broadcasting an update with no change to items does NOT set LastItemsChangedAtUtc
+            state = UpdateState(state);
+
+            Assert.Equal(DateTime.MinValue, state.LastItemsChangedAtUtc);
+
+            // Broadcasting changed items DOES set LastItemsChangedAtUtc
+            state = UpdateState(
+                state,
+                projectSnapshot,
+                sourceSnapshot2);
+
+            Assert.NotEqual(DateTime.MinValue, state.LastItemsChangedAtUtc);
+        }
+
+        [Fact]
+        public void Update_InitialItemDataDoesNotUpdateLastAdditionalDependentFileTimesChangedAtUtc()
+        {
+            var dependentTime = DateTime.UtcNow.AddMinutes(-1);
+            var dependentPath = @"C:\Dev\Solution\Project\Dependent";
+            var dependentTimeFiles = ImmutableDictionary.Create<string, DateTime>(StringComparers.Paths).Add(dependentPath, dependentTime);
+
+            var state = UpToDateCheckImplicitConfiguredInput.Empty;
+            Assert.Equal(DateTime.MinValue, state.LastAdditionalDependentFileTimesChangedAtUtc);
+
+            // Initial change does NOT set LastAdditionalDependentFileTimesChangedAtUtc
+            state = UpdateState(state, dependentFileTimes: dependentTimeFiles);
+
+            Assert.Equal(DateTime.MinValue, state.LastAdditionalDependentFileTimesChangedAtUtc);
+
+            // Broadcasting an update with same Additional Dependent Files does NOT set LastAdditionalDependentFileTimesChangedAtUtc
+            state = UpdateState(state, dependentFileTimes: dependentTimeFiles);
+
+            Assert.Equal(DateTime.MinValue, state.LastAdditionalDependentFileTimesChangedAtUtc);
+
+            // Broadcasting removing Additional Dependent Files DOES set LastAdditionalDependentFileTimesChangedAtUtc
+            state = UpdateState(state, dependentFileTimes: ImmutableDictionary.Create<string, DateTime>(StringComparers.Paths));
+
+            Assert.InRange((DateTime.UtcNow - state.LastAdditionalDependentFileTimesChangedAtUtc).TotalSeconds, 0, 10);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #6185

We use Dataflow blocks to process project data through various transformations, ultimately producing the data needed for the fast up-to-date check. Dataflow processes data asynchronously, fanned across threads.

Previously the output of the Dataflow "graph" was cached to a field on the subscription type. When a query was made, this field was read. It was possible that the Dataflow graph hadn't finished pushing data through its transformations at the time the query was made, meaning the query's result could be based on old data.

With this change, the fast up-to-date check now ensures that the most recent configured project data has flowed through the graph, so that the answer is always based on the latest data.

One complexity of this change relates to Visual Studio's "command line" mode, where `devenv.exe` could be used to perform builds. In such a case, the up-to-date check is called. However, design-time builds are not available in command line mode, and so we are unable to operate the fast up-to-date check. Previously the "state" field would be `null`, and we would return that we weren't up to date. With this change, we don't have a state field, so need to explicitly detect command line mode and bail out when it is enabled. That logic belongs in the VS (host) layer, and so this change introduces a new API via which the host can answer questions that the up-to-date check has for it.

The `LastVersionSeen` value is no longer required, as we now synchronise during the request. This allowed some code to be removed.

Another consequence of the change to Dataflow handling is on the unit tests. Previously we could stage state in the field discussed above. With this change, the field no longer exists. To work around this, an interface was introduced for `Subscription` which allows the logic to be mocked. This change eventually led to clearer test code.

I've verified that there is no regression in build performance due to this change in the case that the solution has been open long enough for things to stabilise. In a future PR, I will make the fast up-to-date check work immediately after solution open. In such a case, it's important that the up-to-date check waits for the first data to arrive, which the change here achieves. That future PR is the motivation for this change.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7427)