### PR TITLE
Honor VS-wide Hot Reload settings

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebuggerSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebuggerSettings.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
+{
+    /// <summary>
+    /// Provides access to debugger settings.
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    internal interface IDebuggerSettings
+    {
+        Task<bool> IsEncEnabledAsync();
+        Task<bool> IsNonDebugHotReloadEnabledAsync();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/RegistryBasedDebuggerSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/RegistryBasedDebuggerSettings.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.IO;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
+{
+    /// <summary>
+    /// Provides access to debugger settings by reading the registry.
+    /// </summary>
+    [Export(typeof(IDebuggerSettings))]
+    internal class RegistryBasedDebuggerSettings : IDebuggerSettings
+    {
+        private readonly IRegistry _registry;
+        private readonly IVsService<SVsShell, IVsShell> _shell;
+        private readonly IVsShellUtilitiesHelper _shellUtilitiesHelper;
+
+        [ImportingConstructor]
+        public RegistryBasedDebuggerSettings(
+            IRegistry registry,
+            IVsService<SVsShell, IVsShell> shell,
+            IVsShellUtilitiesHelper shellUtilitiesHelper)
+        {
+            _registry = registry;
+            _shell = shell;
+            _shellUtilitiesHelper = shellUtilitiesHelper;
+        }
+
+        public async Task<bool> IsEncEnabledAsync()
+        {
+            string? registryRoot = await _shellUtilitiesHelper.GetRegistryRootAsync(_shell);
+            if (registryRoot is not null
+                && _registry.ReadValueForCurrentUser(registryRoot + @"\Debugger", "ENCEnable") is int value)
+            {
+                return value != 0;
+            }
+
+            return true;
+        }
+
+        public async Task<bool> IsNonDebugHotReloadEnabledAsync()
+        {
+            string? registryRoot = await _shellUtilitiesHelper.GetRegistryRootAsync(_shell);
+            if (registryRoot is not null
+                && _registry.ReadValueForCurrentUser(registryRoot + @"\Debugger", "EnableNetHotReloadWhenNoDebugging") is int value)
+            {
+                return value != 0;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsShellUtilitiesHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsShellUtilitiesHelper.cs
@@ -21,5 +21,10 @@ namespace Microsoft.VisualStudio.Shell.Interop
         /// Returns the local app data folder as defined by <see cref="__VSSPROPID4.VSSPROPID_LocalAppDataDir"/>.
         /// </summary>
         Task<string?> GetLocalAppDataFolderAsync(IVsService<IVsShell> vsShellService);
+
+        /// <summary>
+        /// Returns the virtual registry root as defined by <see cref="__VSSPROPID.VSSPROPID_VirtualRegistryRoot"/>.
+        /// </summary>
+        Task<string?> GetRegistryRootAsync(IVsService<IVsShell> vsShellService);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsShellUtilitiesHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsShellUtilitiesHelper.cs
@@ -61,5 +61,19 @@ namespace Microsoft.VisualStudio.Shell.Interop
 
             return null;
         }
+
+        public async Task<string?> GetRegistryRootAsync(IVsService<IVsShell> vsShellService)
+        {
+            await _threadingService.SwitchToUIThread();
+
+            IVsShell shell = await vsShellService.GetValueAsync();
+
+            if (ErrorHandler.Succeeded(shell.GetProperty((int)__VSSPROPID.VSSPROPID_VirtualRegistryRoot, out object value)))
+            {
+                return value as string;
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IRegistry.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IRegistry.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Composition;
+using Microsoft.VisualStudio.ProjectSystem;
+
+namespace Microsoft.VisualStudio.IO
+{
+    /// <summary>
+    ///     Provides methods for reading values from the registry.
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    internal interface IRegistry
+    {
+        /// <summary>
+        /// Opens a registry key denoted by <paramref name="keyPath"/> for the current user,
+        /// and returns the value (if any) associated with <paramref name="name"/>. Returns
+        /// <see langword="null"/> if the registry key or value do not exist, or if an error
+        /// occurs while reading the value.
+        /// </summary>
+        object? ReadValueForCurrentUser(string keyPath, string name);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/WindowsRegistry.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/WindowsRegistry.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.ComponentModel.Composition;
+using Microsoft.Win32;
+
+namespace Microsoft.VisualStudio.IO
+{
+    [Export(typeof(IRegistry))]
+    internal class WindowsRegistry : IRegistry
+    {
+        public object? ReadValueForCurrentUser(string keyPath, string name)
+        {
+            using (RegistryKey registryKey = Registry.CurrentUser.OpenSubKey(keyPath))
+            {
+                if (registryKey is not null)
+                {
+                    try
+                    {
+                        return registryKey.GetValue(name);
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebuggerSettingsFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebuggerSettingsFactory.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.VS.Debug;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal class IDebuggerSettingsFactory
+    {
+        internal static IDebuggerSettings Create(bool encEnabled = true, bool nonDebugHotReloadEnabled = true)
+        {
+            var mock = new Mock<IDebuggerSettings>();
+
+            mock.Setup(settings => settings.IsEncEnabledAsync()).ReturnsAsync(encEnabled);
+            mock.Setup(settings => settings.IsNonDebugHotReloadEnabledAsync()).ReturnsAsync(nonDebugHotReloadEnabled);
+
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -731,7 +731,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             IActiveDebugFrameworkServices? activeDebugFramework = null,
             ProjectProperties? properties = null,
             IProjectThreadingService? threadingService = null,
-            IVsDebugger10? debugger = null)
+            IVsDebugger10? debugger = null,
+            IDebuggerSettings? debuggerSettings = null)
         {
             environment ??= Mock.Of<IEnvironmentHelper>();
             tokenReplacer ??= IDebugTokenReplacerFactory.Create();
@@ -754,7 +755,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 threadingService,
                 IVsUIServiceFactory.Create<SVsShellDebugger, IVsDebugger10>(debugger),
                 remoteDebuggerAuthenticationService,
-                new Lazy<IProjectHotReloadSessionManager>(() => IProjectHotReloadSessionManagerFactory.Create()));
+                new Lazy<IProjectHotReloadSessionManager>(() => IProjectHotReloadSessionManagerFactory.Create()),
+                new Lazy<IDebuggerSettings>(() => debuggerSettings ?? IDebuggerSettingsFactory.Create()));
         }
     }
 }


### PR DESCRIPTION
Currently we enable Hot Reload by default for both F5 and Ctrl+F5 scenarios when executing the "Project" launch command, and we support turning it on and off on per launch profile. However, there are also going to be VS-wide settings that we need to honor as well. For F5 scenarios, we should only turn Hot Reload on if Edit and Continue is enabled. For Ctrl+F5 we need to check a new "Hot Reload in Ctrl+F5" setting that is separate from the EnC setting.

The debugger team is adding the underlying options and related UI, but there is currently no API we can call to retrieve the setting (at least, not for the new option). Instead, we need to read the registry values. This involves hiding the registry behind a new interface, `IRegistry`, consuming that in implementations of a new `IDebuggerSettings` interface, and using _that_ to check the appropriate settings in `ProjectLaunchTargetsProvider`.

Note that we do the "local" checks first as they are cheaper, and only check the VS-wide settings if necessary. This will avoid instantiating the `IDebuggerSettings` at all in some scenarios.

If/when the debugger exposes these settings through an API we may be able to remove much of this code, as this is currently the only place in the project system we need to touch the registry.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7529)