### PR TITLE
Remove duplicate import of configured project

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -60,9 +60,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
             IProjectThreadingService threadingService,
             UnconfiguredProject project,
             IActiveConfiguredProjectSubscriptionService projectSubscriptionService,
-            IUnconfiguredProjectTasksService unconfiguredProjectTasksService,
-            UnconfiguredProject unconfiguredProject)
-            : base(threadingService, unconfiguredProject, useDisplayOrdering: true)
+            IUnconfiguredProjectTasksService unconfiguredProjectTasksService)
+            : base(threadingService, project, useDisplayOrdering: true)
         {
             _project = project;
             _projectSubscriptionService = projectSubscriptionService;


### PR DESCRIPTION
This constructor was importing `UnconfiguredProject` more than once, which makes no sense. The same object is passed for both arguments. We only need one of them.