### PR TITLE
Check if the process has exited

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
@@ -187,10 +187,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
                 {
                     await hotReloadState.Session.StopSessionAsync(cancellationToken);
 
-                    // First try to close the process nicely and if that doesn't work kill it.
-                    if (!hotReloadState.Process.CloseMainWindow())
+                    if (!hotReloadState.Process.HasExited)
                     {
-                        hotReloadState.Process.Kill();
+                        // First try to close the process nicely and if that doesn't work kill it.
+                        if (!hotReloadState.Process.CloseMainWindow())
+                        {
+                            hotReloadState.Process.Kill();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Multiple code paths end up flowing into `ProjectHotReloadSessionManager.StopProjectAsync`. In one scenario, the higher levels of the Hot Reload feature detect that the session and process need to be stopped. For example, a rude edit can lead to stopping the sessions and processes, rebuilding, and re-running with Ctrl+F5. In this case the session and process are both running when `StopProjectAsync` is called.

In another scenario, the process exits and the project system is notified so it can clean up the session. In this case the session is still running when `StopProjectAsync` is called but of course the process is not.

Currently we always try to end the process via `CloseMainWindow` or `Kill`. If the process is already stopped these will throw an `InvalidOperationException` which we immediately catch and report via the Output window. Here we try to avoid the exception by first checking the `HasExited` property. This reduces pointless and possibly confusing noise in the Output window.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7491)