### PR TITLE
Log the missing activeTargetFramework alias in error message

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.CrossTarget
             Requires.Argument(!targetFrameworks.IsDefaultOrEmpty, nameof(targetFrameworks), "Must contain at least one item.");
             Requires.NotNullOrEmpty(configuredProjectByTargetFramework, nameof(configuredProjectByTargetFramework));
             Requires.NotNull(activeTargetFramework, nameof(activeTargetFramework));
-            Requires.Argument(targetFrameworks.Contains(activeTargetFramework), nameof(targetFrameworks), "Must contain 'activeTargetFramework'.");
+            Requires.Argument(targetFrameworks.Contains(activeTargetFramework), nameof(targetFrameworks), $"Must contain 'activeTargetFramework' ({activeTargetFramework.TargetFrameworkAlias}).");
 
             IsCrossTargeting = isCrossTargeting;
             TargetFrameworks = targetFrameworks;


### PR DESCRIPTION
When the activeTargetFramework is missing in the targetFrameworks array passed to the AggregateCrossTargetProjectContext, it would be helpful to know what the active target framework was when diagnosing this failure.

This would be helpful for failures like [#1398765](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1398765.)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7584)