### PR TITLE
Enable XAML Hot Reload

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -436,6 +436,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             if (IsRunProjectCommand(resolvedProfile)
                 && resolvedProfile.IsHotReloadEnabled()
                 && (launchOptions & DebugLaunchOptions.NoDebug) == DebugLaunchOptions.NoDebug
+                && (launchOptions & DebugLaunchOptions.Profiling) != DebugLaunchOptions.Profiling
                 && await _hotReloadSessionManager.Value.TryCreatePendingSessionAsync(settings.Environment))
             {
                 // Enable XAML Hot Reload

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -438,9 +438,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 && (launchOptions & DebugLaunchOptions.NoDebug) == DebugLaunchOptions.NoDebug
                 && await _hotReloadSessionManager.Value.TryCreatePendingSessionAsync(settings.Environment))
             {
-                // TODO:
-                // We want Hot Reload and the session manager successfully created a pending session.
-                // Perform any other work related to setting up Hot Reload.
+                // Enable XAML Hot Reload
+                settings.Environment["ENABLE_XAML_DIAGNOSTICS_SOURCE_INFO"] = "1";
             }
 
             if (settings.Environment.Count > 0)


### PR DESCRIPTION
Fixes #7372.

Before Hot Reload, there was _XAML_ Hot Reload--changes to your .xaml files would immediately be reflected in your process during debugging. We want to enable the same feature during Ctrl+F5 Hot Reload, and to do so we need to set the "ENABLE_XAML_DIAGNOSTICS_SOURCE_INFO" environment variable to "1" to light up the functionality in the running process.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7451)