### PR TITLE
Change MinimumPlatformVersion to SupportedOSPlatformVersion.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private const string TargetPlatformProperty = ConfigurationGeneral.TargetPlatformIdentifierProperty;
         private const string TargetPlatformVersionProperty = ConfigurationGeneral.TargetPlatformVersionProperty;
         private const string TargetFrameworkProperty = ConfigurationGeneral.TargetFrameworkProperty;
-        private const string MinimumPlatformVersionProperty = "MinimumPlatformVersion";
+        private const string SupportedOSPlatformVersionProperty = "SupportedOSPlatformVersion";
 
         private readonly ProjectProperties _properties;
         private readonly ConfiguredProject _configuredProject;
@@ -216,14 +216,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         /// <summary>
-        /// Resets the values on the TargetPlatformProperty and MinimumPlatformVersionProperty.
+        /// Resets the values on the TargetPlatformProperty and SupportedOSPlatformVersionProperty.
         /// </summary>
         /// <param name="projectProperties"></param>
         /// <returns></returns>
         private static async Task ResetPlatformPropertiesAsync(IProjectProperties projectProperties)
         {
             await projectProperties.DeletePropertyAsync(TargetPlatformVersionProperty);
-            await projectProperties.DeletePropertyAsync(MinimumPlatformVersionProperty);
+            await projectProperties.DeletePropertyAsync(SupportedOSPlatformVersionProperty);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -143,9 +143,9 @@
     </DynamicEnumProperty.Metadata>
   </DynamicEnumProperty>
 
-  <DynamicEnumProperty Name="MinimumPlatformVersion"
-                DisplayName="Minimum OS version"
-                Description="Specifies the minimum runtime version of the selected operating system."
+  <DynamicEnumProperty Name="SupportedOSPlatformVersion"
+                DisplayName="Supported OS version"
+                Description="Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value."
                 Category="General"
                 EnumProvider="SdkSupportedTargetPlatformVersionEnumProvider">
     <DynamicEnumProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.cs.xlf
@@ -97,21 +97,6 @@
         <target state="new">TFM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Description">
-        <source>Specifies the minimum runtime version of the selected operating system.</source>
-        <target state="new">Specifies the minimum runtime version of the selected operating system.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|DisplayName">
-        <source>Minimum OS version</source>
-        <target state="new">Minimum OS version</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Metadata|SearchTerms">
-        <source>platform</source>
-        <target state="new">platform</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="translated">Definuje vstupní bod, který se má volat při načtení aplikace. Obecně je tato možnost nastavena buď na hlavní formulář v aplikaci, nebo na proceduru Main, která se má spustit při spuštění aplikace. Knihovny tříd vstupní bod nedefinují.</target>
@@ -120,6 +105,21 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="translated">Spouštěcí objekt</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Description">
+        <source>Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</source>
+        <target state="new">Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|DisplayName">
+        <source>Supported OS version</source>
+        <target state="new">Supported OS version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Metadata|SearchTerms">
+        <source>platform</source>
+        <target state="new">platform</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|TargetPlatformIdentifier|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.de.xlf
@@ -97,21 +97,6 @@
         <target state="new">TFM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Description">
-        <source>Specifies the minimum runtime version of the selected operating system.</source>
-        <target state="new">Specifies the minimum runtime version of the selected operating system.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|DisplayName">
-        <source>Minimum OS version</source>
-        <target state="new">Minimum OS version</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Metadata|SearchTerms">
-        <source>platform</source>
-        <target state="new">platform</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="translated">Hiermit wird der Einstiegspunkt definiert, der beim Laden der Anwendung aufgerufen werden soll. Im Allgemeinen wird dies entweder auf das Hauptformular in Ihrer Anwendung oder auf die Main-Prozedur festgelegt, die beim Starten der Anwendung ausgeführt werden soll. Klassenbibliotheken definieren keinen Einstiegspunkt.</target>
@@ -120,6 +105,21 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="translated">Startobjekt</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Description">
+        <source>Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</source>
+        <target state="new">Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|DisplayName">
+        <source>Supported OS version</source>
+        <target state="new">Supported OS version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Metadata|SearchTerms">
+        <source>platform</source>
+        <target state="new">platform</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|TargetPlatformIdentifier|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.es.xlf
@@ -97,21 +97,6 @@
         <target state="new">TFM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Description">
-        <source>Specifies the minimum runtime version of the selected operating system.</source>
-        <target state="new">Specifies the minimum runtime version of the selected operating system.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|DisplayName">
-        <source>Minimum OS version</source>
-        <target state="new">Minimum OS version</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Metadata|SearchTerms">
-        <source>platform</source>
-        <target state="new">platform</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="translated">Define el punto de entrada al que se va a llamar cuando se cargue la aplicación. Normalmente, se establece en el formulario principal de la aplicación o en el procedimiento "Principal" que debe ejecutarse cuando se inicia la aplicación. Las bibliotecas de clases no definen ningún punto de entrada.</target>
@@ -120,6 +105,21 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="translated">Objeto de inicio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Description">
+        <source>Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</source>
+        <target state="new">Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|DisplayName">
+        <source>Supported OS version</source>
+        <target state="new">Supported OS version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Metadata|SearchTerms">
+        <source>platform</source>
+        <target state="new">platform</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|TargetPlatformIdentifier|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.fr.xlf
@@ -97,21 +97,6 @@
         <target state="new">TFM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Description">
-        <source>Specifies the minimum runtime version of the selected operating system.</source>
-        <target state="new">Specifies the minimum runtime version of the selected operating system.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|DisplayName">
-        <source>Minimum OS version</source>
-        <target state="new">Minimum OS version</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Metadata|SearchTerms">
-        <source>platform</source>
-        <target state="new">platform</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="translated">Définit le point d'entrée à appeler au chargement de l'application. En règle générale, il s'agit du formulaire principal de votre application ou de la procédure 'Main' qui doit s'exécuter au démarrage de l'application. Les bibliothèques de classes ne définissent pas de point d'entrée.</target>
@@ -120,6 +105,21 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="translated">Objet de démarrage</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Description">
+        <source>Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</source>
+        <target state="new">Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|DisplayName">
+        <source>Supported OS version</source>
+        <target state="new">Supported OS version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Metadata|SearchTerms">
+        <source>platform</source>
+        <target state="new">platform</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|TargetPlatformIdentifier|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.it.xlf
@@ -97,21 +97,6 @@
         <target state="new">TFM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Description">
-        <source>Specifies the minimum runtime version of the selected operating system.</source>
-        <target state="new">Specifies the minimum runtime version of the selected operating system.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|DisplayName">
-        <source>Minimum OS version</source>
-        <target state="new">Minimum OS version</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Metadata|SearchTerms">
-        <source>platform</source>
-        <target state="new">platform</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="translated">Definisce il punto di ingresso da chiamare quando l'applicazione viene caricata. In genere viene impostato sul modulo principale dell'applicazione o sulla routine 'Main' che deve essere eseguita all'avvio dell'applicazione. Le librerie di classi non definiscono un punto di ingresso.</target>
@@ -120,6 +105,21 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="translated">Oggetto di avvio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Description">
+        <source>Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</source>
+        <target state="new">Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|DisplayName">
+        <source>Supported OS version</source>
+        <target state="new">Supported OS version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Metadata|SearchTerms">
+        <source>platform</source>
+        <target state="new">platform</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|TargetPlatformIdentifier|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ja.xlf
@@ -97,21 +97,6 @@
         <target state="new">TFM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Description">
-        <source>Specifies the minimum runtime version of the selected operating system.</source>
-        <target state="new">Specifies the minimum runtime version of the selected operating system.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|DisplayName">
-        <source>Minimum OS version</source>
-        <target state="new">Minimum OS version</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Metadata|SearchTerms">
-        <source>platform</source>
-        <target state="new">platform</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="translated">アプリケーションの読み込み時に呼び出されるエントリ ポイントを定義します。通常、これはアプリケーションのメイン フォームか、アプリケーションの起動時に実行する必要がある 'Main' プロシージャに設定されます。クラス ライブラリではエントリ ポイントが定義されていません。</target>
@@ -120,6 +105,21 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="translated">スタートアップ オブジェクト</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Description">
+        <source>Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</source>
+        <target state="new">Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|DisplayName">
+        <source>Supported OS version</source>
+        <target state="new">Supported OS version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Metadata|SearchTerms">
+        <source>platform</source>
+        <target state="new">platform</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|TargetPlatformIdentifier|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ko.xlf
@@ -97,21 +97,6 @@
         <target state="new">TFM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Description">
-        <source>Specifies the minimum runtime version of the selected operating system.</source>
-        <target state="new">Specifies the minimum runtime version of the selected operating system.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|DisplayName">
-        <source>Minimum OS version</source>
-        <target state="new">Minimum OS version</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Metadata|SearchTerms">
-        <source>platform</source>
-        <target state="new">platform</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="translated">애플리케이션이 로드될 때 호출할 진입점을 정의합니다. 일반적으로 애플리케이션의 기본 양식 또는 애플리케이션이 시작할 때 실행되어야 하는 '기본' 프로시저로 설정됩니다. 클래스 라이브러리는 진입점을 정의하지 않습니다.</target>
@@ -120,6 +105,21 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="translated">시작 개체</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Description">
+        <source>Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</source>
+        <target state="new">Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|DisplayName">
+        <source>Supported OS version</source>
+        <target state="new">Supported OS version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Metadata|SearchTerms">
+        <source>platform</source>
+        <target state="new">platform</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|TargetPlatformIdentifier|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pl.xlf
@@ -97,21 +97,6 @@
         <target state="new">TFM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Description">
-        <source>Specifies the minimum runtime version of the selected operating system.</source>
-        <target state="new">Specifies the minimum runtime version of the selected operating system.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|DisplayName">
-        <source>Minimum OS version</source>
-        <target state="new">Minimum OS version</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Metadata|SearchTerms">
-        <source>platform</source>
-        <target state="new">platform</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="translated">Definiuje punkt wejścia do wywołania, gdy aplikacja zostanie załadowana. Ta opcja jest zazwyczaj ustawiana na formularz główny w aplikacji lub na procedurę „Main”, która ma być uruchamiana po uruchomieniu aplikacji. Biblioteki klas nie definiują punktu wejścia.</target>
@@ -120,6 +105,21 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="translated">Obiekt startowy</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Description">
+        <source>Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</source>
+        <target state="new">Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|DisplayName">
+        <source>Supported OS version</source>
+        <target state="new">Supported OS version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Metadata|SearchTerms">
+        <source>platform</source>
+        <target state="new">platform</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|TargetPlatformIdentifier|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pt-BR.xlf
@@ -97,21 +97,6 @@
         <target state="new">TFM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Description">
-        <source>Specifies the minimum runtime version of the selected operating system.</source>
-        <target state="new">Specifies the minimum runtime version of the selected operating system.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|DisplayName">
-        <source>Minimum OS version</source>
-        <target state="new">Minimum OS version</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Metadata|SearchTerms">
-        <source>platform</source>
-        <target state="new">platform</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="translated">Define o ponto de entrada a ser chamado quando o aplicativo é carregado. Geralmente, essa opção é definida como o formulário principal no aplicativo ou como o procedimento 'Main' que deve ser executado quando o aplicativo é iniciado. As bibliotecas de classe não definem um ponto de entrada.</target>
@@ -120,6 +105,21 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="translated">Objeto de inicialização</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Description">
+        <source>Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</source>
+        <target state="new">Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|DisplayName">
+        <source>Supported OS version</source>
+        <target state="new">Supported OS version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Metadata|SearchTerms">
+        <source>platform</source>
+        <target state="new">platform</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|TargetPlatformIdentifier|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ru.xlf
@@ -97,21 +97,6 @@
         <target state="new">TFM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Description">
-        <source>Specifies the minimum runtime version of the selected operating system.</source>
-        <target state="new">Specifies the minimum runtime version of the selected operating system.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|DisplayName">
-        <source>Minimum OS version</source>
-        <target state="new">Minimum OS version</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Metadata|SearchTerms">
-        <source>platform</source>
-        <target state="new">platform</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="translated">Определяет точку входа, вызываемую при загрузке приложения. Обычно в качестве этой точки входа задается главная форма приложения или процедура "Main", которая должна выполняться при запуске приложения. В библиотеках классов точка входа не определяется.</target>
@@ -120,6 +105,21 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="translated">Автоматически запускаемый объект</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Description">
+        <source>Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</source>
+        <target state="new">Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|DisplayName">
+        <source>Supported OS version</source>
+        <target state="new">Supported OS version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Metadata|SearchTerms">
+        <source>platform</source>
+        <target state="new">platform</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|TargetPlatformIdentifier|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.tr.xlf
@@ -97,21 +97,6 @@
         <target state="new">TFM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Description">
-        <source>Specifies the minimum runtime version of the selected operating system.</source>
-        <target state="new">Specifies the minimum runtime version of the selected operating system.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|DisplayName">
-        <source>Minimum OS version</source>
-        <target state="new">Minimum OS version</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Metadata|SearchTerms">
-        <source>platform</source>
-        <target state="new">platform</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="translated">Uygulama yüklediğinde çağrılacak giriş noktasını tanımlar. Bu, genellikle uygulamanızda ana form olarak veya uygulama başladığında çalışması gereken 'Ana' yordam olarak ayarlanır. Sınıf kitaplıkları bir giriş noktası tanımlamaz.</target>
@@ -120,6 +105,21 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="translated">Başlangıç nesnesi</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Description">
+        <source>Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</source>
+        <target state="new">Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|DisplayName">
+        <source>Supported OS version</source>
+        <target state="new">Supported OS version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Metadata|SearchTerms">
+        <source>platform</source>
+        <target state="new">platform</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|TargetPlatformIdentifier|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hans.xlf
@@ -97,21 +97,6 @@
         <target state="new">TFM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Description">
-        <source>Specifies the minimum runtime version of the selected operating system.</source>
-        <target state="new">Specifies the minimum runtime version of the selected operating system.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|DisplayName">
-        <source>Minimum OS version</source>
-        <target state="new">Minimum OS version</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Metadata|SearchTerms">
-        <source>platform</source>
-        <target state="new">platform</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="translated">定义在加载应用程序时要调用的入口点。通常，此项设置为应用程序中的主窗体或应用程序启动时运行的 "Main" 过程。类库不定义入口点。</target>
@@ -120,6 +105,21 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="translated">启动对象</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Description">
+        <source>Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</source>
+        <target state="new">Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|DisplayName">
+        <source>Supported OS version</source>
+        <target state="new">Supported OS version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Metadata|SearchTerms">
+        <source>platform</source>
+        <target state="new">platform</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|TargetPlatformIdentifier|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hant.xlf
@@ -97,21 +97,6 @@
         <target state="new">TFM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Description">
-        <source>Specifies the minimum runtime version of the selected operating system.</source>
-        <target state="new">Specifies the minimum runtime version of the selected operating system.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|DisplayName">
-        <source>Minimum OS version</source>
-        <target state="new">Minimum OS version</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DynamicEnumProperty|MinimumPlatformVersion|Metadata|SearchTerms">
-        <source>platform</source>
-        <target state="new">platform</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="translated">定義應用程式載入時要呼叫的進入點。通常會設定為應用程式的主表單，或應用程式啟動時應執行的 'Main' 程序。類別庫未定義進入點。</target>
@@ -120,6 +105,21 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="translated">啟始物件</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Description">
+        <source>Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</source>
+        <target state="new">Specifies the minimum version of the OS that an app or library supports running on. If it is not specified, it should default to the version equivalent to the Target OS version value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|DisplayName">
+        <source>Supported OS version</source>
+        <target state="new">Supported OS version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|SupportedOSPlatformVersion|Metadata|SearchTerms">
+        <source>platform</source>
+        <target state="new">platform</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|TargetPlatformIdentifier|Description">


### PR DESCRIPTION
Addresses #7502.

The SDK now uses the `SupportedOSPlatformVersion` property. These changes reflect this in the project properties UI and saves it correctly in the project file.