### PR TITLE
Condition the CollectSuggestedWorkloads target on SDK projects with MissingWorkloadPacks

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -377,7 +377,8 @@
   <!-- This target is used to collect the SuggestedWorkload items in the project.-->
   <Target Name="CollectSuggestedWorkloads"
           Returns="@(SuggestedWorkload)"
-          DependsOnTargets="GetSuggestedWorkloads" />
+          DependsOnTargets="GetSuggestedWorkloads"
+          Condition="'$(UsingMicrosoftNETSdk)' == 'true'" />
 
   <!-- Validates that the correct properties have been set for design-time compiles  -->
   <Target Name="_CheckCompileDesignTimePrerequisite">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -378,7 +378,7 @@
   <Target Name="CollectSuggestedWorkloads"
           Returns="@(SuggestedWorkload)"
           DependsOnTargets="GetSuggestedWorkloads"
-          Condition="'$(UsingMicrosoftNETSdk)' == 'true'" />
+          Condition="'@(MissingWorkloadPack)' != '' And '$(UsingMicrosoftNETSdk)' == 'true'" />
 
   <!-- Validates that the correct properties have been set for design-time compiles  -->
   <Target Name="_CheckCompileDesignTimePrerequisite">


### PR DESCRIPTION
This avoids errors about the target GetSuggestedWorkloads not existing in non-SDK projects.

Note: the GetSuggestedWorkloads target is defined in https://github.com/dotnet/sdk/blob/release/6.0.1xx/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportWorkloads.targets

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7553)