### PR TITLE
Fast up-to-date check supports TargetPath for CopyToOutputDirectory items

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
@@ -85,6 +85,18 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <StringProperty Name="TargetPath"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+
   <BoolProperty Name="Visible"
                 Visible="false" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
@@ -85,6 +85,18 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <StringProperty Name="TargetPath"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+
   <BoolProperty Name="Visible"
                 Visible="false" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
@@ -85,6 +85,18 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <StringProperty Name="TargetPath"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+
   <BoolProperty Name="Visible"
                 Visible="false" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.ItemComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.ItemComparer.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 {
     internal sealed partial class BuildUpToDateCheck
     {
-        internal sealed class ItemComparer : IEqualityComparer<(string path, string? link, CopyType copyType)>
+        internal sealed class ItemComparer : IEqualityComparer<(string path, string? targetPath, CopyType copyType)>
         {
             public static readonly ItemComparer Instance = new();
 
@@ -15,14 +15,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             }
 
             public bool Equals(
-                (string path, string? link, CopyType copyType) x,
-                (string path, string? link, CopyType copyType) y)
+                (string path, string? targetPath, CopyType copyType) x,
+                (string path, string? targetPath, CopyType copyType) y)
             {
                 return StringComparers.Paths.Equals(x.path, y.path);
             }
 
             public int GetHashCode(
-                (string path, string? link, CopyType copyType) obj)
+                (string path, string? targetPath, CopyType copyType) obj)
             {
                 return StringComparers.Paths.GetHashCode(obj.path);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.ItemHashing.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.ItemHashing.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 {
     internal sealed partial class BuildUpToDateCheck
     {
-        public static int ComputeItemHash(ImmutableDictionary<string, ImmutableArray<(string Path, string? Link, CopyType CopyType)>> itemsByItemType)
+        public static int ComputeItemHash(ImmutableDictionary<string, ImmutableArray<(string Path, string? TargetPath, CopyType CopyType)>> itemsByItemType)
         {
             int hash = 0;
 
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             // This approach also assumes each path is only included once in the data structure. If a path
             // were to exist twice, its hash would be XORed with itself, which produces zero net change.
 
-            foreach ((string itemType, ImmutableArray<(string Path, string? Link, CopyType CopyType)> items) in itemsByItemType)
+            foreach ((string itemType, ImmutableArray<(string Path, string? TargetPath, CopyType CopyType)> items) in itemsByItemType)
             {
                 int itemHash = 0;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return log.Fail("FirstRun", "The up-to-date check has not yet run for this project. Not up-to-date.");
             }
 
-            foreach ((_, ImmutableArray<(string Path, string? Link, CopyType CopyType)> items) in state.ItemsByItemType)
+            foreach ((_, ImmutableArray<(string Path, string? TargetPath, CopyType CopyType)> items) in state.ItemsByItemType)
             {
                 foreach ((string path, _, CopyType copyType) in items)
                 {
@@ -204,12 +204,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                     if (log.Level <= LogLevel.Info)
                     {
-                        foreach ((bool isAdd, string itemType, string path, string? link, CopyType copyType) in state.LastItemChanges.OrderBy(change => change.ItemType).ThenBy(change => change.Path))
+                        foreach ((bool isAdd, string itemType, string path, string? targetPath, CopyType copyType) in state.LastItemChanges.OrderBy(change => change.ItemType).ThenBy(change => change.Path))
                         {
-                            if (Strings.IsNullOrEmpty(link))
+                            if (Strings.IsNullOrEmpty(targetPath))
                                 log.Info("    {0} item {1} '{2}' (CopyType={3})", itemType, isAdd ? "added" : "removed", path, copyType);
                             else
-                                log.Info("    {0} item {1} '{2}' (CopyType={3}, Link='{4}')", itemType, isAdd ? "added" : "removed", path, copyType, link);
+                                log.Info("    {0} item {1} '{2}' (CopyType={3}, TargetPath='{4}')", itemType, isAdd ? "added" : "removed", path, copyType, targetPath);
                         }
                     }
 
@@ -291,7 +291,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     yield return (Path: state.NewestImportInput, IsRequired: true);
                 }
 
-                foreach ((string itemType, ImmutableArray<(string path, string? link, CopyType copyType)> changes) in state.ItemsByItemType)
+                foreach ((string itemType, ImmutableArray<(string path, string? targetPath, CopyType copyType)> changes) in state.ItemsByItemType)
                 {
                     if (!NonCompilationItemTypes.Contains(itemType))
                     {
@@ -595,9 +595,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         {
             string outputFullPath = Path.Combine(state.MSBuildProjectDirectory, state.OutputRelativeOrFullPath);
 
-            foreach ((_, ImmutableArray<(string Path, string? Link, CopyType CopyType)> items) in state.ItemsByItemType)
+            foreach ((_, ImmutableArray<(string Path, string? TargetPath, CopyType CopyType)> items) in state.ItemsByItemType)
             {
-                foreach ((string path, string? link, CopyType copyType) in items)
+                foreach ((string path, string? targetPath, CopyType copyType) in items)
                 {
                     // Only consider items with CopyType of CopyIfNewer
                     if (copyType != CopyType.CopyIfNewer)
@@ -608,7 +608,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     token.ThrowIfCancellationRequested();
 
                     string rootedPath = _configuredProject.UnconfiguredProject.MakeRooted(path);
-                    string filename = Strings.IsNullOrEmpty(link) ? rootedPath : link;
+                    string filename = Strings.IsNullOrEmpty(targetPath) ? rootedPath : targetPath;
 
                     if (string.IsNullOrEmpty(filename))
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -644,7 +644,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                     if (destinationTime < itemTime)
                     {
-                        return log.Fail("CopyToOutputDirectory", "PreserveNewest source is newer than destination, not up to date.");
+                        return log.Fail("CopyToOutputDirectory", "PreserveNewest source '{0}' is newer than destination '{1}', not up to date.", rootedPath, destination);
                     }
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// </remarks>
         public DateTime LastItemsChangedAtUtc { get; }
 
-        public ImmutableArray<(bool IsAdd, string ItemType, string Path, string? Link, BuildUpToDateCheck.CopyType CopyType)> LastItemChanges { get; }
+        public ImmutableArray<(bool IsAdd, string ItemType, string Path, string? TargetPath, BuildUpToDateCheck.CopyType CopyType)> LastItemChanges { get; }
 
         public int? ItemHash { get; }
 
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         public ImmutableArray<string> ItemTypes { get; }
 
-        public ImmutableDictionary<string, ImmutableArray<(string Path, string? Link, BuildUpToDateCheck.CopyType CopyType)>> ItemsByItemType { get; }
+        public ImmutableDictionary<string, ImmutableArray<(string Path, string? TargetPath, BuildUpToDateCheck.CopyType CopyType)>> ItemsByItemType { get; }
 
         public ImmutableArray<string> SetNames { get; }
 
@@ -128,7 +128,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             LastItemsChangedAtUtc = DateTime.MinValue;
             ItemTypes = ImmutableArray<string>.Empty;
-            ItemsByItemType = ImmutableDictionary.Create<string, ImmutableArray<(string Path, string? Link, BuildUpToDateCheck.CopyType CopyType)>>(StringComparers.ItemTypes);
+            ItemsByItemType = ImmutableDictionary.Create<string, ImmutableArray<(string Path, string? TargetPath, BuildUpToDateCheck.CopyType CopyType)>>(StringComparers.ItemTypes);
             SetNames = ImmutableArray<string>.Empty;
             UpToDateCheckInputItemsByKindBySetName = emptyItemBySetName;
             UpToDateCheckOutputItemsByKindBySetName = emptyItemBySetName;
@@ -161,7 +161,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             IImmutableDictionary<string, DateTime> additionalDependentFileTimes,
             DateTime lastAdditionalDependentFileTimesChangedAtUtc,
             DateTime lastItemsChangedAtUtc,
-            ImmutableArray<(bool IsAdd, string ItemType, string Path, string? Link, BuildUpToDateCheck.CopyType CopyType)> lastItemChanges,
+            ImmutableArray<(bool IsAdd, string ItemType, string Path, string? TargetPath, BuildUpToDateCheck.CopyType CopyType)> lastItemChanges,
             int? itemHash,
             bool wasStateRestored)
         {
@@ -380,7 +380,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             bool itemTypesChanged = false;
 
-            List<(bool IsAdd, string ItemType, string Path, string? Link, BuildUpToDateCheck.CopyType)> changes = new();
+            List<(bool IsAdd, string ItemType, string Path, string? TargetPath, BuildUpToDateCheck.CopyType)> changes = new();
 
             // If an item type was removed, remove all items of that type
             foreach (string removedItemType in itemTypeDiff.Removed)
@@ -389,9 +389,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 if (itemsByItemTypeBuilder.TryGetValue(removedItemType, out var removedItems))
                 {
-                    foreach ((string path, string? link, BuildUpToDateCheck.CopyType copyType) in removedItems)
+                    foreach ((string path, string? targetPath, BuildUpToDateCheck.CopyType copyType) in removedItems)
                     {
-                        changes.Add((false, removedItemType, path, link, copyType));
+                        changes.Add((false, removedItemType, path, targetPath, copyType));
                     }
 
                     itemsByItemTypeBuilder.Remove(removedItemType);
@@ -418,29 +418,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 if (projectChange.After.Items.Count == 0)
                     continue;
 
-                ImmutableArray<(string Path, string? Link, BuildUpToDateCheck.CopyType)> before = ImmutableArray<(string Path, string? Link, BuildUpToDateCheck.CopyType)>.Empty;
-                if (itemsByItemTypeBuilder.TryGetValue(itemType, out ImmutableArray<(string Path, string? Link, BuildUpToDateCheck.CopyType CopyType)> beforeItems))
+                ImmutableArray<(string Path, string? TargetPath, BuildUpToDateCheck.CopyType)> before = ImmutableArray<(string Path, string? TargetPath, BuildUpToDateCheck.CopyType)>.Empty;
+                if (itemsByItemTypeBuilder.TryGetValue(itemType, out ImmutableArray<(string Path, string? TargetPath, BuildUpToDateCheck.CopyType CopyType)> beforeItems))
                     before = beforeItems;
 
-                var after = projectChange.After.Items.Select(item => (Path: item.Key, GetLink(item.Value), GetCopyType(item.Value))).ToHashSet(BuildUpToDateCheck.ItemComparer.Instance);
+                var after = projectChange.After.Items
+                    .Select(item => (Path: item.Key, TargetPath: GetTargetPath(item.Value), CopyType: GetCopyType(item.Value)))
+                    .ToHashSet(BuildUpToDateCheck.ItemComparer.Instance);
 
                 var diff = new SetDiff<(string, string?, BuildUpToDateCheck.CopyType)>(before, after, BuildUpToDateCheck.ItemComparer.Instance);
 
-                foreach ((string path, string? link, BuildUpToDateCheck.CopyType copyType) in diff.Added)
+                foreach ((string path, string? targetPath, BuildUpToDateCheck.CopyType copyType) in diff.Added)
                 {
-                    changes.Add((true, itemType, path, link, copyType));
+                    changes.Add((true, itemType, path, targetPath, copyType));
                 }
 
-                foreach ((string path, string? link, BuildUpToDateCheck.CopyType copyType) in diff.Removed)
+                foreach ((string path, string? targetPath, BuildUpToDateCheck.CopyType copyType) in diff.Removed)
                 {
-                    changes.Add((false, itemType, path, link, copyType));
+                    changes.Add((false, itemType, path, targetPath, copyType));
                 }
 
                 itemsByItemTypeBuilder[itemType] = after.ToImmutableArray();
                 itemsChanged = true;
             }
 
-            ImmutableDictionary<string, ImmutableArray<(string Path, string? Link, BuildUpToDateCheck.CopyType CopyType)>> itemsByItemType = itemsByItemTypeBuilder.ToImmutable();
+            ImmutableDictionary<string, ImmutableArray<(string Path, string? TargetPath, BuildUpToDateCheck.CopyType CopyType)>> itemsByItemType = itemsByItemTypeBuilder.ToImmutable();
 
             int itemHash = BuildUpToDateCheck.ComputeItemHash(itemsByItemType);
 
@@ -521,7 +523,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return BuildUpToDateCheck.CopyType.CopyNever;
             }
 
-            static string? GetLink(IImmutableDictionary<string, string> itemMetadata)
+            static string? GetTargetPath(IImmutableDictionary<string, string> itemMetadata)
             {
                 return itemMetadata.TryGetValue(BuildUpToDateCheck.Link, out string link) ? link : null;
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/ItemRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/ItemRuleTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
+using System.Xml.XPath;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Rules
@@ -35,11 +36,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
 
             string noneFile = Path.Combine(fullPath, "..", "None.xaml");
 
-            XElement none = LoadXamlRule(noneFile);
+            XElement none = LoadXamlRule(noneFile, out var namespaceManager);
             XElement rule = LoadXamlRule(fullPath);
 
             // First fix up the Name as we know they'll differ.
             rule.Attribute("Name").Value = "None";
+
+            if (ruleName is "Compile" or "EditorConfigFiles")
+            {
+                // Remove the "TargetPath" element for these types
+                var targetPathElement = none.XPathSelectElement(@"/msb:Rule/msb:StringProperty[@Name=""TargetPath""]", namespaceManager);
+                Assert.NotNull(targetPathElement);
+                targetPathElement!.Remove();
+            }
 
             AssertXmlEqual(none, rule);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTestBase.cs
@@ -36,6 +36,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             };
         }
 
+        private protected static IProjectRuleSnapshotModel ItemWithMetadata(string itemSpec, params (string MetadataName, string MetadataValue)[] metadata)
+        {
+            return new IProjectRuleSnapshotModel
+            {
+                Items = ImmutableStringDictionary<IImmutableDictionary<string, string>>.EmptyOrdinal.Add(
+                    itemSpec,
+                    metadata.ToImmutableDictionary(pair => pair.MetadataName, pair => pair.MetadataValue, StringComparer.Ordinal))
+            };
+        }
+
         private protected static IProjectRuleSnapshotModel ItemsWithMetadata(params (string itemSpec, string metadataName, string metadataValue)[] items)
         {
             return new IProjectRuleSnapshotModel

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -1051,7 +1051,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         }
 
         [Fact]
-        public async Task IsUpToDateAsync_False_CopyToOutputDirectorySourceIsNewerThanDestination()
+        public async Task IsUpToDateAsync_False_CopyToOutputDirectory_SourceIsNewerThanDestination()
         {
             var sourceSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
             {
@@ -1087,7 +1087,117 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         }
 
         [Fact]
-        public async Task IsUpToDateAsync_False_CopyToOutputDirectorySourceDoesNotExist()
+        public async Task IsUpToDateAsync_False_CopyToOutputDirectory_SourceIsNewerThanDestination_TargetPath()
+        {
+            var sourceSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
+            {
+                [Content.SchemaName] = ItemWithMetadata("Item1", ("CopyToOutputDirectory", "PreserveNewest"), ("TargetPath", "TargetPath"))
+            };
+
+            var destinationPath = @"NewProjectDirectory\NewOutputPath\TargetPath";
+            var sourcePath = @"C:\Dev\Solution\Project\Item1";
+
+            var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
+            var lastCheckTime = DateTime.UtcNow.AddMinutes(-3);
+            var destinationTime = DateTime.UtcNow.AddMinutes(-2);
+            var sourceTime = DateTime.UtcNow.AddMinutes(-1);
+
+            await SetupAsync(
+                sourceSnapshot: sourceSnapshot,
+                lastCheckTimeAtUtc: lastCheckTime,
+                lastItemsChangedAtUtc: itemChangeTime);
+
+            _fileSystem.AddFile(destinationPath, destinationTime);
+            _fileSystem.AddFile(sourcePath, sourceTime);
+
+            await AssertNotUpToDateAsync(
+                new[]
+                {
+                    "No build outputs defined.",
+                    $"Checking PreserveNewest file '{sourcePath}':",
+                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
+                    $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'.",
+                    $"PreserveNewest source '{sourcePath}' is newer than destination '{destinationPath}', not up to date."
+                },
+                "CopyToOutputDirectory");
+        }
+
+        [Fact]
+        public async Task IsUpToDateAsync_False_CopyToOutputDirectory_SourceIsNewerThanDestination_Link()
+        {
+            var sourceSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
+            {
+                [Content.SchemaName] = ItemWithMetadata("Item1", ("CopyToOutputDirectory", "PreserveNewest"), ("Link", "LinkPath"))
+            };
+
+            var destinationPath = @"NewProjectDirectory\NewOutputPath\LinkPath";
+            var sourcePath = @"C:\Dev\Solution\Project\Item1";
+
+            var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
+            var lastCheckTime = DateTime.UtcNow.AddMinutes(-3);
+            var destinationTime = DateTime.UtcNow.AddMinutes(-2);
+            var sourceTime = DateTime.UtcNow.AddMinutes(-1);
+
+            await SetupAsync(
+                sourceSnapshot: sourceSnapshot,
+                lastCheckTimeAtUtc: lastCheckTime,
+                lastItemsChangedAtUtc: itemChangeTime);
+
+            _fileSystem.AddFile(destinationPath, destinationTime);
+            _fileSystem.AddFile(sourcePath, sourceTime);
+
+            await AssertNotUpToDateAsync(
+                new[]
+                {
+                    "No build outputs defined.",
+                    $"Checking PreserveNewest file '{sourcePath}':",
+                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
+                    $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'.",
+                    $"PreserveNewest source '{sourcePath}' is newer than destination '{destinationPath}', not up to date."
+                },
+                "CopyToOutputDirectory");
+        }
+
+        [Fact]
+        public async Task IsUpToDateAsync_False_CopyToOutputDirectory_SourceIsNewerThanDestination_TargetPathAndLink()
+        {
+            // When both "Link" and "TargetPath" are present, "TargetPath" takes precedence
+
+            var sourceSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
+            {
+                [Content.SchemaName] = ItemWithMetadata("Item1", ("CopyToOutputDirectory", "PreserveNewest"), ("Link", "LinkPath"), ("TargetPath", "TargetPath"))
+            };
+
+            var destinationPath = @"NewProjectDirectory\NewOutputPath\TargetPath";
+            var sourcePath = @"C:\Dev\Solution\Project\Item1";
+
+            var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
+            var lastCheckTime = DateTime.UtcNow.AddMinutes(-3);
+            var destinationTime = DateTime.UtcNow.AddMinutes(-2);
+            var sourceTime = DateTime.UtcNow.AddMinutes(-1);
+
+            await SetupAsync(
+                sourceSnapshot: sourceSnapshot,
+                lastCheckTimeAtUtc: lastCheckTime,
+                lastItemsChangedAtUtc: itemChangeTime);
+
+            _fileSystem.AddFile(destinationPath, destinationTime);
+            _fileSystem.AddFile(sourcePath, sourceTime);
+
+            await AssertNotUpToDateAsync(
+                new[]
+                {
+                    "No build outputs defined.",
+                    $"Checking PreserveNewest file '{sourcePath}':",
+                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
+                    $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'.",
+                    $"PreserveNewest source '{sourcePath}' is newer than destination '{destinationPath}', not up to date."
+                },
+                "CopyToOutputDirectory");
+        }
+
+        [Fact]
+        public async Task IsUpToDateAsync_False_CopyToOutputDirectory_SourceDoesNotExist()
         {
             var sourceSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
             {
@@ -1119,7 +1229,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         }
 
         [Fact]
-        public async Task IsUpToDateAsync_False_CopyToOutputDirectoryDestinationDoesNotExist()
+        public async Task IsUpToDateAsync_False_CopyToOutputDirectory_DestinationDoesNotExist()
         {
             var sourceSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -17,6 +17,9 @@ using Moq;
 using Xunit;
 using Xunit.Abstractions;
 
+#pragma warning disable IDE0055
+#pragma warning disable IDE0058
+
 namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 {
     public sealed class BuildUpToDateCheckTests : BuildUpToDateCheckTestBase, IDisposable
@@ -958,7 +961,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await _buildUpToDateCheck.ActivateAsync();
 
-            var destinationOutDir = @"NewProjectDirectory\newOutDir\Item1";
+            var destinationPath = @"NewProjectDirectory\newOutDir\Item1";
             var sourcePath = @"C:\Dev\Solution\Project\Item1";
 
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
@@ -972,7 +975,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 lastCheckTimeAtUtc: lastCheckTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
-            _fileSystem.AddFile(destinationOutDir, destinationTime);
+            _fileSystem.AddFile(destinationPath, destinationTime);
             _fileSystem.AddFile(sourcePath, sourceTime);
 
             await AssertNotUpToDateAsync(
@@ -981,8 +984,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     "No build outputs defined.",
                     $"Checking PreserveNewest file '{sourcePath}':",
                     $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
-                    $"    Destination {destinationTime.ToLocalTime()}: '{destinationOutDir}'.",
-                    "PreserveNewest source is newer than destination, not up to date."
+                    $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'.",
+                    $"PreserveNewest source '{sourcePath}' is newer than destination '{destinationPath}', not up to date."
                 },
                 "CopyToOutputDirectory");
         }
@@ -1078,7 +1081,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     $"Checking PreserveNewest file '{sourcePath}':",
                     $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
                     $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'.",
-                    "PreserveNewest source is newer than destination, not up to date."
+                    $"PreserveNewest source '{sourcePath}' is newer than destination '{destinationPath}', not up to date."
                 },
                 "CopyToOutputDirectory");
         }


### PR DESCRIPTION
Fixes #7276

Source items which participate in `CopyToOutputDirectory` may specify `TargetPath` metadata to control their location relative to the output directory.

Historically, `Link` metadata has been used to control this, and that was supported here. Now, we support both `TargetPath` and `Link`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7470)