### PR TITLE
Fix hang during up-to-date check

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Subscription.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Subscription.cs
@@ -111,10 +111,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 token.ThrowIfCancellationRequested();
 
-                // Wait for our state to be up to date with that of the project
-                IProjectVersionedValue<UpToDateCheckConfiguredInput> state = await _inputDataSource.SourceBlock.GetLatestVersionAsync(
-                    _configuredProject,
-                    cancellationToken: token);
+                IProjectVersionedValue<UpToDateCheckConfiguredInput> state;
+
+                using (_inputDataSource.Join())
+                {
+                    // Wait for our state to be up to date with that of the project
+                    state = await _inputDataSource.SourceBlock.GetLatestVersionAsync(
+                        _configuredProject,
+                        cancellationToken: token);
+                }
 
                 bool result = await func(state.Value, _lastCheckedAtUtc, token);
 


### PR DESCRIPTION
In #7427 we change the fast up-to-date check to make it wait for the latest project data before returning its answer.

This involved a call to `GetLatestVersionAsync`, which is then awaited.

That implementation had a bug that caused a hang while waiting. The up-to-date check is called on the UI thread. It is possible that the dataflow graph, while producing the value we are waiting for, needs access to the UI thread. As we are holding it while waiting, progress cannot be made.

The fix is to "join" the two set of joinable tasks, such that the UI thread is shared between them.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7441)