### PR TITLE
Remove BinaryFormatter telemetry

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
@@ -4,7 +4,6 @@ Imports System.ComponentModel.Design
 Imports System.Drawing
 Imports System.IO
 Imports System.Reflection
-Imports System.Runtime.CompilerServices
 Imports System.Runtime.InteropServices
 Imports System.Runtime.Serialization
 Imports System.Text
@@ -687,21 +686,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
                 telemetryEvent.Properties(EditorCreationPropertyNamePrefix + "FileName") = New TelemetryPiiProperty(fileName)
                 telemetryEvent.Properties(EditorCreationPropertyNamePrefix + "PhysicalView") = physicalView
                 TelemetryService.DefaultSession.PostEvent(telemetryEvent)
-            End Sub
-
-            Private Const BinaryFormatterEventName As String = AppDesignerEventNamePrefix + "binaryformatter"
-            Private Const BinaryFormatterPropertyNamePrefix As String = AppDesignerPropertyNamePrefix + "binaryformatter."
-            Public Enum BinaryFormatterOperation
-                Serialize = 0
-                Deserialize = 1
-            End Enum
-
-            Public Shared Sub LogBinaryFormatterEvent(className As String, operation As BinaryFormatterOperation, <CallerMemberName> Optional functionName As String = Nothing)
-                Dim userTask = New UserTaskEvent(BinaryFormatterEventName, TelemetryResult.Success)
-                userTask.Properties(BinaryFormatterPropertyNamePrefix + "functionname") = functionName
-                userTask.Properties(BinaryFormatterPropertyNamePrefix + "classname") = className
-                userTask.Properties(BinaryFormatterPropertyNamePrefix + "operation") = operation
-                TelemetryService.DefaultSession.PostEvent(userTask)
             End Sub
 
         End Class

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPageSerializationService_Store.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPageSerializationService_Store.vb
@@ -130,8 +130,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             ''' </summary>
             ''' <param name="Stream">The stream to load from</param>
             Public Shared Function Load(Stream As Stream) As PropertyPageSerializationStore
-                TelemetryLogger.LogBinaryFormatterEvent(NameOf(PropertyPageSerializationStore), TelemetryLogger.BinaryFormatterOperation.Deserialize)
-
                 Return DirectCast(ObjectSerializer.Deserialize(Stream), PropertyPageSerializationStore)
             End Function
 
@@ -144,9 +142,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             ''' <param name="stream">The stream to save to</param>
             Public Overrides Sub Save(Stream As Stream)
                 Close()
-
-                TelemetryLogger.LogBinaryFormatterEvent(NameOf(PropertyPageSerializationStore), TelemetryLogger.BinaryFormatterOperation.Serialize)
-
                 ObjectSerializer.Serialize(Stream, Me)
             End Sub
 
@@ -509,8 +504,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' <param name="Object">The object to serialize</param>
                 ''' <returns>The binary serialized object.</returns>
                 Private Shared Function SerializeObject([Object] As Object) As Byte()
-                    TelemetryLogger.LogBinaryFormatterEvent(NameOf(SerializedProperty), TelemetryLogger.BinaryFormatterOperation.Serialize)
-
                     Dim MemoryStream As New MemoryStream
                     ObjectSerializer.Serialize(MemoryStream, [Object])
                     Return MemoryStream.ToArray()
@@ -524,8 +517,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                     If Not IsEntireComponentObject() Then
                         Throw New Package.InternalException
                     End If
-
-                    TelemetryLogger.LogBinaryFormatterEvent(NameOf(SerializedProperty), TelemetryLogger.BinaryFormatterOperation.Deserialize)
 
                     Dim MemoryStream As New MemoryStream(_serializedValue)
                     Return DirectCast(ObjectSerializer.Deserialize(MemoryStream), PropPageDesignerRootComponent)
@@ -543,8 +534,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                     If _serializedValue Is Nothing Then
                         Return Nothing
                     End If
-
-                    TelemetryLogger.LogBinaryFormatterEvent(NameOf(SerializedProperty), TelemetryLogger.BinaryFormatterOperation.Deserialize)
 
                     Dim MemoryStream As New MemoryStream(_serializedValue)
                     Return ObjectSerializer.Deserialize(MemoryStream)

--- a/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
@@ -4,7 +4,6 @@ Imports System.ComponentModel.Design
 Imports System.Drawing
 Imports System.Drawing.Imaging
 Imports System.IO
-Imports System.Runtime.CompilerServices
 Imports System.Runtime.InteropServices
 Imports System.Runtime.Serialization
 Imports System.Runtime.Versioning
@@ -1646,21 +1645,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
             Public Shared Sub LogAdvBuildSettingsPropPageEvent(eventValue As AdvBuildSettingsPropPageEvent)
                 Dim userTask = New UserTaskEvent(AdvBuildSettingsPropPageEventName, TelemetryResult.Success)
                 userTask.Properties(ProjectSystemPropertyNamePrefix + "appdesigner.advbuildsettingsproppage") = eventValue
-                TelemetryService.DefaultSession.PostEvent(userTask)
-            End Sub
-
-            Private Const BinaryFormatterEventName As String = EditorsEventNamePrefix + "binaryformatter"
-            Private Const BinaryFormatterPropertyNamePrefix As String = EditorsPropertyNamePrefix + "binaryformatter."
-            Public Enum BinaryFormatterOperation
-                Serialize = 0
-                Deserialize = 1
-            End Enum
-
-            Public Shared Sub LogBinaryFormatterEvent(className As String, operation As BinaryFormatterOperation, <CallerMemberName> Optional functionName As String = Nothing)
-                Dim userTask = New UserTaskEvent(BinaryFormatterEventName, TelemetryResult.Success)
-                userTask.Properties(BinaryFormatterPropertyNamePrefix + "functionname") = functionName
-                userTask.Properties(BinaryFormatterPropertyNamePrefix + "classname") = className
-                userTask.Properties(BinaryFormatterPropertyNamePrefix + "operation") = operation
                 TelemetryService.DefaultSession.PostEvent(userTask)
             End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationStore.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationStore.vb
@@ -110,8 +110,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="Stream">The stream to load from</param>
         Public Shared Function Load(Stream As Stream) As GenericComponentSerializationStore
-            TelemetryLogger.LogBinaryFormatterEvent(NameOf(GenericComponentSerializationStore), TelemetryLogger.BinaryFormatterOperation.Deserialize)
-
             Return DirectCast(ObjectSerializer.Deserialize(Stream), GenericComponentSerializationStore)
         End Function
 
@@ -124,9 +122,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="stream">The stream to save to</param>
         Public Overrides Sub Save(Stream As Stream)
             Close()
-
-            TelemetryLogger.LogBinaryFormatterEvent(NameOf(GenericComponentSerializationStore), TelemetryLogger.BinaryFormatterOperation.Serialize)
-
             ObjectSerializer.Serialize(Stream, Me)
         End Sub
 
@@ -470,8 +465,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 If [Object] Is Nothing Then
                     Return Array.Empty(Of Byte)
                 Else
-                    TelemetryLogger.LogBinaryFormatterEvent(NameOf(SerializedObjectData), TelemetryLogger.BinaryFormatterOperation.Serialize)
-
                     Dim MemoryStream As New MemoryStream
                     ObjectSerializer.Serialize(MemoryStream, [Object])
                     Return MemoryStream.ToArray()
@@ -482,8 +475,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 If _serializedValue.Length = 0 Then
                     Return Nothing
                 Else
-                    TelemetryLogger.LogBinaryFormatterEvent(NameOf(SerializedObjectData), TelemetryLogger.BinaryFormatterOperation.Deserialize)
-
                     Dim MemoryStream As New MemoryStream(_serializedValue)
                     Return ObjectSerializer.Deserialize(MemoryStream)
                 End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -2491,8 +2491,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '1) Create a structure with our raw resources data (our preferred format)
             Dim ResourcesData As New ResourcesDataFormat(Resources)
 
-            TelemetryLogger.LogBinaryFormatterEvent(NameOf(ResourceEditorView), TelemetryLogger.BinaryFormatterOperation.Serialize)
-
             '... then package it into a serialized blob
             Dim Stream As New MemoryStream
             ObjectSerializer.Serialize(Stream, ResourcesData)
@@ -2989,8 +2987,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ActualEffect = DragDropEffects.None
                 Return
             End If
-
-            TelemetryLogger.LogBinaryFormatterEvent(NameOf(ResourceEditorView), TelemetryLogger.BinaryFormatterOperation.Deserialize)
 
             'Decode the data format
             Dim RawBytes() As Byte = DirectCast(Data.GetData(_CF_RESOURCES), Byte())

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService_Store.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService_Store.vb
@@ -166,8 +166,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' </summary>
             ''' <param name="Stream">The stream to load from</param>
             Public Shared Function Load(Stream As Stream) As ResourceSerializationStore
-                TelemetryLogger.LogBinaryFormatterEvent(NameOf(ResourceSerializationStore), TelemetryLogger.BinaryFormatterOperation.Deserialize)
-
                 Return DirectCast(ObjectSerializer.Deserialize(Stream), ResourceSerializationStore)
             End Function
 
@@ -180,9 +178,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <param name="stream">The stream to save to</param>
             Public Overrides Sub Save(Stream As Stream)
                 Close()
-
-                TelemetryLogger.LogBinaryFormatterEvent(NameOf(ResourceSerializationStore), TelemetryLogger.BinaryFormatterOperation.Serialize)
-
                 ObjectSerializer.Serialize(Stream, Me)
 
                 Trace("Saved store")
@@ -581,8 +576,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' <param name="Object">The object to serialize</param>
                 ''' <returns>The binary serialized object.</returns>
                 Private Shared Function SerializeObject([Object] As Object) As Byte()
-                    TelemetryLogger.LogBinaryFormatterEvent(NameOf(SerializedResourceOrProperty), TelemetryLogger.BinaryFormatterOperation.Serialize)
-
                     Dim MemoryStream As New MemoryStream
                     ObjectSerializer.Serialize(MemoryStream, [Object])
                     Return MemoryStream.ToArray()
@@ -596,8 +589,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     If Not IsEntireResourceObject() Then
                         Throw New Package.InternalException
                     End If
-
-                    TelemetryLogger.LogBinaryFormatterEvent(NameOf(SerializedResourceOrProperty), TelemetryLogger.BinaryFormatterOperation.Deserialize)
 
                     Dim MemoryStream As New MemoryStream(_serializedValue)
                     Return DirectCast(ObjectSerializer.Deserialize(MemoryStream), Resource)
@@ -615,8 +606,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     If _serializedValue Is Nothing Then
                         Return Nothing
                     End If
-
-                    TelemetryLogger.LogBinaryFormatterEvent(NameOf(SerializedResourceOrProperty), TelemetryLogger.BinaryFormatterOperation.Deserialize)
 
                     Dim MemoryStream As New MemoryStream(_serializedValue)
                     Return ObjectSerializer.Deserialize(MemoryStream)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/7349

Since we don't use BinaryFormatter anymore, the telemetry when we do serialization is no longer needed. This was only added during investigation of BinaryFormatter usage.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7501)