### PR TITLE
Use asynchronous IO for file reads and writes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Web/RemoteCacheFile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Web/RemoteCacheFile.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
 
                 // Make sure it is valid data before we write to the file (will throw on failure, we don't need the returned data)
                 VersionCompatibilityData.DeserializeVersionData(downLoadedVersionData);
-                _fileSystem.WriteAllText(_cacheFilePath, downLoadedVersionData);
+                await _fileSystem.WriteAllTextAsync(_cacheFilePath, downLoadedVersionData);
                 callBackOnSuccess?.Invoke();
             }
             catch

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Web/RemoteCacheFile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Web/RemoteCacheFile.cs
@@ -37,19 +37,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
         /// <summary>
         /// If the cached file exists reads the data and returns it as a string
         /// </summary>
-        public string? ReadCacheFile()
+        public async Task<string?> ReadCacheFileAsync()
         {
             try
             {
                 // If the cached file exists read it
                 if (_fileSystem.FileExists(_cacheFilePath))
                 {
-                    return _fileSystem.ReadAllText(_cacheFilePath);
+                    return await _fileSystem.ReadAllTextAsync(_cacheFilePath);
                 }
             }
             catch (System.IO.IOException)
             {
             }
+
             return null;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Web/RemoteCacheFile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Web/RemoteCacheFile.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
             try
             {
                 // If the cached file exists read it
-                if (_fileSystem.FileExists(_cacheFilePath))
+                if (CacheFileExists())
                 {
                     return await _fileSystem.ReadAllTextAsync(_cacheFilePath);
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetector.cs
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                         // Run on the background
                         await TaskScheduler.Default;
 
-                        VersionCompatibilityData compatData = GetVersionCompatibilityData();
+                        VersionCompatibilityData compatData = await GetVersionCompatibilityDataAsync();
 
                         // We need to check if this project has been newly created. Our projects will implement IProjectCreationState -we can 
                         // skip any that don't
@@ -220,7 +220,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             // Run on the background
             await TaskScheduler.Default;
 
-            VersionCompatibilityData compatDataToUse = GetVersionCompatibilityData();
+            VersionCompatibilityData compatDataToUse = await GetVersionCompatibilityDataAsync();
             CompatibilityLevel finalCompatLevel = CompatibilityLevel.Recommended;
             IProjectService projectService = _projectServiceAccessor.Value.GetProjectService();
             IEnumerable<UnconfiguredProject> projects = projectService.LoadedUnconfiguredProjects;
@@ -427,7 +427,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// less than 24 hours old, it uses that data. Otherwise it downloads from the server. If the download fails it will use the previously cached
         /// file, or if that file doesn't not exist, it uses the data baked into this class
         /// </summary>
-        private VersionCompatibilityData GetVersionCompatibilityData()
+        private async Task<VersionCompatibilityData> GetVersionCompatibilityDataAsync()
         {
             // Do we need to update our cached data? Note that since the download could take a long time like tens of seconds we don't really want to
             // start showing messages to the user well after their project is opened and they are interacting with it. Thus we start a task to update the 
@@ -440,7 +440,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             try
             {
                 // Try the cache file
-                Dictionary<Version, VersionCompatibilityData>? versionCompatData = GetCompatibilityDataFromCacheFile();
+                Dictionary<Version, VersionCompatibilityData>? versionCompatData = await GetCompatibilityDataFromCacheFileAsync();
 
                 // See if the cache file needs refreshing and if so, kick off a task to do so
                 if (_versionDataCacheFile?.CacheFileIsStale() == true)
@@ -494,11 +494,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// <summary>
         /// If the cached file exists reads the data and returns it
         /// </summary>
-        private Dictionary<Version, VersionCompatibilityData>? GetCompatibilityDataFromCacheFile()
+        private async Task<Dictionary<Version, VersionCompatibilityData>?> GetCompatibilityDataFromCacheFileAsync()
         {
+            if (_versionDataCacheFile is null)
+            {
+                return null;
+            }
+
             try
             {
-                string? data = _versionDataCacheFile?.ReadCacheFile();
+                string? data = await _versionDataCacheFile.ReadCacheFileAsync();
+
                 if (data != null)
                 {
                     return VersionCompatibilityData.DeserializeVersionData(data);
@@ -507,6 +513,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             catch
             {
             }
+
             return null;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.IO
     [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IFileSystem
     {
-        Stream Create(string path);
+        void Create(string path);
 
         bool PathExists(string path);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.ProjectSystem;
@@ -25,10 +24,7 @@ namespace Microsoft.VisualStudio.IO
         void RemoveFile(string path);
         void CopyFile(string source, string destination, bool overwrite);
         Task<string> ReadAllTextAsync(string path);
-        void WriteAllText(string path, string content);
         Task WriteAllTextAsync(string path, string content);
-        void WriteAllText(string path, string content, Encoding encoding);
-        void WriteAllBytes(string path, byte[] bytes);
 
         /// <summary>
         ///     Return the date and time, in coordinated universal time (UTC), that the specified file or directory was last written to,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.ProjectSystem;
@@ -41,29 +39,8 @@ namespace Microsoft.VisualStudio.IO
         /// </returns>
         bool TryGetLastFileWriteTimeUtc(string path, [NotNullWhen(true)]out DateTime? result);
 
-        long FileLength(string filename);
-
         bool DirectoryExists(string path);
         void CreateDirectory(string path);
-        void RemoveDirectory(string path, bool recursive);
-        void SetDirectoryAttribute(string path, FileAttributes newAttribute);
-        string GetCurrentDirectory();
-        void SetCurrentDirectory(string directory);
         string GetFullPath(string path);
-
-        IEnumerable<string> EnumerateDirectories(string path);
-        IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption);
-        IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption);
-
-        /// <summary>
-        ///     Returns a name suitable for usage as a file or directory name.
-        /// </summary>
-        /// <returns>
-        ///     A <see cref="string"/> containing a name suitable for usage as a file or directory name.
-        /// </returns>
-        /// <remarks>
-        ///     NOTE: Unlike <see cref="Path.GetTempFileName"/>, this method does not create a zero byte file on disk.
-        /// </remarks>
-        string GetTempDirectoryOrFileName();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -24,7 +24,6 @@ namespace Microsoft.VisualStudio.IO
         bool FileExists(string path);
         void RemoveFile(string path);
         void CopyFile(string source, string destination, bool overwrite);
-        string ReadAllText(string path);
         Task<string> ReadAllTextAsync(string path);
         void WriteAllText(string path, string content);
         void WriteAllText(string path, string content, Encoding encoding);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.ProjectSystem;
 
@@ -24,6 +25,7 @@ namespace Microsoft.VisualStudio.IO
         void RemoveFile(string path);
         void CopyFile(string source, string destination, bool overwrite);
         string ReadAllText(string path);
+        Task<string> ReadAllTextAsync(string path);
         void WriteAllText(string path, string content);
         void WriteAllText(string path, string content, Encoding encoding);
         void WriteAllBytes(string path, byte[] bytes);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -26,6 +26,7 @@ namespace Microsoft.VisualStudio.IO
         void CopyFile(string source, string destination, bool overwrite);
         Task<string> ReadAllTextAsync(string path);
         void WriteAllText(string path, string content);
+        Task WriteAllTextAsync(string path, string content);
         void WriteAllText(string path, string content, Encoding encoding);
         void WriteAllBytes(string path, byte[] bytes);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.IO
 {
@@ -49,6 +50,13 @@ namespace Microsoft.VisualStudio.IO
         public string ReadAllText(string path)
         {
             return File.ReadAllText(path);
+        }
+
+        public async Task<string> ReadAllTextAsync(string path)
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read);
+            using var reader = new StreamReader(stream);
+            return await reader.ReadToEndAsync();
         }
 
         public void WriteAllText(string path, string content)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
@@ -59,6 +59,13 @@ namespace Microsoft.VisualStudio.IO
             File.WriteAllText(path, content);
         }
 
+        public async Task WriteAllTextAsync(string path, string content)
+        {
+            using var stream = new FileStream(path, FileMode.Create, FileAccess.Write);
+            using var writer = new StreamWriter(stream);
+            await writer.WriteAsync(content);
+        }
+
         public void WriteAllText(string path, string content, Encoding encoding)
         {
             File.WriteAllText(path, content, encoding);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
@@ -19,9 +19,9 @@ namespace Microsoft.VisualStudio.IO
     {
         private static readonly DateTime s_minFileTime = DateTime.FromFileTimeUtc(0);
 
-        public Stream Create(string path)
+        public void Create(string path)
         {
-            return File.Create(path);
+            File.Create(path).Dispose();
         }
 
         public bool FileExists(string path)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
@@ -47,11 +47,6 @@ namespace Microsoft.VisualStudio.IO
             File.Copy(source, destination, overwrite);
         }
 
-        public string ReadAllText(string path)
-        {
-            return File.ReadAllText(path);
-        }
-
         public async Task<string> ReadAllTextAsync(string path)
         {
             using var stream = new FileStream(path, FileMode.Open, FileAccess.Read);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -91,11 +90,6 @@ namespace Microsoft.VisualStudio.IO
             return false;
         }
 
-        public long FileLength(string path)
-        {
-            return new FileInfo(path).Length;
-        }
-
         public bool DirectoryExists(string dirPath)
         {
             return Directory.Exists(dirPath);
@@ -106,55 +100,9 @@ namespace Microsoft.VisualStudio.IO
             Directory.CreateDirectory(dirPath);
         }
 
-        public void RemoveDirectory(string path, bool recursive)
-        {
-            Directory.Delete(path, recursive);
-        }
-
-        public void SetDirectoryAttribute(string path, FileAttributes newAttribute)
-        {
-            var di = new DirectoryInfo(path);
-            if ((di.Attributes & newAttribute) != newAttribute)
-            {
-                di.Attributes |= newAttribute;
-            }
-        }
-
-        public string GetCurrentDirectory()
-        {
-            return Directory.GetCurrentDirectory();
-        }
-
-        public void SetCurrentDirectory(string directory)
-        {
-            Directory.SetCurrentDirectory(directory);
-        }
-
         public string GetFullPath(string path)
         {
             return Path.GetFullPath(path);
-        }
-
-        public IEnumerable<string> EnumerateDirectories(string path)
-        {
-            return Directory.EnumerateDirectories(path);
-        }
-
-        public IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
-        {
-            return Directory.EnumerateDirectories(path, searchPattern, searchOption);
-        }
-
-        public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
-        {
-            return Directory.EnumerateFiles(path, searchPattern, searchOption);
-        }
-
-        public string GetTempDirectoryOrFileName()
-        {
-            string fileNameWithoutPath = Path.GetRandomFileName();
-
-            return Path.Combine(Path.GetTempPath(), fileNameWithoutPath);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.IO
@@ -54,26 +53,11 @@ namespace Microsoft.VisualStudio.IO
             return await reader.ReadToEndAsync();
         }
 
-        public void WriteAllText(string path, string content)
-        {
-            File.WriteAllText(path, content);
-        }
-
         public async Task WriteAllTextAsync(string path, string content)
         {
             using var stream = new FileStream(path, FileMode.Create, FileAccess.Write);
             using var writer = new StreamWriter(stream);
             await writer.WriteAsync(content);
-        }
-
-        public void WriteAllText(string path, string content, Encoding encoding)
-        {
-            File.WriteAllText(path, content, encoding);
-        }
-
-        public void WriteAllBytes(string path, byte[] bytes)
-        {
-            File.WriteAllBytes(path, bytes);
         }
 
         public DateTime GetLastFileWriteTimeOrMinValueUtc(string path)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -510,7 +510,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 string jsonString = JsonConvert.SerializeObject(serializationData, Formatting.Indented, settings);
 
                 IgnoreFileChanges = true;
-                _fileSystem.WriteAllText(fileName, jsonString);
+                await _fileSystem.WriteAllTextAsync(fileName, jsonString);
 
                 // Update the last write time
                 LastSettingsFileSyncTimeUtc = _fileSystem.GetLastFileWriteTimeOrMinValueUtc(fileName);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -423,7 +423,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             string fileName = await GetLaunchSettingsFilePathAsync();
 
-            string jsonString = _fileSystem.ReadAllText(fileName);
+            string jsonString = await _fileSystem.ReadAllTextAsync(fileName);
 
             // Since the sections in the settings file are extensible we iterate through each one and have the appropriate provider
             // serialize their section. Unfortunately, this means the data is string to object which is messy to deal with

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
@@ -45,9 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             string fullPath = _project.MakeRooted(path);
 
-            using (_fileSystem.Value.Create(fullPath))
-            {
-            }
+            _fileSystem.Value.Create(fullPath);
 
             await _configuredImports.Value.SourceItemsProvider.AddAsync(fullPath);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
@@ -53,9 +53,6 @@ namespace Microsoft.VisualStudio.IO
 
             if (readAllTextFunc is not null)
             {
-                mock.Setup(f => f.ReadAllText(It.IsAny<string>()))
-                    .Returns(readAllTextFunc);
-
                 mock.Setup(f => f.ReadAllTextAsync(It.IsAny<string>()))
                     .Returns((Func<string, Task<string>>)(path => Task.FromResult(readAllTextFunc(path))));
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.IO;
 using System.Threading.Tasks;
 using Moq;
 
@@ -24,11 +23,11 @@ namespace Microsoft.VisualStudio.IO
             return Mock.Of<IFileSystem>();
         }
 
-        public static IFileSystem ImplementCreate(Func<string, Stream> action)
+        public static IFileSystem ImplementCreate(Action<string> action)
         {
             var mock = new Mock<IFileSystem>();
             mock.Setup(f => f.Create(It.IsAny<string>()))
-                .Returns(action);
+                .Callback(action);
 
             return mock.Object;
         }
@@ -44,7 +43,6 @@ namespace Microsoft.VisualStudio.IO
 
         public static IFileSystem Create(
             Func<string, bool> existsFunc,
-            Func<string, FileStream>? createFunc = null,
             Func<string, string>? readAllTextFunc = null)
         {
             var mock = new Mock<IFileSystem>();
@@ -55,11 +53,6 @@ namespace Microsoft.VisualStudio.IO
             {
                 mock.Setup(f => f.ReadAllTextAsync(It.IsAny<string>()))
                     .Returns((Func<string, Task<string>>)(path => Task.FromResult(readAllTextFunc(path))));
-            }
-
-            if (createFunc is not null)
-            {
-                mock.Setup(f => f.Create(It.IsAny<string>())).Returns(createFunc);
             }
 
             return mock.Object;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using Moq;
 
 namespace Microsoft.VisualStudio.IO
@@ -49,9 +50,17 @@ namespace Microsoft.VisualStudio.IO
             var mock = new Mock<IFileSystem>();
 
             mock.Setup(f => f.FileExists(It.IsAny<string>())).Returns(existsFunc);
-            mock.Setup(f => f.ReadAllText(It.IsAny<string>())).Returns(readAllTextFunc);
 
-            if (createFunc != null)
+            if (readAllTextFunc is not null)
+            {
+                mock.Setup(f => f.ReadAllText(It.IsAny<string>()))
+                    .Returns(readAllTextFunc);
+
+                mock.Setup(f => f.ReadAllTextAsync(It.IsAny<string>()))
+                    .Returns((Func<string, Task<string>>)(path => Task.FromResult(readAllTextFunc(path))));
+            }
+
+            if (createFunc is not null)
             {
                 mock.Setup(f => f.Create(It.IsAny<string>())).Returns(createFunc);
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -51,12 +51,9 @@ namespace Microsoft.VisualStudio.IO
 
         public Dictionary<string, FileData> Files { get; } = new Dictionary<string, FileData>(StringComparer.OrdinalIgnoreCase);
 
-        public Stream Create(string path)
+        public void Create(string path)
         {
-            WriteAllText(path, "");
-
-            // Caller does not check the return value.
-            return null!;
+            _ = WriteAllTextAsync(path, "");
         }
 
         public void AddFile(string path, DateTime? lastWriteTime = null)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -189,23 +189,9 @@ namespace Microsoft.VisualStudio.IO
             }
         }
 
-        public string ReadAllText(string path)
-        {
-            if (!FileExists(path))
-            {
-                throw new FileNotFoundException();
-            }
-            return Files[path].FileContents!;
-        }
-
         public Task<string> ReadAllTextAsync(string path)
         {
-            if (!Files.TryGetValue(path, out FileData fileData))
-            {
-                throw new FileNotFoundException();
-            }
-
-            return Task.FromResult(fileData.FileContents!);
+            return Task.FromResult(GetFileData(path).FileContents!);
         }
 
         public void WriteAllText(string path, string content)
@@ -288,12 +274,22 @@ namespace Microsoft.VisualStudio.IO
 
         public long FileLength(string filename)
         {
-            return ReadAllText(filename).Length;
+            return GetFileData(filename).FileContents!.Length;
         }
 
         public bool PathExists(string path)
         {
             throw new NotImplementedException();
+        }
+
+        private FileData GetFileData(string path)
+        {
+            if (!Files.TryGetValue(path, out FileData fileData))
+            {
+                throw new FileNotFoundException();
+            }
+
+            return fileData;
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -199,6 +199,12 @@ namespace Microsoft.VisualStudio.IO
             WriteAllText(path, content, Encoding.Default);
         }
 
+        public Task WriteAllTextAsync(string path, string content)
+        {
+            WriteAllText(path, content, Encoding.Default);
+            return Task.CompletedTask;
+        }
+
         public void WriteAllText(string path, string content, Encoding encoding)
         {
             if (Files.TryGetValue(path, out FileData data))

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.IO
 {
@@ -195,6 +196,16 @@ namespace Microsoft.VisualStudio.IO
                 throw new FileNotFoundException();
             }
             return Files[path].FileContents!;
+        }
+
+        public Task<string> ReadAllTextAsync(string path)
+        {
+            if (!Files.TryGetValue(path, out FileData fileData))
+            {
+                throw new FileNotFoundException();
+            }
+
+            return Task.FromResult(fileData.FileContents!);
         }
 
         public void WriteAllText(string path, string content)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -191,24 +191,13 @@ namespace Microsoft.VisualStudio.IO
             return Task.FromResult(GetFileData(path).FileContents!);
         }
 
-        public void WriteAllText(string path, string content)
-        {
-            WriteAllText(path, content, Encoding.Default);
-        }
-
         public Task WriteAllTextAsync(string path, string content)
-        {
-            WriteAllText(path, content, Encoding.Default);
-            return Task.CompletedTask;
-        }
-
-        public void WriteAllText(string path, string content, Encoding encoding)
         {
             if (Files.TryGetValue(path, out FileData data))
             {
                 // This makes sure each write to the file increases the timestamp
                 data.FileContents = content;
-                data.FileEncoding = encoding;
+                data.FileEncoding = Encoding.Default;
                 data.SetLastWriteTime();
             }
             else
@@ -216,10 +205,12 @@ namespace Microsoft.VisualStudio.IO
                 Files[path] = new FileData
                 {
                     FileContents = content,
-                    FileEncoding = encoding,
+                    FileEncoding = Encoding.Default,
                     LastWriteTimeUtc = DateTime.UtcNow
                 };
             }
+
+            return Task.CompletedTask;
         }
 
         public DateTime GetLastFileWriteTimeOrMinValueUtc(string path)
@@ -269,10 +260,6 @@ namespace Microsoft.VisualStudio.IO
         public string GetTempDirectoryOrFileName()
         {
             return _tempFile!;
-        }
-
-        public void WriteAllBytes(string path, byte[] bytes)
-        {
         }
 
         public long FileLength(string filename)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var moqFS = new IFileSystemMock();
             using var provider = GetLaunchSettingsProvider(moqFS);
-            moqFS.WriteAllText(provider.LaunchSettingsFile, JsonString1);
+            await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, JsonString1);
 
             await provider.UpdateProfilesAsyncTest(null);
             Assert.Equal(4, provider.CurrentSnapshot.Profiles.Count);
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var moqFS = new IFileSystemMock();
             using var provider1 = GetLaunchSettingsProvider(moqFS);
-            moqFS.WriteAllText(provider1.LaunchSettingsFile, JsonString1);
+            await moqFS.WriteAllTextAsync(provider1.LaunchSettingsFile, JsonString1);
 
             // Change the value of activeDebugProfile to web it should be the active one. Simulates a change
             // on disk doesn't affect active profile
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var moqFS = new IFileSystemMock();
             using var provider = GetLaunchSettingsProvider(moqFS);
-            moqFS.WriteAllText(provider.LaunchSettingsFile, JsonString1);
+            await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, JsonString1);
             await provider.UpdateProfilesAsyncTest(null);
             provider.SetNextVersionTest(123);
 
@@ -150,10 +150,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var moqFS = new IFileSystemMock();
             using var provider = GetLaunchSettingsProvider(moqFS);
-            moqFS.WriteAllText(provider.LaunchSettingsFile, JsonString1);
+            await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, JsonString1);
             await provider.UpdateProfilesAsyncTest(null);
 
-            moqFS.WriteAllText(provider.LaunchSettingsFile, BadJsonString);
+            await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, BadJsonString);
             await provider.UpdateProfilesAsyncTest("Docker");
             Assert.Equal(4, provider.CurrentSnapshot.Profiles.Count);
             Assert.Empty(provider.CurrentSnapshot.GlobalSettings);
@@ -165,7 +165,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var moqFS = new IFileSystemMock();
             using var provider = GetLaunchSettingsProvider(moqFS);
-            moqFS.WriteAllText(provider.LaunchSettingsFile, BadJsonString);
+            await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, BadJsonString);
 
             await provider.UpdateProfilesAsyncTest("Docker");
             Assert.Single(provider.CurrentSnapshot.Profiles);
@@ -178,7 +178,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var moqFS = new IFileSystemMock();
             using var provider = GetLaunchSettingsProvider(moqFS);
-            moqFS.WriteAllText(provider.LaunchSettingsFile, JsonString1);
+            await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, JsonString1);
 
             var curProfiles = new Mock<ILaunchSettings>();
             curProfiles.Setup(m => m.Profiles).Returns(() =>
@@ -205,7 +205,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var moqFS = new IFileSystemMock();
             using var provider = GetLaunchSettingsProvider(moqFS);
-            moqFS.WriteAllText(provider.LaunchSettingsFile, JsonString1);
+            await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, JsonString1);
 
             var curProfiles = new Mock<ILaunchSettings>();
             curProfiles.Setup(m => m.Profiles).Returns(() =>
@@ -234,7 +234,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var moqFS = new IFileSystemMock();
             using var provider = GetLaunchSettingsProvider(moqFS);
-            moqFS.WriteAllText(provider.LaunchSettingsFile, JsonStringWithWebSettings);
+            await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, JsonStringWithWebSettings);
 
             var curProfiles = new Mock<ILaunchSettings>();
             curProfiles.Setup(m => m.Profiles).Returns(() =>
@@ -269,7 +269,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var moqFS = new IFileSystemMock();
             using var provider = GetLaunchSettingsProvider(moqFS);
             Assert.True(await provider.SettingsFileHasChangedAsyncTest());
-            moqFS.WriteAllText(provider.LaunchSettingsFile, JsonString1);
+            await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, JsonString1);
 
             Assert.True(await provider.SettingsFileHasChangedAsyncTest());
             provider.LastSettingsFileSyncTimeTest = moqFS.GetLastFileWriteTimeOrMinValueUtc(provider.LaunchSettingsFile);
@@ -292,7 +292,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var moqFS = new IFileSystemMock();
             using var provider = GetLaunchSettingsProvider(moqFS);
-            moqFS.WriteAllText(provider.LaunchSettingsFile, JsonString1);
+            await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, JsonString1);
 
             var launchSettings = await provider.ReadSettingsFileFromDiskTestAsync();
 
@@ -304,7 +304,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var moqFS = new IFileSystemMock();
             using var provider = GetLaunchSettingsProvider(moqFS);
-            moqFS.WriteAllText(provider.LaunchSettingsFile, BadJsonString);
+            await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, BadJsonString);
 
             await Assert.ThrowsAsync<JsonReaderException>(() =>
             {
@@ -317,7 +317,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var moqFS = new IFileSystemMock();
             using var provider = GetLaunchSettingsProvider(moqFS);
-            moqFS.WriteAllText(provider.LaunchSettingsFile, JsonStringWithWebSettings);
+            await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, JsonStringWithWebSettings);
 
             var launchSettings = await provider.ReadSettingsFileFromDiskTestAsync();
 
@@ -331,7 +331,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var moqFS = new IFileSystemMock();
             using var provider = GetLaunchSettingsProvider(moqFS);
-            moqFS.WriteAllText(provider.LaunchSettingsFile, JsonStringWithWebSettings);
+            await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, JsonStringWithWebSettings);
 
             // Set the serialization provider
             SetJsonSerializationProviders(provider);
@@ -390,7 +390,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var moqFS = new IFileSystemMock();
             using var provider = GetLaunchSettingsProvider(moqFS);
             provider.SetNextVersionTest(123);
-            moqFS.WriteAllText(provider.LaunchSettingsFile, JsonString1);
+            await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, JsonString1);
             // Wait for completion of task
             await provider.LaunchSettingsFile_ChangedTest();
 
@@ -406,7 +406,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             using var provider = GetLaunchSettingsProvider(moqFS);
             string fileName = await provider.GetLaunchSettingsFilePathNoCacheAsync();
             // Write file and generate disk change
-            moqFS.WriteAllText(fileName, JsonString1);
+            await moqFS.WriteAllTextAsync(fileName, JsonString1);
 
             // Set the ignore flag. It should be ignored.
             provider.LastSettingsFileSyncTimeTest = DateTime.MinValue;
@@ -426,17 +426,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var moqFS = new IFileSystemMock();
             using var provider = GetLaunchSettingsProvider(moqFS);
-            moqFS.WriteAllText(provider.LaunchSettingsFile, JsonString1);
+            await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, JsonString1);
             await provider.LaunchSettingsFile_ChangedTest();
             Assert.Equal(4, provider.CurrentSnapshot.Profiles.Count);
 
             // Write new file, but set the timestamp to match
-            moqFS.WriteAllText(provider.LaunchSettingsFile, JsonStringWithWebSettings);
+            await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, JsonStringWithWebSettings);
             provider.LastSettingsFileSyncTimeTest = moqFS.GetLastFileWriteTimeOrMinValueUtc(provider.LaunchSettingsFile);
             Assert.Equal(provider.LaunchSettingsFile_ChangedTest(), Task.CompletedTask);
             AssertEx.CollectionLength(provider.CurrentSnapshot.Profiles, 4);
 
-            moqFS.WriteAllText(provider.LaunchSettingsFile, JsonStringWithWebSettings);
+            await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, JsonStringWithWebSettings);
             await provider.LaunchSettingsFile_ChangedTest();
             AssertEx.CollectionLength(provider.CurrentSnapshot.Profiles, 2);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -381,7 +381,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.Equal(moqFS.GetLastFileWriteTimeOrMinValueUtc(provider.LaunchSettingsFile), provider.LastSettingsFileSyncTimeTest);
 
             // Check disk contents
-            Assert.Equal(JsonStringWithWebSettings, moqFS.ReadAllText(provider.LaunchSettingsFile), ignoreLineEndingDifferences: true);
+            Assert.Equal(JsonStringWithWebSettings, await moqFS.ReadAllTextAsync(provider.LaunchSettingsFile), ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -498,7 +498,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             await provider.UpdateAndSaveSettingsAsync(testSettings.Object);
 
             // Check disk contents
-            Assert.Equal(JsonStringWithWebSettings, moqFS.ReadAllText(provider.LaunchSettingsFile), ignoreLineEndingDifferences: true);
+            Assert.Equal(JsonStringWithWebSettings, await moqFS.ReadAllTextAsync(provider.LaunchSettingsFile), ignoreLineEndingDifferences: true);
 
             // Check snapshot
             AssertEx.CollectionLength(provider.CurrentSnapshot.Profiles, 2);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.IO;
 using Xunit;
@@ -103,7 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             string? result = null;
             var project = UnconfiguredProjectFactory.Create(fullPath: @"C:\Project\Project.csproj");
-            var fileSystem = IFileSystemFactory.ImplementCreate((path) => { result = path; return new MemoryStream(); });
+            var fileSystem = IFileSystemFactory.ImplementCreate((path) => { result = path; });
 
             var storage = CreateInstance(fileSystem: fileSystem, project: project);
 
@@ -244,7 +243,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var project = UnconfiguredProjectFactory.Create(fullPath: projectPath);
             string? result = null;
-            var fileSystem = IFileSystemFactory.ImplementCreate(path => { result = path; return new MemoryStream(); });
+            var fileSystem = IFileSystemFactory.ImplementCreate(path => { result = path; });
 
             var storage = CreateInstance(fileSystem: fileSystem, project: project);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             var debugger = GetDebugTargetsProvider();
 
-            _mockFS.WriteAllText(@"c:\program files\dotnet\dotnet.exe", "");
+            await _mockFS.WriteAllTextAsync(@"c:\program files\dotnet\dotnet.exe", "");
             _mockFS.CreateDirectory(@"c:\test\project");
 
             var activeProfile = new LaunchProfile { Name = "MyApplication", CommandName = "Project", CommandLineArgs = "--someArgs" };
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             var debugger = GetDebugTargetsProvider();
 
-            _mockFS.WriteAllText(@"c:\program files\dotnet\dotnet.exe", "");
+            await _mockFS.WriteAllTextAsync(@"c:\program files\dotnet\dotnet.exe", "");
             _mockFS.CreateDirectory(@"c:\test\project");
 
             var activeProfile = new LaunchProfile
@@ -206,8 +206,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             var debugger = GetDebugTargetsProvider("exe", properties);
 
             // Exe relative, no working dir
-            _mockFS.WriteAllText(@"c:\test\project\bin\test.exe", string.Empty);
-            _mockFS.WriteAllText(@"c:\test\project\test.exe", string.Empty);
+            await _mockFS.WriteAllTextAsync(@"c:\test\project\bin\test.exe", string.Empty);
+            await _mockFS.WriteAllTextAsync(@"c:\test\project\test.exe", string.Empty);
             var activeProfile = new LaunchProfile { Name = "run", ExecutablePath = ".\\test.exe" };
             var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
             Assert.Single(targets);
@@ -231,7 +231,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             var debugger = GetDebugTargetsProvider();
 
             // Exe relative to full working dir
-            _mockFS.WriteAllText(@"c:\WorkingDir\mytest.exe", string.Empty);
+            await _mockFS.WriteAllTextAsync(@"c:\WorkingDir\mytest.exe", string.Empty);
             _mockFS.SetCurrentDirectory(@"c:\Test");
             _mockFS.CreateDirectory(@"c:\WorkingDir");
             var activeProfile = new LaunchProfile { Name = "run", ExecutablePath = ".\\mytest.exe", WorkingDirectory = workingDir };
@@ -247,7 +247,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             var debugger = GetDebugTargetsProvider();
 
             // Exe relative to full working dir
-            _mockFS.WriteAllText(@"c:\WorkingDir\mytest.exe", string.Empty);
+            await _mockFS.WriteAllTextAsync(@"c:\WorkingDir\mytest.exe", string.Empty);
             _mockFS.CreateDirectory(@"c:\WorkingDir");
             var activeProfile = new LaunchProfile { Name = "run", ExecutablePath = "./mytest.exe", WorkingDirectory = @"c:/WorkingDir" };
             var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
@@ -288,7 +288,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public async Task QueryDebugTargetsAsync_ExeProfileExeRelativeToCurrentDirectory(string exeName)
         {
             var debugger = GetDebugTargetsProvider();
-            _mockFS.WriteAllText(@"c:\CurrentDirectory\myexe.exe", string.Empty);
+            await _mockFS.WriteAllTextAsync(@"c:\CurrentDirectory\myexe.exe", string.Empty);
             _mockFS.SetCurrentDirectory(@"c:\CurrentDirectory");
 
             // Exe relative to path
@@ -302,7 +302,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public async Task QueryDebugTargetsAsync_ExeProfileExeIsRootedWithNoDrive()
         {
             var debugger = GetDebugTargetsProvider();
-            _mockFS.WriteAllText(@"e:\myexe.exe", string.Empty);
+            await _mockFS.WriteAllTextAsync(@"e:\myexe.exe", string.Empty);
             _mockFS.SetCurrentDirectory(@"e:\CurrentDirectory");
 
             // Exe relative to path
@@ -378,7 +378,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 {"TargetFrameworkIdentifier", @".NETFramework"}
             };
 
-            _mockFS.WriteAllText(@"C:\library.dll", string.Empty);
+            await _mockFS.WriteAllTextAsync(@"C:\library.dll", string.Empty);
 
             var debugger = GetDebugTargetsProvider("Library", properties);
 
@@ -396,7 +396,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 {"TargetFrameworkIdentifier", @".NETFramework"}
             };
 
-            _mockFS.WriteAllText(@"C:\library.dll", string.Empty);
+            await _mockFS.WriteAllTextAsync(@"C:\library.dll", string.Empty);
 
             var debugger = GetDebugTargetsProvider("Library", properties);
 
@@ -577,7 +577,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             string? workingDir = null;
             var debugger = GetDebugTargetsProvider();
             var profileName = "run";
-            _mockFS.WriteAllText(executable, "");
+            _mockFS.Create(executable);
 
             debugger.ValidateSettings(executable, workingDir!, profileName);
             Assert.True(true);
@@ -685,10 +685,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
         private ProjectLaunchTargetsProvider GetDebugTargetsProvider(string outputType = "exe", Dictionary<string, string?>? properties = null, IVsDebugger10? debugger = null, IProjectCapabilitiesScope? scope = null)
         {
-            _mockFS.WriteAllText(@"c:\test\Project\someapp.exe", "");
+            _mockFS.Create(@"c:\test\Project\someapp.exe");
             _mockFS.CreateDirectory(@"c:\test\Project");
             _mockFS.CreateDirectory(@"c:\test\Project\bin\");
-            _mockFS.WriteAllText(@"c:\program files\dotnet\dotnet.exe", "");
+            _mockFS.Create(@"c:\program files\dotnet\dotnet.exe");
 
             var project = UnconfiguredProjectFactory.Create(fullPath: _ProjectFile);
 


### PR DESCRIPTION
Contributes to #7549.

Our file system abstraction does not provide asynchronous methods for reading and writing files. We should avoid such synchronous operations and use async ones instead, as file IO tends to be "slow", and blocking threads during IO can prevent other useful work from occurring.

This PR adds new async methods for reading and writing files. It also removes the synchronous read/write methods, along with a bunch of other abstraction methods we do not currently use.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7551)