### PR TITLE
Fix NFE in the imports tree

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -206,27 +206,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
 
                                     IProjectTree updatedTree = SyncNode(
                                         imports: e.Value.Item1.Value,
-                                        tree: (IProjectTree2)currentTree.Value.Tree);
+                                        node: (IProjectTree2)currentTree.Value.Tree);
 
                                     return Task.FromResult(new TreeUpdateResult(updatedTree, e.DataSourceVersions));
                                 });
 
                             return;
 
-                            IProjectTree2 SyncNode(IReadOnlyList<IProjectImportSnapshot> imports, IProjectTree2 tree)
+                            IProjectTree2 SyncNode(IReadOnlyList<IProjectImportSnapshot> imports, IProjectTree2 node)
                             {
                                 var existingChildByPath = new Dictionary<string, IProjectTree2>(StringComparers.Paths);
 
-                                foreach (IProjectTree2 existingNode in tree.Children)
+                                foreach (IProjectTree2 existingNode in node.Children)
                                 {
                                     Assumes.NotNullOrEmpty(existingNode.FilePath);
 
                                     if (!imports.Any(import => StringComparers.Paths.Equals(import.ProjectPath, existingNode.FilePath)))
                                     {
                                         // Remove child that's no longer present
-                                        if (tree.TryFind(existingNode.Identity, out IProjectTree? child))
+                                        if (node.TryFind(existingNode.Identity, out IProjectTree? child))
                                         {
-                                            tree = (IProjectTree2)child.Remove();
+                                            node = (IProjectTree2)child.Remove();
                                         }
                                     }
                                     else
@@ -256,12 +256,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                                         // Recur down the tree
                                         newChild = SyncNode(import.Imports, newChild);
 
-                                        tree = AddChild(newChild);
+                                        node = AddChild(newChild);
                                     }
                                     else if (child.DisplayOrder != displayOrder)
                                     {
                                         // Child exists but with the wrong display order
-                                        tree = (IProjectTree2)child.SetDisplayOrder(displayOrder).Parent!;
+                                        node = (IProjectTree2)child.SetDisplayOrder(displayOrder).Parent!;
                                     }
                                     else
                                     {
@@ -270,15 +270,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
 
                                         if (!ReferenceEquals(child, newChild))
                                         {
-                                            tree = ReplaceChild(child, newChild);
+                                            node = ReplaceChild(child, newChild);
                                         }
                                     }
                                 }
 
-                                return tree;
+                                return node;
 
-                                IProjectTree2 AddChild(IProjectTree2 child) => (IProjectTree2)tree.Add(child).Parent!;
-                                IProjectTree2 ReplaceChild(IProjectTree2 oldChild, IProjectTree2 newChild) => (IProjectTree2)tree.Remove(oldChild).Add(newChild).Parent!;
+                                IProjectTree2 AddChild(IProjectTree2 child) => (IProjectTree2)node.Add(child).Parent!;
+                                IProjectTree2 ReplaceChild(IProjectTree2 oldChild, IProjectTree2 newChild) => (IProjectTree2)node.Remove(oldChild).Add(newChild).Parent!;
                             }
                         }
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -171,6 +171,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                             DataflowBlockFactory.CreateActionBlock<IProjectVersionedValue<ValueTuple<IProjectImportTreeSnapshot, IProjectSubscriptionUpdate>>>(
                                 SyncTree,
                                 _project,
+                                skipIntermediateInputData: true, // We can skip versions without breaking the tree
                                 nameFormat: "Import Tree Action: {1}");
 
                         _subscriptions.Add(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -215,8 +215,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
 
                             IProjectTree2 SyncNode(IReadOnlyList<IProjectImportSnapshot> imports, IProjectTree2 node)
                             {
-                                var existingChildByPath = new Dictionary<string, IProjectTree2>(StringComparers.Paths);
-
                                 foreach (IProjectTree2 existingNode in node.Children)
                                 {
                                     Assumes.NotNullOrEmpty(existingNode.FilePath);
@@ -229,16 +227,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                                             node = (IProjectTree2)child.Remove();
                                         }
                                     }
-                                    else
-                                    {
-                                        existingChildByPath[existingNode.FilePath] = existingNode;
-                                    }
                                 }
 
                                 for (int displayOrder = 0; displayOrder < imports.Count; displayOrder++)
                                 {
                                     IProjectImportSnapshot import = imports[displayOrder];
-                                    if (!existingChildByPath.TryGetValue(import.ProjectPath, out IProjectTree2 child))
+
+                                    // Attempt to find the existing child in the tree, based on file path
+                                    IProjectTree2? child = (IProjectTree2?)node.Children.FirstOrDefault(c => StringComparers.Paths.Equals(c.FilePath, import.ProjectPath));
+
+                                    if (child is null)
                                     {
                                         // No child exists for this import, so add it
                                         bool isImplicit = _projectFileClassifier.IsNonUserEditable(import.ProjectPath);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -261,7 +261,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                                     else if (child.DisplayOrder != displayOrder)
                                     {
                                         // Child exists but with the wrong display order
-                                        tree = ReplaceChild(child, child.SetDisplayOrder(displayOrder));
+                                        tree = (IProjectTree2)child.SetDisplayOrder(displayOrder).Parent!;
                                     }
                                     else
                                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                                 actionBlock,
                                 linkOptions: DataflowOption.PropagateCompletion));
 
-                        JoinUpstreamDataSources(_projectSubscriptionService.ImportTreeSource);
+                        JoinUpstreamDataSources(_projectSubscriptionService.ImportTreeSource, _projectSubscriptionService.ProjectRuleSource);
 
                         return;
 


### PR DESCRIPTION
Fixes #6675

This is a top NFE as reported by CPS.

As discussed in https://github.com/dotnet/project-system/issues/6675#issuecomment-913578589 the imports tree shows project file names as captions in the tree. While there are no duplicate paths, two different paths in a given level of the tree may have the same file name. That is supported on the initial population of the tree, as we also differentiate them by display order. However if these items are reordered, we attempt to update their display orders which can produce a transient state in which duplicates exist, which results in the _The node to add collides with a node already present_ error message we see.

The primary fix here is to look for duplicate file names in any given level of the tree and disambiguate them by including their path in parentheses in the caption.

A .NET 5 application will imports several `WorkloadManifest.targets` files at the same level of the tree. With this change they now appear as:

![image](https://user-images.githubusercontent.com/350947/132222311-728c6196-295c-44b5-a495-ee3e539533ac.png)

The full path should be used here (rather than numeric suffixes) as that remains stable in the face of reordering within the project that imports these.

Other fixes in this PR:

- Joining an upstream data source that was missing, which may help prevent dead locks.
- Avoid caching `IProjectTree` objects beyond their lifetimes by looking them up on each iteration.
- Optimise child node replacement.
- Enable skipping of dataflow items by our action block, as it is safe to do so.