### PR TITLE
Enable Hot Reload during debugging

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -45,7 +45,7 @@
     <PackageReference Update="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.0.0-preview-2-31223-026"/>
     <PackageReference Update="Microsoft.VisualStudio.Data.Services"                                   Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.DataTools.Interop"                               Version="17.0.0-preview-2-31223-026" />
-    <PackageReference Update="Microsoft.VisualStudio.Debugger.Contracts"                              Version="17.2.0-beta.21278.1" />
+    <PackageReference Update="Microsoft.VisualStudio.Debugger.Contracts"                              Version="17.2.0-beta.21378.1" />
     <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces"                             Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.0.0-previews-2-31421-281" />
     <PackageReference Update="Microsoft.VisualStudio.Interop"                                         Version="17.0.0-previews-2-31423-289"/>
@@ -96,7 +96,7 @@
     <PackageReference Update="Microsoft.IO.Redist"                                                    Version="4.7.1" />
 
     <!-- Hot Reload -->
-    <PackageReference Update="Microsoft.VisualStudio.HotReload.Components"                            Version="6.0.0-preview.6.21330.17" />
+    <PackageReference Update="Microsoft.VisualStudio.HotReload.Components"                            Version="6.0.0-preview.6.21380.4" />
 
     <!-- 3rd party -->
     <PackageReference Update="Newtonsoft.Json"                                                        Version="12.0.2"/>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -107,7 +107,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             await TaskScheduler.Default;
 
-            await _hotReloadSessionManager.Value.ActivateSessionAsync((int)processInfos[0].dwProcessId);
+            bool runningUnderDebugger = (launchOptions & DebugLaunchOptions.NoDebug) != DebugLaunchOptions.NoDebug;
+
+            await _hotReloadSessionManager.Value.ActivateSessionAsync((int)processInfos[0].dwProcessId, runningUnderDebugger);
         }
 
         private Task<bool> IsClassLibraryAsync() => IsOutputTypeAsync(ConfigurationGeneral.OutputTypeValues.Library);
@@ -435,7 +437,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             if (IsRunProjectCommand(resolvedProfile)
                 && resolvedProfile.IsHotReloadEnabled()
-                && (launchOptions & DebugLaunchOptions.NoDebug) == DebugLaunchOptions.NoDebug
                 && (launchOptions & DebugLaunchOptions.Profiling) != DebugLaunchOptions.Profiling
                 && await _hotReloadSessionManager.Value.TryCreatePendingSessionAsync(settings.Environment))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSession.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,7 +21,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
         /// <summary>
         /// Starts the Hot Reload Session.
         /// </summary>
+        /// <remarks>
+        /// TODO: remove when Web Tools is no longer calling this method.
+        /// </remarks>
+        [Obsolete("This should no longer be used; please use StartSessionAsync(bool, CancellationToken) instead.", false)]
         Task StartSessionAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Starts the Hot Reload Session.
+        /// </summary>
+        /// <param name="runningUnderDebugger">
+        /// <see langword="true"/> if the process is being run under a debugger;
+        /// <see langword="false"/> otherwise.
+        /// </param>
+        /// <param name="cancellationToken">A token indicating if the operation has been cancelled.</param>
+        Task StartSessionAsync(bool runningUnderDebugger, CancellationToken cancellationToken);
 
         /// <summary>
         /// Stops the Hot Reload Session.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionManager.cs
@@ -25,6 +25,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
         /// Activates the pending Hot Reload session and associates it with the specified
         /// process.
         /// </summary>
-        Task ActivateSessionAsync(int processId);
+        Task ActivateSessionAsync(int processId, bool runningUnderDebugger);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
@@ -73,13 +73,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             }
 
             return false;
+}
+
+        // TODO: remove when Web Tools is no longer calling this method.
+        public Task StartSessionAsync(CancellationToken cancellationToken)
+        {
+            return StartSessionAsync(runningUnderDebugger: false, cancellationToken);
         }
 
-        public async Task StartSessionAsync(CancellationToken cancellationToken)
+        public async Task StartSessionAsync(bool runningUnderDebugger, CancellationToken cancellationToken)
         {
             if (!_sessionActive)
             {
-                await _hotReloadAgentManagerClient.Value.AgentStartedAsync(this, cancellationToken);
+                HotReloadAgentFlags flags = runningUnderDebugger ? HotReloadAgentFlags.IsDebuggedProcess : HotReloadAgentFlags.None;
+                await _hotReloadAgentManagerClient.Value.AgentStartedAsync(this, flags, cancellationToken);
                 await WriteToOutputWindowAsync(VSResources.HotReloadStartSession);
                 _sessionActive = true;
                 EnsureDeltaApplierforSession();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             }
 
             return false;
-}
+        }
 
         // TODO: remove when Web Tools is no longer calling this method.
         public Task StartSessionAsync(CancellationToken cancellationToken)
@@ -83,14 +83,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 
         public async Task StartSessionAsync(bool runningUnderDebugger, CancellationToken cancellationToken)
         {
-            if (!_sessionActive)
+            if (_sessionActive)
             {
-                HotReloadAgentFlags flags = runningUnderDebugger ? HotReloadAgentFlags.IsDebuggedProcess : HotReloadAgentFlags.None;
-                await _hotReloadAgentManagerClient.Value.AgentStartedAsync(this, flags, cancellationToken);
-                await WriteToOutputWindowAsync(VSResources.HotReloadStartSession);
-                _sessionActive = true;
-                EnsureDeltaApplierforSession();
+                throw new InvalidOperationException("Attempting to start a Hot Reload session that is already running.");
             }
+
+            HotReloadAgentFlags flags = runningUnderDebugger ? HotReloadAgentFlags.IsDebuggedProcess : HotReloadAgentFlags.None;
+            await _hotReloadAgentManagerClient.Value.AgentStartedAsync(this, flags, cancellationToken);
+            await WriteToOutputWindowAsync(VSResources.HotReloadStartSession);
+            _sessionActive = true;
+            EnsureDeltaApplierforSession();
         }
 
         public async Task StopSessionAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             _hotReloadDiagnosticOutputService = hotReloadDiagnosticOutputService;
         }
 
-        public async Task ActivateSessionAsync(int processId)
+        public async Task ActivateSessionAsync(int processId, bool runningUnderDebugger)
         {
             if (_pendingSessionState is not null)
             {
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
                 }
                 else
                 {
-                    _ = _pendingSessionState.Session.StartSessionAsync(default);
+                    _ = _pendingSessionState.Session.StartSessionAsync(runningUnderDebugger, cancellationToken: default);
                     ImmutableInterlocked.TryAdd(ref _activeSessions, processId, _pendingSessionState);
                 }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -9,6 +9,7 @@ Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.ApplyChangesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.ApplyLaunchVariablesAsync(System.Collections.Generic.IDictionary<string!, string!>! envVars, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.Name.get -> string!
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.StartSessionAsync(bool runningUnderDebugger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.StartSessionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSession.StopSessionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadSessionCallback

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectHotReloadSessionManagerFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectHotReloadSessionManagerFactory.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             mock.Setup(manager => manager.TryCreatePendingSessionAsync(It.IsAny<IDictionary<string, string>>()))
                 .ReturnsAsync(true);
 
-            mock.Setup(manager => manager.ActivateSessionAsync(It.IsAny<int>()))
+            mock.Setup(manager => manager.ActivateSessionAsync(It.IsAny<int>(), It.IsAny<bool>()))
                 .Returns(Task.CompletedTask);
 
             return mock.Object;


### PR DESCRIPTION
Currently, we only enable Hot Reload in non-debugging (i.e., Ctrl+F5) scenarios, and equivalent functionality is provided by Edit and Continue (EnC) in debugging scenarios. Under the hood, however, EnC and Hot Reload are use mostly the same code paths and are really just two different names for the same feature.

And now that the feature is orthogonal to debugging, we would like to have one way to turn it on that is not tied to whether or not we are debugging the running process. Here we remove the check in `ProjectLaunchTargetsProvider` that limited Hot Reload to Ctrl+F5 scenarios.

However, there are some aspects of Hot Reload that need to understand whether or not the process is running under the debugger, and we are now also responsible for passing that information along. This is largely a matter of calling a different overload of `IHotReloadAgentManagerClient.AgentStartedAsync`, which in turn requires a number of changes to pipe the value through.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7452)