### PR TITLE
Replace Enumerable.ToDictionary in GetCaptionByProjectPath

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -282,7 +282,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
 
                                 Dictionary<string, string> GetCaptionByProjectPath()
                                 {
-                                    var result = imports.ToDictionary(i => i.ProjectPath, i => Path.GetFileName(i.ProjectPath));
+                                    var result = CreateProjectPathDictionaryFromImports();
 
                                     var isDuplicateByFileName = new Dictionary<string, bool>(StringComparers.Paths);
 
@@ -299,6 +299,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                                         {
                                             result[import.ProjectPath] = $"{fileName} ({Path.GetDirectoryName(import.ProjectPath)})";
                                         }
+                                    }
+
+                                    return result;
+                                }
+
+                                // Creates a map from each import's project path to the filename of that project path.
+                                // Although LINQ's Enumerable.ToDictionary extension method can be used to create such
+                                // a map, that implementation fails when there are duplicate entries in the imports.
+                                // Therefore, this implementation loops through the imports to create the map.
+                                Dictionary<string, string> CreateProjectPathDictionaryFromImports()
+                                {
+                                    Dictionary<string, string> result = new(StringComparers.Paths);
+
+                                    for (int i = 0; i < imports.Count; i++)
+                                    {
+                                        var importAtIndex = imports[i];
+                                        result[importAtIndex.ProjectPath] = Path.GetFileName(importAtIndex.ProjectPath);
                                     }
 
                                     return result;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -302,23 +302,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                                     }
 
                                     return result;
-                                }
 
-                                // Creates a map from each import's project path to the filename of that project path.
-                                // Although LINQ's Enumerable.ToDictionary extension method can be used to create such
-                                // a map, that implementation fails when there are duplicate entries in the imports.
-                                // Therefore, this implementation loops through the imports to create the map.
-                                Dictionary<string, string> CreateProjectPathDictionaryFromImports()
-                                {
-                                    Dictionary<string, string> result = new(StringComparers.Paths);
-
-                                    for (int i = 0; i < imports.Count; i++)
+                                    // Creates a map from each import's project path to the filename of that project path.
+                                    // Although LINQ's Enumerable.ToDictionary extension method can be used to create such
+                                    // a map, that implementation fails when there are duplicate entries in the imports.
+                                    // Therefore, this implementation loops through the imports to create the map.
+                                    Dictionary<string, string> CreateProjectPathDictionaryFromImports()
                                     {
-                                        var importAtIndex = imports[i];
-                                        result[importAtIndex.ProjectPath] = Path.GetFileName(importAtIndex.ProjectPath);
-                                    }
+                                        Dictionary<string, string> result = new(StringComparers.Paths);
 
-                                    return result;
+                                        foreach (var importAtIndex in imports)
+                                        {
+                                            result[importAtIndex.ProjectPath] = Path.GetFileName(importAtIndex.ProjectPath);
+                                        }
+
+                                        return result;
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Fixes #7645

This prevents System.ArgumentExceptions when there are duplicate entries in the import list.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7646)