### PR TITLE
Ensure trailing slash in ProjectFileClassifier paths

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectFileClassifier.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectFileClassifier.cs
@@ -81,6 +81,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 {
                     _nuGetPackageFoldersString = value;
                     _nuGetPackageFolders = value.Split(Delimiter.Semicolon, StringSplitOptions.RemoveEmptyEntries);
+
+                    for (int i = 0; i < _nuGetPackageFolders.Length; i++)
+                    {
+                        EnsureTrailingSlash(ref _nuGetPackageFolders[i]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
The `ProjectFileClassifier` parses a semicolon-delimited list of paths to NuGet package folders. As we will use these strings in a prefix test to determine whether a file exists within one of these paths, each path must have a trailing slash (directory separator) in order to prevent accidentally matching a file.

This bug is unlikely, but possible. For example, if the path is `A/B/C` then we could match a file `A/B/C.txt`. By ensuring a trailing slash, this can not happen.