### PR TITLE
Make Settings usable in .NET scenarios

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -414,7 +414,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 _projectSystemSupportsUserScope = True
             End If
 
-            ' Do not allow browsing or serializing arbitrary types for .NET scenarios
+            ' Do not allow browsing or serializing arbitrary types for .NET Core scenarios.
+            ' We don't currently have a general mechanism to identify types known to both the
+            ' designer (running on .NET Framework) and the application (running on .NET Core).
             Dim multiTargetService = New MultiTargetService(_hierarchy, VSConstants.VSITEMID_ROOT, False)
             If (multiTargetService.TargetFrameworkName.Identifier <> ".NETCoreApp") Then
                 TypeColumn.Items.Add(My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_ComboBoxItem_BrowseType)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -18,6 +18,7 @@ Imports Microsoft.VisualStudio.Editors.PropertyPages
 Imports Microsoft.VisualStudio.Utilities
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports Microsoft.VSDesigner.VSDesignerPackage
+Imports Microsoft.VSDesigner
 
 Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
@@ -385,7 +386,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ' Add the "connection string" pseudo type
             TypeColumn.Items.Add(_typeNameResolver.PersistedSettingTypeNameToTypeDisplayName(SettingsSerializer.CultureInvariantVirtualTypeNameWebReference))
             TypeColumn.Items.Add(_typeNameResolver.PersistedSettingTypeNameToTypeDisplayName(SettingsSerializer.CultureInvariantVirtualTypeNameConnectionString))
-            TypeColumn.Items.Add(My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_ComboBoxItem_BrowseType)
+
             TypeColumn.Width = DpiAwareness.LogicalToDeviceUnits(Handle, TypeColumn.GetPreferredWidth(DataGridViewAutoSizeColumnMode.AllCells, False) + SystemInformation.VerticalScrollBarWidth + InternalComboBoxPadding)
 
             ScopeColumn.Width = DpiAwareness.LogicalToDeviceUnits(Handle, ScopeColumn.GetPreferredWidth(DataGridViewAutoSizeColumnMode.AllCells, False) + SystemInformation.VerticalScrollBarWidth + InternalComboBoxPadding)
@@ -411,6 +412,12 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 _projectSystemSupportsUserScope = Not ShellUtil.IsWebProject(_hierarchy)
             Else
                 _projectSystemSupportsUserScope = True
+            End If
+
+            ' Do not allow browsing or serializing arbitrary types for .NET scenarios
+            Dim multiTargetService = New MultiTargetService(_hierarchy, VSConstants.VSITEMID_ROOT, False)
+            If (multiTargetService.TargetFrameworkName.Identifier <> ".NETCoreApp") Then
+                TypeColumn.Items.Add(My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_ComboBoxItem_BrowseType)
             End If
 
             Settings = Designer.Settings

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsTypeCache.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsTypeCache.vb
@@ -137,6 +137,16 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             Dim qualifiedAssemblyName As String = Nothing
 
             If Not String.IsNullOrEmpty(sourceTypeName) Then
+
+                ' The configuration types represent a stable contract, for .NET scenarios pin all these type names to the desktop identities.
+                ' This will ensure that when we create required sections in app.config we'll be able to read them back.
+                If (_multiTargetService.TargetFrameworkName.Identifier = ".NETCoreApp" AndAlso
+                   (sourceTypeName = "System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" Or
+                    sourceTypeName = "System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" Or
+                    sourceTypeName = "System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")) Then
+                    Return sourceTypeName
+                End If
+
                 Dim t As Type = _typeResolutionService.GetType(sourceTypeName, False, Not _caseSensitive)
                 If t IsNot Nothing Then
                     qualifiedAssemblyName = _multiTargetService.TypeNameConverter(t)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsTypeCache.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsTypeCache.vb
@@ -138,8 +138,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
             If Not String.IsNullOrEmpty(sourceTypeName) Then
 
-                ' The configuration types represent a stable contract, for .NET scenarios pin all these type names to the desktop identities.
+                ' The configuration types represent a stable contract, for .NET scenarios pin all these type names to the .NET Framework identities.
                 ' This will ensure that when we create required sections in app.config we'll be able to read them back.
+                ' Note that when the designer moves off of .NET Framework we may need to revisit this.
                 If (_multiTargetService.TargetFrameworkName.Identifier = ".NETCoreApp" AndAlso
                    (sourceTypeName = "System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" Or
                     sourceTypeName = "System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" Or


### PR DESCRIPTION
### Changes

1. Pin configuration type names to the desktop identities so not only we can create necessary configuration sections and serialize data, but also that we can deserialize those as well.
Affected types:
    - `System.Configuration.ApplicationSettingsGroup`
    - `System.Configuration.ClientSettingsSection`
    - `System.Configuration.UserSettingsGroup`

    Fixes #6784
    Resolves dotnet/winforms#4308

2. Remove ability to browse and serialize arbitrary types, and restrict the set of type to the the known list

    Resolves https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1388857/

### Tests

Manual using a multi-project solution including
- .NET Framework C# 4.0 (Console) and C# 4.7.2 (WinForms), 
- .NET C# (WinForms) 3.1, 5.0, 6.0
- .NET VB (WinForms) 5.0, 6.0

https://user-images.githubusercontent.com/4403806/135218957-ae46a104-67d6-4b9c-a6d3-d6948deabdec.mp4

/cc: @dotnet/dotnet-winforms 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7647)