### PR TITLE
Update "Resources" -> "Win32 Resources"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -12,7 +12,7 @@
               DisplayName="General"
               Description="General settings for the application." />
     <Category Name="Resources"
-              DisplayName="Resources"
+              DisplayName="Win32 Resources"
               Description="Resource settings for the application." />
     <Category Name="Packaging"
               DisplayName="Packaging"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.cs.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Category|Resources|DisplayName">
-        <source>Resources</source>
-        <target state="translated">Prostředky</target>
+        <source>Win32 Resources</source>
+        <target state="needs-review-translation">Prostředky</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|InterceptedTargetFramework|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.de.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Category|Resources|DisplayName">
-        <source>Resources</source>
-        <target state="translated">Ressourcen</target>
+        <source>Win32 Resources</source>
+        <target state="needs-review-translation">Ressourcen</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|InterceptedTargetFramework|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.es.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Category|Resources|DisplayName">
-        <source>Resources</source>
-        <target state="translated">Recursos</target>
+        <source>Win32 Resources</source>
+        <target state="needs-review-translation">Recursos</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|InterceptedTargetFramework|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.fr.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Category|Resources|DisplayName">
-        <source>Resources</source>
-        <target state="translated">Ressources</target>
+        <source>Win32 Resources</source>
+        <target state="needs-review-translation">Ressources</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|InterceptedTargetFramework|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.it.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Category|Resources|DisplayName">
-        <source>Resources</source>
-        <target state="translated">Risorse</target>
+        <source>Win32 Resources</source>
+        <target state="needs-review-translation">Risorse</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|InterceptedTargetFramework|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ja.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Category|Resources|DisplayName">
-        <source>Resources</source>
-        <target state="translated">リソース</target>
+        <source>Win32 Resources</source>
+        <target state="needs-review-translation">リソース</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|InterceptedTargetFramework|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ko.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Category|Resources|DisplayName">
-        <source>Resources</source>
-        <target state="translated">리소스</target>
+        <source>Win32 Resources</source>
+        <target state="needs-review-translation">리소스</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|InterceptedTargetFramework|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pl.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Category|Resources|DisplayName">
-        <source>Resources</source>
-        <target state="translated">Zasoby</target>
+        <source>Win32 Resources</source>
+        <target state="needs-review-translation">Zasoby</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|InterceptedTargetFramework|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pt-BR.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Category|Resources|DisplayName">
-        <source>Resources</source>
-        <target state="translated">Recursos</target>
+        <source>Win32 Resources</source>
+        <target state="needs-review-translation">Recursos</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|InterceptedTargetFramework|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ru.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Category|Resources|DisplayName">
-        <source>Resources</source>
-        <target state="translated">Ресурсы</target>
+        <source>Win32 Resources</source>
+        <target state="needs-review-translation">Ресурсы</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|InterceptedTargetFramework|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.tr.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Category|Resources|DisplayName">
-        <source>Resources</source>
-        <target state="translated">Kaynaklar</target>
+        <source>Win32 Resources</source>
+        <target state="needs-review-translation">Kaynaklar</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|InterceptedTargetFramework|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hans.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Category|Resources|DisplayName">
-        <source>Resources</source>
-        <target state="translated">资源</target>
+        <source>Win32 Resources</source>
+        <target state="needs-review-translation">资源</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|InterceptedTargetFramework|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hant.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Category|Resources|DisplayName">
-        <source>Resources</source>
-        <target state="translated">資源</target>
+        <source>Win32 Resources</source>
+        <target state="needs-review-translation">資源</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|InterceptedTargetFramework|Description">


### PR DESCRIPTION
Fixes #7517.

To distinguish the "Resources" category on the Application property page from the "Resources" page, we're renaming the former "Win32 Resources". This reflects that it deals with Windows-specific concepts.

![image](https://user-images.githubusercontent.com/10506730/134247191-c09d79a7-b076-43b5-9f51-031b8baa5ac8.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7630)