### PR TITLE
Update build queue

### DIFF
--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -10,7 +10,7 @@ resources:
 - repo: self
   clean: true
 queue:
-  name: VSEngSS-MicroBuild2019
+  name: VSEngSS-MicroBuild2019-1ES
   demands: Cmd
   timeoutInMinutes: 90
 variables:


### PR DESCRIPTION
The VSEngSS-MicroBuild2019 pool is being phased out in favor of a new pool, VSEngSS-MicroBuild2019-1ES. This should be exactly the same setup, just managed by the 1ES team.

We have until the end of September 2021 to switch over, so if we experience problems with this new pool we can fall back to the old one while they are worked out.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7570)