### PR TITLE
Remove redundant calls to base method

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 return string.Empty;
             }
 
-            return await base.OnGetEvaluatedPropertyValueAsync(propertyName, storedValue, defaultProperties);
+            return storedValue;
         }
 
         public override async Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 return string.Empty;
             }
 
-            return await base.OnGetUnevaluatedPropertyValueAsync(propertyName, storedValue, defaultProperties);
+            return storedValue;
         }
 
         private static async Task<ComplexTargetFramework> GetStoredComplexTargetFrameworkAsync(ConfigurationGeneral configuration)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/DebugTypeValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/DebugTypeValueProvider.cs
@@ -7,18 +7,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [ExportInterceptingPropertyValueProvider("DebugType", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     internal sealed class DebugTypeValueProvider : InterceptingPropertyValueProviderBase
     {
-        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        public override Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            string value = await base.OnGetEvaluatedPropertyValueAsync(propertyName, evaluatedPropertyValue, defaultProperties);
+            string value = evaluatedPropertyValue == "pdbonly"
+                ? "full"
+                : evaluatedPropertyValue;
 
-            return value == "pdbonly" ? "full" : value;
+            return Task.FromResult(value);
         }
 
-        public override async Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+        public override Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            string value = await base.OnGetUnevaluatedPropertyValueAsync(propertyName, unevaluatedPropertyValue, defaultProperties);
+            string value = unevaluatedPropertyValue == "pdbonly"
+                ? "full"
+                : unevaluatedPropertyValue;
 
-            return value == "pdbonly" ? "full" : value;
+            return Task.FromResult(value);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/RunPostBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/RunPostBuildEventValueProvider.cs
@@ -14,28 +14,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [ExportInterceptingPropertyValueProvider(ConfigurationGeneralBrowseObject.RunPostBuildEventProperty, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     internal sealed class RunPostBuildEventValueProvider : InterceptingPropertyValueProviderBase
     {
-        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        public override Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            string value = await base.OnGetEvaluatedPropertyValueAsync(propertyName, evaluatedPropertyValue, defaultProperties);
-
-            if (string.IsNullOrEmpty(value))
+            if (string.IsNullOrEmpty(evaluatedPropertyValue))
             {
-                value = ConfigurationGeneralBrowseObject.RunPostBuildEventValues.OnBuildSuccess;
+                return Task.FromResult(ConfigurationGeneralBrowseObject.RunPostBuildEventValues.OnBuildSuccess);
             }
 
-            return value;
+            return Task.FromResult(evaluatedPropertyValue);
         }
 
-        public override async Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+        public override Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            string value = await base.OnGetUnevaluatedPropertyValueAsync(propertyName, unevaluatedPropertyValue, defaultProperties);
-
-            if (string.IsNullOrEmpty(value))
+            if (string.IsNullOrEmpty(unevaluatedPropertyValue))
             {
-                value = ConfigurationGeneralBrowseObject.RunPostBuildEventValues.OnBuildSuccess;
+                return Task.FromResult(ConfigurationGeneralBrowseObject.RunPostBuildEventValues.OnBuildSuccess);
             }
 
-            return value;
+            return Task.FromResult(unevaluatedPropertyValue);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/TreatWarningsAsErrorsValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/TreatWarningsAsErrorsValueProvider.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             await defaultProperties.DeletePropertyAsync(removePropertyName, dimensionalConditions);
             await defaultProperties.RestoreValueIfNotCurrentlySetAsync(restorePropertyName, _temporaryPropertyStorage);
 
-            return await base.OnSetPropertyValueAsync(propertyName, unevaluatedPropertyValue, defaultProperties, dimensionalConditions);
+            return unevaluatedPropertyValue;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/BaseVersionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/BaseVersionValueProvider.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
                 }
             }
 
-            return await base.OnSetPropertyValueAsync(propertyName, unevaluatedPropertyValue, defaultProperties, dimensionalConditions);
+            return unevaluatedPropertyValue;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/TargetFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/TargetFrameworkValueProvider.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 return propertyValue.ToString();
             }
 
-            return await base.OnGetEvaluatedPropertyValueAsync(propertyName, evaluatedPropertyValue, defaultProperties);
+            return evaluatedPropertyValue;
         }
     }
 }


### PR DESCRIPTION
The base methods here just wrap a parameter in a task and return it.

Avoid such allocations by inlining the argument at the call site.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7536)