### PR TITLE
Show the language version

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/LangVersionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/LangVersionValueProvider.cs
@@ -1,9 +1,0 @@
-﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
-
-namespace Microsoft.VisualStudio.ProjectSystem.Properties
-{
-    [ExportInterceptingPropertyValueProvider("LangVersion", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
-    internal sealed class LangVersionValueProvider : NoOpInterceptingPropertyValueProvider
-    {
-    }
-}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -381,18 +381,14 @@
 
   <StringProperty Name="LangVersion"
                   DisplayName="Language version"
-                  Description="Why can't I select the C# language version?"
+                  Description="The version of the language available to code in this project."
+                  HelpUrl="https://aka.ms/csharp-versions"
+                  ReadOnly="true"
                   Category="Advanced">
-    <StringProperty.DataSource>
-      <DataSource PersistedName="LangVersion"
-                  Persistence="ProjectFileWithInterception"
-                  HasConfigurationCondition="False" />
-    </StringProperty.DataSource>
     <StringProperty.ValueEditors>
-      <ValueEditor EditorType="LinkAction">
+      <ValueEditor EditorType="String">
         <ValueEditor.Metadata>
-          <NameValuePair Name="Action" Value="URL" />
-          <NameValuePair Name="URL" Value="https://aka.ms/csharp-versions" />
+          <NameValuePair Name="ShowEvaluatedPreviewOnly" Value="True" />
         </ValueEditor.Metadata>
       </ValueEditor>
     </StringProperty.ValueEditors>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.cs.xlf
@@ -448,8 +448,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|Description">
-        <source>Why can't I select the C# language version?</source>
-        <target state="translated">Proč nemůžu vybrat verzi jazyka C#?</target>
+        <source>The version of the language available to code in this project.</source>
+        <target state="needs-review-translation">Proč nemůžu vybrat verzi jazyka C#?</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.de.xlf
@@ -448,8 +448,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|Description">
-        <source>Why can't I select the C# language version?</source>
-        <target state="translated">Warum kann ich die C#-Sprachversion nicht auswählen?</target>
+        <source>The version of the language available to code in this project.</source>
+        <target state="needs-review-translation">Warum kann ich die C#-Sprachversion nicht auswählen?</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.es.xlf
@@ -448,8 +448,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|Description">
-        <source>Why can't I select the C# language version?</source>
-        <target state="translated">¿Por qué no puedo seleccionar la versión del lenguaje C#?</target>
+        <source>The version of the language available to code in this project.</source>
+        <target state="needs-review-translation">¿Por qué no puedo seleccionar la versión del lenguaje C#?</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.fr.xlf
@@ -448,8 +448,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|Description">
-        <source>Why can't I select the C# language version?</source>
-        <target state="translated">Pourquoi ne puis-je pas sélectionner la version de langage C# ?</target>
+        <source>The version of the language available to code in this project.</source>
+        <target state="needs-review-translation">Pourquoi ne puis-je pas sélectionner la version de langage C# ?</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.it.xlf
@@ -448,8 +448,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|Description">
-        <source>Why can't I select the C# language version?</source>
-        <target state="translated">Perché non è possibile selezionare la versione del linguaggio C#?</target>
+        <source>The version of the language available to code in this project.</source>
+        <target state="needs-review-translation">Perché non è possibile selezionare la versione del linguaggio C#?</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ja.xlf
@@ -448,8 +448,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|Description">
-        <source>Why can't I select the C# language version?</source>
-        <target state="translated">C# 言語バージョンを選択できないのはなぜですか?</target>
+        <source>The version of the language available to code in this project.</source>
+        <target state="needs-review-translation">C# 言語バージョンを選択できないのはなぜですか?</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ko.xlf
@@ -448,8 +448,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|Description">
-        <source>Why can't I select the C# language version?</source>
-        <target state="translated">C# 언어 버전을 선택할 수 없는 이유는 무엇인가요?</target>
+        <source>The version of the language available to code in this project.</source>
+        <target state="needs-review-translation">C# 언어 버전을 선택할 수 없는 이유는 무엇인가요?</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pl.xlf
@@ -448,8 +448,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|Description">
-        <source>Why can't I select the C# language version?</source>
-        <target state="translated">Dlaczego nie mogę wybrać wersji języka C#?</target>
+        <source>The version of the language available to code in this project.</source>
+        <target state="needs-review-translation">Dlaczego nie mogę wybrać wersji języka C#?</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pt-BR.xlf
@@ -448,8 +448,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|Description">
-        <source>Why can't I select the C# language version?</source>
-        <target state="translated">Por que não consigo selecionar a versão da linguagem C#?</target>
+        <source>The version of the language available to code in this project.</source>
+        <target state="needs-review-translation">Por que não consigo selecionar a versão da linguagem C#?</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ru.xlf
@@ -448,8 +448,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|Description">
-        <source>Why can't I select the C# language version?</source>
-        <target state="translated">Почему не удается выбрать версию языка C#?</target>
+        <source>The version of the language available to code in this project.</source>
+        <target state="needs-review-translation">Почему не удается выбрать версию языка C#?</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.tr.xlf
@@ -448,8 +448,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|Description">
-        <source>Why can't I select the C# language version?</source>
-        <target state="translated">Neden C# dil sürümünü seçemiyorum?</target>
+        <source>The version of the language available to code in this project.</source>
+        <target state="needs-review-translation">Neden C# dil sürümünü seçemiyorum?</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hans.xlf
@@ -448,8 +448,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|Description">
-        <source>Why can't I select the C# language version?</source>
-        <target state="translated">为何无法选择 C# 语言版本?</target>
+        <source>The version of the language available to code in this project.</source>
+        <target state="needs-review-translation">为何无法选择 C# 语言版本?</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hant.xlf
@@ -448,8 +448,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|Description">
-        <source>Why can't I select the C# language version?</source>
-        <target state="translated">為什麼無法選取其他 C# 語言版本?</target>
+        <source>The version of the language available to code in this project.</source>
+        <target state="needs-review-translation">為什麼無法選取其他 C# 語言版本?</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|LangVersion|DisplayName">


### PR DESCRIPTION
Fixes #7185

Previously, for language version, we showed a link to an explanation of why the language version could not be modified. #7185 tracks removal of this link, and suggests showing the language version instead.

This change moves the link to the help button, and displays the evaluated language version(s) based on target framework(s) in the UI. These remain read-only values.

For a .NET 6 project:

![image](https://user-images.githubusercontent.com/350947/130715979-017b08bb-f973-4d7b-a3cb-d0f7543e2ff3.png)

This change is particularly helpful for multi-targeting projects as it shows how the language level varies by target:

![image](https://user-images.githubusercontent.com/350947/130715850-6957865d-e89d-452a-b1b4-8b97dcc7620b.png)
