### PR TITLE
Fix a potential race condition in ActiveProfile

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
                     computedProfile ??= !Profiles.IsEmpty ? Profiles[0] : null;
 
-                    Interlocked.CompareExchange(ref _activeProfile, computedProfile, null);
+                    Interlocked.CompareExchange(ref _activeProfile, value: computedProfile, comparand: null);
                 }
 
                 return _activeProfile;


### PR DESCRIPTION
This PR is to fix a potential race condition in the code. It could lead to #7596, but I don't have a proof. 

Unfortunately, it is a come-and-go race condition to make it hard to reproduce. Fixing the race condition to eliminate one potential source of the problem.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7674)