### PR TITLE
Reverted changes from https://github.com/dotnet/project-system/pull/7444

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
@@ -20,10 +20,6 @@
   <StringProperty Name="TargetPath"
                   ReadOnly="True"
                   Visible="False" />
-
-  <StringProperty Name="TargetRefPath"
-                  ReadOnly="True"
-                  Visible="False" />
   
   <StringProperty Name="MaxSupportedLangVersion"
                   ReadOnly="True"


### PR DESCRIPTION
Build test failures are happening between these 2 insertion PRs:
- https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/342381
- https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/342544

Failures are:
- VC.ProjectSystem.BuildCommands
- VC.MSBuild.Upgrade.PropertyMapping.ResourceTool
- VC.MSBuild.PropertyMapping.VC6DefaultPropertyValues
- VC.MSBuild.PropertyMapping.CLTool
- VC.MSBuild.Upgrade.PropertyMapping.BrowseTool	
- VC.MSBuild.PropertyMapping.MIDL
- VC.MSBuild.PropertyMapping.LinkTool

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7475)