### PR TITLE
Make ConfiguredProjectImplicitActivationTrackingInstance contribute to operation progress

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ConfiguredProjectImplicitActivationTracking.Instance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ConfiguredProjectImplicitActivationTracking.Instance.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
+using Microsoft.VisualStudio.ProjectSystem.OperationProgress;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
@@ -16,21 +17,25 @@ namespace Microsoft.VisualStudio.ProjectSystem
             private readonly ConfiguredProject _project;
             private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
             private readonly ITargetBlock<IProjectVersionedValue<(IProjectCapabilitiesSnapshot, IConfigurationGroup<ProjectConfiguration>)>> _targetBlock;
+            private readonly IDataProgressTrackerService _dataProgressTrackerService;
             private readonly OrderPrecedenceImportCollection<IImplicitlyActiveConfigurationComponent> _components;
 
             private IReadOnlyCollection<IImplicitlyActiveConfigurationComponent> _activeComponents = Array.Empty<IImplicitlyActiveConfigurationComponent>();
             private IDisposable? _subscription;
+            private IDataProgressTrackerServiceRegistration? _dataProgressTrackerRegistration;
 
             public ConfiguredProjectImplicitActivationTrackingInstance(
                 IProjectThreadingService threadingService,
                 ConfiguredProject project,
                 IActiveConfigurationGroupService activeConfigurationGroupService,
+                IDataProgressTrackerService dataProgressTrackerService,
                 OrderPrecedenceImportCollection<IImplicitlyActiveConfigurationComponent> components)
                 : base(threadingService.JoinableTaskContext)
             {
                 _project = project;
                 _activeConfigurationGroupService = activeConfigurationGroupService;
                 _targetBlock = DataflowBlockFactory.CreateActionBlock<IProjectVersionedValue<(IProjectCapabilitiesSnapshot, IConfigurationGroup<ProjectConfiguration>)>>(OnChangeAsync, project.UnconfiguredProject, ProjectFaultSeverity.LimitedFunctionality);
+                _dataProgressTrackerService = dataProgressTrackerService;
                 _components = components;
             }
 
@@ -41,6 +46,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
             {
+                _dataProgressTrackerRegistration = _dataProgressTrackerService.RegisterForIntelliSense(this, _project, nameof(ConfiguredProjectImplicitActivationTrackingInstance));
+
                 _subscription = ProjectDataSources.SyncLinkTo(
                     _project.Capabilities.SourceBlock.SyncLinkOptions(),
                     _activeConfigurationGroupService.ActiveConfigurationGroupSource.SourceBlock.SyncLinkOptions(),
@@ -53,6 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             protected override Task DisposeCoreAsync(bool initialized)
             {
+                _dataProgressTrackerRegistration?.Dispose();
                 _subscription?.Dispose();
                 _targetBlock.Complete();
 
@@ -87,6 +95,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 await ActivateAsync(diff.Added);
 
                 _activeComponents = futureComponents;
+
+                _dataProgressTrackerRegistration?.NotifyOutputDataCalculated(e.DataSourceVersions);
             }
 
             private static Task DeactivateAsync(IEnumerable<IImplicitlyActiveConfigurationComponent> services)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ConfiguredProjectImplicitActivationTracking.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ConfiguredProjectImplicitActivationTracking.cs
@@ -22,17 +22,20 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private readonly IProjectThreadingService _threadingService;
         private readonly ConfiguredProject _project;
         private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
+        private readonly IDataProgressTrackerService _dataProgressTrackerService;
 
         [ImportingConstructor]
         public ConfiguredProjectImplicitActivationTracking(
             IProjectThreadingService threadingService,
             ConfiguredProject project,
-            IActiveConfigurationGroupService activeConfigurationGroupService)
+            IActiveConfigurationGroupService activeConfigurationGroupService,
+            IDataProgressTrackerService dataProgressTrackerService)
             : base(threadingService.JoinableTaskContext)
         {
             _threadingService = threadingService;
             _project = project;
             _activeConfigurationGroupService = activeConfigurationGroupService;
+            _dataProgressTrackerService = dataProgressTrackerService;
 
             Components = new OrderPrecedenceImportCollection<IImplicitlyActiveConfigurationComponent>(projectCapabilityCheckProvider: project);
         }
@@ -46,6 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 _threadingService,
                 _project,
                 _activeConfigurationGroupService,
+                _dataProgressTrackerService,
                 Components);
         }
     }


### PR DESCRIPTION
Fixes #7468

During project load, we have several implicitly activated components (implementations of `IImplicitlyActiveConfigurationComponent`) who may themselves contribute to operation progress. It's important that we give them a chance to do so before operation progress completes.

Previously that was not guaranteed. Our `IProjectDynamicLoadComponent.LoadAsync` method in `ConfiguredProjectImplicitActivationTracking` would indirectly set up a dataflow before completing, but that dataflow would have to pump before the `IImplicitlyActiveConfigurationComponent` instances could be activated. Until those messages arrived, there existed a window during which operation progress could complete before the component (e.g. `PackageRestoreProgressTrackerInstance`) could register its data source with `IDataProgressTrackerService`.

This commit adds an additional `IDataProgressTrackerServiceRegistration` to cover that window of time. It is registered during `IProjectDynamicLoadComponent.LoadAsync`, and updated after each round of component activation/deactivation.