### PR TITLE
Don't enable Hot Reload when remote debugging

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -437,6 +437,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             if (IsRunProjectCommand(resolvedProfile)
                 && resolvedProfile.IsHotReloadEnabled()
+                && !resolvedProfile.IsRemoteDebugEnabled()
                 && (launchOptions & DebugLaunchOptions.Profiling) != DebugLaunchOptions.Profiling
                 && await _hotReloadSessionManager.Value.TryCreatePendingSessionAsync(settings.Environment))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -435,10 +435,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 settings.Options = JsonConvert.SerializeObject(debuggerLaunchOptions);
             }
 
-            if (IsRunProjectCommand(resolvedProfile)
-                && resolvedProfile.IsHotReloadEnabled()
-                && !resolvedProfile.IsRemoteDebugEnabled()
-                && (launchOptions & DebugLaunchOptions.Profiling) != DebugLaunchOptions.Profiling
+            if (HotReloadShouldBeEnabled(resolvedProfile, launchOptions)
                 && await _hotReloadSessionManager.Value.TryCreatePendingSessionAsync(settings.Environment))
             {
                 // Enable XAML Hot Reload
@@ -451,6 +448,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             }
 
             return settings;
+        }
+
+        private static bool HotReloadShouldBeEnabled(ILaunchProfile resolvedProfile, DebugLaunchOptions launchOptions)
+        {
+            return IsRunProjectCommand(resolvedProfile)
+                && resolvedProfile.IsHotReloadEnabled()
+                && !resolvedProfile.IsRemoteDebugEnabled()
+                && (launchOptions & DebugLaunchOptions.Profiling) != DebugLaunchOptions.Profiling;
         }
 
         private static bool UseCmdShellForConsoleLaunch(ILaunchProfile profile, DebugLaunchOptions options)


### PR DESCRIPTION
Currently we enable Hot Reload for both local and remote debugging. While it is not infeasible to make it work for remote debugging, our tooling does not currently support this. I doubt the Hot Reload transport layer currently supports moving the IL and metadata changes to a remote system, but more to the point for this bug we end up setting environment variables on the remote process with file paths that only make sense on the local machine. This causes the remote process to fail immediately as it isn't able to find the relevant file.

The fix here is to disable Hot Reload when remote debugging.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7497)