### PR TITLE
Fix SetAttributeCommand in Remove Unused References

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/SetAttributeCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/SetAttributeCommand.cs
@@ -9,8 +9,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         public SetAttributeCommand(AbstractReferenceHandler abstractReferenceHandler, ConfiguredProject selectedConfiguredProject, string itemSpecification)
         : base(abstractReferenceHandler, selectedConfiguredProject, itemSpecification)
         {
-            UnsetValue = PropertySerializer.SimpleTypes.ToString(true);
-            SetValue = PropertySerializer.SimpleTypes.ToString(false);
+            UnsetTreatAsUsed = PropertySerializer.SimpleTypes.ToString(false);
+            SetTreatAsUsed = PropertySerializer.SimpleTypes.ToString(true);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/SetTreatAsUsedAttributeCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/SetTreatAsUsedAttributeCommand.cs
@@ -13,8 +13,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         private readonly ConfiguredProject _selectedConfiguredProject;
         private readonly string _itemSpecification;
         private readonly AbstractReferenceHandler _referenceHandler;
-        protected string SetValue = PropertySerializer.SimpleTypes.ToString(true);
-        protected string UnsetValue = PropertySerializer.SimpleTypes.ToString(false);
+        protected string SetTreatAsUsed = PropertySerializer.SimpleTypes.ToString(true);
+        protected string UnsetTreatAsUsed = PropertySerializer.SimpleTypes.ToString(false);
 
         public SetTreatAsUsedAttributeCommand(AbstractReferenceHandler abstractReferenceHandler, ConfiguredProject selectedConfiguredProject, string itemSpecification)
         {
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
                 return false;
             }
 
-            await item.Metadata.SetPropertyValueAsync(ProjectReference.TreatAsUsedProperty, SetValue);
+            await item.Metadata.SetPropertyValueAsync(ProjectReference.TreatAsUsedProperty, SetTreatAsUsed);
 
             return true;
         }
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
                 return false;
             }
 
-            await item.Metadata.SetPropertyValueAsync(ProjectReference.TreatAsUsedProperty, UnsetValue);
+            await item.Metadata.SetPropertyValueAsync(ProjectReference.TreatAsUsedProperty, UnsetTreatAsUsed);
 
             return true;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/UnSetAttributeCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/UnSetAttributeCommand.cs
@@ -9,8 +9,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         public UnsetAttributeCommand(AbstractReferenceHandler abstractReferenceHandler, ConfiguredProject selectedConfiguredProject, string itemSpecification)
         : base(abstractReferenceHandler, selectedConfiguredProject, itemSpecification) {
 
-            UnsetValue = PropertySerializer.SimpleTypes.ToString(true);
-            SetValue = PropertySerializer.SimpleTypes.ToString(false);
+            UnsetTreatAsUsed = PropertySerializer.SimpleTypes.ToString(false);
+            SetTreatAsUsed = PropertySerializer.SimpleTypes.ToString(true);
         }
     }
 }


### PR DESCRIPTION
This reverts the logic when setting the property TreatAsUsed in csproj

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7450)