### PR TITLE
Class libraries cannot be startup projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
                 IProjectProperties properties = configuredProject.Services.ProjectPropertiesProvider.GetCommonProperties();
 
-                string? runCommand = await GetTargetCommandAsync(properties, validateSettings: false);
+                string? runCommand = await GetTargetCommandAsync(properties, validateSettings: true);
                 if (string.IsNullOrWhiteSpace(runCommand))
                 {
                     return false;


### PR DESCRIPTION
Fixes #1308

The boolean argument for `validateSettings` controls whether class libraries are considered launchable or not.

The changed invocation here is only used when computing items to appear in the startup project list. When `validateSettings` is `false` (as before) then all projects appear, including class libraries. When `validateSettings` is `true` (as now) then they are excluded.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7429)