### PR TITLE
Don't force load of VC projects

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetectorTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetectorTests.cs
@@ -162,6 +162,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.VersionCompatibility
                                                                                           bool isSolutionOpen = false,
                                                                                           bool hasNewProjects = false,
                                                                                           bool usingPreviewSDK = false,
+                                                                                          bool isCapabilityMatch = true,
                                                                                           string targetFrameworkMoniker = ".NETCoreApp,Version=v3.0")
         {
             dialogServices = IDialogServicesFactory.Create();
@@ -194,7 +195,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.VersionCompatibility
                                                                                        vsAppIdService,
                                                                                        vsShellService,
                                                                                        hasNewProjects,
-                                                                                       usingPreviewSDK);
+                                                                                       usingPreviewSDK,
+                                                                                       isCapabilityMatch);
             return compatibilityDetector;
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VersionCompatibility/TestDotNetCoreProjectCompatibilityDetector.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VersionCompatibility/TestDotNetCoreProjectCompatibilityDetector.cs
@@ -15,6 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.VersionCompatibility
     {
         private readonly bool _hasNewProjects;
         private readonly bool _usingPreviewSDK;
+        private readonly bool _isCapabilityMatch;
 
         public TestDotNetCoreProjectCompatibilityDetector(Lazy<IProjectServiceAccessor> projectAccessor,
                                                           Lazy<IDialogServices> dialogServices,
@@ -27,15 +28,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.VersionCompatibility
                                                           IVsService<SVsSolution, IVsSolution> vsSolutionService,
                                                           IVsService<SVsAppId, IVsAppId> vsAppIdService,
                                                           IVsService<SVsShell, IVsShell> vsShellService,
-                                                          bool hasNewProjects = false,
-                                                          bool usingPreviewSDK = false) :
-            base(projectAccessor, dialogServices, threadHandling, vsShellUtilitiesHelper, fileSystem, httpClient, vsUIShellService, settingsManagerService, vsSolutionService, vsAppIdService, vsShellService)
+                                                          bool hasNewProjects,
+                                                          bool usingPreviewSDK,
+                                                          bool isCapabilityMatch)
+            : base(projectAccessor, dialogServices, threadHandling, vsShellUtilitiesHelper, fileSystem, httpClient, vsUIShellService, settingsManagerService, vsSolutionService, vsAppIdService, vsShellService)
         {
             _hasNewProjects = hasNewProjects;
             _usingPreviewSDK = usingPreviewSDK;
+            _isCapabilityMatch = isCapabilityMatch;
         }
 
         protected override Task<bool> IsPreviewSDKInUseAsync() => Task.FromResult(_usingPreviewSDK);
         protected override bool IsNewlyCreated(UnconfiguredProject project) => _hasNewProjects;
+        protected override bool IsCapabilityMatch(IVsHierarchy hierarchy) => _isCapabilityMatch;
     }
 }


### PR DESCRIPTION
Fixes [AB#1388556](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1388556)

When a solution contains both VC and SDK-style projects, the `DotNetCoreProjectCompatibilityDetector` can unwittingly force VS to fully load projects rather than serve them from the cache.

It does this by retrieving the `UnconfiguredProject` from the `IVsHierarchy`, which internally QIs a `IVsBrowseObjectContext` interface, which loads the project.

We avoid that load by performing a capability query on the project instead.