### PR TITLE
Fix log level comparisons

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -202,7 +202,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     log.Fail("Outputs", "The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up to date.", state.LastItemsChangedAtUtc, earliestOutputPath, earliestOutputTime);
 
-                    if (log.Level <= LogLevel.Info)
+                    if (log.Level >= LogLevel.Info)
                     {
                         foreach ((bool isAdd, string itemType, string path, string? targetPath, CopyType copyType) in state.LastItemChanges.OrderBy(change => change.ItemType).ThenBy(change => change.Path))
                         {
@@ -256,7 +256,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     hasInput = true;
                 }
 
-                if (log.Level <= LogLevel.Info)
+                if (log.Level >= LogLevel.Info)
                 {
                     if (!hasInput)
                     {
@@ -477,7 +477,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     return false;
                 }
 
-                if (log.Level == LogLevel.Verbose)
+                if (log.Level >= LogLevel.Verbose)
                 {
                     foreach (string path in items)
                     {
@@ -506,7 +506,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             string markerFile = _configuredProject.UnconfiguredProject.MakeRooted(state.CopyUpToDateMarkerItem);
 
-            if (log.Level <= LogLevel.Verbose)
+            if (log.Level >= LogLevel.Verbose)
             {
                 log.Verbose("Adding input reference copy markers:");
 


### PR DESCRIPTION
Flips some inequalities to correctly assess when log operations should occur.

- For comparisons with `LogLevel.Info`, this means that users specifying a preference for `Verbose` logging will now see these log messages correctly.
- For comparisons with `LogLevel.Verbose`, there should be no observable behaviour change.

In both cases, the previous comparisons caused redundant work to occur during up-to-date checks. This fix may have some performance impact too, in addition to correctness.