### PR TITLE
Fix hang in ActiveWorkspaceProjectContextHost

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ActiveWorkspaceProjectContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ActiveWorkspaceProjectContextHost.cs
@@ -31,7 +31,41 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             _tasksService = tasksService;
         }
 
-        public async Task PublishAsync(CancellationToken cancellationToken = default)
+        public Task PublishAsync(CancellationToken cancellationToken = default)
+        {
+            return DoWithConfigurationChangeProtectionAsync<object?>(
+                static async (host, token) =>
+                {
+                    await host.PublishAsync(token);
+                    return null;
+                },
+                cancellationToken);
+        }
+
+        public Task OpenContextForWriteAsync(Func<IWorkspaceProjectContextAccessor, Task> action)
+        {
+            return DoWithConfigurationChangeProtectionAsync<object?>(
+                async (host, token) =>
+                {
+                    await host.OpenContextForWriteAsync(action).WithCancellation(token);
+                    return null;
+                });
+        }
+
+        public Task<T?> OpenContextForWriteAsync<T>(Func<IWorkspaceProjectContextAccessor, Task<T>> action)
+        {
+            return DoWithConfigurationChangeProtectionAsync(
+                async (host, token) => await host.OpenContextForWriteAsync(action).WithCancellation(token));
+        }
+
+        /// <summary>
+        /// Ensures the project is initialized and that the active configuration remains active throughout
+        /// an async operation. If the active configuration changes before <paramref name="func"/> completes,
+        /// it is cancelled and invoked again with the newly active configuration.
+        /// </summary>
+        private async Task<T?> DoWithConfigurationChangeProtectionAsync<T>(
+            Func<IWorkspaceProjectContextHost, CancellationToken, Task<T>> func,
+            CancellationToken cancellationToken = default)
         {
             // The active configuration can change multiple times during initialization in cases where we've incorrectly
             // guessed the configuration via our IProjectConfigurationDimensionsProvider3 implementation.
@@ -40,62 +74,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             while (true)
             {
+                IWorkspaceProjectContextHost? host = _activeHost.Value;
+
+                if (host is null)
+                {
+                    // No configuration is active
+                    return default;
+                }
+
                 CancellationToken activeConfigChangedToken = _activeConfiguredProjectProvider.ConfigurationActiveCancellationToken;
 
                 using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(activeConfigChangedToken, cancellationToken);
 
                 try
                 {
-                    IWorkspaceProjectContextHost? host = _activeHost.Value;
-                    if (host != null)
-                    {
-                        await host.PublishAsync(tokenSource.Token);
-                    }
-
-                    return;
+                    return await func(host, tokenSource.Token);
                 }
                 catch (OperationCanceledException) when (activeConfigChangedToken.IsCancellationRequested)
                 {
-                }
-            }
-        }
-
-        public async Task OpenContextForWriteAsync(Func<IWorkspaceProjectContextAccessor, Task> action)
-        {
-            while (true)
-            {
-                try
-                {
-                    IWorkspaceProjectContextHost? host = _activeHost.Value;
-                    if (host != null)
-                    {
-                        await host.OpenContextForWriteAsync(action);
-                    }
-
-                    return;
-                }
-                catch (ActiveProjectConfigurationChangedException)
-                {   // Host was unloaded because configuration changed, retry on new config
-                }
-            }
-        }
-
-        public async Task<T?> OpenContextForWriteAsync<T>(Func<IWorkspaceProjectContextAccessor, Task<T>> action)
-        {
-            while (true)
-            {
-                try
-                {
-                    IWorkspaceProjectContextHost? host = _activeHost.Value;
-                    if (host != null)
-                    {
-                        return await host.OpenContextForWriteAsync(action);
-                    }
-
-                    return default;
-                }
-                catch (ActiveProjectConfigurationChangedException)
-                {   // Host was unloaded because configuration changed, retry on new config
+                    // Host was unloaded because configuration changed, retry on new config
                 }
             }
         }


### PR DESCRIPTION
Fixes #7615.

Ensure that changing the active configuration doesn't leave `OpenContextForWriteAsync` operations waiting indefinitely.

This change duplicates the protection used previously in `PublishAsync` (via `ConfigurationActiveCancellationToken`) for the two `OpenContextForWriteAsync` overloads, and adds `WithCancellation` so that waiters can be cancelled on project unload.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7618)