### PR TITLE
Rename WritableLaunchSettingsExtension to WritableLaunchSettingsExtensions

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettingsExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettingsExtensions.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.Collections;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
-    internal static class WritableLaunchSettingsExtension
+    internal static class WritableLaunchSettingsExtensions
     {
         public static bool SettingsDiffer(this IWritableLaunchSettings launchSettings, IWritableLaunchSettings settingsToCompare)
         {


### PR DESCRIPTION
This file contains a class for extension methods. The convention is to use `Extensions` (plural) for these files. Renamed this file and the class to match that pattern.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7676)