### PR TITLE
Remove a time out

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
@@ -74,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             // Get the active debug profile (timeout of 5s, though in reality is should never take this long as even in error conditions
             // a snapshot is produced).
-            ILaunchSettings? currentProfiles = await _launchSettingsProvider.WaitForFirstSnapshot(5000);
+            ILaunchSettings? currentProfiles = await _launchSettingsProvider.WaitForFirstSnapshot(Timeout.Infinite);
             ILaunchProfile? activeProfile = currentProfiles?.ActiveProfile;
 
             // Should have a profile


### PR DESCRIPTION
Fixes [VS 1370386](https://devdiv.visualstudio.com/devdiv/_queries/edit/1370386).
Fixes [VS 1386457](https://devdiv.visualstudio.com/devdiv/_queries/edit/1386457).

The `ILaunchSettingsProvider` exposes launch settings as a series of `ILaunchSettings` instances exposed to TPL data flows via the `SourceBlock` property. For convenience, it also exposes the current instance (if any) through the `CurrentSnapshot` property, and supports waiting for the first snapshot to become available via the `WaitForFirstSnapshot` method. `WaitForFirstSnapshot` accepts a timeout in millseconds. If no snapshot becomes available in this time it bails out and returns `null`.

Meanwhile, the `LaunchProfilesDebugLaunchProvider` is responsible for telling CPS if a project can be a startup project. It does this by getting the active profile, finding the `IDebugProfileLaunchTargetsProvider` that will handle that profile, and delegating to that provider. The important part is that it gets the active profile by calling `ILaunchSettingsProvider.WaitForFirstSnapshot`--and passes in a five-second timeout.

_Most_ of the time we can retrieve a snapshot within five seconds, but if the system is heavily loaded (e.g. while opening a large solution) we may not be able to. In this case we will end up throwing an exception stating that no launch profile is available, which will propagate out and result in a gold bar warning the user something went wrong. It probably also prevents us from correctly identifying a "startable" project as such, and the user won't be able to debug it.

Here we remove the five-second time out in favor of just waiting as long as we need to.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7542)