### PR TITLE
Only show Enable Hot Reload setting when supported

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ProjectDebugPropertyPage.xaml
@@ -66,7 +66,13 @@
 
   <BoolProperty Name="HotReloadEnabled"
                 DisplayName="Enable Hot Reload"
-                Description="Apply code changes to the running application." />
+                Description="Apply code changes to the running application.">
+    <BoolProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-project-capability "SupportsHotReload")</NameValuePair.Value>
+      </NameValuePair>
+    </BoolProperty.Metadata>
+  </BoolProperty>
   
   <BoolProperty Name="NativeDebugging"
                 DisplayName="Enable native code debugging"


### PR DESCRIPTION
Fixes #7474.

The _Enable Hot Reload_ launch profile option will only be displayed for projects having the `SupportsHotReload` project capability defined.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7478)