### PR TITLE
Fast up-to-date check works on solution open

### DIFF
--- a/docs/repo/up-to-date-check-implementation.md
+++ b/docs/repo/up-to-date-check-implementation.md
@@ -7,6 +7,8 @@ The `IBuildUpToDateCheckProvider` interface (from CPS) has two members:
 - `IsUpToDateCheckEnabledAsync`, which is serviced by `IProjectSystemOptions.GetFastUpToDateLoggingLevelAsync`
 - `IsUpToDateAsync` which performs the checks described below
 
+We implement the derived `IBuildUpToDateCheckProvider2` version of the interface, which gives us access to the set of global properties used in the build. A build may use global properties to exlude certain "kinds" of inputs and outputs if necessary.
+
 ## What is checked
 
 There are several checks which must all pass. 
@@ -68,6 +70,15 @@ For each `_copiedOutputFiles` source/destination
 - :heavy_check_mark: ...the source must exist
 - :heavy_check_mark: ...the destination must exist
 - :heavy_check_mark: ...the destination must be older or the same age as the source
+
+## Persistence
+
+Our up-to-date check persists data to the `.vs` folder, in a binary file such as `.vs/MySolution/v17/.futdcache.v1`.
+
+This file contains, per project:
+
+1. A hash of the items in the project, so that we can tell whether the items have changed since the last time we loaded the project. If not, we can consider the project up-to-date on solution open, which can save a lot of time for the user's first build/test/debug operations.
+2. The time at which the last set of items was observed to have changed. This is also important on solution open, to correctly handle the first up-to-date check of a project.
 
 ## Implementation
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckStatePersistence.ConfiguredProjectComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckStatePersistence.ConfiguredProjectComparer.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
+{
+    internal sealed partial class UpToDateCheckStatePersistence
+    {
+        /// <summary>
+        /// Compares projects and dimensions.
+        /// </summary>
+        private sealed class ConfiguredProjectComparer : IEqualityComparer<(string ProjectPath, IImmutableDictionary<string, string> ConfigurationDimensions)>
+        {
+            public static ConfiguredProjectComparer Instance { get; } = new();
+
+            public bool Equals(
+                (string ProjectPath, IImmutableDictionary<string, string> ConfigurationDimensions) x,
+                (string ProjectPath, IImmutableDictionary<string, string> ConfigurationDimensions) y)
+            {
+                if (!StringComparers.Paths.Equals(x.ProjectPath, y.ProjectPath))
+                    return false;
+
+                if (x.ConfigurationDimensions.Count != y.ConfigurationDimensions.Count)
+                    return false;
+
+                foreach ((string name, string xValue) in x.ConfigurationDimensions)
+                {
+                    if (!y.ConfigurationDimensions.TryGetValue(name, out string? yValue) ||
+                        !StringComparers.ConfigurationDimensionValues.Equals(xValue, yValue))
+                        return false;
+                }
+
+                return true;
+            }
+
+            public int GetHashCode((string ProjectPath, IImmutableDictionary<string, string> ConfigurationDimensions) obj)
+            {
+                unchecked
+                {
+                    int hash = obj.ProjectPath.GetHashCode();
+
+                    foreach ((string name, string value) in obj.ConfigurationDimensions)
+                    {
+                        // XOR values so that order doesn't matter
+                        hash ^= (name.GetHashCode() * 397) ^ value.GetHashCode();
+                    }
+
+                    return hash;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckStatePersistence.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckStatePersistence.cs
@@ -1,0 +1,242 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Internal.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.ProjectSystem.UpToDate;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
+{
+    /// <summary>
+    /// Implementation of <see cref="IUpToDateCheckStatePersistence" /> for use in Visual Studio.
+    /// </summary>
+    /// <remarks>
+    /// Stores the required data to disk in the <c>.vs</c> folder.
+    /// </remarks>
+    [Export(typeof(IUpToDateCheckStatePersistence))]
+    [AppliesTo(BuildUpToDateCheck.AppliesToExpression)]
+    internal sealed partial class UpToDateCheckStatePersistence : OnceInitializedOnceDisposedAsync, IUpToDateCheckStatePersistence, IVsSolutionEvents
+    {
+        private const string ProjectItemCacheFileName = ".futdcache.v1";
+
+        private readonly object _lock = new();
+
+        private Dictionary<(string ProjectPath, IImmutableDictionary<string, string> ConfigurationDimensions), (int ItemHash, DateTime ItemsChangedAtUtc)>? _dataByConfiguredProject;
+
+        private readonly IVsUIService<SVsSolution, IVsSolution> _solution;
+
+        private bool _hasUnsavedChange;
+        private uint _cookie = VSConstants.VSCOOKIE_NIL;
+        private string? _cacheFilePath;
+
+        [ImportingConstructor]
+        public UpToDateCheckStatePersistence(
+            IVsUIService<SVsSolution, IVsSolution> solution,
+            JoinableTaskContext joinableTaskContext)
+            : base(new JoinableTaskContextNode(joinableTaskContext))
+        {
+            _solution = solution;
+        }
+
+        protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
+        {
+            await JoinableFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            Verify.HResult(_solution.Value.AdviseSolutionEvents(this, out _cookie));
+        }
+
+        protected override async Task DisposeCoreAsync(bool initialized)
+        {
+            if (initialized)
+            {
+                if (_cookie != VSConstants.VSCOOKIE_NIL)
+                {
+                    await JoinableFactory.SwitchToMainThreadAsync();
+
+                    Verify.HResult(_solution.Value.UnadviseSolutionEvents(_cookie));
+
+                    _cookie = VSConstants.VSCOOKIE_NIL;
+                }
+            }
+        }
+
+        public async Task<(int ItemHash, DateTime ItemsChangedAtUtc)?> RestoreStateAsync(string projectPath, IImmutableDictionary<string, string> configurationDimensions)
+        {
+            await InitializeAsync();
+            await InitializeDataAsync();
+
+            lock (_lock)
+            {
+                Assumes.NotNull(_dataByConfiguredProject);
+
+                if (_dataByConfiguredProject.TryGetValue((projectPath, configurationDimensions), out (int ItemHash, DateTime ItemsChangedAtUtc) storedData))
+                    return storedData;
+
+                return null;
+            }
+
+            async Task InitializeDataAsync()
+            {
+                if (_cacheFilePath is null || _dataByConfiguredProject is null)
+                {
+                    string filePath = await GetCacheFilePathAsync(CancellationToken.None);
+
+                    // Switch to a background thread before doing file I/O
+                    await TaskScheduler.Default;
+
+                    lock (_lock)
+                    {
+                        if (_cacheFilePath is null || _dataByConfiguredProject is null)
+                        {
+                            _cacheFilePath = filePath;
+                            _dataByConfiguredProject = Deserialize(_cacheFilePath);
+                        }
+                    }
+                }
+
+                return;
+
+                async Task<string> GetCacheFilePathAsync(CancellationToken cancellationToken)
+                {
+                    await JoinableFactory.SwitchToMainThreadAsync(cancellationToken);
+
+                    var solutionWorkingFolder = _solution.Value as IVsSolutionWorkingFolders;
+
+                    Assumes.Present(solutionWorkingFolder);
+
+                    solutionWorkingFolder.GetFolder(
+                        (uint)__SolutionWorkingFolder.SlnWF_StatePersistence,
+                        guidProject: Guid.Empty,
+                        fVersionSpecific: true,
+                        fEnsureCreated: true,
+                        out bool isTemporary,
+                        out string workingFolderPath);
+
+                    return Path.Combine(workingFolderPath, ProjectItemCacheFileName);
+                }
+            }
+        }
+
+        public void StoreState(string projectPath, IImmutableDictionary<string, string> configurationDimensions, int itemHash, DateTime itemsChangedAtUtc)
+        {
+            lock (_lock)
+            {
+                Assumes.NotNull(_dataByConfiguredProject);
+
+                (string ProjectPath, IImmutableDictionary<string, string> ConfigurationDimensions) key = (ProjectPath: projectPath, ConfigurationDimensions: configurationDimensions);
+
+                if (!_dataByConfiguredProject.TryGetValue(key, out (int ItemHash, DateTime ItemsChangedAtUtc) storedData) ||
+                    storedData.ItemHash != itemHash ||
+                    storedData.ItemsChangedAtUtc != itemsChangedAtUtc)
+                {
+                    _dataByConfiguredProject[key] = (itemHash, itemsChangedAtUtc);
+                    _hasUnsavedChange = true;
+                }
+            }
+        }
+
+        #region Serialization
+
+        private static void Serialize(string cacheFilePath, Dictionary<(string ProjectPath, IImmutableDictionary<string, string> ConfigurationDimensions), (int ItemHash, DateTime ItemsChangedAtUtc)> dataByConfiguredProject)
+        {
+            using var stream = new FileStream(cacheFilePath, FileMode.Create, FileAccess.Write, FileShare.None);
+            using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+            writer.Write(dataByConfiguredProject.Count);
+
+            foreach (((string path, IImmutableDictionary<string, string> dimensions), (int ItemHash, DateTime ItemsChangedAtUtc) data) in dataByConfiguredProject)
+            {
+                writer.Write(path);
+
+                writer.Write(dimensions.Count);
+
+                foreach ((string name, string value) in dimensions)
+                {
+                    writer.Write(name);
+                    writer.Write(value);
+                }
+
+                writer.Write(data.ItemHash);
+                writer.Write(data.ItemsChangedAtUtc.Ticks);
+            }
+        }
+
+        private static Dictionary<(string ProjectPath, IImmutableDictionary<string, string> ConfigurationDimensions), (int ItemHash, DateTime ItemsChangedAtUtc)> Deserialize(string cacheFilePath)
+        {
+            var data = new Dictionary<(string ProjectPath, IImmutableDictionary<string, string> ConfigurationDimensions), (int ItemHash, DateTime ItemsChangedAtUtc)>(ConfiguredProjectComparer.Instance);
+
+            if (!File.Exists(cacheFilePath))
+            {
+                return data;
+            }
+
+            using var stream = new FileStream(cacheFilePath, FileMode.Open, FileAccess.Read, FileShare.None);
+            using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+
+            int configuredProjectCount = reader.ReadInt32();
+
+            while (configuredProjectCount-- != 0)
+            {
+                string path = reader.ReadString();
+
+                int dimensionCount = reader.ReadInt32();
+                var dimensions = ImmutableStringDictionary<string>.EmptyOrdinal.ToBuilder();
+
+                while (dimensionCount-- != 0)
+                {
+                    string name = reader.ReadString();
+                    string value = reader.ReadString();
+                    dimensions[name] = value;
+                }
+
+                int hash = reader.ReadInt32();
+                long ticks = reader.ReadInt64();
+                var itemsChangedAtUtc = new DateTime(ticks, DateTimeKind.Utc);
+
+                data[(path, dimensions.ToImmutable())] = (hash, itemsChangedAtUtc);
+            }
+
+            return data;
+        }
+
+        #endregion
+
+        #region IVsSolutionEvents
+
+        public int OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded) => HResult.NotImplemented;
+        public int OnQueryCloseProject(IVsHierarchy pHierarchy, int fRemoving, ref int pfCancel) => HResult.NotImplemented;
+        public int OnBeforeCloseProject(IVsHierarchy pHierarchy, int fRemoved) => HResult.NotImplemented;
+        public int OnAfterLoadProject(IVsHierarchy pStubHierarchy, IVsHierarchy pRealHierarchy) => HResult.NotImplemented;
+        public int OnQueryUnloadProject(IVsHierarchy pRealHierarchy, ref int pfCancel) => HResult.NotImplemented;
+        public int OnBeforeUnloadProject(IVsHierarchy pRealHierarchy, IVsHierarchy pStubHierarchy) => HResult.NotImplemented;
+        public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution) => HResult.NotImplemented;
+        public int OnQueryCloseSolution(object pUnkReserved, ref int pfCancel) => HResult.NotImplemented;
+        public int OnBeforeCloseSolution(object pUnkReserved) => HResult.NotImplemented;
+
+        public int OnAfterCloseSolution(object pUnkReserved)
+        {
+            lock (_lock)
+            {
+                if (_hasUnsavedChange && _cacheFilePath is not null && _dataByConfiguredProject is not null)
+                {
+                    Serialize(_cacheFilePath, _dataByConfiguredProject);
+                }
+
+                _cacheFilePath = null;
+                _dataByConfiguredProject = null;
+            }
+
+            return HResult.OK;
+        }
+
+        #endregion
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.ItemHashing.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.ItemHashing.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
+{
+    internal sealed partial class BuildUpToDateCheck
+    {
+        public static int ComputeItemHash(ImmutableDictionary<string, ImmutableArray<(string Path, string? Link, CopyType CopyType)>> itemsByItemType)
+        {
+            int hash = 0;
+
+            // Use XOR so the order of items is not important. We are using string hash codes which are
+            // quite well distributed. This approach might not work as well for other types, such as integers.
+            //
+            // This approach also assumes each path is only included once in the data structure. If a path
+            // were to exist twice, its hash would be XORed with itself, which produces zero net change.
+
+            foreach ((string itemType, ImmutableArray<(string Path, string? Link, CopyType CopyType)> items) in itemsByItemType)
+            {
+                int itemHash = 0;
+
+                foreach ((string path, _, _) in items)
+                {
+                    itemHash ^= path.GetHashCode();
+                }
+
+                // Multiply by the item type hash, so that if an item changes type the hash will change.
+                // The rest of the system does not really need this though, as it is assumed the only way
+                // an item can change type is if a project file changes, which would be detected via
+                // file timestamp changes.
+                hash ^= itemHash * itemType.GetHashCode();
+            }
+
+            return hash;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -113,8 +113,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return log.Fail("Disabled", "The 'DisableFastUpToDateCheck' property is true, not up to date.");
             }
 
-            if (lastCheckedAtUtc == DateTime.MinValue)
+            if (!state.WasStateRestored && lastCheckedAtUtc == DateTime.MinValue)
             {
+                // We had no persisted state, and this is the first run. We cannot know if the project is up-to-date
+                // or not, so schedule a build.
                 return log.Fail("FirstRun", "The up-to-date check has not yet run for this project. Not up-to-date.");
             }
 
@@ -245,8 +247,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         return log.Fail("Outputs", "Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up to date.", input, inputTime.Value, earliestOutputPath, earliestOutputTime);
                     }
 
-                    if (inputTime > lastCheckedAtUtc)
+                    if (inputTime > lastCheckedAtUtc && lastCheckedAtUtc != DateTime.MinValue)
                     {
+                        // Bypass this test if no check has yet been performed. We handle that in CheckGlobalConditions.
                         return log.Fail("Outputs", "Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up to date.", input, inputTime.Value, lastCheckedAtUtc);
                     }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/IUpToDateCheckStatePersistence.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/IUpToDateCheckStatePersistence.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
+{
+    /// <summary>
+    /// Persists fast up-to-date check state across solution lifetimes.
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.OneOrZero)]
+    internal interface IUpToDateCheckStatePersistence
+    {
+        /// <summary>
+        /// Retrieves the stored up-to-date check state for a given configured project.
+        /// </summary>
+        /// <param name="projectPath">The full path of the project.</param>
+        /// <param name="configurationDimensions">The map of dimension names and values that describes the project configuration.</param>
+        /// <returns>The hash and time at which items were last known to have changed (in UTC).</returns>
+        Task<(int ItemHash, DateTime ItemsChangedAtUtc)?> RestoreStateAsync(string projectPath, IImmutableDictionary<string, string> configurationDimensions);
+
+        /// <summary>
+        /// Stores up-to-date check state for a given configured project.
+        /// </summary>
+        /// <param name="projectPath">The full path of the project.</param>
+        /// <param name="configurationDimensions">The map of dimension names and values that describes the project configuration.</param>
+        /// <param name="itemHash">The hash of items to be stored.</param>
+        /// <param name="itemsChangedAtUtc">The time at which items were last known to have changed (in UTC).</param>
+        void StoreState(string projectPath, IImmutableDictionary<string, string> configurationDimensions, int itemHash, DateTime itemsChangedAtUtc);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
@@ -24,6 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
     {
         private readonly ConfiguredProject _configuredProject;
         private readonly IProjectItemSchemaService _projectItemSchemaService;
+        private readonly IUpToDateCheckStatePersistence? _persistentState;
 
         private static ImmutableHashSet<string> ProjectPropertiesSchemas => ImmutableStringHashSet.EmptyOrdinal
             .Add(ConfigurationGeneral.SchemaName)
@@ -37,23 +39,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         [ImportingConstructor]
         public UpToDateCheckImplicitConfiguredInputDataSource(
             ConfiguredProject containingProject,
-            IProjectItemSchemaService projectItemSchemaService)
+            IProjectItemSchemaService projectItemSchemaService,
+            [Import(AllowDefault = true)] IUpToDateCheckStatePersistence? persistentState)
             : base(containingProject, synchronousDisposal: false, registerDataSource: false)
         {
             _configuredProject = containingProject;
             _projectItemSchemaService = projectItemSchemaService;
+            _persistentState = persistentState;
         }
 
         protected override IDisposable LinkExternalInput(ITargetBlock<IProjectVersionedValue<UpToDateCheckImplicitConfiguredInput>> targetBlock)
         {
             Assumes.Present(_configuredProject.Services.ProjectSubscription);
 
+            bool attemptedStateRestore = false;
+
             // Initial state is empty. We will evolve this reference over time, updating it iteratively
             // on each new data update.
             UpToDateCheckImplicitConfiguredInput state = UpToDateCheckImplicitConfiguredInput.Empty;
 
             IPropagatorBlock<IProjectVersionedValue<UpdateValues>, IProjectVersionedValue<UpToDateCheckImplicitConfiguredInput>> transformBlock
-                = DataflowBlockSlim.CreateTransformBlock<IProjectVersionedValue<UpdateValues>, IProjectVersionedValue<UpToDateCheckImplicitConfiguredInput>>(Transform);
+                = DataflowBlockSlim.CreateTransformBlock<IProjectVersionedValue<UpdateValues>, IProjectVersionedValue<UpToDateCheckImplicitConfiguredInput>>(TransformAsync);
 
             IProjectValueDataSource<IProjectSubscriptionUpdate> source1 = _configuredProject.Services.ProjectSubscription.JointRuleSource;
             IProjectValueDataSource<IProjectSubscriptionUpdate> source2 = _configuredProject.Services.ProjectSubscription.SourceItemsRuleSource;
@@ -80,8 +86,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 JoinUpstreamDataSources(source1, source2, source3, source4, source5)
             };
 
-            IProjectVersionedValue<UpToDateCheckImplicitConfiguredInput> Transform(IProjectVersionedValue<UpdateValues> e)
+            async Task<IProjectVersionedValue<UpToDateCheckImplicitConfiguredInput>> TransformAsync(IProjectVersionedValue<UpdateValues> e)
             {
+                if (!attemptedStateRestore)
+                {
+                    attemptedStateRestore = true;
+
+                    if (_persistentState is not null)
+                    {
+                        (int ItemHash, DateTime InputsChangedAtUtc)? restoredState = await _persistentState.RestoreStateAsync(_configuredProject.UnconfiguredProject.FullPath, _configuredProject.ProjectConfiguration.Dimensions);
+
+                        if (restoredState is not null)
+                        {
+                            state = state.WithRestoredState(restoredState.Value.ItemHash, restoredState.Value.InputsChangedAtUtc);
+                        }
+                    }
+                }
+
+                int? priorItemHash = state.ItemHash;
+                DateTime priorLastItemsChangedAtUtc = state.LastItemsChangedAtUtc;
+
                 var snapshot = e.Value.Item3 as IProjectSnapshot2;
                 Assumes.NotNull(snapshot);
 
@@ -91,6 +115,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     projectSnapshot: snapshot,
                     projectItemSchema: e.Value.Item4,
                     projectCatalogSnapshot: e.Value.Item5);
+
+                if (_persistentState != null && (priorItemHash != state.ItemHash || priorLastItemsChangedAtUtc != state.LastItemsChangedAtUtc))
+                {
+                    // The input hash is always non-null after calling Update.
+                    Assumes.NotNull(state.ItemHash);
+
+                    _persistentState.StoreState(_configuredProject.UnconfiguredProject.FullPath, _configuredProject.ProjectConfiguration.Dimensions, state.ItemHash.Value, state.LastItemsChangedAtUtc);
+                }
 
                 return new ProjectVersionedValue<UpToDateCheckImplicitConfiguredInput>(state, e.DataSourceVersions);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
@@ -21,6 +21,7 @@ namespace Microsoft.VisualStudio
         public static StringComparer RuleNames => StringComparer.OrdinalIgnoreCase;
         public static StringComparer CategoryNames => StringComparer.OrdinalIgnoreCase;
         public static StringComparer ConfigurationDimensionNames => StringComparer.Ordinal;
+        public static StringComparer ConfigurationDimensionValues => StringComparer.Ordinal;
         public static StringComparer DependencyProviderTypes => StringComparer.OrdinalIgnoreCase;
         public static StringComparer DependencyTreeIds => StringComparer.OrdinalIgnoreCase;
         public static StringComparer ItemNames => StringComparer.OrdinalIgnoreCase;
@@ -57,6 +58,7 @@ namespace Microsoft.VisualStudio
         public static StringComparison PropertyValues => StringComparison.Ordinal;
         public static StringComparison RuleNames => StringComparison.OrdinalIgnoreCase;
         public static StringComparison ConfigurationDimensionNames => StringComparison.Ordinal;
+        public static StringComparison ConfigurationDimensionValues => StringComparison.Ordinal;
         public static StringComparison DependencyProviderTypes => StringComparison.OrdinalIgnoreCase;
         public static StringComparison DependencyTreeIds => StringComparison.OrdinalIgnoreCase;
         public static StringComparison ItemNames => StringComparison.OrdinalIgnoreCase;


### PR DESCRIPTION
Fixes #6633
Fixes #3826

Previously, the first up-to-date check that runs after a project loads always reports that a build is required. This avoided an uncommon yet serious potential issue.

Consider a project that brings in all `.cs` files via a glob, with the following steps:

1. Load the project
1. Build the project
1. Close the project
1. Delete one of the input `.cs` files from disk
1. Reopen the project

If the fast up-to-date check only considered the timestamps of input and output files, the project would appear up-to-date. However, it is not.

If an item is removed while Visual Studio has the project loaded, the change is observed and handled correctly.

Note that it is also possible to trigger this situation by adding a file, however usually when a file is added its timestamp is updated. Of course software can set the timestamp to whatever it wants. One easy way to do this is to undelete a file, which restores it with the original timestamp.

In order to correctly handle the above scenario, we need to persist some information about the project's inputs, so that when it is reloaded we can decide whether any inputs have been removed from disk.

That is what this change does. We introduce `IUpToDateCheckStatePersistence` which stores state in the `.vs` folder. That state contains a hash of the items in each project configuration.

With this change, we are now able to correctly identify whether a reloaded project is up-to-date or not, and avoid the precautionary build.

For OrchardCore, this cuts the time for first build after solution load from just over a minute to around one second, in the case that all 157 projects were already up-to-date.

This change will also reduce wait times when running unit tests after loading a solution, or launching a debugger. It will also reduce wait times when building after the solution being reloaded, perhaps due to the `.sln` file changing during a branch switch.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7428)