### PR TITLE
Fix WAPPPROJ not in Startup Project

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -109,12 +109,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
         private async Task<bool> IsDebuggableAsync()
         {
+            var foundStartupProjectProvider = false;
+
             foreach (Lazy<IDebugLaunchProvider> provider in _launchProviders.Values)
             {
-                if (provider.Value is IStartupProjectProvider startupProjectProvider &&
-                    await startupProjectProvider.CanBeStartupProjectAsync(DebugLaunchOptions.DesignTimeExpressionEvaluation))
+                if (provider.Value is IStartupProjectProvider startupProjectProvider)
                 {
-                    return true;
+                    foundStartupProjectProvider = true;
+                    if (await startupProjectProvider.CanBeStartupProjectAsync(DebugLaunchOptions.DesignTimeExpressionEvaluation))
+                    {
+                        return true;
+                    }
+                } 
+            }
+
+            if (!foundStartupProjectProvider)
+            {
+                foreach (Lazy<IDebugLaunchProvider> provider in _launchProviders.Values)
+                {
+                    if (await provider.Value.CanLaunchAsync(DebugLaunchOptions.DesignTimeExpressionEvaluation))
+                    {
+                        return true;
+                    }
                 }
             }
 


### PR DESCRIPTION
This will allow external project like WAP to implement this interface and make them visible in the startup project drop-down.

Using `CanLaunchAsync `as a fallback if none of providers implement `IStartupProjectProvider`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7588)