### PR TITLE
Remove unneeded UI thread dependency

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextFactoryFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextFactoryFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
+using System.Threading;
 using Moq;
 
 namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
@@ -12,14 +13,12 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
             return Mock.Of<IWorkspaceProjectContextFactory>();
         }
 
-        public static IWorkspaceProjectContextFactory ImplementCreateProjectContext(Func<string, string, string, Guid, object, string, string, IWorkspaceProjectContext?> action)
+        public static IWorkspaceProjectContextFactory ImplementCreateProjectContext(Func<string, string, string, Guid, object?, string?, string?, CancellationToken, IWorkspaceProjectContext> action)
         {
             var mock = new Mock<IWorkspaceProjectContextFactory>();
 
-#pragma warning disable 612,618
-            mock.Setup(c => c.CreateProjectContext(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<object>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(action!);
-#pragma warning restore 612,618
+            mock.Setup(c => c.CreateProjectContextAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<object?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(action!);
 
             return mock.Object;
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextProviderTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var snapshot = IProjectRuleSnapshotFactory.FromJson(json);
 
             int callCount = 0;
-            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, _, _, _, _, _, _) => { callCount++; return null; });
+            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, _, _, _, _, _, _, _) => { callCount++; return null!; });
             var provider = CreateInstance(workspaceProjectContextFactory: workspaceProjectContextFactory, projectRuleSnapshot: snapshot);
 
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration("Debug|AnyCPU");
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var projectGuidService = ISafeProjectGuidServiceFactory.ImplementGetProjectGuidAsync(new Guid(guid));
 
             string? result = null;
-            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, id, _, _, _, _, _) => { result = id; return null; });
+            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, id, _, _, _, _, _, _) => { result = id; return null!; });
             var provider = CreateInstance(workspaceProjectContextFactory: workspaceProjectContextFactory, projectGuidService: projectGuidService);
 
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration(configuration);
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             Guid? projectGuidResult = null;
             object? hierarchyResult = null;
             string? assemblyNameResult = null;
-            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((languageName, _, projectFilePath, guid, hierarchy, binOutputPath, assemblyName) =>
+            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((languageName, _, projectFilePath, guid, hierarchy, binOutputPath, assemblyName, _) =>
             {
                 languageNameResult = languageName;
                 projectFilePathResult = projectFilePath;
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 hierarchyResult = hierarchy;
                 binOutputPathResult = binOutputPath;
                 assemblyNameResult = assemblyName;
-                return null;
+                return null!;
             });
 
             var provider = CreateInstance(project: unconfiguredProject, workspaceProjectContextFactory: workspaceProjectContextFactory, projectGuidService: projectGuidService);
@@ -157,7 +157,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         public async Task CreateProjectContextAsync_ReturnsContextWithLastDesignTimeBuildSucceededSetToFalse()
         {
             var context = IWorkspaceProjectContextMockFactory.Create();
-            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, _, _, _, _, _, _) => context);
+            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, _, _, _, _, _, _, _) => context);
             var provider = CreateInstance(workspaceProjectContextFactory: workspaceProjectContextFactory);
 
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration("Debug|AnyCPU");
@@ -171,7 +171,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         [Fact]
         public async Task CreateProjectContextAsync_WhenCreateProjectContextThrows_ReturnsNull()
         {
-            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, _, _, _, _, _, _) => { throw new Exception(); });
+            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, _, _, _, _, _, _, _) => { throw new Exception(); });
             var provider = CreateInstance(workspaceProjectContextFactory: workspaceProjectContextFactory);
 
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration("Debug|AnyCPU");
@@ -220,11 +220,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var projectFaultService = IProjectFaultHandlerServiceFactory.Create();
             project ??= UnconfiguredProjectFactory.Create();
-            threadingService ??= IProjectThreadingServiceFactory.Create();
             workspaceProjectContextFactory ??= IWorkspaceProjectContextFactoryFactory.Create();
             projectGuidService ??= ISafeProjectGuidServiceFactory.ImplementGetProjectGuidAsync(Guid.NewGuid());
 
-            var mock = new Mock<WorkspaceProjectContextProvider>(project, threadingService, projectGuidService, projectFaultService, workspaceProjectContextFactory.AsLazy());
+            var mock = new Mock<WorkspaceProjectContextProvider>(project, projectGuidService, projectFaultService, workspaceProjectContextFactory.AsLazy());
             mock.Protected().Setup<Task<IProjectRuleSnapshot>>("GetLatestSnapshotAsync", ItExpr.IsAny<ConfiguredProject>())
                             .ReturnsAsync(projectRuleSnapshot);
 


### PR DESCRIPTION
Fixes: .NET Project System's side of https://github.com/dotnet/project-system/issues/353.

Roslyn already immediately switches to the UI thread CreateProjectContextAsync, so this should be a no-op. However, this enables the above bug to be moved over to Roslyn and for them to remove the UI thread dependency in the future.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7446)