### PR TITLE
Specify extensions for dialog shown for file properties

### DIFF
--- a/docs/repo/property-pages/property-specification.md
+++ b/docs/repo/property-pages/property-specification.md
@@ -348,16 +348,41 @@ internal sealed class MyCommandActionHandler : ILinkActionHandler
 }
 ```
 
-## File and Directory Properties
+## File Properties
 
-When a property's value represents a file or directory path, it should be modelled as a `StringProperty` with its `Subtype` attribute set to `file` or `directory` respectively. `folder` is an equivalent alternative to `directory`.
+When a property's value represents a file path, it should be modelled as a `StringProperty` with its `Subtype` attribute set to `file`.
 
 ```xml
 <StringProperty Subtype="file"
                 ...>
 ```
 
-This will produce an editor that comprises a text box and _Browse_ button, which launches a file or directory picker dialog.
+This will produce an editor that comprises a text box and _Browse_ button, which launches a file picker dialog.
+
+To control the set of file extensions the user is allowed to select, add metadata resembling the following:
+
+```xml
+  <StringProperty.ValueEditors>
+    <ValueEditor EditorType="FilePath">
+      <ValueEditor.Metadata>
+        <NameValuePair Name="FileTypeFilter" Value="Image files (*.png,*.jpg,*.jpeg)|*.png;*.jpg;*.jpeg|All files (*.*)|*.*" />
+      </ValueEditor.Metadata>
+    </ValueEditor>
+  </StringProperty.ValueEditors>
+```
+
+The format of the `FileTypeFilter` property is important, and invalid values will cause an exception when _Browse_ is clicked. Be sure to test your values. For information on this format, read [this documentation](https://docs.microsoft.com/dotnet/api/microsoft.win32.filedialog.filter?view=net-5.0).
+
+## Directory Properties
+
+When a property's value represents a directory path, it should be modelled as a `StringProperty` with its `Subtype` attribute set to `directory` (`folder` is also accepted, and is equivalent to `directory`).
+
+```xml
+<StringProperty Subtype="folder"
+                ...>
+```
+
+This will produce an editor that comprises a text box and _Browse_ button, which launches a directory picker dialog.
 
 ## Synthetic Properties
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -260,6 +260,13 @@
                   Category="Resources"
                   Description="Sets the .ico file that you want to use as your program icon."
                   Subtype="file">
+    <StringProperty.ValueEditors>
+      <ValueEditor EditorType="FilePath">
+        <ValueEditor.Metadata>
+          <NameValuePair Name="FileTypeFilter" Value="Icon files (*.ico)|*.ico|All files (*.*)|*.*" />
+        </ValueEditor.Metadata>
+      </ValueEditor>
+    </StringProperty.ValueEditors>
     <StringProperty.Metadata>
       <NameValuePair Name="DependsOn" Value="Application::ResourceSpecificationKind" />
       <NameValuePair Name="VisibilityCondition">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
@@ -97,6 +97,13 @@
                   HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147134"
                   Category="General"
                   Subtype="file">
+    <StringProperty.ValueEditors>
+      <ValueEditor EditorType="FilePath">
+        <ValueEditor.Metadata>
+          <NameValuePair Name="FileTypeFilter" Value="Image files (*.png,*.jpg,*.jpeg)|*.png;*.jpg;*.jpeg|All files (*.*)|*.*" />
+        </ValueEditor.Metadata>
+      </ValueEditor>
+    </StringProperty.ValueEditors>
     <StringProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception"
                   HasConfigurationCondition="False" />
@@ -109,6 +116,13 @@
                   HelpUrl="https://go.microsoft.com/fwlink/?linkid=2168540"
                   Category="General"
                   Subtype="file">
+    <StringProperty.ValueEditors>
+      <ValueEditor EditorType="FilePath">
+        <ValueEditor.Metadata>
+          <NameValuePair Name="FileTypeFilter" Value="Markdown files (*.md)|*.md|All files (*.*)|*.*" />
+        </ValueEditor.Metadata>
+      </ValueEditor>
+    </StringProperty.ValueEditors>
     <StringProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception"
                   HasConfigurationCondition="False" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
@@ -105,7 +105,7 @@
 
   <StringProperty Name="PackageReadmeFile"
                   DisplayName="README"
-                  Description="The readme document for the package. Supported file formats include only Markdown (.md)."
+                  Description="The README document for the package. Must be a Markdown (.md) file."
                   HelpUrl="https://go.microsoft.com/fwlink/?linkid=2168540"
                   Category="General"
                   Subtype="file">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.cs.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|Description">
-        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
-        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <source>The README document for the package. Must be a Markdown (.md) file.</source>
+        <target state="new">The README document for the package. Must be a Markdown (.md) file.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.de.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|Description">
-        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
-        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <source>The README document for the package. Must be a Markdown (.md) file.</source>
+        <target state="new">The README document for the package. Must be a Markdown (.md) file.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.es.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|Description">
-        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
-        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <source>The README document for the package. Must be a Markdown (.md) file.</source>
+        <target state="new">The README document for the package. Must be a Markdown (.md) file.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.fr.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|Description">
-        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
-        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <source>The README document for the package. Must be a Markdown (.md) file.</source>
+        <target state="new">The README document for the package. Must be a Markdown (.md) file.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.it.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|Description">
-        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
-        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <source>The README document for the package. Must be a Markdown (.md) file.</source>
+        <target state="new">The README document for the package. Must be a Markdown (.md) file.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ja.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|Description">
-        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
-        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <source>The README document for the package. Must be a Markdown (.md) file.</source>
+        <target state="new">The README document for the package. Must be a Markdown (.md) file.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ko.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|Description">
-        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
-        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <source>The README document for the package. Must be a Markdown (.md) file.</source>
+        <target state="new">The README document for the package. Must be a Markdown (.md) file.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pl.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|Description">
-        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
-        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <source>The README document for the package. Must be a Markdown (.md) file.</source>
+        <target state="new">The README document for the package. Must be a Markdown (.md) file.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pt-BR.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|Description">
-        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
-        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <source>The README document for the package. Must be a Markdown (.md) file.</source>
+        <target state="new">The README document for the package. Must be a Markdown (.md) file.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ru.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|Description">
-        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
-        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <source>The README document for the package. Must be a Markdown (.md) file.</source>
+        <target state="new">The README document for the package. Must be a Markdown (.md) file.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.tr.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|Description">
-        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
-        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <source>The README document for the package. Must be a Markdown (.md) file.</source>
+        <target state="new">The README document for the package. Must be a Markdown (.md) file.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hans.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|Description">
-        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
-        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <source>The README document for the package. Must be a Markdown (.md) file.</source>
+        <target state="new">The README document for the package. Must be a Markdown (.md) file.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hant.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|Description">
-        <source>The readme document for the package. Supported file formats include only Markdown (.md).</source>
-        <target state="new">The readme document for the package. Supported file formats include only Markdown (.md).</target>
+        <source>The README document for the package. Must be a Markdown (.md) file.</source>
+        <target state="new">The README document for the package. Must be a Markdown (.md) file.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageReadmeFile|DisplayName">


### PR DESCRIPTION
Fixes #7420

In https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/341091 we add support for properties to specify specific file extensions to be used as filters in the "open file dialog" we use when clicking "Browse" next to certain file path properties.

This PR adds the metadata to drive that feature, and documents its use for future.

![image](https://user-images.githubusercontent.com/350947/127492190-ee57c5bd-8e16-4734-ab1d-e44bff3586cb.png)

![image](https://user-images.githubusercontent.com/350947/127492243-1cff1941-8df1-45fe-8b49-8196499589ec.png)

![image](https://user-images.githubusercontent.com/350947/127492266-245d7e01-4c8a-449c-a3b7-a9b4e85f04f5.png)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7442)