### PR TITLE
Add more information when the activeTargetFramework is not present

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.CrossTarget
 {
@@ -27,7 +28,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.CrossTarget
             Requires.Argument(!targetFrameworks.IsDefaultOrEmpty, nameof(targetFrameworks), "Must contain at least one item.");
             Requires.NotNullOrEmpty(configuredProjectByTargetFramework, nameof(configuredProjectByTargetFramework));
             Requires.NotNull(activeTargetFramework, nameof(activeTargetFramework));
-            Requires.Argument(targetFrameworks.Contains(activeTargetFramework), nameof(targetFrameworks), $"Must contain 'activeTargetFramework' ({activeTargetFramework.TargetFrameworkAlias}).");
+
+            if (!targetFrameworks.Contains(activeTargetFramework))
+            {
+                Requires.Argument(false, nameof(targetFrameworks), $"Must contain 'activeTargetFramework' ({activeTargetFramework.TargetFrameworkAlias}). Contains {string.Join(", ", targetFrameworks.Select(targetFramework => $"'{targetFramework.TargetFrameworkAlias}'"))}.");
+            }
 
             IsCrossTargeting = isCrossTargeting;
             TargetFrameworks = targetFrameworks;


### PR DESCRIPTION
Contributes to [AB#1378497](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1378497) and [AB#1398765](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1398765).

This adds the set of targetFramework values that are actually present, to help debugging.

Also avoids allocating a message string when no error will be thrown.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7608)