### PR TITLE
Populate categories and properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchProfileActionBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchProfileActionBase.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,15 +23,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         /// need to obtain an entity for it.
         /// </summary>
         private static readonly LaunchProfilePropertiesAvailableStatus s_requestedLaunchProfileProperties;
+        private static readonly CategoryPropertiesAvailableStatus s_requestedCategoryProperties;
+        private static readonly UIPropertyPropertiesAvailableStatus s_requestedPropertyProperties;
 
         protected readonly List<(IEntityValue projectEntity, EntityIdentity)> AddedLaunchProfiles = new();
         protected readonly List<(IEntityValue projectEntity, EntityIdentity)> RemovedLaunchProfiles = new();
 
         static LaunchProfileActionBase()
         {
-            // TODO: Note that even though we indicate here that the categories and properties
-            // child entities should be included we are still responsible for populating them
-            // manually.
             s_requestedLaunchProfileProperties = new LaunchProfilePropertiesAvailableStatus();
             s_requestedLaunchProfileProperties.RequireProperty(LaunchProfileType.CategoriesPropertyName);
             s_requestedLaunchProfileProperties.RequireProperty(LaunchProfileType.CommandNamePropertyName);
@@ -38,10 +38,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             s_requestedLaunchProfileProperties.RequireProperty(LaunchProfileType.OrderPropertyName);
             s_requestedLaunchProfileProperties.RequireProperty(LaunchProfileType.PropertiesPropertyName);
             s_requestedLaunchProfileProperties.Freeze();
+
+            s_requestedCategoryProperties = new CategoryPropertiesAvailableStatus();
+            s_requestedCategoryProperties.RequireProperty(CategoryType.DisplayNamePropertyName);
+            s_requestedCategoryProperties.RequireProperty(CategoryType.NamePropertyName);
+            s_requestedCategoryProperties.RequireProperty(CategoryType.OrderPropertyName);
+            s_requestedCategoryProperties.Freeze();
+
+            s_requestedPropertyProperties = new UIPropertyPropertiesAvailableStatus();
+            s_requestedPropertyProperties.RequireProperty(UIPropertyType.CategoryNamePropertyName);
+            s_requestedPropertyProperties.RequireProperty(UIPropertyType.ConfigurationIndependentPropertyName);
+            s_requestedPropertyProperties.RequireProperty(UIPropertyType.DescriptionPropertyName);
+            s_requestedPropertyProperties.RequireProperty(UIPropertyType.DependsOnPropertyName);
+            s_requestedPropertyProperties.RequireProperty(UIPropertyType.DisplayNamePropertyName);
+            s_requestedPropertyProperties.RequireProperty(UIPropertyType.HelpUrlPropertyName);
+            s_requestedPropertyProperties.RequireProperty(UIPropertyType.IsReadOnlyPropertyName);
+            s_requestedPropertyProperties.RequireProperty(UIPropertyType.IsVisiblePropertyName);
+            s_requestedPropertyProperties.RequireProperty(UIPropertyType.NamePropertyName);
+            s_requestedPropertyProperties.RequireProperty(UIPropertyType.OrderPropertyName);
+            s_requestedPropertyProperties.RequireProperty(UIPropertyType.SearchTermsPropertyName);
+            s_requestedPropertyProperties.RequireProperty(UIPropertyType.TypePropertyName);
+            s_requestedPropertyProperties.RequireProperty(UIPropertyType.VisibilityConditionPropertyName);
+            s_requestedPropertyProperties.Freeze();
         }
 
         public async Task OnRequestProcessFinishedAsync(IQueryProcessRequest request)
         {
+            CategoryFromRuleDataProducer categoryDataProducer = new CategoryFromRuleDataProducer(s_requestedCategoryProperties);
+
             foreach (IGrouping<IEntityValue, (IEntityValue projectEntity, EntityIdentity profileId)> group in AddedLaunchProfiles.GroupBy(item => item.projectEntity))
             {
                 var projectValue = (IEntityValueFromProvider)group.Key;
@@ -58,7 +82,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     {
                         if (await handler.RetrieveLaunchProfileEntityAsync(request.QueryExecutionContext, addedProfileId, s_requestedLaunchProfileProperties) is IEntityValue launchProfileEntity)
                         {
-                            // TODO: Actually populate the categories and properties child entities.
+                            if (launchProfileEntity is IEntityValueFromProvider launchProfileEntityFromProvider
+                                && launchProfileEntityFromProvider.ProviderState is ContextAndRuleProviderState state)
+                            {
+                                // This is a bit of a hack. We can safely assume that we should update the query
+                                // with the entity for the new launch profile. However, there is no way for us to
+                                // know which properties or child entities are desired. Here we make the somewhat
+                                // arbitrary decision to include the categories and properties, but not the propery
+                                // values. We already requested the non-entity properties when creating the entity
+                                // for the launch profile.
+
+                                ImmutableArray<IEntityValue> categories = ImmutableArray.CreateRange(
+                                    CategoryDataProducer.CreateCategoryValues(request.QueryExecutionContext, launchProfileEntity, state.Rule, s_requestedCategoryProperties));
+                                launchProfileEntity.SetRelatedEntities(LaunchProfileType.CategoriesPropertyName, categories);
+
+                                ImmutableArray<IEntityValue> properties = ImmutableArray.CreateRange(
+                                    UIPropertyDataProducer.CreateUIPropertyValues(request.QueryExecutionContext, launchProfileEntity, state.ProjectState, state.PropertiesContext, state.Rule, s_requestedPropertyProperties));
+                                launchProfileEntity.SetRelatedEntities(LaunchProfileType.PropertiesPropertyName, properties);
+                            }
+
                             returnedLaunchProfiles.Add(launchProfileEntity);
                         }
                     }


### PR DESCRIPTION
When running a query to retrieve data, the query engine tells us which properties to include on the created entity, and also handles calling into the appropriate data producers to create the requested child entities (if any) _and_ hooks them up to them parent.

When running an update query that may create a new entity (such as when adding a launch profile), however, we don't know which properties and sub-entities to create. This is a limitation of the current Project Query API.

Currently when we create an entity for a new launch profile we just populate all the "simple" properties like name, command name, and order. Here we add support for adding all the related entities representing categories and properties, and the simple properties of both. Note this does not include any information about the editor, value, or supported values of a property.

In the absence of information about what was requested in the original property, our goal here is to provide the minimum set of data the UI will need after an update query has finished.