### PR TITLE
Annotate IInterceptingPropertyValueProvider MEF contract

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/IInterceptingPropertyValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/IInterceptingPropertyValueProvider.cs
@@ -9,6 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     /// A project property provider that intercepts all the callbacks for a specific property name
     /// on the default <see cref="IProjectPropertiesProvider"/> for validation and/or transformation of the property value.
     /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Extension, Cardinality = Composition.ImportCardinality.ZeroOrMore)]
     public interface IInterceptingPropertyValueProvider
     {
         /// <summary>


### PR DESCRIPTION
All interfaces used for MEF exports should be annotated with details of their scope, their provider, and their cardinality.

I discovered this was not annotated while investigating something for the Xamarin folks. Will let CI run the unit tests.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7632)