### PR TITLE
Add ProjectHotReloadSessionManager tests

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IHotReloadDiagnosticOutputServiceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IHotReloadDiagnosticOutputServiceFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using Microsoft.VisualStudio.ProjectSystem.VS.HotReload;
 using Moq;
 
@@ -7,9 +8,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     internal static class IHotReloadDiagnosticOutputServiceFactory
     {
-        public static IHotReloadDiagnosticOutputService Create()
+        public static IHotReloadDiagnosticOutputService Create(Action<string>? writeLineCallback = null)
         {
             var mock = new Mock<IHotReloadDiagnosticOutputService>();
+
+            if (writeLineCallback is not null)
+            {
+                mock.Setup(service => service.WriteLine(It.IsAny<string>()))
+                    .Callback(writeLineCallback);
+            }
 
             return mock.Object;
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectHotReloadAgentFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectHotReloadAgentFactory.cs
@@ -7,12 +7,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     internal static class IProjectHotReloadAgentFactory
     {
-        public static IProjectHotReloadAgent Create()
+        public static IProjectHotReloadAgent Create(IProjectHotReloadSession? session = null)
         {
             var mock = new Mock<IProjectHotReloadAgent>();
 
+            if (session is null)
+            {
+                session = IProjectHotReloadSessionFactory.Create();
+            }
+
             mock.Setup(agent => agent.CreateHotReloadSession(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IProjectHotReloadSessionCallback>()))
-                .Returns((IProjectHotReloadSession)null!);
+                .Returns(session);
 
             return mock.Object;
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectHotReloadSessionFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectHotReloadSessionFactory.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.VisualStudio.ProjectSystem.VS.HotReload;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal static class IProjectHotReloadSessionFactory
+    {
+        public static IProjectHotReloadSession Create()
+        {
+            var mock = new Mock<IProjectHotReloadSession>();
+
+            mock.Setup(session => session.ApplyLaunchVariablesAsync(It.IsAny<IDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManagerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManagerTests.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
+{
+    public class ProjectHotReloadSessionManagerTests
+    {
+        [Fact]
+        public async Task WhenActiveFrameworkMeetsRequirements_APendingSessionIsCreated()
+        {
+            var capabilities = new[] { "SupportsHotReload" };
+            var propertyNamesAndValues = new Dictionary<string, string?>()
+            {
+                { "TargetFrameworkVersion", "v6.0" }
+            };
+
+            var activeConfiguredProject = CreateConfiguredProject(capabilities, propertyNamesAndValues);
+            var manager = CreateHotReloadSessionManager(activeConfiguredProject);
+
+            var environmentVariables = new Dictionary<string, string>();
+            var sessionCreated = await manager.TryCreatePendingSessionAsync(environmentVariables);
+
+            Assert.True(sessionCreated);
+        }
+
+        [Fact]
+        public async Task WhenTheSupportsHotReloadCapabilityIsMissing_APendingSessionIsNotCreated()
+        {
+            var capabilities = new[] { "ARandomCapabilityUnrelatedToHotReload" };
+            var propertyNamesAndValues = new Dictionary<string, string?>()
+            {
+                { "TargetFrameworkVersion", "v6.0" }
+            };
+
+            var activeConfiguredProject = CreateConfiguredProject(capabilities, propertyNamesAndValues);
+            var manager = CreateHotReloadSessionManager(activeConfiguredProject);
+
+            var environmentVariables = new Dictionary<string, string>();
+            var sessionCreated = await manager.TryCreatePendingSessionAsync(environmentVariables);
+
+            Assert.False(sessionCreated);
+        }
+
+        [Fact(Skip = "Bug: if TargetFrameworkVersion is not defined we still get a session")]
+        public async Task WhenTheTargetFrameworkVersionIsNotDefined_APendingSessionIsNotCreated()
+        {
+            var capabilities = new[] { "SupportsHotReload" };
+            var propertyNamesAndValues = new Dictionary<string, string?>()
+            {
+                { "ARandomProperty", "WithARandomValue" }
+            };
+
+            var activeConfiguredProject = CreateConfiguredProject(capabilities, propertyNamesAndValues);
+            var manager = CreateHotReloadSessionManager(activeConfiguredProject);
+
+            var environmentVariables = new Dictionary<string, string>();
+            var sessionCreated = await manager.TryCreatePendingSessionAsync(environmentVariables);
+
+            Assert.False(sessionCreated);
+        }
+
+        [Fact]
+        public async Task WhenStartupHooksAreDisabled_APendingSessionIsNotCreated()
+        {
+            var capabilities = new[] { "SupportsHotReload" };
+            var propertyNamesAndValues = new Dictionary<string, string?>()
+            {
+                { "TargetFrameworkVersion", "v6.0" },
+                { "StartupHookSupport", "false" }
+            };
+
+            var activeConfiguredProject = CreateConfiguredProject(capabilities, propertyNamesAndValues);
+            bool outputServiceCalled = false;
+            Action<string> outputServiceCallback = message => outputServiceCalled = true;
+            var manager = CreateHotReloadSessionManager(activeConfiguredProject, outputServiceCallback);
+
+            var environmentVariables = new Dictionary<string, string>();
+            var sessionCreated = await manager.TryCreatePendingSessionAsync(environmentVariables);
+
+            Assert.False(sessionCreated);
+            Assert.True(outputServiceCalled);
+        }
+
+        private static ProjectHotReloadSessionManager CreateHotReloadSessionManager(ConfiguredProject activeConfiguredProject, Action<string>? outputServiceCallback = null)
+        {
+            var activeDebugFrameworkServices = new IActiveDebugFrameworkServicesMock()
+                .ImplementGetConfiguredProjectForActiveFrameworkAsync(activeConfiguredProject)
+                .Object;
+
+            var manager = new ProjectHotReloadSessionManager(
+                UnconfiguredProjectFactory.Create(),
+                IProjectThreadingServiceFactory.Create(),
+                IProjectFaultHandlerServiceFactory.Create(),
+                activeDebugFrameworkServices,
+                new Lazy<IProjectHotReloadAgent>(() => IProjectHotReloadAgentFactory.Create()),
+                new Lazy<IHotReloadDiagnosticOutputService>(() => IHotReloadDiagnosticOutputServiceFactory.Create(outputServiceCallback)));
+
+            return manager;
+        }
+
+        private static ConfiguredProject CreateConfiguredProject(string[] capabilities, Dictionary<string, string?> propertyNamesAndValues)
+        {
+            return ConfiguredProjectFactory.Create(
+                IProjectCapabilitiesScopeFactory.Create(capabilities),
+                services: ConfiguredProjectServicesFactory.Create(
+                    projectPropertiesProvider: IProjectPropertiesProviderFactory.Create(
+                        commonProps: IProjectPropertiesFactory.CreateWithPropertiesAndValues(
+                            propertyNamesAndValues))));
+        }
+    }
+}


### PR DESCRIPTION
Add some unit tests for the `ProjectHotReloadSessionManager`, specifically around creating pending sessions. Right now we largely check if the project has the "SupportsHotReload" capability, but there are a couple other things we should look at as well. Before I add those, however, I want to have some unit testing infrastructure in place.