### PR TITLE
Added new F# build properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.FSharp.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.FSharp.xaml
@@ -35,20 +35,16 @@
                 HelpUrl="https://docs.microsoft.com/dotnet/fsharp/language-reference/compiler-options"
                 Category="General" />
 
-  <EnumProperty Name="FSharpPreferNetFrameworkTools"
+  <BoolProperty Name="FSharpPreferNetFrameworkTools"
               DisplayName="Framework tools"
-              Description="Specifies which compiler to use when building the project."
+              Description="Prefer .NET Framework version of the compiler when available."
               Category="General">
-    <EnumValue Name="True"
-             DisplayName=".NET Framework" />
-    <EnumValue Name="False"
-             DisplayName=".NET SDK" />
-    <EnumProperty.DataSource>
+    <BoolProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception"
                  SourceOfDefaultValue="AfterContext"
                  HasConfigurationCondition="False" />
-    </EnumProperty.DataSource>
-  </EnumProperty>
+    </BoolProperty.DataSource>
+  </BoolProperty>
 
   <BoolProperty Name="FSharpPrefer64BitTools"
             DisplayName="Prefer 64 bit tools"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.FSharp.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.FSharp.xaml
@@ -44,7 +44,7 @@
   </EnumProperty>
 
   <EnumProperty Name="FSharpPrefer64BitTools"
-            DisplayName="Perfer 64 bit tools"
+            DisplayName="Prefer 64 bit tools"
             Description="Use a 64 bit or 32 bit version of the compiler when available"
             Category="General">
     <EnumValue Name="false"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.FSharp.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.FSharp.xaml
@@ -45,7 +45,7 @@
 
   <EnumProperty Name="FSharpPrefer64BitTools"
             DisplayName="Prefer 64 bit tools"
-            Description="Use a 64 bit or 32 bit version of the compiler when available"
+            Description="Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers."
             Category="General">
     <EnumValue Name="false"
            DisplayName="32 bit compiler" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.FSharp.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.FSharp.xaml
@@ -35,7 +35,7 @@
 
   <EnumProperty Name="FSharpPreferNetFrameworkTools"
               DisplayName="Framework tools"
-              Description="Compiler to use when building the project"
+              Description="Compiler to use when building the project."
               Category="General">
     <EnumValue Name="true"
              DisplayName=".NET Framework" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.FSharp.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.FSharp.xaml
@@ -37,7 +37,7 @@
 
   <EnumProperty Name="FSharpPreferNetFrameworkTools"
               DisplayName="Framework tools"
-              Description="Compiler to use when building the project."
+              Description="Specifies which compiler to use when building the project."
               Category="General">
     <EnumValue Name="True"
              DisplayName=".NET Framework" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.FSharp.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.FSharp.xaml
@@ -33,6 +33,26 @@
                 HelpUrl="https://docs.microsoft.com/dotnet/fsharp/language-reference/compiler-options"
                 Category="General" />
 
+  <EnumProperty Name="FSharpPreferNetFrameworkTools"
+              DisplayName="Framework tools"
+              Description="Compiler to use when building the project"
+              Category="General">
+    <EnumValue Name="true"
+             DisplayName=".NET Framework" />
+    <EnumValue Name="false"
+             DisplayName=".NET SDK" />
+  </EnumProperty>
+
+  <EnumProperty Name="FSharpPrefer64BitTools"
+            DisplayName="Perfer 64 bit tools"
+            Description="Use a 64 bit or 32 bit version of the compiler when available"
+            Category="General">
+    <EnumValue Name="false"
+           DisplayName="32 bit compiler" />
+    <EnumValue Name="true"
+           DisplayName="64 bit compiler" />
+  </EnumProperty>
+
   <EnumProperty Name="DebugType"
               DisplayName="Debug symbols"
               Description="Specifies the kind of debug symbols produced during build."

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.FSharp.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.FSharp.xaml
@@ -3,7 +3,9 @@
       OverrideMode="Extend"
       xmlns="http://schemas.microsoft.com/build/2009/properties">
 
-  <!-- TODO: We need fwlink urls generated for all the help pages -->
+  <!-- TODO (https://github.com/dotnet/fsharp/issues/12102):
+       Missing HelpUrl links need to be added.
+  -->
   <EnumProperty Name="Nullable" Category="General" Visible="False" />
   <BoolProperty Name="AllowUnsafeBlocks" Category="General" Visible="False" />
 
@@ -37,21 +39,27 @@
               DisplayName="Framework tools"
               Description="Compiler to use when building the project."
               Category="General">
-    <EnumValue Name="true"
+    <EnumValue Name="True"
              DisplayName=".NET Framework" />
-    <EnumValue Name="false"
+    <EnumValue Name="False"
              DisplayName=".NET SDK" />
+    <EnumProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                 SourceOfDefaultValue="AfterContext"
+                 HasConfigurationCondition="False" />
+    </EnumProperty.DataSource>
   </EnumProperty>
 
-  <EnumProperty Name="FSharpPrefer64BitTools"
+  <BoolProperty Name="FSharpPrefer64BitTools"
             DisplayName="Prefer 64 bit tools"
             Description="Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers."
             Category="General">
-    <EnumValue Name="false"
-           DisplayName="32 bit compiler" />
-    <EnumValue Name="true"
-           DisplayName="64 bit compiler" />
-  </EnumProperty>
+    <BoolProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                 SourceOfDefaultValue="AfterContext"
+                 HasConfigurationCondition="False" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
 
   <EnumProperty Name="DebugType"
               DisplayName="Debug symbols"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.cs.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project.</source>
-        <target state="new">Compiler to use when building the project.</target>
+        <source>Specifies which compiler to use when building the project.</source>
+        <target state="new">Specifies which compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.cs.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Perfer 64 bit tools</source>
-        <target state="new">Perfer 64 bit tools</target>
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.cs.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../BuildPropertyPage.FSharp.xaml">
     <body>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</source>
+        <target state="new">Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -47,19 +57,9 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
-        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
-        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Prefer 64 bit tools</source>
-        <target state="new">Prefer 64 bit tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project</source>
-        <target state="new">Compiler to use when building the project</target>
+        <source>Compiler to use when building the project.</source>
+        <target state="new">Compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
-        <source>32 bit compiler</source>
-        <target state="new">32 bit compiler</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
-        <source>64 bit compiler</source>
-        <target state="new">64 bit compiler</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.cs.xlf
@@ -47,6 +47,26 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
+        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Perfer 64 bit tools</source>
+        <target state="new">Perfer 64 bit tools</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Compiler to use when building the project</source>
+        <target state="new">Compiler to use when building the project</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -65,6 +85,26 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
+        <source>32 bit compiler</source>
+        <target state="new">32 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
+        <source>64 bit compiler</source>
+        <target state="new">64 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+        <source>.NET SDK</source>
+        <target state="new">.NET SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+        <source>.NET Framework</source>
+        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.cs.xlf
@@ -87,12 +87,12 @@
         <target state="new">PDB file, portable across platforms</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
         <source>.NET SDK</source>
         <target state="new">.NET SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
         <source>.NET Framework</source>
         <target state="new">.NET Framework</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.cs.xlf
@@ -12,6 +12,16 @@
         <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Prefer .NET Framework version of the compiler when available.</source>
+        <target state="new">Prefer .NET Framework version of the compiler when available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -57,16 +67,6 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Specifies which compiler to use when building the project.</source>
-        <target state="new">Specifies which compiler to use when building the project.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
-        <source>Framework tools</source>
-        <target state="new">Framework tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
-        <source>.NET SDK</source>
-        <target state="new">.NET SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
-        <source>.NET Framework</source>
-        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.de.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../BuildPropertyPage.FSharp.xaml">
     <body>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</source>
+        <target state="new">Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -47,19 +57,9 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
-        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
-        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Prefer 64 bit tools</source>
-        <target state="new">Prefer 64 bit tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project</source>
-        <target state="new">Compiler to use when building the project</target>
+        <source>Compiler to use when building the project.</source>
+        <target state="new">Compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
-        <source>32 bit compiler</source>
-        <target state="new">32 bit compiler</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
-        <source>64 bit compiler</source>
-        <target state="new">64 bit compiler</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.de.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project.</source>
-        <target state="new">Compiler to use when building the project.</target>
+        <source>Specifies which compiler to use when building the project.</source>
+        <target state="new">Specifies which compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.de.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Perfer 64 bit tools</source>
-        <target state="new">Perfer 64 bit tools</target>
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.de.xlf
@@ -47,6 +47,26 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
+        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Perfer 64 bit tools</source>
+        <target state="new">Perfer 64 bit tools</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Compiler to use when building the project</source>
+        <target state="new">Compiler to use when building the project</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -65,6 +85,26 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
+        <source>32 bit compiler</source>
+        <target state="new">32 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
+        <source>64 bit compiler</source>
+        <target state="new">64 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+        <source>.NET SDK</source>
+        <target state="new">.NET SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+        <source>.NET Framework</source>
+        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.de.xlf
@@ -87,12 +87,12 @@
         <target state="new">PDB file, portable across platforms</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
         <source>.NET SDK</source>
         <target state="new">.NET SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
         <source>.NET Framework</source>
         <target state="new">.NET Framework</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.de.xlf
@@ -12,6 +12,16 @@
         <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Prefer .NET Framework version of the compiler when available.</source>
+        <target state="new">Prefer .NET Framework version of the compiler when available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -57,16 +67,6 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Specifies which compiler to use when building the project.</source>
-        <target state="new">Specifies which compiler to use when building the project.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
-        <source>Framework tools</source>
-        <target state="new">Framework tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
-        <source>.NET SDK</source>
-        <target state="new">.NET SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
-        <source>.NET Framework</source>
-        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.es.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project.</source>
-        <target state="new">Compiler to use when building the project.</target>
+        <source>Specifies which compiler to use when building the project.</source>
+        <target state="new">Specifies which compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.es.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Perfer 64 bit tools</source>
-        <target state="new">Perfer 64 bit tools</target>
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.es.xlf
@@ -47,6 +47,26 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
+        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Perfer 64 bit tools</source>
+        <target state="new">Perfer 64 bit tools</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Compiler to use when building the project</source>
+        <target state="new">Compiler to use when building the project</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -65,6 +85,26 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
+        <source>32 bit compiler</source>
+        <target state="new">32 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
+        <source>64 bit compiler</source>
+        <target state="new">64 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+        <source>.NET SDK</source>
+        <target state="new">.NET SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+        <source>.NET Framework</source>
+        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.es.xlf
@@ -87,12 +87,12 @@
         <target state="new">PDB file, portable across platforms</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
         <source>.NET SDK</source>
         <target state="new">.NET SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
         <source>.NET Framework</source>
         <target state="new">.NET Framework</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.es.xlf
@@ -12,6 +12,16 @@
         <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Prefer .NET Framework version of the compiler when available.</source>
+        <target state="new">Prefer .NET Framework version of the compiler when available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -57,16 +67,6 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Specifies which compiler to use when building the project.</source>
-        <target state="new">Specifies which compiler to use when building the project.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
-        <source>Framework tools</source>
-        <target state="new">Framework tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
-        <source>.NET SDK</source>
-        <target state="new">.NET SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
-        <source>.NET Framework</source>
-        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.es.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../BuildPropertyPage.FSharp.xaml">
     <body>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</source>
+        <target state="new">Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -47,19 +57,9 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
-        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
-        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Prefer 64 bit tools</source>
-        <target state="new">Prefer 64 bit tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project</source>
-        <target state="new">Compiler to use when building the project</target>
+        <source>Compiler to use when building the project.</source>
+        <target state="new">Compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
-        <source>32 bit compiler</source>
-        <target state="new">32 bit compiler</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
-        <source>64 bit compiler</source>
-        <target state="new">64 bit compiler</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.fr.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project.</source>
-        <target state="new">Compiler to use when building the project.</target>
+        <source>Specifies which compiler to use when building the project.</source>
+        <target state="new">Specifies which compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.fr.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Perfer 64 bit tools</source>
-        <target state="new">Perfer 64 bit tools</target>
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.fr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../BuildPropertyPage.FSharp.xaml">
     <body>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</source>
+        <target state="new">Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -47,19 +57,9 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
-        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
-        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Prefer 64 bit tools</source>
-        <target state="new">Prefer 64 bit tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project</source>
-        <target state="new">Compiler to use when building the project</target>
+        <source>Compiler to use when building the project.</source>
+        <target state="new">Compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
-        <source>32 bit compiler</source>
-        <target state="new">32 bit compiler</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
-        <source>64 bit compiler</source>
-        <target state="new">64 bit compiler</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.fr.xlf
@@ -47,6 +47,26 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
+        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Perfer 64 bit tools</source>
+        <target state="new">Perfer 64 bit tools</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Compiler to use when building the project</source>
+        <target state="new">Compiler to use when building the project</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -65,6 +85,26 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
+        <source>32 bit compiler</source>
+        <target state="new">32 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
+        <source>64 bit compiler</source>
+        <target state="new">64 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+        <source>.NET SDK</source>
+        <target state="new">.NET SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+        <source>.NET Framework</source>
+        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.fr.xlf
@@ -87,12 +87,12 @@
         <target state="new">PDB file, portable across platforms</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
         <source>.NET SDK</source>
         <target state="new">.NET SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
         <source>.NET Framework</source>
         <target state="new">.NET Framework</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.fr.xlf
@@ -12,6 +12,16 @@
         <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Prefer .NET Framework version of the compiler when available.</source>
+        <target state="new">Prefer .NET Framework version of the compiler when available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -57,16 +67,6 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Specifies which compiler to use when building the project.</source>
-        <target state="new">Specifies which compiler to use when building the project.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
-        <source>Framework tools</source>
-        <target state="new">Framework tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
-        <source>.NET SDK</source>
-        <target state="new">.NET SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
-        <source>.NET Framework</source>
-        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.it.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../BuildPropertyPage.FSharp.xaml">
     <body>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</source>
+        <target state="new">Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -47,19 +57,9 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
-        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
-        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Prefer 64 bit tools</source>
-        <target state="new">Prefer 64 bit tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project</source>
-        <target state="new">Compiler to use when building the project</target>
+        <source>Compiler to use when building the project.</source>
+        <target state="new">Compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
-        <source>32 bit compiler</source>
-        <target state="new">32 bit compiler</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
-        <source>64 bit compiler</source>
-        <target state="new">64 bit compiler</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.it.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project.</source>
-        <target state="new">Compiler to use when building the project.</target>
+        <source>Specifies which compiler to use when building the project.</source>
+        <target state="new">Specifies which compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.it.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Perfer 64 bit tools</source>
-        <target state="new">Perfer 64 bit tools</target>
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.it.xlf
@@ -47,6 +47,26 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
+        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Perfer 64 bit tools</source>
+        <target state="new">Perfer 64 bit tools</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Compiler to use when building the project</source>
+        <target state="new">Compiler to use when building the project</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -65,6 +85,26 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
+        <source>32 bit compiler</source>
+        <target state="new">32 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
+        <source>64 bit compiler</source>
+        <target state="new">64 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+        <source>.NET SDK</source>
+        <target state="new">.NET SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+        <source>.NET Framework</source>
+        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.it.xlf
@@ -87,12 +87,12 @@
         <target state="new">PDB file, portable across platforms</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
         <source>.NET SDK</source>
         <target state="new">.NET SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
         <source>.NET Framework</source>
         <target state="new">.NET Framework</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.it.xlf
@@ -12,6 +12,16 @@
         <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Prefer .NET Framework version of the compiler when available.</source>
+        <target state="new">Prefer .NET Framework version of the compiler when available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -57,16 +67,6 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Specifies which compiler to use when building the project.</source>
-        <target state="new">Specifies which compiler to use when building the project.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
-        <source>Framework tools</source>
-        <target state="new">Framework tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
-        <source>.NET SDK</source>
-        <target state="new">.NET SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
-        <source>.NET Framework</source>
-        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ja.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project.</source>
-        <target state="new">Compiler to use when building the project.</target>
+        <source>Specifies which compiler to use when building the project.</source>
+        <target state="new">Specifies which compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ja.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Perfer 64 bit tools</source>
-        <target state="new">Perfer 64 bit tools</target>
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ja.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../BuildPropertyPage.FSharp.xaml">
     <body>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</source>
+        <target state="new">Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -47,19 +57,9 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
-        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
-        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Prefer 64 bit tools</source>
-        <target state="new">Prefer 64 bit tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project</source>
-        <target state="new">Compiler to use when building the project</target>
+        <source>Compiler to use when building the project.</source>
+        <target state="new">Compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
-        <source>32 bit compiler</source>
-        <target state="new">32 bit compiler</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
-        <source>64 bit compiler</source>
-        <target state="new">64 bit compiler</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ja.xlf
@@ -47,6 +47,26 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
+        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Perfer 64 bit tools</source>
+        <target state="new">Perfer 64 bit tools</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Compiler to use when building the project</source>
+        <target state="new">Compiler to use when building the project</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -65,6 +85,26 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
+        <source>32 bit compiler</source>
+        <target state="new">32 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
+        <source>64 bit compiler</source>
+        <target state="new">64 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+        <source>.NET SDK</source>
+        <target state="new">.NET SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+        <source>.NET Framework</source>
+        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ja.xlf
@@ -87,12 +87,12 @@
         <target state="new">PDB file, portable across platforms</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
         <source>.NET SDK</source>
         <target state="new">.NET SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
         <source>.NET Framework</source>
         <target state="new">.NET Framework</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ja.xlf
@@ -12,6 +12,16 @@
         <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Prefer .NET Framework version of the compiler when available.</source>
+        <target state="new">Prefer .NET Framework version of the compiler when available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -57,16 +67,6 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Specifies which compiler to use when building the project.</source>
-        <target state="new">Specifies which compiler to use when building the project.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
-        <source>Framework tools</source>
-        <target state="new">Framework tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
-        <source>.NET SDK</source>
-        <target state="new">.NET SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
-        <source>.NET Framework</source>
-        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ko.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../BuildPropertyPage.FSharp.xaml">
     <body>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</source>
+        <target state="new">Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -47,19 +57,9 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
-        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
-        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Prefer 64 bit tools</source>
-        <target state="new">Prefer 64 bit tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project</source>
-        <target state="new">Compiler to use when building the project</target>
+        <source>Compiler to use when building the project.</source>
+        <target state="new">Compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
-        <source>32 bit compiler</source>
-        <target state="new">32 bit compiler</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
-        <source>64 bit compiler</source>
-        <target state="new">64 bit compiler</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ko.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project.</source>
-        <target state="new">Compiler to use when building the project.</target>
+        <source>Specifies which compiler to use when building the project.</source>
+        <target state="new">Specifies which compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ko.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Perfer 64 bit tools</source>
-        <target state="new">Perfer 64 bit tools</target>
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ko.xlf
@@ -47,6 +47,26 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
+        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Perfer 64 bit tools</source>
+        <target state="new">Perfer 64 bit tools</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Compiler to use when building the project</source>
+        <target state="new">Compiler to use when building the project</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -65,6 +85,26 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
+        <source>32 bit compiler</source>
+        <target state="new">32 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
+        <source>64 bit compiler</source>
+        <target state="new">64 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+        <source>.NET SDK</source>
+        <target state="new">.NET SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+        <source>.NET Framework</source>
+        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ko.xlf
@@ -87,12 +87,12 @@
         <target state="new">PDB file, portable across platforms</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
         <source>.NET SDK</source>
         <target state="new">.NET SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
         <source>.NET Framework</source>
         <target state="new">.NET Framework</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ko.xlf
@@ -12,6 +12,16 @@
         <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Prefer .NET Framework version of the compiler when available.</source>
+        <target state="new">Prefer .NET Framework version of the compiler when available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -57,16 +67,6 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Specifies which compiler to use when building the project.</source>
-        <target state="new">Specifies which compiler to use when building the project.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
-        <source>Framework tools</source>
-        <target state="new">Framework tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
-        <source>.NET SDK</source>
-        <target state="new">.NET SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
-        <source>.NET Framework</source>
-        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pl.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../BuildPropertyPage.FSharp.xaml">
     <body>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</source>
+        <target state="new">Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -47,19 +57,9 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
-        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
-        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Prefer 64 bit tools</source>
-        <target state="new">Prefer 64 bit tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project</source>
-        <target state="new">Compiler to use when building the project</target>
+        <source>Compiler to use when building the project.</source>
+        <target state="new">Compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
-        <source>32 bit compiler</source>
-        <target state="new">32 bit compiler</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
-        <source>64 bit compiler</source>
-        <target state="new">64 bit compiler</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pl.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project.</source>
-        <target state="new">Compiler to use when building the project.</target>
+        <source>Specifies which compiler to use when building the project.</source>
+        <target state="new">Specifies which compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pl.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Perfer 64 bit tools</source>
-        <target state="new">Perfer 64 bit tools</target>
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pl.xlf
@@ -47,6 +47,26 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
+        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Perfer 64 bit tools</source>
+        <target state="new">Perfer 64 bit tools</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Compiler to use when building the project</source>
+        <target state="new">Compiler to use when building the project</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -65,6 +85,26 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
+        <source>32 bit compiler</source>
+        <target state="new">32 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
+        <source>64 bit compiler</source>
+        <target state="new">64 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+        <source>.NET SDK</source>
+        <target state="new">.NET SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+        <source>.NET Framework</source>
+        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pl.xlf
@@ -87,12 +87,12 @@
         <target state="new">PDB file, portable across platforms</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
         <source>.NET SDK</source>
         <target state="new">.NET SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
         <source>.NET Framework</source>
         <target state="new">.NET Framework</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pl.xlf
@@ -12,6 +12,16 @@
         <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Prefer .NET Framework version of the compiler when available.</source>
+        <target state="new">Prefer .NET Framework version of the compiler when available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -57,16 +67,6 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Specifies which compiler to use when building the project.</source>
-        <target state="new">Specifies which compiler to use when building the project.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
-        <source>Framework tools</source>
-        <target state="new">Framework tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
-        <source>.NET SDK</source>
-        <target state="new">.NET SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
-        <source>.NET Framework</source>
-        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pt-BR.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../BuildPropertyPage.FSharp.xaml">
     <body>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</source>
+        <target state="new">Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -47,19 +57,9 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
-        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
-        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Prefer 64 bit tools</source>
-        <target state="new">Prefer 64 bit tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project</source>
-        <target state="new">Compiler to use when building the project</target>
+        <source>Compiler to use when building the project.</source>
+        <target state="new">Compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
-        <source>32 bit compiler</source>
-        <target state="new">32 bit compiler</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
-        <source>64 bit compiler</source>
-        <target state="new">64 bit compiler</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pt-BR.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project.</source>
-        <target state="new">Compiler to use when building the project.</target>
+        <source>Specifies which compiler to use when building the project.</source>
+        <target state="new">Specifies which compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pt-BR.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Perfer 64 bit tools</source>
-        <target state="new">Perfer 64 bit tools</target>
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pt-BR.xlf
@@ -47,6 +47,26 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
+        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Perfer 64 bit tools</source>
+        <target state="new">Perfer 64 bit tools</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Compiler to use when building the project</source>
+        <target state="new">Compiler to use when building the project</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -65,6 +85,26 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
+        <source>32 bit compiler</source>
+        <target state="new">32 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
+        <source>64 bit compiler</source>
+        <target state="new">64 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+        <source>.NET SDK</source>
+        <target state="new">.NET SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+        <source>.NET Framework</source>
+        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pt-BR.xlf
@@ -87,12 +87,12 @@
         <target state="new">PDB file, portable across platforms</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
         <source>.NET SDK</source>
         <target state="new">.NET SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
         <source>.NET Framework</source>
         <target state="new">.NET Framework</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pt-BR.xlf
@@ -12,6 +12,16 @@
         <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Prefer .NET Framework version of the compiler when available.</source>
+        <target state="new">Prefer .NET Framework version of the compiler when available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -57,16 +67,6 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Specifies which compiler to use when building the project.</source>
-        <target state="new">Specifies which compiler to use when building the project.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
-        <source>Framework tools</source>
-        <target state="new">Framework tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
-        <source>.NET SDK</source>
-        <target state="new">.NET SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
-        <source>.NET Framework</source>
-        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ru.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../BuildPropertyPage.FSharp.xaml">
     <body>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</source>
+        <target state="new">Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -47,19 +57,9 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
-        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
-        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Prefer 64 bit tools</source>
-        <target state="new">Prefer 64 bit tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project</source>
-        <target state="new">Compiler to use when building the project</target>
+        <source>Compiler to use when building the project.</source>
+        <target state="new">Compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
-        <source>32 bit compiler</source>
-        <target state="new">32 bit compiler</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
-        <source>64 bit compiler</source>
-        <target state="new">64 bit compiler</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ru.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project.</source>
-        <target state="new">Compiler to use when building the project.</target>
+        <source>Specifies which compiler to use when building the project.</source>
+        <target state="new">Specifies which compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ru.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Perfer 64 bit tools</source>
-        <target state="new">Perfer 64 bit tools</target>
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ru.xlf
@@ -47,6 +47,26 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
+        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Perfer 64 bit tools</source>
+        <target state="new">Perfer 64 bit tools</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Compiler to use when building the project</source>
+        <target state="new">Compiler to use when building the project</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -65,6 +85,26 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
+        <source>32 bit compiler</source>
+        <target state="new">32 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
+        <source>64 bit compiler</source>
+        <target state="new">64 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+        <source>.NET SDK</source>
+        <target state="new">.NET SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+        <source>.NET Framework</source>
+        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ru.xlf
@@ -87,12 +87,12 @@
         <target state="new">PDB file, portable across platforms</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
         <source>.NET SDK</source>
         <target state="new">.NET SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
         <source>.NET Framework</source>
         <target state="new">.NET Framework</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ru.xlf
@@ -12,6 +12,16 @@
         <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Prefer .NET Framework version of the compiler when available.</source>
+        <target state="new">Prefer .NET Framework version of the compiler when available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -57,16 +67,6 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Specifies which compiler to use when building the project.</source>
-        <target state="new">Specifies which compiler to use when building the project.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
-        <source>Framework tools</source>
-        <target state="new">Framework tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
-        <source>.NET SDK</source>
-        <target state="new">.NET SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
-        <source>.NET Framework</source>
-        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.tr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../BuildPropertyPage.FSharp.xaml">
     <body>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</source>
+        <target state="new">Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -47,19 +57,9 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
-        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
-        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Prefer 64 bit tools</source>
-        <target state="new">Prefer 64 bit tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project</source>
-        <target state="new">Compiler to use when building the project</target>
+        <source>Compiler to use when building the project.</source>
+        <target state="new">Compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
-        <source>32 bit compiler</source>
-        <target state="new">32 bit compiler</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
-        <source>64 bit compiler</source>
-        <target state="new">64 bit compiler</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.tr.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project.</source>
-        <target state="new">Compiler to use when building the project.</target>
+        <source>Specifies which compiler to use when building the project.</source>
+        <target state="new">Specifies which compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.tr.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Perfer 64 bit tools</source>
-        <target state="new">Perfer 64 bit tools</target>
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.tr.xlf
@@ -47,6 +47,26 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
+        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Perfer 64 bit tools</source>
+        <target state="new">Perfer 64 bit tools</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Compiler to use when building the project</source>
+        <target state="new">Compiler to use when building the project</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -65,6 +85,26 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
+        <source>32 bit compiler</source>
+        <target state="new">32 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
+        <source>64 bit compiler</source>
+        <target state="new">64 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+        <source>.NET SDK</source>
+        <target state="new">.NET SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+        <source>.NET Framework</source>
+        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.tr.xlf
@@ -87,12 +87,12 @@
         <target state="new">PDB file, portable across platforms</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
         <source>.NET SDK</source>
         <target state="new">.NET SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
         <source>.NET Framework</source>
         <target state="new">.NET Framework</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.tr.xlf
@@ -12,6 +12,16 @@
         <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Prefer .NET Framework version of the compiler when available.</source>
+        <target state="new">Prefer .NET Framework version of the compiler when available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -57,16 +67,6 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Specifies which compiler to use when building the project.</source>
-        <target state="new">Specifies which compiler to use when building the project.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
-        <source>Framework tools</source>
-        <target state="new">Framework tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
-        <source>.NET SDK</source>
-        <target state="new">.NET SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
-        <source>.NET Framework</source>
-        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hans.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project.</source>
-        <target state="new">Compiler to use when building the project.</target>
+        <source>Specifies which compiler to use when building the project.</source>
+        <target state="new">Specifies which compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hans.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Perfer 64 bit tools</source>
-        <target state="new">Perfer 64 bit tools</target>
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hans.xlf
@@ -47,6 +47,26 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
+        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Perfer 64 bit tools</source>
+        <target state="new">Perfer 64 bit tools</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Compiler to use when building the project</source>
+        <target state="new">Compiler to use when building the project</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -65,6 +85,26 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
+        <source>32 bit compiler</source>
+        <target state="new">32 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
+        <source>64 bit compiler</source>
+        <target state="new">64 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+        <source>.NET SDK</source>
+        <target state="new">.NET SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+        <source>.NET Framework</source>
+        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hans.xlf
@@ -87,12 +87,12 @@
         <target state="new">PDB file, portable across platforms</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
         <source>.NET SDK</source>
         <target state="new">.NET SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
         <source>.NET Framework</source>
         <target state="new">.NET Framework</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hans.xlf
@@ -12,6 +12,16 @@
         <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Prefer .NET Framework version of the compiler when available.</source>
+        <target state="new">Prefer .NET Framework version of the compiler when available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -57,16 +67,6 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Specifies which compiler to use when building the project.</source>
-        <target state="new">Specifies which compiler to use when building the project.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
-        <source>Framework tools</source>
-        <target state="new">Framework tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
-        <source>.NET SDK</source>
-        <target state="new">.NET SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
-        <source>.NET Framework</source>
-        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hans.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../BuildPropertyPage.FSharp.xaml">
     <body>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</source>
+        <target state="new">Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -47,19 +57,9 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
-        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
-        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Prefer 64 bit tools</source>
-        <target state="new">Prefer 64 bit tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project</source>
-        <target state="new">Compiler to use when building the project</target>
+        <source>Compiler to use when building the project.</source>
+        <target state="new">Compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
-        <source>32 bit compiler</source>
-        <target state="new">32 bit compiler</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
-        <source>64 bit compiler</source>
-        <target state="new">64 bit compiler</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hant.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project.</source>
-        <target state="new">Compiler to use when building the project.</target>
+        <source>Specifies which compiler to use when building the project.</source>
+        <target state="new">Specifies which compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hant.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Perfer 64 bit tools</source>
-        <target state="new">Perfer 64 bit tools</target>
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hant.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../BuildPropertyPage.FSharp.xaml">
     <body>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</source>
+        <target state="new">Use a 64-bit compiler on systems that support both 32-bit and 64-bit compilers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Prefer 64 bit tools</source>
+        <target state="new">Prefer 64 bit tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -47,19 +57,9 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
-        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
-        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
-        <source>Prefer 64 bit tools</source>
-        <target state="new">Prefer 64 bit tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Compiler to use when building the project</source>
-        <target state="new">Compiler to use when building the project</target>
+        <source>Compiler to use when building the project.</source>
+        <target state="new">Compiler to use when building the project.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
-        <source>32 bit compiler</source>
-        <target state="new">32 bit compiler</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
-        <source>64 bit compiler</source>
-        <target state="new">64 bit compiler</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hant.xlf
@@ -47,6 +47,26 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|Description">
+        <source>Use a 64 bit or 32 bit version of the compiler when available</source>
+        <target state="new">Use a 64 bit or 32 bit version of the compiler when available</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPrefer64BitTools|DisplayName">
+        <source>Perfer 64 bit tools</source>
+        <target state="new">Perfer 64 bit tools</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Compiler to use when building the project</source>
+        <target state="new">Compiler to use when building the project</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -65,6 +85,26 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.false|DisplayName">
+        <source>32 bit compiler</source>
+        <target state="new">32 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPrefer64BitTools.true|DisplayName">
+        <source>64 bit compiler</source>
+        <target state="new">64 bit compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+        <source>.NET SDK</source>
+        <target state="new">.NET SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+        <source>.NET Framework</source>
+        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hant.xlf
@@ -87,12 +87,12 @@
         <target state="new">PDB file, portable across platforms</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.false|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
         <source>.NET SDK</source>
         <target state="new">.NET SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.true|DisplayName">
+      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
         <source>.NET Framework</source>
         <target state="new">.NET Framework</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hant.xlf
@@ -12,6 +12,16 @@
         <target state="new">Prefer 64 bit tools</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|Description">
+        <source>Prefer .NET Framework version of the compiler when available.</source>
+        <target state="new">Prefer .NET Framework version of the compiler when available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|FSharpPreferNetFrameworkTools|DisplayName">
+        <source>Framework tools</source>
+        <target state="new">Framework tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="new">Enable compiler optimizations for smaller, faster, and more efficient output.</target>
@@ -57,16 +67,6 @@
         <target state="new">debug type</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|Description">
-        <source>Specifies which compiler to use when building the project.</source>
-        <target state="new">Specifies which compiler to use when building the project.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|FSharpPreferNetFrameworkTools|DisplayName">
-        <source>Framework tools</source>
-        <target state="new">Framework tools</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="new">Embedded in DLL/EXE, portable across platforms</target>
@@ -85,16 +85,6 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="new">PDB file, portable across platforms</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.False|DisplayName">
-        <source>.NET SDK</source>
-        <target state="new">.NET SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|FSharpPreferNetFrameworkTools.True|DisplayName">
-        <source>.NET Framework</source>
-        <target state="new">.NET Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">


### PR DESCRIPTION
### This adds 2 dropdowns for new F# target settings:
```xml
<PropertyGroup>
    <!-- Whether to use .NET Framework or .NET SDK (coreclr) version of compiler -->
    <FSharpPreferNetFrameworkTools>true</FSharpPreferNetFrameworkTools>
    <!-- Whether to use 64 or 32 bit version of compiler -->
    <FSharpPrefer64BitTools>true</FSharpPrefer64BitTools>
  </PropertyGroup>
```

(F# Pull Request: https://github.com/dotnet/fsharp/pull/11998)

@KevinRansom - Please, have a look and let me know if the following look OK (I've used wording you've sent in the e-mail):

### Here's an overview of new Build page:
![buildpage-overview](https://user-images.githubusercontent.com/1260985/131695378-8891e664-aadb-4855-8d49-3eed29a04f1b.png)


### Here's how the `Framework tools` selector looks:
![framework-tools-overview](https://user-images.githubusercontent.com/1260985/131695411-95148083-a056-47b7-8fbb-ea6243770c66.png)
![framework-tools-expanded](https://user-images.githubusercontent.com/1260985/131695595-769b67b2-b9c5-4c8d-8784-4fcddb460372.png)


### Generated XML, when `.NET Framework` is selected:

```xml
  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
    <FSharpPreferNetFrameworkTools>true</FSharpPreferNetFrameworkTools>
  </PropertyGroup>

  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
    <FSharpPreferNetFrameworkTools>true</FSharpPreferNetFrameworkTools>
  </PropertyGroup>
```

### And when `.NET SDK` is selected:
```xml
  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
    <FSharpPreferNetFrameworkTools>false</FSharpPreferNetFrameworkTools>
  </PropertyGroup>

  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
    <FSharpPreferNetFrameworkTools>false</FSharpPreferNetFrameworkTools>
  </PropertyGroup>
```

### Here's how the `Prefer 64 bit tools` selector looks:
![prefer64bit-overview](https://user-images.githubusercontent.com/1260985/131695509-4bb01bc8-4c2b-4ca2-8da2-f845b73dbf1b.png)

![prefer64bit-expanded](https://user-images.githubusercontent.com/1260985/131695672-51cd6271-e66f-46a8-8d26-c6974a97b0d6.png)


### Generated XML, when `32 bit compiler` is selected:
```xml
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
    <FSharpPrefer64BitTools>false</FSharpPrefer64BitTools>
  </PropertyGroup>

  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
    <FSharpPrefer64BitTools>false</FSharpPrefer64BitTools>
  </PropertyGroup>
```

### And when `64 bit compiler` is selected:
```xml
  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
    <FSharpPrefer64BitTools>true</FSharpPrefer64BitTools>
  </PropertyGroup>

  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
    <FSharpPrefer64BitTools>true</FSharpPrefer64BitTools>
  </PropertyGroup>
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7552)