### PR TITLE
Add package readme property

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/PackageReadmeFileValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/PackageReadmeFileValueProvider.cs
@@ -7,28 +7,28 @@ using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
 {
-    // Sets the PackageIcon property to the path from the root of the package, and creates the
+    // Sets the PackageReadmeFile property to the path from the root of the package, and creates the
     // None item associated with the file on disk. The Include metadata of the None item is a relative
     // path to the file on disk from the project's directory. The None item includes 2 metadata elements
     // as Pack (set to True to be included in the package) and PackagePath (directory structure in the package
-    // for the file to be placed). The PackageIcon property will use the directory indicated in PackagePath,
+    // for the file to be placed). The PackageReadmeFile property will use the directory indicated in PackagePath,
     // and the filename of the file in the Include filepath.
     //
     // Example:
     // <PropertyGroup>
-    //   <PackageIcon>content\shell32_192.png</PackageIcon>
+    //   <PackageReadmeFile>docs\readme.md</PackageReadmeFile>
     // </PropertyGroup>
     //
     // <ItemGroup>
-    //   <None Include="..\..\..\shell32_192.png">
+    //   <None Include="..\..\..\readme.md">
     //     <Pack>True</Pack>
-    //     <PackagePath>content</PackagePath>
+    //     <PackagePath>docs</PackagePath>
     //   </None>
     // </ItemGroup>
-    [ExportInterceptingPropertyValueProvider(PackageIconPropertyName, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
-    internal sealed class PackageIconValueProvider : InterceptingPropertyValueProviderBase
+    [ExportInterceptingPropertyValueProvider(PackageReadmeFilePropertyName, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    internal sealed class PackageReadmeFileValueProvider : InterceptingPropertyValueProviderBase
     {
-        private const string PackageIconPropertyName = "PackageIcon";
+        private const string PackageReadmeFilePropertyName = "PackageReadmeFile";
         private const string PackMetadataName = "Pack";
         private const string PackagePathMetadataName = "PackagePath";
 
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
         private readonly UnconfiguredProject _unconfiguredProject;
 
         [ImportingConstructor]
-        public PackageIconValueProvider(
+        public PackageReadmeFileValueProvider(
             [Import(ExportContractNames.ProjectItemProviders.SourceFiles)] IProjectItemProvider sourceItemsProvider,
             UnconfiguredProject unconfiguredProject)
         {
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
         }
 
         // https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packageicon
-        private static string CreatePackageIcon(string filePath, string packagePath)
+        private static string CreatePackageReadmeFile(string filePath, string packagePath)
         {
             string filename = Path.GetFileName(filePath);
             // Make a slash-only value into empty string, so it won't get prepended onto the path.
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
         public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
             string relativePath = PathHelper.MakeRelative(_unconfiguredProject, unevaluatedPropertyValue);
-            string existingPropertyValue = await defaultProperties.GetEvaluatedPropertyValueAsync(PackageIconPropertyName);
+            string existingPropertyValue = await defaultProperties.GetEvaluatedPropertyValueAsync(PackageReadmeFilePropertyName);
             IProjectItem? existingItem = await GetExistingNoneItemAsync(existingPropertyValue);
             string packagePath = string.Empty;
             if (existingItem != null)
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
                 // The new filepath is the same as the current. No item changes are required.
                 if (relativePath.Equals(existingItem.EvaluatedInclude, StringComparisons.Paths))
                 {
-                    return CreatePackageIcon(existingItem.EvaluatedInclude, packagePath);
+                    return CreatePackageReadmeFile(existingItem.EvaluatedInclude, packagePath);
                 }
             }
 
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
                 await _sourceItemsProvider.AddAsync(None.SchemaName, relativePath, new Dictionary<string, string> { { PackMetadataName, bool.TrueString }, { PackagePathMetadataName, packagePath } });
             }
 
-            return CreatePackageIcon(relativePath, packagePath);
+            return CreatePackageReadmeFile(relativePath, packagePath);
         }
 
         private async Task<string> GetItemIncludeValueAsync(string propertyValue)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
@@ -220,4 +220,16 @@
     </BoolProperty.Metadata>
   </BoolProperty>
 
+  <StringProperty Name="PackageReadmeFile"
+                  DisplayName="README"
+                  Description="The readme document for the package. Supported file formats include only Markdown (.md)."
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2168540"
+                  Category="General"
+                  Subtype="file">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
@@ -103,6 +103,18 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <StringProperty Name="PackageReadmeFile"
+                  DisplayName="README"
+                  Description="The readme document for the package. Supported file formats include only Markdown (.md)."
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2168540"
+                  Category="General"
+                  Subtype="file">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
   <StringProperty Name="RepositoryUrl"
                   DisplayName="Repository URL"
                   Description="Specifies the URL for the repository where the source code for the package resides and/or from which it's being built. For linking to the project page, use the 'Project URL' field, instead."
@@ -219,17 +231,5 @@
       </NameValuePair>
     </BoolProperty.Metadata>
   </BoolProperty>
-
-  <StringProperty Name="PackageReadmeFile"
-                  DisplayName="README"
-                  Description="The readme document for the package. Supported file formats include only Markdown (.md)."
-                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2168540"
-                  Category="General"
-                  Subtype="file">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterception"
-                  HasConfigurationCondition="False" />
-    </StringProperty.DataSource>
-  </StringProperty>
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.cs.xlf
@@ -172,6 +172,16 @@
         <target state="translated">Adresa URL projektu</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|Description">
+        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
+        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">
+        <source>README</source>
+        <target state="new">README</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageReleaseNotes|Description">
         <source>A description of the changes made in this release of the package, often used in UI like the Updates tab of the Visual Studio Package Manager in place of the package description.</source>
         <target state="translated">Popis změn provedených v této verzi balíčku, který se často používá v uživatelském rozhraní jako karta Aktualizace ve Správci balíčků sady Visual Studio namísto popisu balíčku</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.de.xlf
@@ -172,6 +172,16 @@
         <target state="translated">Projekt-URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|Description">
+        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
+        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">
+        <source>README</source>
+        <target state="new">README</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageReleaseNotes|Description">
         <source>A description of the changes made in this release of the package, often used in UI like the Updates tab of the Visual Studio Package Manager in place of the package description.</source>
         <target state="translated">Eine Beschreibung der Änderungen, die an dieser Version des Pakets vorgenommen wurden. Wird häufig anstelle der Paketbeschreibung in der Benutzeroberfläche verwendet, beispielsweise auf der Registerkarte "Updates" im Visual Studio-Paket-Manager.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.es.xlf
@@ -172,6 +172,16 @@
         <target state="translated">Dirección URL del proyecto</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|Description">
+        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
+        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">
+        <source>README</source>
+        <target state="new">README</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageReleaseNotes|Description">
         <source>A description of the changes made in this release of the package, often used in UI like the Updates tab of the Visual Studio Package Manager in place of the package description.</source>
         <target state="translated">Descripción de los cambios realizados en esta versión del paquete. A menudo se usa en la interfaz de usuario como pestaña Actualizaciones del Administrador de paquetes de Visual Studio, en lugar de la descripción del paquete.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.fr.xlf
@@ -172,6 +172,16 @@
         <target state="translated">URL de projet</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|Description">
+        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
+        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">
+        <source>README</source>
+        <target state="new">README</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageReleaseNotes|Description">
         <source>A description of the changes made in this release of the package, often used in UI like the Updates tab of the Visual Studio Package Manager in place of the package description.</source>
         <target state="translated">Description des changements apportés à cette version Release du package, souvent utilisée dans l'IU (interface utilisateur), par exemple sous l'onglet Mises à jour du Gestionnaire de package Visual Studio, à la place de la description du package.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.it.xlf
@@ -172,6 +172,16 @@
         <target state="translated">URL del progetto</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|Description">
+        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
+        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">
+        <source>README</source>
+        <target state="new">README</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageReleaseNotes|Description">
         <source>A description of the changes made in this release of the package, often used in UI like the Updates tab of the Visual Studio Package Manager in place of the package description.</source>
         <target state="translated">Descrizione delle modifiche apportate in questa versione del pacchetto, spesso usata nell'interfaccia utente, come la scheda Aggiornamenti di Gestione pacchetti di Visual Studio, in sostituzione della descrizione del pacchetto.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ja.xlf
@@ -172,6 +172,16 @@
         <target state="translated">プロジェクトの URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|Description">
+        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
+        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">
+        <source>README</source>
+        <target state="new">README</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageReleaseNotes|Description">
         <source>A description of the changes made in this release of the package, often used in UI like the Updates tab of the Visual Studio Package Manager in place of the package description.</source>
         <target state="translated">このリリースのパッケージで行われた変更の説明。Visual Studio パッケージ マネージャーの [更新] タブなどの UI で、パッケージの説明の代わりによく利用されます。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ko.xlf
@@ -172,6 +172,16 @@
         <target state="translated">프로젝트 URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|Description">
+        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
+        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">
+        <source>README</source>
+        <target state="new">README</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageReleaseNotes|Description">
         <source>A description of the changes made in this release of the package, often used in UI like the Updates tab of the Visual Studio Package Manager in place of the package description.</source>
         <target state="translated">패키지 설명 대신에 Visual Studio 패키지 관리자의 [업데이트] 탭처럼 종종 UI에 사용되는, 이 패키지 릴리스의 변경 사항에 대한 설명입니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pl.xlf
@@ -172,6 +172,16 @@
         <target state="translated">Adres URL projektu</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|Description">
+        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
+        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">
+        <source>README</source>
+        <target state="new">README</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageReleaseNotes|Description">
         <source>A description of the changes made in this release of the package, often used in UI like the Updates tab of the Visual Studio Package Manager in place of the package description.</source>
         <target state="translated">Opis zmian wprowadzonych w tej wersji pakietu często używany w interfejsie użytkownika, na przykład na karcie Aktualizacje menedżera pakietów programu Visual Studio, w miejscu opisu pakietu.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pt-BR.xlf
@@ -172,6 +172,16 @@
         <target state="translated">URL do Projeto</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|Description">
+        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
+        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">
+        <source>README</source>
+        <target state="new">README</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageReleaseNotes|Description">
         <source>A description of the changes made in this release of the package, often used in UI like the Updates tab of the Visual Studio Package Manager in place of the package description.</source>
         <target state="translated">Uma descrição das alterações feitas nesta versão do pacote, frequentemente usado na interface do usuário como a guia Atualizações do Gerenciador de Pacotes do Visual Studio em vez da descrição do pacote.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ru.xlf
@@ -172,6 +172,16 @@
         <target state="translated">URL-адрес проекта</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|Description">
+        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
+        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">
+        <source>README</source>
+        <target state="new">README</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageReleaseNotes|Description">
         <source>A description of the changes made in this release of the package, often used in UI like the Updates tab of the Visual Studio Package Manager in place of the package description.</source>
         <target state="translated">Описание изменений, внесенных в этот выпуск пакета; часто используется в пользовательском интерфейсе, например на вкладке "Обновления" диспетчера пакетов Visual Studio, вместо описания пакета.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.tr.xlf
@@ -172,6 +172,16 @@
         <target state="translated">Proje URL'si</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|Description">
+        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
+        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">
+        <source>README</source>
+        <target state="new">README</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageReleaseNotes|Description">
         <source>A description of the changes made in this release of the package, often used in UI like the Updates tab of the Visual Studio Package Manager in place of the package description.</source>
         <target state="translated">Paketin bu sürümünde yapılan değişikliklere ilişkin bir açıklama; genellikle Visual Studio Paket Yöneticisi'nin Güncelleştirmeler sekmesi gibi kullanıcı arabirimi bölümlerinde paket açıklaması olarak kullanılır.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hans.xlf
@@ -172,6 +172,16 @@
         <target state="translated">项目 URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|Description">
+        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
+        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">
+        <source>README</source>
+        <target state="new">README</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageReleaseNotes|Description">
         <source>A description of the changes made in this release of the package, often used in UI like the Updates tab of the Visual Studio Package Manager in place of the package description.</source>
         <target state="translated">此版本包中所作更改的说明，通常代替包说明用在 UI 中，如 Visual Studio 包管理器的“更新”选项卡。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hant.xlf
@@ -172,6 +172,16 @@
         <target state="translated">專案 URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|Description">
+        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
+        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">
+        <source>README</source>
+        <target state="new">README</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageReleaseNotes|Description">
         <source>A description of the changes made in this release of the package, often used in UI like the Updates tab of the Visual Studio Package Manager in place of the package description.</source>
         <target state="translated">在此版套件中進行的變更描述，通常用於 UI (如 Visual Studio 套件管理員的 [更新] 索引標籤) 以取代套件說明。</target>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/6457
Related: https://github.com/dotnet/project-system/pull/7422

This is a quick implementation of the [PackageReadmeFile](https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packagereadmefile) property. It is copy-pasted logic from the PackageIcon property that I implemented recently. I'd recommend we extract this logic into some shared code between the 2 providers, but I'll do that in a follow-up PR. For now, this adds the PackageReadmeFile property and the associate None item (and metadata) to the project.

I also did some very minor cleanup to the PackageIcon value provider as I realized I can describe it more accurately and generically at the same time.

The package is loading both PackageReadmeFile and PackageIcon properly.
![image](https://user-images.githubusercontent.com/17788297/127414685-eba3bfd7-358f-4c89-a2bf-47965ce41be9.png)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7440)