### PR TITLE
Don't perform file access on UI thread

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Web/RemoteCacheFile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Web/RemoteCacheFile.cs
@@ -29,6 +29,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
             return _fileSystem.GetLastFileWriteTimeOrMinValueUtc(_cacheFilePath).Add(_cacheExpiration) < DateTime.UtcNow;
         }
 
+        public bool CacheFileExists()
+        {
+            return _fileSystem.FileExists(_cacheFilePath);
+        }
+
         /// <summary>
         /// If the cached file exists reads the data and returns it as a string
         /// </summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetector.cs
@@ -108,6 +108,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 // do not block package initialization on this
                 _threadHandling.Value.RunAndForget(async () =>
                 {
+                    // Perform file IO on the thread pool
+                    await TaskScheduler.Default;
+
                     // First make sure that the cache file exists
                     if (_versionDataCacheFile != null && _versionDataCacheFile.ReadCacheFile() is null)
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetector.cs
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     await TaskScheduler.Default;
 
                     // First make sure that the cache file exists
-                    if (_versionDataCacheFile != null && _versionDataCacheFile.ReadCacheFile() is null)
+                    if (_versionDataCacheFile != null && !_versionDataCacheFile.CacheFileExists())
                     {
                         await _versionDataCacheFile.TryToUpdateCacheFileAsync();
                     }


### PR DESCRIPTION
Fixes [AB#1371899](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1371899) where a file read is performed on the UI thread, which can lead to UI delays.

We also avoid reading the file in one scenario, where we only want to verify the existence of the file and would ignore the read contents anyway.

There is also a URL download that has moved from the UI thread to a background thread, however this was an async path so less likely to block.

The file read here is synchronous, so this change will unblock the UI thread while the file is being read. #7549 tracks making this (and other) file IO async, so it won't block thread pool threads either.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7550)