### PR TITLE
Document up-to-date logging for legacy projects

### DIFF
--- a/docs/up-to-date-check.md
+++ b/docs/up-to-date-check.md
@@ -138,7 +138,7 @@ Enabling up-to-date check logging for old-style (non-SDK) projects is a little m
 
 1. Open a "Developer Command Prompt" for the particular version of Visual Studio you are using.
 2. Enter command:
-   ```
+   ```text
    vsregedit set "%cd%" HKCU General U2DCheckVerbosity dword 1
    ```
 3. The message `Set value for U2DCheckVerbosity` should be displayed
@@ -152,6 +152,14 @@ You can change this value while VS is running and it will take effect immediatel
 When logging is enabled you'll see messages such as this in build output:
 
 > Project 'MyProject' is not up to date. Input file 'c:\path\myproject\class1.cs' is modified after output file 'C:\Path\MyProject\bin\Debug\MyProject.pdb'.
+
+#### Logging from the experimental hive
+
+If you wish to enable this logging for a particular hive (this is an advanced scenario) then pass the hive's name after the path. For example:
+
+```text
+vsregedit set "%cd%" Exp HKCU General U2DCheckVerbosity dword 1
+```
 
 ## Disabling the Up-to-date Check
 

--- a/docs/up-to-date-check.md
+++ b/docs/up-to-date-check.md
@@ -108,6 +108,8 @@ features do not compose. If both properties are present, `Original` will take ef
 
 ## Debugging
 
+### SDK-Style projects
+
 By default the up-to-date check does not log anything, though you can infer its decision from your build output summary:
 
 ```text
@@ -129,6 +131,27 @@ build output.
 - `None` disables log output.
 - `Minimal` produces a single message per out-of-date project.
 - `Info` and `Verbose` provide increasingly detailed information about the inner workings of the check, which are useful for debugging.
+
+### .NET Framework projects
+
+Enabling up-to-date check logging for old-style (non-SDK) projects is a little more manual:
+
+1. Open a "Developer Command Prompt" for the particular version of Visual Studio you are using.
+2. Enter command:
+   ```
+   vsregedit set "%cd%" HKCU General U2DCheckVerbosity dword 1
+   ```
+3. The message `Set value for U2DCheckVerbosity` should be displayed
+
+Run the same command with a `0` instead of a `1` to disable this logging.
+
+Note that `"%cd%"` evaluates to the current directory. When you first open a Developer Prompt, this path will be correct. To execute this command from arbitrary locations, you'll need to substitute the relevant quoted path, such as `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise"`, with no trailing `/` or `>` character.
+
+You can change this value while VS is running and it will take effect immediately.
+
+When logging is enabled you'll see messages such as this in build output:
+
+> Project 'MyProject' is not up to date. Input file 'c:\path\myproject\class1.cs' is modified after output file 'C:\Path\MyProject\bin\Debug\MyProject.pdb'.
 
 ## Disabling the Up-to-date Check
 


### PR DESCRIPTION
Add a section explaining how to enable logging from the fast up-to-date check in legacy (csproj) projects.

Thanks to @adrianvmsft for help with the `vsregedit` command line.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7603)