### PR TITLE
ApplicationIcon property fix

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationIconValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationIconValueProvider.cs
@@ -51,8 +51,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
                     var destinationInfo = new FileInfo(Path.Combine(Path.GetDirectoryName(_unconfiguredProject.FullPath), fileName));
                     if (destinationInfo.Exists && destinationInfo.IsReadOnly)
                     {
-                        // https://stackoverflow.com/a/8081331/294804
-                        File.SetAttributes(destinationInfo.FullName, destinationInfo.Attributes & ~FileAttributes.ReadOnly);
+                        // The file cannot be copied over; return the previous value.
+                        return await defaultProperties.GetUnevaluatedPropertyValueAsync(propertyName);
                     }
                     _fileSystem.CopyFile(unevaluatedPropertyValue, destinationInfo.FullName, overwrite: true);
                     return fileName;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationIconValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationIconValueProvider.cs
@@ -8,24 +8,12 @@ using Microsoft.VisualStudio.IO;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
 {
-    // Sets the PackageIcon property to the path from the root of the package, and creates the
-    // None item associated with the file on disk. The Include metadata of the None item is a relative
-    // path to the file on disk from the project's directory. The None item includes 2 metadata elements
-    // as Pack (set to True to be included in the package) and PackagePath (directory structure in the package
-    // for the file to be placed). The PackageIcon property will use the directory indicated in PackagePath,
-    // and the filename of the file in the Include filepath.
-    //
-    // Example:
-    // <PropertyGroup>
-    //   <PackageIcon>content\shell32_192.png</PackageIcon>
-    // </PropertyGroup>
-    //
-    // <ItemGroup>
-    //   <None Include="..\..\..\shell32_192.png">
-    //     <Pack>True</Pack>
-    //     <PackagePath>content</PackagePath>
-    //   </None>
-    // </ItemGroup>
+    // Sets the ApplicationIcon property to the path to the .ico file. This path is relative
+    // to the project file directory. If the selected file is not within the project directory
+    // tree, the file will be copied into the project file directory. Previously copied files
+    // are not deleted when a new file is selected. ApplicationIcon allows for both full paths
+    // and relative paths anywhere on disk, but we are not utilizing that in this implementation.
+    // The icon file does not need to be included in the project (such as a None/Content item).
     [ExportInterceptingPropertyValueProvider(ApplicationIconPropertyName, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     internal sealed class ApplicationIconValueProvider : InterceptingPropertyValueProviderBase
     {
@@ -41,8 +29,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
             _fileSystem = fileSystem;
         }
 
-        // TODO: Check if we need to delete previous file
-        // TODO: Check if file is already imported as a none/content item
         public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
             // Allows the user to clear the application icon.
@@ -68,32 +54,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
             }
 
             return PathHelper.MakeRelative(_unconfiguredProject, unevaluatedPropertyValue);
-
-            //string relativePath = PathHelper.MakeRelative(_unconfiguredProject, unevaluatedPropertyValue);
-            //string existingPropertyValue = await defaultProperties.GetEvaluatedPropertyValueAsync(PackageIconPropertyName);
-            //IProjectItem? existingItem = await GetExistingNoneItemAsync(existingPropertyValue);
-            //string packagePath = string.Empty;
-            //if (existingItem != null)
-            //{
-            //    packagePath = await existingItem.Metadata.GetEvaluatedPropertyValueAsync(PackagePathMetadataName);
-            //    // The new filepath is the same as the current. No item changes are required.
-            //    if (relativePath.Equals(existingItem.EvaluatedInclude, StringComparisons.Paths))
-            //    {
-            //        return CreatePackageIcon(existingItem.EvaluatedInclude, packagePath);
-            //    }
-            //}
-
-            //// None items outside of the project file cannot be updated.
-            //if (existingItem?.PropertiesContext.IsProjectFile ?? false)
-            //{
-            //    await existingItem.SetUnevaluatedIncludeAsync(relativePath);
-            //}
-            //else
-            //{
-            //    await _sourceItemsProvider.AddAsync(None.SchemaName, relativePath, new Dictionary<string, string> { { PackMetadataName, bool.TrueString }, { PackagePathMetadataName, packagePath } });
-            //}
-
-            //return CreatePackageIcon(relativePath, packagePath);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationIconValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationIconValueProvider.cs
@@ -1,0 +1,99 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.IO;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
+{
+    // Sets the PackageIcon property to the path from the root of the package, and creates the
+    // None item associated with the file on disk. The Include metadata of the None item is a relative
+    // path to the file on disk from the project's directory. The None item includes 2 metadata elements
+    // as Pack (set to True to be included in the package) and PackagePath (directory structure in the package
+    // for the file to be placed). The PackageIcon property will use the directory indicated in PackagePath,
+    // and the filename of the file in the Include filepath.
+    //
+    // Example:
+    // <PropertyGroup>
+    //   <PackageIcon>content\shell32_192.png</PackageIcon>
+    // </PropertyGroup>
+    //
+    // <ItemGroup>
+    //   <None Include="..\..\..\shell32_192.png">
+    //     <Pack>True</Pack>
+    //     <PackagePath>content</PackagePath>
+    //   </None>
+    // </ItemGroup>
+    [ExportInterceptingPropertyValueProvider(ApplicationIconPropertyName, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    internal sealed class ApplicationIconValueProvider : InterceptingPropertyValueProviderBase
+    {
+        private const string ApplicationIconPropertyName = "ApplicationIcon";
+
+        private readonly UnconfiguredProject _unconfiguredProject;
+        private readonly IFileSystem _fileSystem;
+
+        [ImportingConstructor]
+        public ApplicationIconValueProvider(UnconfiguredProject unconfiguredProject, IFileSystem fileSystem)
+        {
+            _unconfiguredProject = unconfiguredProject;
+            _fileSystem = fileSystem;
+        }
+
+        // TODO: Check if we need to delete previous file
+        // TODO: Check if file is already imported as a none/content item
+        public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+        {
+            // Allows the user to clear the application icon.
+            if (string.IsNullOrEmpty(unevaluatedPropertyValue))
+            {
+                return null;
+            }
+
+            // If selected path is invalid, ignore and return previous value.
+            if (!File.Exists(unevaluatedPropertyValue))
+            {
+                return await defaultProperties.GetUnevaluatedPropertyValueAsync(propertyName);
+            }
+
+            // Copy the file into the project directory.
+            // This isn't a limitation of ApplicationIcon; it is to simply mimic the legacy property page interaction.
+            if (_unconfiguredProject.IsOutsideProjectDirectory(unevaluatedPropertyValue))
+            {
+                string fileName = Path.GetFileName(unevaluatedPropertyValue);
+                string destination = Path.Combine(Path.GetDirectoryName(_unconfiguredProject.FullPath), fileName);
+                _fileSystem.CopyFile(unevaluatedPropertyValue, destination, overwrite: true);
+                return fileName;
+            }
+
+            return PathHelper.MakeRelative(_unconfiguredProject, unevaluatedPropertyValue);
+
+            //string relativePath = PathHelper.MakeRelative(_unconfiguredProject, unevaluatedPropertyValue);
+            //string existingPropertyValue = await defaultProperties.GetEvaluatedPropertyValueAsync(PackageIconPropertyName);
+            //IProjectItem? existingItem = await GetExistingNoneItemAsync(existingPropertyValue);
+            //string packagePath = string.Empty;
+            //if (existingItem != null)
+            //{
+            //    packagePath = await existingItem.Metadata.GetEvaluatedPropertyValueAsync(PackagePathMetadataName);
+            //    // The new filepath is the same as the current. No item changes are required.
+            //    if (relativePath.Equals(existingItem.EvaluatedInclude, StringComparisons.Paths))
+            //    {
+            //        return CreatePackageIcon(existingItem.EvaluatedInclude, packagePath);
+            //    }
+            //}
+
+            //// None items outside of the project file cannot be updated.
+            //if (existingItem?.PropertiesContext.IsProjectFile ?? false)
+            //{
+            //    await existingItem.SetUnevaluatedIncludeAsync(relativePath);
+            //}
+            //else
+            //{
+            //    await _sourceItemsProvider.AddAsync(None.SchemaName, relativePath, new Dictionary<string, string> { { PackMetadataName, bool.TrueString }, { PackagePathMetadataName, packagePath } });
+            //}
+
+            //return CreatePackageIcon(relativePath, packagePath);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationIconValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationIconValueProvider.cs
@@ -92,7 +92,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
             foreach (IProjectItem item in await _sourceItemsProvider.GetItemsAsync(Content.SchemaName))
             {
                 // If the filename of this item and the filename of the property's value match, consider those to be related to one another.
-                if (Path.GetFileName(item.EvaluatedInclude).Equals(Path.GetFileName(existingPropertyValue), StringComparisons.PropertyLiteralValues))
+                if (item.PropertiesContext.IsProjectFile &&
+                    Path.GetFileName(item.EvaluatedInclude).Equals(Path.GetFileName(existingPropertyValue), StringComparisons.PropertyLiteralValues))
                 {
                     return item;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -260,6 +260,10 @@
                   Category="Resources"
                   Description="Sets the .ico file that you want to use as your program icon."
                   Subtype="file">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False" />
+    </StringProperty.DataSource>
     <StringProperty.ValueEditors>
       <ValueEditor EditorType="FilePath">
         <ValueEditor.Metadata>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/7167

## Description
This allows the ApplicationIcon property to function similarly to how it did in the old property pages. How it worked was, if the file was within the project directory structure (project directory and below), it would use a relative path (from the project directory) to that file and set that as the ApplicationIcon's value. If the file was not within the project directory structure, it would copy it to the project directory and then simply have the filename as the path (which is effectively a relative path to the file). This implementation does that same interaction.

One minor difference here is, in the old pages, if the file already existed in the project directory when trying to copy it, it would show this error.
![image](https://user-images.githubusercontent.com/17788297/128263947-491d8b34-3310-4519-8950-9b85dc94f5fc.png)
In this implementation, I simply override the file if it already exists in the project directory. Therefore, no error occurs.

The legacy property pages also used a completely different kind of text input control. It used a free-form dropdown. The dropdown itself contained .ico files that are already part of the project. Here, we don't have a control like that, so that implementation is not featured in the new pages. If we wanted something like that, we'd likely have a selector-style control. If I'm not mistaken, we might be implementing something like that for the VB property pages, so if that is desired here, we can make the switch. Otherwise, this works just as a text field with a Browse button, which is more than enough in a majority of scenarios.

NOTE: I believe the file filter to not be present in the Browse window since I haven't updated my VS version on this machine. I'm going to do that now, but I wanted to get the PR in first.

## GIF
![ApplicationIconFix](https://user-images.githubusercontent.com/17788297/128264396-444933a6-96a4-41fb-8ed3-071042abd895.gif)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7461)