### PR TITLE
Opt into Load context binds for package

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -7,6 +7,7 @@
     <!-- VSIX -->
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <CreateVsixContainer>false</CreateVsixContainer>
+    <UseCodebase>false</UseCodebase>
     
     <!-- Nuget -->
     <IsPackable>true</IsPackable>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -13,7 +13,7 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.VisualStudio.Packaging
 {
     [Guid(PackageGuid)]
-    [PackageRegistration(AllowsBackgroundLoading = true, RegisterUsing = RegistrationMethod.CodeBase, UseManagedResourcesOnly = true)]
+    [PackageRegistration(AllowsBackgroundLoading = true, RegisterUsing = RegistrationMethod.Assembly, UseManagedResourcesOnly = true)]
     [ProvideProjectFactory(typeof(XprojProjectFactory), null, "#27", "xproj", "xproj", null)]
     [ProvideAutoLoad(ActivationContextGuid, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideUIContextRule(ActivationContextGuid,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FSharp/FSharpProjectSelector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FSharp/FSharpProjectSelector.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.FSharp
 {
     [Export(typeof(IPackageService))]
     [Guid("E720DAD0-1854-47FC-93AF-E719B54B84E6")]
-    [ProvideObject(typeof(FSharpProjectSelector), RegisterUsing = RegistrationMethod.CodeBase)]
+    [ProvideObject(typeof(FSharpProjectSelector), RegisterUsing = RegistrationMethod.Assembly)]
     internal sealed class FSharpProjectSelector : IVsProjectSelector, IPackageService, IDisposable
     {
         private const string MSBuildXmlNamespace = "http://schemas.microsoft.com/developer/msbuild/2003";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPropertyPage.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 {
     [Guid("0273C280-1882-4ED0-9308-52914672E3AA")]
     [ExcludeFromCodeCoverage]
-    [ProvideObject(typeof(DebugPropertyPage), RegisterUsing = RegistrationMethod.CodeBase)]
+    [ProvideObject(typeof(DebugPropertyPage), RegisterUsing = RegistrationMethod.Assembly)]
     internal class DebugPropertyPage : WpfBasedPropertyPage
     {
         internal static readonly string PageName = PropertyPageResources.DebugPropertyPageTitle;


### PR DESCRIPTION
https://github.com/dotnet/project-system/pull/7447 opt'd Managed.VS into NGEN image.

Before this change, this dll used to be attempted to be loaded in two ways;

- Load context via the MEF cache
- LoadFrom via the [PackageRegistration] and [ProjectObject]

The latter would actually just respect the existing binary in the Load context resulting in a single load.

After NGEN, however, this changed - a Fusion limitation caused to actually load the IL image in the second step, resulting in two versions of the same assembly loaded.

This change forces the second step to use the Load context.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7462)