### PR TITLE
Exclude Razor property pages explicitly

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
@@ -124,6 +124,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                     if (projectCatalog.GetSchema(schemaName) is Rule rule
                         && !rule.PropertyPagesHidden)
                     {
+                        if (rule.Name == "RazorGeneral" || rule.Name == "RazorExtension")
+                        {
+                            // Some versions of the .NET SDK include a Razor property page that appears
+                            // in the UI. This page is not intended for display.
+                            //
+                            // We cannot remove this page from existing versions of the SDK, so have to
+                            // explicitly exclude it from query results so that it doesn't appear in any
+                            // UI.
+
+                            continue;
+                        }
+
                         IEntityValue propertyPageValue = CreatePropertyPageValue(queryExecutionContext, parent, projectState, propertiesContext, rule, requestedProperties: requestedProperties);
                         yield return propertyPageValue;
                     }


### PR DESCRIPTION
Fixes #7627

Some versions of the .NET SDK include a Razor property page that appears in the UI. This page is not intended for display.

We cannot remove this page from existing versions of the SDK, so have to explicitly exclude it from query results so that it doesn't appear in any UI.

## Before

![image](https://user-images.githubusercontent.com/350947/135641370-3c6f9b54-053f-4932-9cb6-12b847314031.png)

## After

![image](https://user-images.githubusercontent.com/350947/135641429-e87cce64-34a4-4301-9814-33ba197653df.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7654)