### PR TITLE
Rename IProjectConfigurationDimensionsProvider5 to *Internal

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
     /// <summary>
     /// Base project configuration dimension provider
     /// </summary>
-    internal abstract class BaseProjectConfigurationDimensionProvider : IProjectConfigurationDimensionsProvider5
+    internal abstract class BaseProjectConfigurationDimensionProvider : IProjectConfigurationDimensionsProviderInternal
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseProjectConfigurationDimensionProvider"/> class.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/IProjectConfigurationDimensionsProviderInternal.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/IProjectConfigurationDimensionsProviderInternal.cs
@@ -6,7 +6,7 @@ using Microsoft.Build.Construction;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal interface IProjectConfigurationDimensionsProvider5 : IProjectConfigurationDimensionsProvider3
+    internal interface IProjectConfigurationDimensionsProviderInternal : IProjectConfigurationDimensionsProvider3
     {
         IEnumerable<string> GetBestGuessDimensionNames(ImmutableArray<ProjectPropertyElement> properties);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Reload/ProjectReloadInterceptor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Reload/ProjectReloadInterceptor.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             // Look through the properties and find all declared dimensions (ie <Configurations>, <Platforms>, <TargetFrameworks>) 
             // and return their dimension name equivalents (Configuration, Platform, TargetFramework)
             return DimensionProviders.Select(v => v.Value)
-                                     .OfType<IProjectConfigurationDimensionsProvider5>()
+                                     .OfType<IProjectConfigurationDimensionsProviderInternal>()
                                      .SelectMany(p => p.GetBestGuessDimensionNames(properties));
         }
     }


### PR DESCRIPTION
Renames the internal configuration dimensions provider to internal to keep the public  interface chain continuous.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7508)