### PR TITLE
Check StartupHookSupport

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -347,4 +347,12 @@
   <StringProperty Name="WinRTReferenceTabs"
                   Visible="False" />
 
+  <StringProperty Name="StartupHookSupport"
+                  Visible="False" >
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 </Rule>


### PR DESCRIPTION
In .NET Core startup hooks allow code to run _before_ the application entry point (e.g. `static void Main(...)`) runs. This is used to inject the application-side parts of Hot Reload into the app without requiring changes to the user code or more invasive process control such as that done by the debugger. Startup hooks are turned on by default in the runtime, but as a runtime feature switch then can be turned off.

One case where this happens is if the user turns on trimming. Trimming reduces the size of a self-contained application (one that bundles its own complete copy of the runtime and framework) by stripping out types and methods not used by the application. The actual trimming of an application happens during publishing, not as part of the build, so it generally does not affect debugging. However, when you turn on trimming it turns off startup hooks for the _built_ binary, not just the _published_ binary.

If we try to use Hot Reload when trimming is turned on the session will appear to start normally, but then various parts of Hot Reload will fail to work and may raise exceptions. Rather than subject the user to a broken experience, here we check if startup hooks are turned on, and if not we bail out of creating a Hot Reload session. Note that startup hooks are on by default, so we need to check whether or not the underlying property is explicitly set to `false`.

A separate commit will add a message to the Hot Reload output pane explaining why it was turned off so the user has _some_ indication. At this point in the release cycle, however, we won't have a chance to localize the new string and we will need an exception to the localization requirements. I don't want to gate the entire change on getting that exception.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7604)