### PR TITLE
Pass TargetRefPath to Roslyn language service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
@@ -21,6 +21,10 @@
                   ReadOnly="True"
                   Visible="False" />
 
+  <StringProperty Name="TargetRefPath"
+                  ReadOnly="True"
+                  Visible="False" />
+  
   <StringProperty Name="MaxSupportedLangVersion"
                   ReadOnly="True"
                   Visible="False" />


### PR DESCRIPTION
This fixes part of the issue [AB#1361354](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1361354)

The other part of the fix is in https://github.com/dotnet/roslyn/pull/55244

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7444)