### PR TITLE
Ensure there is a LocalizedControlType property in DataGridViewUITypeEditorColumn

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorCell.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorCell.vb
@@ -282,6 +282,23 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             End Get
         End Property
 
-    End Class
+        Protected Overrides Function CreateAccessibilityInstance() As AccessibleObject
+            Return New DerivedClass(Me)
+        End Function
 
+        Protected Class DerivedClass
+            Inherits DataGridViewCellAccessibleObject
+
+            Public Sub New(owner As DataGridViewCell)
+                MyBase.New(owner)
+            End Sub
+
+            Public Overrides ReadOnly Property Role As AccessibleRole
+                Get
+                    Return AccessibleRole.Cell
+                End Get
+            End Property
+        End Class
+
+    End Class
 End Namespace


### PR DESCRIPTION
Fixes [AzDO#1324876](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1324876)

The Settings Designer has an accessibility bug where the last column, the one with the value of that row's setting, was missing a `LocalizedControlType`.

![image](https://user-images.githubusercontent.com/8518253/131427281-47494143-7c8b-4eb8-9448-560f9f597c43.png)

A little bit of context of `ControlType`s:
A control type defines what information a UI element contains and what it can do; control type is used by accessibility tools for users to know what operations can perform on these elements. More about them and [UI Automation Control Types.](https://docs.microsoft.com/en-us/dotnet/framework/ui-automation/ui-automation-control-types-overview).

When looking at how we construct the Settings Designer, we can see that we use a custom `DataGridViewColumn` for the 'Value' column (look at [SettingsDesignerView.vb, line 163](https://github.com/dotnet/project-system/blob/124c733ab0e0966db02ba9fa61020c25d1fd17d4/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb#L163)). 

Following an entry in our Microsoft Docs on how to set the localized control type on a custom control (read more about it [here](https://docs.microsoft.com/en-us/accessibility-tools-docs/items/wpf/customcontrol_localizedcontroltype#code-sample-1-setting-the-controltype-of-a-custom-control-to-a-known-uia-controltype)), I was able to add a function in `DataGridViewUITypeEditorColumn` to call the `AutomationPeer` class that will set that specific `AutomationControlType` to be `AutomationControlType.Edit`.

This is what Accessibility Insights looks like with these changes with a WinForms' Setitngs Designer:
![image](https://user-images.githubusercontent.com/8518253/131428569-271e4420-d43a-4f02-9fb9-fe23e4faa9cd.png)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7544)