### PR TITLE
Fix hang in fast up-to-date check

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
@@ -94,7 +94,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                     if (_persistentState is not null)
                     {
-                        (int ItemHash, DateTime InputsChangedAtUtc)? restoredState = await _persistentState.RestoreStateAsync(_configuredProject.UnconfiguredProject.FullPath, _configuredProject.ProjectConfiguration.Dimensions);
+                        // Restoring state requires the UI thread. We must use JTF.RunAsync here to ensure the UI
+                        // thread is shared between related work and prevent deadlocks.
+                        (int ItemHash, DateTime InputsChangedAtUtc)? restoredState =
+                            await JoinableFactory.RunAsync(() => _persistentState.RestoreStateAsync(_configuredProject.UnconfiguredProject.FullPath, _configuredProject.ProjectConfiguration.Dimensions));
 
                         if (restoredState is not null)
                         {


### PR DESCRIPTION
The FUTD check restores state from disk, and requires the UI thread in order to determine the location of the .vs folder in which the file is stored.

Dataflow blocks do not run their async delegates within JTF, for performance reasons. Most dataflow blocks do not require the UI thread. In this case, because the block can require the UI thread, we must use a JTF.RunAsync call to join that work with the block and its upstream sources.

Without this, a build scheduled soon after project load can cause a hang due to a deadlock for the UI thread.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7454)