### PR TITLE
Avoid disposing DependenciesSnapshotProvider on the UI thread

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -201,8 +201,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
                     throw new ObjectDisposedException(nameof(DependenciesSnapshotProvider));
                 }
 
-                _commonServices.Project.ProjectUnloading += OnUnconfiguredProjectUnloadingAsync;
-
                 foreach (Lazy<IProjectDependenciesSubTreeProvider, IOrderPrecedenceMetadataView> provider in _subTreeProviders)
                 {
                     provider.Value.DependenciesChanged += OnSubtreeProviderDependenciesChanged;
@@ -212,8 +210,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
                     new DisposableDelegate(
                         () =>
                         {
-                            _commonServices.Project.ProjectUnloading -= OnUnconfiguredProjectUnloadingAsync;
-
                             foreach (Lazy<IProjectDependenciesSubTreeProvider, IOrderPrecedenceMetadataView> provider in _subTreeProviders)
                             {
                                 provider.Value.DependenciesChanged -= OnSubtreeProviderDependenciesChanged;
@@ -222,14 +218,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
             }
 
             return;
-
-            Task OnUnconfiguredProjectUnloadingAsync(object? sender, EventArgs args)
-            {
-                // If our project unloads, we have no more work to do
-                DisposeCore();
-
-                return Task.CompletedTask;
-            }
 
             void OnSubtreeProviderDependenciesChanged(object? sender, DependenciesChangedEventArgs e)
             {


### PR DESCRIPTION
Fixes #7635

Previously we handled the `ProjectUnloading` event, which fired on the UI thread. As called out in #7635, this accounts for 111ms of UI delay when closing Roslyn.sln.

`DependenciesSnapshotProvider` is in the `UnconfiguredProject` scope and will be disposed along with the rest of the project's MEF parts without this special handling. That disposal happens async, on the thread pool.

By removing the `ProjectUnloading` hook, disposal happens a little later, and off the UI thread.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7637)