### PR TITLE
Update documentation

### DIFF
--- a/docs/repo/property-pages/how-to-add-a-new-launch-profile-kind.md
+++ b/docs/repo/property-pages/how-to-add-a-new-launch-profile-kind.md
@@ -156,7 +156,7 @@ namespace MyNamespace
             xamlResourceStreamName: "XamlRuleToCode:MyLaunchProfile.xaml",
             context: PropertyPageContexts.Project)]
         [AppliesTo("MyUniqueProjectCapability")]
-        [Order(Order.Default)]
+        [Order(orderPrecedence: 0)]
         public static int MyLaunchProfileRule;
     }
 }
@@ -168,7 +168,7 @@ Important points:
 - The `xamlResourceStreamName` parameter specifies the name of the embedded resource. This will be of the form "XamlRuleToCode:<XAMl file name>".
 - The `context` parameter should always be `PropertyPageContexts.Project`.
 - The `AppliesTo` attribute is required. The `Rule` will only be available to projects with the matching capability.
-- The `Order` attribute is also required. Generally `Order.Default` is fine.
+- The `Order` attribute is also required. Generally an `orderPrecedence` of "0" is fine as there are limited situations where you would want to have multiple exports with the same `xamlResourceAssemblyName` and `xamlResourceStreamName` and so the order won't matter. Generally this would only be done to override the other metadata, such as the `AppliesTo` attribute, on an existing `ExportPropertyXamlRuleDefinitionAttribute`.
 
 ### Step 7: Add the assembly as MEF asset
 

--- a/docs/repo/property-pages/how-to-add-a-new-launch-profile-kind.md
+++ b/docs/repo/property-pages/how-to-add-a-new-launch-profile-kind.md
@@ -156,6 +156,7 @@ namespace MyNamespace
             xamlResourceStreamName: "XamlRuleToCode:MyLaunchProfile.xaml",
             context: PropertyPageContexts.Project)]
         [AppliesTo("MyUniqueProjectCapability")]
+        [Order(Order.Default)]
         public static int MyLaunchProfileRule;
     }
 }
@@ -167,6 +168,7 @@ Important points:
 - The `xamlResourceStreamName` parameter specifies the name of the embedded resource. This will be of the form "XamlRuleToCode:<XAMl file name>".
 - The `context` parameter should always be `PropertyPageContexts.Project`.
 - The `AppliesTo` attribute is required. The `Rule` will only be available to projects with the matching capability.
+- The `Order` attribute is also required. Generally `Order.Default` is fine.
 
 ### Step 7: Add the assembly as MEF asset
 


### PR DESCRIPTION
Update the documentation on adding a new launch profile kind to reflect the fact that the use of the `ExportPropertyXamlRuleDefinitionAttribute` de facto requires the `OrderAttribute` as well since the metadata is pulled into an `OrderPrecedenceImportCollection`. Without the `OrderAttribute` the item isn't pulled into the collection at all.

I'm not entirely sure why `ExportPropertyXamlRuleDefinitionAttribute` data is being ordered to begin with. The only thing I can think of is to provide a mechanism for effectively adjusting the `AppliesTo` attribute.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7623)