### PR TITLE
Display message about Hot Reload being disabled

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -479,6 +479,15 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming..
+        /// </summary>
+        internal static string ProjectHotReloadSessionManager_StartupHooksDisabled {
+            get {
+                return ResourceManager.GetString("ProjectHotReloadSessionManager_StartupHooksDisabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A project with an Output Type of Class Library cannot be started directly.
         ///
         ///In order to debug this project, add an executable project to this solution which references the library project. Set the executable project as the startup project..

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -309,4 +309,8 @@ In order to debug this project, add an executable project to this solution which
 {2}</value>
     <comment>{0} is the Hot Reload session identifier. {1} is the exception type name. {2} is the exception message.</comment>
   </data>
+  <data name="ProjectHotReloadSessionManager_StartupHooksDisabled" xml:space="preserve">
+    <value>{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</value>
+    <comment>{0} is the project name.</comment>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -140,6 +140,11 @@
         <target state="new">{0}: The process has exited.</target>
         <note>{0} is the Hot Reload session identifier.</note>
       </trans-unit>
+      <trans-unit id="ProjectHotReloadSessionManager_StartupHooksDisabled">
+        <source>{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</source>
+        <target state="new">{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</target>
+        <note>{0} is the project name.</note>
+      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">Přejmenování prvku kódu {0} nebylo úspěšné.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -140,6 +140,11 @@
         <target state="new">{0}: The process has exited.</target>
         <note>{0} is the Hot Reload session identifier.</note>
       </trans-unit>
+      <trans-unit id="ProjectHotReloadSessionManager_StartupHooksDisabled">
+        <source>{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</source>
+        <target state="new">{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</target>
+        <note>{0} is the project name.</note>
+      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">Fehler beim Umbenennen des Codeelements "{0}".</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -140,6 +140,11 @@
         <target state="new">{0}: The process has exited.</target>
         <note>{0} is the Hot Reload session identifier.</note>
       </trans-unit>
+      <trans-unit id="ProjectHotReloadSessionManager_StartupHooksDisabled">
+        <source>{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</source>
+        <target state="new">{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</target>
+        <note>{0} is the project name.</note>
+      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">No se pudo cambiar el nombre del elemento de código '{0}'.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -140,6 +140,11 @@
         <target state="new">{0}: The process has exited.</target>
         <note>{0} is the Hot Reload session identifier.</note>
       </trans-unit>
+      <trans-unit id="ProjectHotReloadSessionManager_StartupHooksDisabled">
+        <source>{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</source>
+        <target state="new">{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</target>
+        <note>{0} is the project name.</note>
+      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">Échec du changement de nom de l'élément de code en '{0}'.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -140,6 +140,11 @@
         <target state="new">{0}: The process has exited.</target>
         <note>{0} is the Hot Reload session identifier.</note>
       </trans-unit>
+      <trans-unit id="ProjectHotReloadSessionManager_StartupHooksDisabled">
+        <source>{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</source>
+        <target state="new">{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</target>
+        <note>{0} is the project name.</note>
+      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">La ridenominazione dell'elemento di codice '{0}' non è riuscita.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -140,6 +140,11 @@
         <target state="new">{0}: The process has exited.</target>
         <note>{0} is the Hot Reload session identifier.</note>
       </trans-unit>
+      <trans-unit id="ProjectHotReloadSessionManager_StartupHooksDisabled">
+        <source>{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</source>
+        <target state="new">{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</target>
+        <note>{0} is the project name.</note>
+      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">コード要素 '{0}' の名前変更に失敗しました。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -140,6 +140,11 @@
         <target state="new">{0}: The process has exited.</target>
         <note>{0} is the Hot Reload session identifier.</note>
       </trans-unit>
+      <trans-unit id="ProjectHotReloadSessionManager_StartupHooksDisabled">
+        <source>{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</source>
+        <target state="new">{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</target>
+        <note>{0} is the project name.</note>
+      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">코드 포인트 '{0}'의 이름을 바꾸지 못했습니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -140,6 +140,11 @@
         <target state="new">{0}: The process has exited.</target>
         <note>{0} is the Hot Reload session identifier.</note>
       </trans-unit>
+      <trans-unit id="ProjectHotReloadSessionManager_StartupHooksDisabled">
+        <source>{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</source>
+        <target state="new">{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</target>
+        <note>{0} is the project name.</note>
+      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">Zmiana nazwy elementu kodu „{0}” nie powiodła się.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -140,6 +140,11 @@
         <target state="new">{0}: The process has exited.</target>
         <note>{0} is the Hot Reload session identifier.</note>
       </trans-unit>
+      <trans-unit id="ProjectHotReloadSessionManager_StartupHooksDisabled">
+        <source>{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</source>
+        <target state="new">{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</target>
+        <note>{0} is the project name.</note>
+      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">Falha ao renomear o elemento de código '{0}'.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -140,6 +140,11 @@
         <target state="new">{0}: The process has exited.</target>
         <note>{0} is the Hot Reload session identifier.</note>
       </trans-unit>
+      <trans-unit id="ProjectHotReloadSessionManager_StartupHooksDisabled">
+        <source>{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</source>
+        <target state="new">{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</target>
+        <note>{0} is the project name.</note>
+      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">Ошибка переименования элемента кода "{0}".</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -140,6 +140,11 @@
         <target state="new">{0}: The process has exited.</target>
         <note>{0} is the Hot Reload session identifier.</note>
       </trans-unit>
+      <trans-unit id="ProjectHotReloadSessionManager_StartupHooksDisabled">
+        <source>{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</source>
+        <target state="new">{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</target>
+        <note>{0} is the project name.</note>
+      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">'{0}' kod öğesi yeniden adlandırılamadı.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -140,6 +140,11 @@
         <target state="new">{0}: The process has exited.</target>
         <note>{0} is the Hot Reload session identifier.</note>
       </trans-unit>
+      <trans-unit id="ProjectHotReloadSessionManager_StartupHooksDisabled">
+        <source>{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</source>
+        <target state="new">{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</target>
+        <note>{0} is the project name.</note>
+      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">重命名代码元素“{0}”失败。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -140,6 +140,11 @@
         <target state="new">{0}: The process has exited.</target>
         <note>{0} is the Hot Reload session identifier.</note>
       </trans-unit>
+      <trans-unit id="ProjectHotReloadSessionManager_StartupHooksDisabled">
+        <source>{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</source>
+        <target state="new">{0}: Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</target>
+        <note>{0} is the project name.</note>
+      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">重新命名程式碼項目 '{0}' 失敗。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -347,4 +347,12 @@
   <StringProperty Name="WinRTReferenceTabs"
                   Visible="False" />
 
+  <StringProperty Name="StartupHookSupport"
+                  Visible="False" >
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 </Rule>


### PR DESCRIPTION
Builds on #7604.

Display a message in the Hot Reload output pane when it is disabled because startup hooks are disabled:

![image](https://user-images.githubusercontent.com/10506730/133690281-f4d587d2-7f0c-46b2-8ea1-f8dab54d1cec.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7605)