### PR TITLE
Update xunit

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -102,9 +102,9 @@
 
     <!-- Tests -->
     <PackageReference Update="Moq"                                                                    Version="4.12.0"/>
-    <PackageReference Update="xunit"                                                                  Version="2.4.1" />
-    <PackageReference Update="xunit.assert"                                                           Version="2.4.1" />
-    <PackageReference Update="xunit.extensibility.core"                                               Version="2.4.1" />
+    <PackageReference Update="xunit"                                                                  Version="2.4.2-pre.13" />
+    <PackageReference Update="xunit.assert"                                                           Version="2.4.2-pre.13" />
+    <PackageReference Update="xunit.extensibility.core"                                               Version="2.4.2-pre.13" />
     <PackageReference Update="xunit.runner.visualstudio"                                              Version="2.4.3" />
     <PackageReference Update="xunit.runner.console"                                                   Version="2.4.1" />
     <PackageReference Update="xunit.analyzers"                                                        Version="0.10.0"/>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Build/BuildUtilitiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Build/BuildUtilitiesTests.cs
@@ -150,7 +150,7 @@ namespace Microsoft.VisualStudio.Build
             BuildUtilities.AppendPropertyValue(project, "1;2", "MyProperty", "3");
             var property = BuildUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
-            Assert.Equal("1;2;3", property!.Value);
+            Assert.Equal("1;2;3", property.Value);
         }
 
         [Fact]
@@ -167,7 +167,7 @@ namespace Microsoft.VisualStudio.Build
             BuildUtilities.AppendPropertyValue(project, "", "MyProperty", "1");
             var property = BuildUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
-            Assert.Equal("1", property!.Value);
+            Assert.Equal("1", property.Value);
         }
 
         [Fact]
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.Build
             BuildUtilities.AppendPropertyValue(project, "1;2", "MyProperty", "3");
             var property = BuildUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
-            Assert.Equal("1;2;3", property!.Value);
+            Assert.Equal("1;2;3", property.Value);
         }
 
         [Fact]
@@ -187,7 +187,7 @@ namespace Microsoft.VisualStudio.Build
             BuildUtilities.AppendPropertyValue(project, "", "MyProperty", "1");
             var property = BuildUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
-            Assert.Equal("1", property!.Value);
+            Assert.Equal("1", property.Value);
         }
 
         [Fact]
@@ -204,7 +204,7 @@ namespace Microsoft.VisualStudio.Build
             BuildUtilities.RemovePropertyValue(project, "1;2", "MyProperty", "2");
             var property = BuildUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
-            Assert.Equal("1", property!.Value);
+            Assert.Equal("1", property.Value);
         }
 
         [Fact]
@@ -221,7 +221,7 @@ namespace Microsoft.VisualStudio.Build
             BuildUtilities.RemovePropertyValue(project, "1", "MyProperty", "1");
             var property = BuildUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
-            Assert.Equal(string.Empty, property!.Value);
+            Assert.Equal(string.Empty, property.Value);
         }
 
         [Fact]
@@ -231,7 +231,7 @@ namespace Microsoft.VisualStudio.Build
             BuildUtilities.RemovePropertyValue(project, "1;2", "MyProperty", "1");
             var property = BuildUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
-            Assert.Equal("2", property!.Value);
+            Assert.Equal("2", property.Value);
         }
 
         [Fact]
@@ -241,7 +241,7 @@ namespace Microsoft.VisualStudio.Build
             Assert.Throws<ArgumentException>("valueToRemove", () => BuildUtilities.RemovePropertyValue(project, "", "MyProperty", "1"));
             var property = BuildUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
-            Assert.Equal(string.Empty, property!.Value);
+            Assert.Equal(string.Empty, property.Value);
         }
 
         [Fact]
@@ -258,7 +258,7 @@ namespace Microsoft.VisualStudio.Build
             BuildUtilities.RenamePropertyValue(project, "1;2", "MyProperty", "2", "5");
             var property = BuildUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
-            Assert.Equal("1;5", property!.Value);
+            Assert.Equal("1;5", property.Value);
         }
 
         [Fact]
@@ -268,7 +268,7 @@ namespace Microsoft.VisualStudio.Build
             BuildUtilities.RenamePropertyValue(project, "1;2", "MyProperty", "1", "3");
             var property = BuildUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
-            Assert.Equal("3;2", property!.Value);
+            Assert.Equal("3;2", property.Value);
         }
 
         [Fact]
@@ -278,7 +278,7 @@ namespace Microsoft.VisualStudio.Build
             Assert.Throws<ArgumentException>("oldValue", () => BuildUtilities.RenamePropertyValue(project, "", "MyProperty", "1", "2"));
             var property = BuildUtilities.GetProperty(project, "MyProperty");
             Assert.NotNull(property);
-            Assert.Equal(string.Empty, property!.Value);
+            Assert.Equal(string.Empty, property.Value);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ConfiguredProjectFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ConfiguredProjectFactory.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             mock.Setup(c => c.Capabilities).Returns(capabilities!);
             mock.Setup(c => c.ProjectConfiguration).Returns(projectConfiguration!);
             mock.Setup(c => c.Services).Returns(services!);
-            mock.SetupGet(c => c.UnconfiguredProject).Returns(unconfiguredProject! ?? UnconfiguredProjectFactory.Create());
+            mock.SetupGet(c => c.UnconfiguredProject).Returns(unconfiguredProject ?? UnconfiguredProjectFactory.Create());
             return mock.Object;
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextFactoryFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextFactoryFactory.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
             var mock = new Mock<IWorkspaceProjectContextFactory>();
 
             mock.Setup(c => c.CreateProjectContextAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<object?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(action!);
+                .ReturnsAsync(action);
 
             return mock.Object;
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsProviderTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var activeConfigs = ProjectConfigurationFactory.CreateMany(expected.Split(';'));
 
             Assert.NotNull(result);
-            Assert.Equal(activeConfigs.OrderBy(c => c.Name), result!.Objects.OrderBy(c => c.Name));
+            Assert.Equal(activeConfigs.OrderBy(c => c.Name), result.Objects.OrderBy(c => c.Name));
             Assert.Equal(new[] { "TargetFramework" }, result.DimensionNames);
         }
 
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var result = await provider.GetActiveConfiguredProjectsAsync();
 
             Assert.NotNull(result);
-            Assert.Single(result!.Objects);
+            Assert.Single(result.Objects);
             Assert.Equal(activeConfiguration, result.Objects[0].ProjectConfiguration.Name);
             Assert.Empty(result.DimensionNames);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ProjectConfigurationDimensionProviderTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ProjectConfigurationDimensionProviderTestBase.cs
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             await provider.OnDimensionValueChangedAsync(args);
             var property = BuildUtilities.GetProperty(rootElement, PropertyName);
             Assert.NotNull(property);
-            Assert.Equal("A;B;C", property!.Value);
+            Assert.Equal("A;B;C", property.Value);
 
             // On ChangeEventStage.Before the property should be added
             args = new ProjectConfigurationDimensionValueChangedEventArgs(
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             await provider.OnDimensionValueChangedAsync(args);
             property = BuildUtilities.GetProperty(rootElement, PropertyName);
             Assert.NotNull(property);
-            Assert.Equal("A;B;C;Added", property!.Value);
+            Assert.Equal("A;B;C;Added", property.Value);
         }
 
         [Fact]
@@ -178,7 +178,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             await provider.OnDimensionValueChangedAsync(args);
             var property = BuildUtilities.GetProperty(rootElement, PropertyName);
             Assert.NotNull(property);
-            Assert.Equal("A;B;C", property!.Value);
+            Assert.Equal("A;B;C", property.Value);
 
             // On ChangeEventStage.Before the property should be removed
             args = new ProjectConfigurationDimensionValueChangedEventArgs(
@@ -190,7 +190,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             await provider.OnDimensionValueChangedAsync(args);
             property = BuildUtilities.GetProperty(rootElement, PropertyName);
             Assert.NotNull(property);
-            Assert.Equal("A;C", property!.Value);
+            Assert.Equal("A;C", property.Value);
         }
 
         [Fact]
@@ -218,7 +218,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             await Assert.ThrowsAsync<ArgumentException>(() => provider.OnDimensionValueChangedAsync(args));
             var property = BuildUtilities.GetProperty(rootElement, PropertyName);
             Assert.NotNull(property);
-            Assert.Equal("A;B;C", property!.Value);
+            Assert.Equal("A;B;C", property.Value);
         }
 
         [Fact]
@@ -248,7 +248,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             await provider.OnDimensionValueChangedAsync(args);
             var property = BuildUtilities.GetProperty(rootElement, PropertyName);
             Assert.NotNull(property);
-            Assert.Equal("A;B;C", property!.Value);
+            Assert.Equal("A;B;C", property.Value);
 
             // On ChangeEventStage.Before the property should be renamed
             args = new ProjectConfigurationDimensionValueChangedEventArgs(
@@ -261,7 +261,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             await provider.OnDimensionValueChangedAsync(args);
             property = BuildUtilities.GetProperty(rootElement, PropertyName);
             Assert.NotNull(property);
-            Assert.Equal("A;Renamed;C", property!.Value);
+            Assert.Equal("A;Renamed;C", property.Value);
         }
 
         [Fact]
@@ -290,7 +290,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             await Assert.ThrowsAsync<ArgumentException>(() => provider.OnDimensionValueChangedAsync(args));
             var property = BuildUtilities.GetProperty(rootElement, PropertyName);
             Assert.NotNull(property);
-            Assert.Equal("A;B;C", property!.Value);
+            Assert.Equal("A;B;C", property.Value);
         }
 
         [Theory]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ActiveDebugFrameworkServicesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ActiveDebugFrameworkServicesTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Input.Commands
             var result = await debugFrameworkSvcs.GetProjectFrameworksAsync();
 
             Assert.NotNull(result);
-            Assert.Equal(expectedOrder.Length, result!.Count);
+            Assert.Equal(expectedOrder.Length, result.Count);
             for (int i = 0; i < result.Count; i++)
             {
                 Assert.Equal(expectedOrder[i], result[i]);
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Input.Commands
             var debugFrameworkSvcs = new ActiveDebugFrameworkServices(projectConfigProvider.Object, commonServices);
             var activeConfiguredProject = await debugFrameworkSvcs.GetConfiguredProjectForActiveFrameworkAsync();
             Assert.NotNull(activeConfiguredProject);
-            Assert.Equal(selectedConfigFramework, activeConfiguredProject!.ProjectConfiguration.Dimensions.GetValueOrDefault("TargetFramework"));
+            Assert.Equal(selectedConfigFramework, activeConfiguredProject.ProjectConfiguration.Dimensions.GetValueOrDefault("TargetFramework"));
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileDataTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileDataTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.Null(profile.LaunchUrl);
             Assert.Null(profile.EnvironmentVariables);
             Assert.NotNull(profile.OtherSettings);
-            Assert.True((bool)profile.OtherSettings!["custom1"]);
+            Assert.True((bool)profile.OtherSettings["custom1"]);
             Assert.Equal(124, profile.OtherSettings["custom2"]);
             Assert.Equal("mycustomVal", profile.OtherSettings["custom3"]);
             Assert.False(profile.InMemoryProfile);
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.Null(profile.LaunchUrl);
             Assert.Null(profile.EnvironmentVariables);
             Assert.NotNull(profile.OtherSettings);
-            Assert.Equal("some option in docker", profile.OtherSettings!["dockerOption1"]);
+            Assert.Equal("some option in docker", profile.OtherSettings["dockerOption1"]);
             Assert.Equal("Another option in docker", profile.OtherSettings["dockerOption2"]);
             Assert.False(profile.InMemoryProfile);
 
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.True(profile.LaunchBrowser);
             Assert.Null(profile.LaunchUrl);
             Assert.NotNull(profile.EnvironmentVariables);
-            Assert.Equal("Development", profile.EnvironmentVariables!["ASPNET_ENVIRONMENT"]);
+            Assert.Equal("Development", profile.EnvironmentVariables["ASPNET_ENVIRONMENT"]);
             Assert.Equal("c:\\Users\\billhie\\Documents\\projects\\WebApplication8\\src\\WebApplication8", profile.EnvironmentVariables["ASPNET_APPLICATIONBASE"]);
             Assert.Null(profile.OtherSettings);
             Assert.False(profile.InMemoryProfile);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileTests.cs
@@ -34,8 +34,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.Equal(data.WorkingDirectory, profile.WorkingDirectory);
             Assert.Equal(data.LaunchBrowser, profile.LaunchBrowser);
             Assert.Equal(data.LaunchUrl, profile.LaunchUrl);
-            Assert.True(DictionaryEqualityComparer<string, string>.Instance.Equals(data.EnvironmentVariables.ToImmutableDictionary(), profile.EnvironmentVariables!));
-            Assert.True(DictionaryEqualityComparer<string, object>.Instance.Equals(data.OtherSettings.ToImmutableDictionary(), profile.OtherSettings!));
+            Assert.True(DictionaryEqualityComparer<string, string>.Instance.Equals(data.EnvironmentVariables.ToImmutableDictionary(), profile.EnvironmentVariables));
+            Assert.True(DictionaryEqualityComparer<string, object>.Instance.Equals(data.OtherSettings.ToImmutableDictionary(), profile.OtherSettings));
             Assert.Equal(data.InMemoryProfile, profile.DoNotPersist);
 
             // Test overload
@@ -46,8 +46,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.Equal(profile.WorkingDirectory, profile2.WorkingDirectory);
             Assert.Equal(profile.LaunchBrowser, profile2.LaunchBrowser);
             Assert.Equal(profile.LaunchUrl, profile2.LaunchUrl);
-            Assert.True(DictionaryEqualityComparer<string, string>.Instance.Equals(profile.EnvironmentVariables!, profile2.EnvironmentVariables!));
-            Assert.True(DictionaryEqualityComparer<string, object>.Instance.Equals(profile.OtherSettings!.ToImmutableDictionary(), profile2.OtherSettings!));
+            Assert.True(DictionaryEqualityComparer<string, string>.Instance.Equals(profile.EnvironmentVariables, profile2.EnvironmentVariables));
+            Assert.True(DictionaryEqualityComparer<string, object>.Instance.Equals(profile.OtherSettings!.ToImmutableDictionary(), profile2.OtherSettings));
             Assert.Equal(profile.DoNotPersist, profile2.DoNotPersist);
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -321,9 +321,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             var launchSettings = await provider.ReadSettingsFileFromDiskTestAsync();
 
-            AssertEx.CollectionLength(launchSettings.Profiles!, 2);
+            Assert.NotNull(launchSettings.Profiles);
+            AssertEx.CollectionLength(launchSettings.Profiles, 2);
+            
+            Assert.NotNull(launchSettings.OtherSettings);
             Assert.Single(launchSettings.OtherSettings);
-            Assert.True(launchSettings.OtherSettings!["iisSettings"] is JObject);
+            Assert.True(launchSettings.OtherSettings["iisSettings"] is JObject);
         }
 
         [Fact]
@@ -337,10 +340,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             SetJsonSerializationProviders(provider);
 
             var launchSettings = await provider.ReadSettingsFileFromDiskTestAsync();
-
-            AssertEx.CollectionLength(launchSettings.Profiles!, 2);
+            
+            Assert.NotNull(launchSettings.Profiles);
+            AssertEx.CollectionLength(launchSettings.Profiles, 2);
+            
+            Assert.NotNull(launchSettings.OtherSettings);
             Assert.Single(launchSettings.OtherSettings);
-            Assert.True(launchSettings.OtherSettings!["iisSettings"] is IISSettingsData);
+            Assert.True(launchSettings.OtherSettings["iisSettings"] is IISSettingsData);
         }
 
         [Fact]
@@ -777,7 +783,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             // Check snapshot
             Assert.True(provider.CurrentSnapshot.GlobalSettings.TryGetValue("iisSettings", out object? updatedSettings));
-            Assert.True(((IISSettingsData)updatedSettings!).WindowsAuthentication);
+            Assert.True(((IISSettingsData)updatedSettings).WindowsAuthentication);
             Assert.True(((IVersionedLaunchSettings)provider.CurrentSnapshot).Version >= 123);
         }
 
@@ -813,7 +819,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             // Check snapshot
             Assert.True(provider.CurrentSnapshot.GlobalSettings.TryGetValue("iisSettings", out object? updatedSettings));
-            Assert.True(((IISSettingsData)updatedSettings!).WindowsAuthentication);
+            Assert.True(((IISSettingsData)updatedSettings).WindowsAuthentication);
             Assert.True(((IVersionedLaunchSettings)provider.CurrentSnapshot).Version >= 123);
         }
 
@@ -849,7 +855,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Check snapshot
             AssertEx.CollectionLength(provider.CurrentSnapshot.GlobalSettings, 2);
             Assert.True(provider.CurrentSnapshot.GlobalSettings.TryGetValue("iisSettings", out object? updatedSettings));
-            Assert.True(((IISSettingsData)updatedSettings!).WindowsAuthentication);
+            Assert.True(((IISSettingsData)updatedSettings).WindowsAuthentication);
             Assert.True(((IVersionedLaunchSettings)provider.CurrentSnapshot).Version >= 123);
         }
 
@@ -889,7 +895,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Check snapshot
             AssertEx.CollectionLength(provider.CurrentSnapshot.GlobalSettings, 2);
             Assert.True(provider.CurrentSnapshot.GlobalSettings.TryGetValue("iisSettings", out object? updatedSettings));
-            Assert.True(((IISSettingsData)updatedSettings!).WindowsAuthentication);
+            Assert.True(((IISSettingsData)updatedSettings).WindowsAuthentication);
             Assert.True(((IVersionedLaunchSettings)provider.CurrentSnapshot).Version >= 123);
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/OnceInitializedOnceDisposedUnderLockAsyncTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/OnceInitializedOnceDisposedUnderLockAsyncTests.cs
@@ -277,9 +277,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var firstRelease = new AsyncManualResetEvent();
             var disposeEntered = new AsyncManualResetEvent();
 
-            ConcreteOnceInitializedOnceDisposedUnderLockAsync? instance = null;
+            ConcreteOnceInitializedOnceDisposedUnderLockAsync? instance;
 
-            Task firstAction() => instance!.ExecuteUnderLockAsync(async (ct) =>
+            Task firstAction() => instance.ExecuteUnderLockAsync(async (ct) =>
             {
                 firstEntered.Set();
                 await firstRelease.WaitAsync();
@@ -291,7 +291,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 return Task.CompletedTask;
             });
 
-            Task disposeAction() => Task.Run(instance!.DisposeAsync);
+            Task disposeAction() => Task.Run(instance.DisposeAsync);
 
             await AssertNoOverlap(firstAction, disposeAction, firstEntered, firstRelease, disposeEntered);
         }
@@ -303,9 +303,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var firstRelease = new AsyncManualResetEvent();
             var disposeEntered = new AsyncManualResetEvent();
 
-            ConcreteOnceInitializedOnceDisposedUnderLockAsync? instance = null;
+            ConcreteOnceInitializedOnceDisposedUnderLockAsync? instance;
 
-            Task firstAction() => instance!.ExecuteUnderLockAsync(async (ct) =>
+            Task firstAction() => instance.ExecuteUnderLockAsync(async (ct) =>
             {
                 firstEntered.Set();
                 await firstRelease.WaitAsync();
@@ -319,7 +319,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 return Task.CompletedTask;
             });
 
-            Task disposeAction() => Task.Run(instance!.DisposeAsync);
+            Task disposeAction() => Task.Run(instance.DisposeAsync);
 
             await AssertNoOverlap(firstAction, disposeAction, firstEntered, firstRelease, disposeEntered);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectItemProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectItemProviderTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var item = await itemProvider.GetItemAsync(context);
 
             Assert.NotNull(item);
-            Assert.Equal("Profile2", item!.EvaluatedInclude);
+            Assert.Equal("Profile2", item.EvaluatedInclude);
         }
 
         [Fact]
@@ -201,7 +201,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var item = await itemProvider.GetItemAsync(context);
 
             Assert.NotNull(item);
-            Assert.Equal("Profile2", item!.EvaluatedInclude);
+            Assert.Equal("Profile2", item.EvaluatedInclude);
         }
 
         [Fact]
@@ -252,7 +252,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var item = await itemProvider.FindItemByNameAsync("Profile2");
 
             Assert.NotNull(item);
-            Assert.Equal(expected: "Profile2", actual: item!.EvaluatedInclude);
+            Assert.Equal(expected: "Profile2", actual: item.EvaluatedInclude);
         }
 
         [Fact]
@@ -305,7 +305,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 getProfilesCallback: initialProfiles =>
                 {
                     Assert.NotNull(newProfile);
-                    return initialProfiles.Add(newProfile!);
+                    return initialProfiles.Add(newProfile);
                 });
 
             var itemProvider = new LaunchProfileProjectItemProvider(
@@ -461,7 +461,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             Assert.NotNull(projectItem);
 
-            Assert.Equal(expected: "Profile2", actual: projectItem!.EvaluatedInclude);
+            Assert.Equal(expected: "Profile2", actual: projectItem.EvaluatedInclude);
         }
 
         [Fact]
@@ -480,7 +480,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             Assert.NotNull(projectItem);
 
-            Assert.Equal(expected: "Profile2", actual: projectItem!.UnevaluatedInclude);
+            Assert.Equal(expected: "Profile2", actual: projectItem.UnevaluatedInclude);
         }
 
         [Fact]
@@ -499,7 +499,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             Assert.NotNull(projectItem);
 
-            Assert.Equal(expected: LaunchProfileProjectItemProvider.ItemType, actual: projectItem!.ItemType);
+            Assert.Equal(expected: LaunchProfileProjectItemProvider.ItemType, actual: projectItem.ItemType);
         }
 
         [Fact]
@@ -518,8 +518,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             Assert.NotNull(projectItem);
 
-            Assert.Equal(expected: string.Empty, actual: projectItem!.EvaluatedIncludeAsFullPath);
-            Assert.Equal(expected: string.Empty, actual: projectItem!.EvaluatedIncludeAsRelativePath);
+            Assert.Equal(expected: string.Empty, actual: projectItem.EvaluatedIncludeAsFullPath);
+            Assert.Equal(expected: string.Empty, actual: projectItem.EvaluatedIncludeAsRelativePath);
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/DependencyRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/DependencyRuleTests.cs
@@ -148,24 +148,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
 
             Assert.NotNull(dataSource);
 
-            Assert.Null(dataSource!.Attribute("MSBuildTarget")); // Must come from evaluation
+            Assert.Null(dataSource.Attribute("MSBuildTarget"));  // Must come from evaluation
             Assert.Null(dataSource.Attribute("SourceType"));     // Must come from evaluation
 
             var hasConfigurationCondition = dataSource.Attribute("HasConfigurationCondition");
             Assert.NotNull(hasConfigurationCondition);
-            Assert.Equal("False", hasConfigurationCondition!.Value, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("False", hasConfigurationCondition.Value, StringComparer.OrdinalIgnoreCase);
 
             var itemType = dataSource.Attribute("ItemType");
             Assert.NotNull(itemType);
-            Assert.False(string.IsNullOrEmpty(itemType!.Value));
+            Assert.False(string.IsNullOrEmpty(itemType.Value));
 
             var persistence = dataSource.Attribute("Persistence");
             Assert.NotNull(persistence);
-            Assert.Equal("ProjectFile", persistence!.Value, StringComparer.Ordinal);
+            Assert.Equal("ProjectFile", persistence.Value, StringComparer.Ordinal);
 
             var sourceOfDefaultValue = dataSource.Attribute("SourceOfDefaultValue");
             Assert.NotNull(sourceOfDefaultValue);
-            Assert.Equal("AfterContext", sourceOfDefaultValue!.Value, StringComparer.Ordinal);
+            Assert.Equal("AfterContext", sourceOfDefaultValue.Value, StringComparer.Ordinal);
 
             Assert.Equal(4, dataSource.Attributes().Count());
         }
@@ -180,29 +180,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
 
             Assert.NotNull(dataSource);
 
-            var hasConfigurationCondition = dataSource!.Attribute("HasConfigurationCondition");
+            var hasConfigurationCondition = dataSource.Attribute("HasConfigurationCondition");
             Assert.NotNull(hasConfigurationCondition);
-            Assert.Equal("False", hasConfigurationCondition!.Value, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("False", hasConfigurationCondition.Value, StringComparer.OrdinalIgnoreCase);
 
             var itemType = dataSource.Attribute("ItemType");
             Assert.NotNull(itemType);
-            Assert.False(string.IsNullOrEmpty(itemType!.Value));
+            Assert.False(string.IsNullOrEmpty(itemType.Value));
 
             var msBuildTarget = dataSource.Attribute("MSBuildTarget");
             Assert.NotNull(msBuildTarget);
-            Assert.False(string.IsNullOrEmpty(msBuildTarget!.Value));
+            Assert.False(string.IsNullOrEmpty(msBuildTarget.Value));
 
             var persistence = dataSource.Attribute("Persistence");
             Assert.NotNull(persistence);
-            Assert.Equal("ResolvedReference", persistence!.Value, StringComparer.Ordinal);
+            Assert.Equal("ResolvedReference", persistence.Value, StringComparer.Ordinal);
 
             var sourceOfDefaultValue = dataSource.Attribute("SourceOfDefaultValue");
             Assert.NotNull(sourceOfDefaultValue);
-            Assert.Equal("AfterContext", sourceOfDefaultValue!.Value, StringComparer.Ordinal);
+            Assert.Equal("AfterContext", sourceOfDefaultValue.Value, StringComparer.Ordinal);
 
             var sourceType = dataSource.Attribute("SourceType");
             Assert.NotNull(sourceType);
-            Assert.Equal("TargetResults", sourceType!.Value, StringComparer.Ordinal);
+            Assert.Equal("TargetResults", sourceType.Value, StringComparer.Ordinal);
 
             Assert.Equal(6, dataSource.Attributes().Count());
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/ItemRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/ItemRuleTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
                 // Remove the "TargetPath" element for these types
                 var targetPathElement = none.XPathSelectElement(@"/msb:Rule/msb:StringProperty[@Name=""TargetPath""]", namespaceManager);
                 Assert.NotNull(targetPathElement);
-                targetPathElement!.Remove();
+                targetPathElement.Remove();
             }
 
             AssertXmlEqual(none, rule);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProviderTests.cs
@@ -592,7 +592,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
         {
             Assert.NotNull(resultTree);
 
-            string actual = ToTestDataString((TestProjectTree)resultTree!);
+            string actual = ToTestDataString((TestProjectTree)resultTree);
 
             if (expected != actual)
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
@@ -73,8 +73,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 
             Assert.NotNull(result.GroupNodeViewModel);
             Assert.Equal(DependencyTreeFlags.ProjectDependencyGroup, result.GroupNodeFlag);
-            Assert.Equal("ZzzDependencyRoot", result.GroupNodeViewModel!.Caption);
-            Assert.Equal(KnownMonikers.AboutBox, result.GroupNodeViewModel!.Icon);
+            Assert.Equal("ZzzDependencyRoot", result.GroupNodeViewModel.Caption);
+            Assert.Equal(KnownMonikers.AboutBox, result.GroupNodeViewModel.Icon);
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/IDependencyModelEqualityComparerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/IDependencyModelEqualityComparerTests.cs
@@ -51,15 +51,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.True(IDependencyModelEqualityComparer.Instance.Equals(null, null));
 
             Assert.Equal(
-                IDependencyModelEqualityComparer.Instance.GetHashCode(model1!),
+                IDependencyModelEqualityComparer.Instance.GetHashCode(model1),
                 IDependencyModelEqualityComparer.Instance.GetHashCode(model2));
 
             Assert.NotEqual(
-                IDependencyModelEqualityComparer.Instance.GetHashCode(model1!),
+                IDependencyModelEqualityComparer.Instance.GetHashCode(model1),
                 IDependencyModelEqualityComparer.Instance.GetHashCode(model3));
 
             Assert.NotEqual(
-                IDependencyModelEqualityComparer.Instance.GetHashCode(model1!),
+                IDependencyModelEqualityComparer.Instance.GetHashCode(model1),
                 IDependencyModelEqualityComparer.Instance.GetHashCode(model4));
 
             Assert.NotEqual(

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -1520,7 +1520,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             Assert.Equal(TelemetryEventName.UpToDateCheckFail, telemetryEvent.EventName);
             Assert.NotNull(telemetryEvent.Properties);
-            Assert.Equal(4, telemetryEvent.Properties!.Count);
+            Assert.Equal(4, telemetryEvent.Properties.Count);
 
             var reasonProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckFailReason));
             Assert.Equal(reason, reasonProp.propertyValue);
@@ -1547,7 +1547,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             Assert.Equal(TelemetryEventName.UpToDateCheckSuccess, telemetryEvent.EventName);
 
             Assert.NotNull(telemetryEvent.Properties);
-            Assert.Equal(3, telemetryEvent.Properties!.Count);
+            Assert.Equal(3, telemetryEvent.Properties.Count);
 
             var durationProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckDurationMillis));
             var duration = Assert.IsType<double>(durationProp.propertyValue);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionBuildManager2Factory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionBuildManager2Factory.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
             {
                 int onBuildStartedWithReturn()
                 {
-                    solutionEventsListener!.UpdateSolution_Begin(It.IsAny<int>());
+                    solutionEventsListener.UpdateSolution_Begin(It.IsAny<int>());
 
                     if (cancelBuild)
                     {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentVerificationTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentVerificationTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             Assert.NotNull(part);
 
-            foreach ((ImportDefinitionBinding import, IReadOnlyList<ExportDefinitionBinding> exports) in part!.SatisfyingExports)
+            foreach ((ImportDefinitionBinding import, IReadOnlyList<ExportDefinitionBinding> exports) in part.SatisfyingExports)
             {
                 var importingProperty = import.ImportingMember as PropertyInfo;
                 if (importingProperty == null)  // We don't verify ImportingConstructor, only check properties.
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             // Gather the appliesTo metadata from all exports of the same part.
             var appliesToMetadata = new List<string>();
-            foreach (KeyValuePair<MemberRef?, ExportDefinition> exportDefinitionPair in definition!.ExportDefinitions)
+            foreach (KeyValuePair<MemberRef?, ExportDefinition> exportDefinitionPair in definition.ExportDefinitions)
             {
                 if (exportDefinitionPair.Key?.IsStatic == true)
                     continue;
@@ -117,10 +117,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             Assert.NotNull(definition);
 
             // BUG: https://github.com/dotnet/project-system/issues/5519
-            if (definition!.Type.FullName == "Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.DependenciesSnapshotProvider")
+            if (definition.Type.FullName == "Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.DependenciesSnapshotProvider")
                 return;
 
-            foreach (KeyValuePair<MemberRef?, ExportDefinition> exportDefinitionPair in definition!.ExportDefinitions)
+            foreach (KeyValuePair<MemberRef?, ExportDefinition> exportDefinitionPair in definition.ExportDefinitions)
             {
                 ExportDefinition export = exportDefinitionPair.Value;
                 if (contractsWithFixedCapabilities.Contains(export.ContractName) &&
@@ -189,7 +189,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             Assert.NotNull(definition);
 
-            foreach (KeyValuePair<MemberRef?, ExportDefinition> export in definition!.ExportDefinitions)
+            foreach (KeyValuePair<MemberRef?, ExportDefinition> export in definition.ExportDefinitions)
             {
                 var contractsRequiringMetadata = ComponentComposition.Instance.ContractsRequiringAppliesTo;
 
@@ -233,7 +233,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             Assert.NotNull(definition);
 
-            foreach (ImportDefinitionBinding import in definition!.Imports)
+            foreach (ImportDefinitionBinding import in definition.Imports)
             {
                 ImportDefinition importDefinition = import.ImportDefinition;
                 if (contracts.TryGetValue(importDefinition.ContractName, out ComponentComposition.ContractMetadata contractMetadata))
@@ -256,7 +256,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             Assert.NotNull(definition);
 
-            foreach (ImportDefinitionBinding import in definition!.Imports)
+            foreach (ImportDefinitionBinding import in definition.Imports)
             {
                 ImportDefinition importDefinition = import.ImportDefinition;
                 if (importDefinition.ExportFactorySharingBoundaries.Count > 0)
@@ -291,7 +291,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             Assert.NotNull(definition);
 
-            foreach (ImportDefinitionBinding import in definition!.Imports)
+            foreach (ImportDefinitionBinding import in definition.Imports)
             {
                 ImportDefinition importDefinition = import.ImportDefinition;
                 if (!CheckContractHasMetadata(GetContractName(importDefinition), definition, ComponentComposition.Instance.Contracts, ComponentComposition.Instance.InterfaceNames))
@@ -311,7 +311,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             Assert.NotNull(definition);
 
-            foreach (KeyValuePair<MemberRef?, ExportDefinition> export in definition!.ExportDefinitions)
+            foreach (KeyValuePair<MemberRef?, ExportDefinition> export in definition.ExportDefinitions)
             {
                 ExportDefinition exportDefinition = export.Value;
                 if (!CheckContractHasMetadata(exportDefinition.ContractName, definition, ComponentComposition.Instance.Contracts, ComponentComposition.Instance.InterfaceNames))

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasic/MapDynamicEnumValuesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasic/MapDynamicEnumValuesProviderTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic
         private static void VerifySameValue(IEnumValue? actual, IEnumValue expected, bool checkMapNameOnly = false)
         {
             Assert.NotNull(actual);
-            Assert.Equal(expected.Name, actual!.Name);
+            Assert.Equal(expected.Name, actual.Name);
 
             if (!checkMapNameOnly)
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/DebugPageViewModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/DebugPageViewModelTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             await viewModel.Object.InitializeAsync();
 
             Assert.NotNull(viewModelData.FirstSnapshotComplete);
-            await viewModelData.FirstSnapshotComplete!.Task;
+            await viewModelData.FirstSnapshotComplete.Task;
 
             Assert.True(viewModel.Object.HasProfiles);
             Assert.True(viewModel.Object.IsProfileSelected);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/LaunchProfiles/ProjectLaunchProfileHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/LaunchProfiles/ProjectLaunchProfileHandlerTests.cs
@@ -34,13 +34,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.LaunchProfiles
             var newProfileId = await handler.AddLaunchProfileAsync(context, parent, commandName: "Alpha", newProfileName: "Beta");
 
             Assert.NotNull(newProfile);
-            Assert.Equal(expected: "Beta", actual: newProfile!.Name);
-            Assert.Equal(expected: "Alpha", actual: newProfile!.CommandName);
+            Assert.Equal(expected: "Beta", actual: newProfile.Name);
+            Assert.Equal(expected: "Alpha", actual: newProfile.CommandName);
             Assert.Single(profiles);
 
             Assert.NotNull(newProfileId);
-            Assert.Equal(expected: "LaunchProfile", actual: newProfileId![ProjectModelIdentityKeys.SourceItemType]);
-            Assert.Equal(expected: "Beta", actual: newProfileId![ProjectModelIdentityKeys.SourceItemName]);
+            Assert.Equal(expected: "LaunchProfile", actual: newProfileId[ProjectModelIdentityKeys.SourceItemType]);
+            Assert.Equal(expected: "Beta", actual: newProfileId[ProjectModelIdentityKeys.SourceItemName]);
         }
 
         [Fact]
@@ -65,26 +65,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.LaunchProfiles
             var newProfileId = await handler.AddLaunchProfileAsync(context, parent, commandName: "Alpha", newProfileName: null);
 
             Assert.NotNull(newProfile);
-            Assert.Equal(expected: "Alpha", actual: newProfile!.CommandName);
+            Assert.Equal(expected: "Alpha", actual: newProfile.CommandName);
             Assert.NotNull(newProfile.Name);
 
             var firstProfileName = newProfile.Name;
 
             Assert.NotNull(newProfileId);
-            Assert.Equal(expected: "LaunchProfile", actual: newProfileId![ProjectModelIdentityKeys.SourceItemType]);
-            Assert.Equal(expected: newProfile.Name, actual: newProfileId![ProjectModelIdentityKeys.SourceItemName]);
+            Assert.Equal(expected: "LaunchProfile", actual: newProfileId[ProjectModelIdentityKeys.SourceItemType]);
+            Assert.Equal(expected: newProfile.Name, actual: newProfileId[ProjectModelIdentityKeys.SourceItemName]);
 
             newProfileId = await handler.AddLaunchProfileAsync(context, parent, commandName: "Beta", newProfileName: null);
 
             Assert.NotNull(newProfile);
-            Assert.Equal(expected: "Beta", actual: newProfile!.CommandName);
+            Assert.Equal(expected: "Beta", actual: newProfile.CommandName);
             Assert.NotNull(newProfile.Name);
 
             var secondProfileName = newProfile.Name;
 
             Assert.NotNull(newProfileId);
-            Assert.Equal(expected: "LaunchProfile", actual: newProfileId![ProjectModelIdentityKeys.SourceItemType]);
-            Assert.Equal(expected: newProfile.Name, actual: newProfileId![ProjectModelIdentityKeys.SourceItemName]);
+            Assert.Equal(expected: "LaunchProfile", actual: newProfileId[ProjectModelIdentityKeys.SourceItemType]);
+            Assert.Equal(expected: newProfile.Name, actual: newProfileId[ProjectModelIdentityKeys.SourceItemName]);
 
             Assert.NotEqual(firstProfileName, secondProfileName);
 
@@ -122,8 +122,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.LaunchProfiles
             Assert.Equal(expected: 2, actual: profiles.Count);
 
             Assert.NotNull(duplicatedProfileId);
-            Assert.Equal(expected: "LaunchProfile", actual: duplicatedProfileId![ProjectModelIdentityKeys.SourceItemType]);
-            Assert.Equal(expected: duplicatedProfile.Name, actual: duplicatedProfileId![ProjectModelIdentityKeys.SourceItemName]);
+            Assert.Equal(expected: "LaunchProfile", actual: duplicatedProfileId[ProjectModelIdentityKeys.SourceItemType]);
+            Assert.Equal(expected: duplicatedProfile.Name, actual: duplicatedProfileId[ProjectModelIdentityKeys.SourceItemName]);
         }
 
         [Fact]
@@ -151,15 +151,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.LaunchProfiles
 
             var duplicatedProfileId = await handler.DuplicateLaunchProfileAsync(context, parent, currentProfileName: "Alpha", newProfileName: null, newProfileCommandName: null);
 
-            Assert.NotNull(duplicatedProfile!.Name);
-            Assert.NotEqual(expected: "Alpha", actual: duplicatedProfile!.Name);
-            Assert.Equal(expected: "Beta", actual: duplicatedProfile!.CommandName);
-            Assert.Equal(expected: @"C:\iguana\aardvark.exe", actual: duplicatedProfile!.ExecutablePath);
+            Assert.NotNull(duplicatedProfile);
+            Assert.NotNull(duplicatedProfile.Name);
+            Assert.NotEqual(expected: "Alpha", actual: duplicatedProfile.Name);
+            Assert.Equal(expected: "Beta", actual: duplicatedProfile.CommandName);
+            Assert.Equal(expected: @"C:\iguana\aardvark.exe", actual: duplicatedProfile.ExecutablePath);
             Assert.Equal(expected: 2, actual: profiles.Count);
 
             Assert.NotNull(duplicatedProfileId);
-            Assert.Equal(expected: "LaunchProfile", actual: duplicatedProfileId![ProjectModelIdentityKeys.SourceItemType]);
-            Assert.Equal(expected: duplicatedProfile.Name, actual: duplicatedProfileId![ProjectModelIdentityKeys.SourceItemName]);
+            Assert.Equal(expected: "LaunchProfile", actual: duplicatedProfileId[ProjectModelIdentityKeys.SourceItemType]);
+            Assert.Equal(expected: duplicatedProfile.Name, actual: duplicatedProfileId[ProjectModelIdentityKeys.SourceItemName]);
         }
 
         [Fact]
@@ -234,8 +235,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.LaunchProfiles
             Assert.Equal(expected: "Alpha", actual: removedProfileName);
 
             Assert.NotNull(removedProfileId);
-            Assert.Equal(expected: "LaunchProfile", actual: removedProfileId![ProjectModelIdentityKeys.SourceItemType]);
-            Assert.Equal(expected: "Alpha", actual: removedProfileId![ProjectModelIdentityKeys.SourceItemName]);
+            Assert.Equal(expected: "LaunchProfile", actual: removedProfileId[ProjectModelIdentityKeys.SourceItemType]);
+            Assert.Equal(expected: "Alpha", actual: removedProfileId[ProjectModelIdentityKeys.SourceItemName]);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VersionCompatibility/VersionCompatibilityTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VersionCompatibility/VersionCompatibilityTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.VersionCompatibility
 }}";
             var data = VersionCompatibilityData.DeserializeVersionData(versionDataString);
             Assert.NotNull(data);
-            Assert.False(data!.TryGetValue(new Version("15.5"), out _));
+            Assert.False(data.TryGetValue(new Version("15.5"), out _));
             Assert.True(data.TryGetValue(new Version("15.6"), out _));
             Assert.True(data.TryGetValue(new Version("15.8"), out _));
             Assert.True(data.TryGetValue(new Version("16.0"), out _));
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.VersionCompatibility
 }}";
             var data = VersionCompatibilityData.DeserializeVersionData(versionDataString);
             Assert.NotNull(data);
-            Assert.True(data!.TryGetValue(new Version("16.1"), out var compatibilityData));
+            Assert.True(data.TryGetValue(new Version("16.1"), out var compatibilityData));
             Assert.Null(compatibilityData.SupportedVersion);
             Assert.Null(compatibilityData.UnsupportedVersion);
             Assert.Null(compatibilityData.OpenSupportedMessage);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProviderTests.cs
@@ -233,7 +233,7 @@ Project
             var result = await provider.GetSpecificEditorAsync(@"C:\Foo.cs");
 
             Assert.NotNull(result);
-            Assert.NotEmpty(result!.DisplayName);
+            Assert.NotEmpty(result.DisplayName);
             Assert.Equal(VSConstants.LOGVIEWID.Designer_guid, result.DefaultView);
             Assert.Equal(useDesignerByDefault, result.IsDefaultEditor);
             Assert.Equal(defaultEditorFactory, result.EditorFactory);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/SDKVersionTelemetryTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/SDKVersionTelemetryTests.cs
@@ -19,8 +19,10 @@ namespace Microsoft.VisualStudio.Telemetry
             var guid = Guid.NewGuid();
             var version = "42.42.42.42";
             var (success, result) = await CreateComponentAndGetResult(guid, version);
+            Assert.NotNull(result);
+            Assert.NotNull(result.Properties);
             Assert.True(success);
-            Assert.Equal("vs/projectsystem/managed/sdkversion", result!.EventName);
+            Assert.Equal("vs/projectsystem/managed/sdkversion", result.EventName);
             Assert.Collection(result.Properties,
                 args =>
                 {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/VsTelemetryServiceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/VsTelemetryServiceTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.VisualStudio.Telemetry
             service.PostProperty(TelemetryEventName.UpToDateCheckFail, TelemetryPropertyName.UpToDateCheckFailReason, "Reason");
 
             Assert.NotNull(result);
-            Assert.Equal(TelemetryEventName.UpToDateCheckFail, result!.Name);
+            Assert.Equal(TelemetryEventName.UpToDateCheckFail, result.Name);
             Assert.Contains(new KeyValuePair<string, object>(TelemetryPropertyName.UpToDateCheckFailReason, "Reason"), result.Properties);
         }
 
@@ -170,7 +170,7 @@ namespace Microsoft.VisualStudio.Telemetry
             });
 
             Assert.NotNull(result);
-            Assert.Equal(TelemetryEventName.DesignTimeBuildComplete, result!.Name);
+            Assert.Equal(TelemetryEventName.DesignTimeBuildComplete, result.Name);
             Assert.Contains(new KeyValuePair<string, object>(TelemetryPropertyName.DesignTimeBuildCompleteSucceeded, true), result.Properties);
             Assert.Contains(new KeyValuePair<string, object>(TelemetryPropertyName.DesignTimeBuildCompleteTargets, "Compile"), result.Properties);
         }


### PR DESCRIPTION
The xUnit project is currently working on version 2.4.2 and has [asked for feedback](https://twitter.com/bradwilson/status/1444766450657333253) ahead of RTM. I wanted to try integrating the new version to find any issues and contribute feedback. So far the upgrade seems to have gone smoothly.

The most notable change from our perspective seems to be the introduction of null annotations in the assertions library. This required a few updates to test code, and allowed removing quite a few null suppressions.