### PR TITLE
Optimize when fast up-to-date check is disabled

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -19,6 +19,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
     {
         public static UpToDateCheckImplicitConfiguredInput Empty { get; } = new();
 
+        public static UpToDateCheckImplicitConfiguredInput Disabled { get; } = new UpToDateCheckImplicitConfiguredInput(
+            msBuildProjectFullPath:                       null,
+            msBuildProjectDirectory:                      null,
+            copyUpToDateMarkerItem:                       null,
+            outputRelativeOrFullPath:                     null,
+            newestImportInput:                            null,
+            isDisabled:                                   true,
+            itemTypes:                                    ImmutableArray<string>.Empty,
+            itemsByItemType:                              ImmutableDictionary<string, ImmutableArray<(string, string?, BuildUpToDateCheck.CopyType)>>.Empty,
+            upToDateCheckInputItemsByKindBySetName:       ImmutableDictionary<string, ImmutableDictionary<string, ImmutableArray<string>>>.Empty,
+            upToDateCheckOutputItemsByKindBySetName:      ImmutableDictionary<string, ImmutableDictionary<string, ImmutableArray<string>>>.Empty,
+            upToDateCheckBuiltItemsByKindBySetName:       ImmutableDictionary<string, ImmutableDictionary<string, ImmutableArray<string>>>.Empty,
+            copiedOutputFiles:                            ImmutableArray<(string DestinationRelative, string SourceRelative)>.Empty,
+            resolvedAnalyzerReferencePaths:               ImmutableArray<string>.Empty,
+            resolvedCompilationReferencePaths:            ImmutableArray<string>.Empty,
+            copyReferenceInputs:                          ImmutableArray<string>.Empty,
+            additionalDependentFileTimes:                 ImmutableDictionary<string, DateTime>.Empty,
+            lastAdditionalDependentFileTimesChangedAtUtc: DateTime.MinValue,
+            lastItemsChangedAtUtc:                        DateTime.MinValue,
+            lastItemChanges:                              ImmutableArray<(bool IsAdd, string ItemType, string Path, string? TargetPath, BuildUpToDateCheck.CopyType CopyType)>.Empty,
+            itemHash:                                     null,
+            wasStateRestored:                             false);
+
         public string? MSBuildProjectFullPath { get; }
 
         public string? MSBuildProjectDirectory { get; }
@@ -211,6 +234,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             IProjectCatalogSnapshot projectCatalogSnapshot)
         {
             bool isDisabled = jointRuleUpdate.CurrentState.IsPropertyTrue(ConfigurationGeneral.SchemaName, ConfigurationGeneral.DisableFastUpToDateCheckProperty, defaultValue: false);
+
+            if (isDisabled)
+            {
+                return UpToDateCheckImplicitConfiguredInput.Disabled;
+            }
 
             string? msBuildProjectFullPath = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, MSBuildProjectFullPath);
             string? msBuildProjectDirectory = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectDirectoryProperty, MSBuildProjectDirectory);


### PR DESCRIPTION
Previously when the fast up-to-date check was disabled we would still perform all project data ingestion, only to not use that data.

We would also allocate a new instance of `UpToDateCheckImplicitConfiguredInput` for each project configuration.

With this change we no longer perform data ingestion when disabled, and no longer allocate a data object each time the project updates.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7687)