### PR TITLE
Fix a deadlock in Hot Reload

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/HotReloadDiagnosticOutputService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/HotReloadDiagnosticOutputService.cs
@@ -26,6 +26,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             _outputWindowPane = new AsyncLazy<IVsOutputWindowPane?>(CreateOutputWindowPaneAsync, threadingService.JoinableTaskFactory);
         }
 
+        public void WriteLine(string outputMessage)
+        {
+            _threadingService.RunAndForget(() => WriteLineAsync(outputMessage), unconfiguredProject: null);
+        }
+
         private async Task<IVsOutputWindowPane?> CreateOutputWindowPaneAsync()
         {
             await _threadingService.SwitchToUIThread();
@@ -60,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             return pane;
         }
 
-        public async Task WriteLineAsync(string outputMessage)
+        private async Task WriteLineAsync(string outputMessage)
         {
             await _threadingService.SwitchToUIThread();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/HotReloadDiagnosticOutputService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/HotReloadDiagnosticOutputService.cs
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             IVsOutputWindowPane? pane = await _outputWindowPane.GetValueAsync();
             if (pane is not null)
             {
-                pane.OutputString(outputMessage + Environment.NewLine);
+                pane.OutputStringNoPump(outputMessage + Environment.NewLine);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IHotReloadDiagnosticOutputService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IHotReloadDiagnosticOutputService.cs
@@ -1,7 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System.Threading.Tasks;
-
 namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 {
     /// <summary>
@@ -14,6 +12,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
         /// Writes a message to the Hot Reload diagnostic output window.
         /// </summary>
         /// <param name="outputMessage">The message to write.</param>
-        Task WriteLineAsync(string outputMessage);
+        void WriteLine(string outputMessage);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
@@ -61,14 +61,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
                 {
                     Process? process = Process.GetProcessById(processId);
 
-                    await WriteOutputMessageAsync(string.Format(VSResources.ProjectHotReloadSessionManager_AttachingToProcess, _pendingSessionState.Session.Name, processId));
+                    WriteOutputMessage(string.Format(VSResources.ProjectHotReloadSessionManager_AttachingToProcess, _pendingSessionState.Session.Name, processId));
 
                     process.Exited += _pendingSessionState.OnProcessExited;
                     process.EnableRaisingEvents = true;
 
                     if (process.HasExited)
                     {
-                        await WriteOutputMessageAsync(string.Format(VSResources.ProjectHotReloadSessionManager_ProcessAlreadyExited, _pendingSessionState.Session.Name));
+                        WriteOutputMessage(string.Format(VSResources.ProjectHotReloadSessionManager_ProcessAlreadyExited, _pendingSessionState.Session.Name));
                         process.Exited -= _pendingSessionState.OnProcessExited;
                         process = null;
                     }
@@ -77,12 +77,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
                 }
                 catch (Exception ex)
                 {
-                    await WriteOutputMessageAsync(string.Format(VSResources.ProjectHotReloadSessionManager_ErrorAttachingToProcess, _pendingSessionState.Session.Name, processId, ex.GetType(), ex.Message));
+                    WriteOutputMessage(string.Format(VSResources.ProjectHotReloadSessionManager_ErrorAttachingToProcess, _pendingSessionState.Session.Name, processId, ex.GetType(), ex.Message));
                 }
 
                 if (_pendingSessionState.Process is null)
                 {
-                    await WriteOutputMessageAsync(string.Format(VSResources.ProjectHotReloadSessionManager_NoActiveProcess, _pendingSessionState.Session.Name));
+                    WriteOutputMessage(string.Format(VSResources.ProjectHotReloadSessionManager_NoActiveProcess, _pendingSessionState.Session.Name));
                 }
                 else
                 {
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
                 else
                 {
                     // If startup hooks are not supported then tell the user why Hot Reload isn't available.
-                    await WriteOutputMessageAsync(string.Format(VSResources.ProjectHotReloadSessionManager_StartupHooksDisabled, Path.GetFileNameWithoutExtension(_project.FullPath)));
+                    WriteOutputMessage(string.Format(VSResources.ProjectHotReloadSessionManager_StartupHooksDisabled, Path.GetFileNameWithoutExtension(_project.FullPath)));
                 }
             }
 
@@ -148,7 +148,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             _activeSessions.Clear();
         }
 
-        private Task WriteOutputMessageAsync(string outputMessage) => _hotReloadDiagnosticOutputService.Value.WriteLineAsync(outputMessage);
+        private void WriteOutputMessage(string outputMessage) => _hotReloadDiagnosticOutputService.Value.WriteLine(outputMessage);
 
         /// <summary>
         /// Checks if the project configuration targeted for debugging/launch meets the
@@ -224,7 +224,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             Assumes.NotNull(hotReloadState.Session);
             Assumes.NotNull(hotReloadState.Process);
 
-            await WriteOutputMessageAsync(string.Format(VSResources.ProjectHotReloadSessionManager_ProcessExited, hotReloadState.Session.Name));
+            WriteOutputMessage(string.Format(VSResources.ProjectHotReloadSessionManager_ProcessExited, hotReloadState.Session.Name));
 
             await StopProjectAsync(hotReloadState, default);
 
@@ -272,7 +272,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             }
             catch (Exception ex)
             {
-                await WriteOutputMessageAsync(string.Format(VSResources.ProjectHotReloadSessionManager_ErrorStoppingTheSession, hotReloadState.Session.Name, ex.GetType(), ex.Message));
+                WriteOutputMessage(string.Format(VSResources.ProjectHotReloadSessionManager_ErrorStoppingTheSession, hotReloadState.Session.Name, ex.GetType(), ex.Message));
             }
 
             return true;


### PR DESCRIPTION
Fixes [AB#1412179](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1412179).

It is possible to run into a deadlock if you start a project with Hot Reload turned on, exit the process, and then quickly start the project again. On a thread pool thread we'll be processing the `Exit` event for the process, and have entered the semaphore that protects our internal Hot Reload state (in `ProjectHotReloadSessionManager`). We then try to write a message to the Output Windows which requires a transition to the UI thread. Meanwhile, on the UI thread we trying to create a new Hot Reload session for the second project start, but to do that we need to enter the semaphore. And there's the deadlock: the main thread is blocked waiting for the semaphore, but the semaphore can't be released until code runs on the main thread.

Note that we're following the VS threading rules and I had expected that to prevent this sort of issue (for example, by allowing the main thread to pump messages while waiting to enter the semaphore) but perhaps it isn't enough. Regardless, we can solve this ourselves.

One option would be to avoid outputting any messages while the semaphore is held. However, this would be difficult to enforce and would make the code more complex as we would need to separate generating the message from actually outputting the message in several places.

Instead, this change recognizes that when we output a message we don't actually care if it is output right away or at some later time, so long as that later time isn't too far in the future. The messages we output are strictly for the benefit of the user, not for the correct operation of Hot Reload. As such we can replace the awaitable `IHotReloadDiagnosticOutputService.WriteLineAsync` with the fire-and-forget `IHotReloadDiagnosticOutputService.WriteLine`. We can still write output where it is convenient for us to do so, but we will no longer delay releasing the semaphore in order to do so.

While I was at it, I replaced the use of `IVsOutputWindowPane.OutputString` with the `IVsOutputWindowPaneExtensions.OutputStringNoPump` extension method. This calls the preferred forms `IVsOutputWindowPaneNoPump.OutputStringNoPump` or `IVsOutputWindowPane.OutputStringThreadSafe`, as available.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7656)