### PR TITLE
Remove "LanguageVersion" property from GeneralConfiguredBrowseObject

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
@@ -96,16 +96,6 @@
     </StringProperty.DataSource>
   </StringProperty>
 
-  <EnumProperty Name="LanguageVersion"
-                Visible="False">
-    <EnumProperty.DataSource>
-      <DataSource HasConfigurationCondition="False"
-                  PersistedName="LangVersion"
-                  Persistence="ProjectFile"
-                  SourceOfDefaultValue="AfterContext" />
-    </EnumProperty.DataSource>
-  </EnumProperty>
-
   <StringProperty Name="LangVersion"
                   Visible="False">
     <StringProperty.DataSource>


### PR DESCRIPTION
We have "LangVersion" here, which matches the actual MSBuild property. I've searched for potential consumers of this alias and haven't found any, so consider this unused.

My understanding is that this was needed prior to fc1f7f691851670909ed38fdfc3b4a4ac79c5e4b. That commit removed use of it from the legacy project property pages.