### PR TITLE
Switch to 1ES servicing pools on dev16.11.x

### DIFF
--- a/build/ci/integration-tests.yml
+++ b/build/ci/integration-tests.yml
@@ -10,8 +10,8 @@ trigger: none
 jobs:
 - job: Visual_Studio
   pool:
-    name: NetCorePublic-Pool
-    queue: buildpool.windows.10.amd64.vs2019.pre.open
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -equals build.windows.10.amd64.vs2019.pre.open
   strategy:
     maxParallel: 2
     matrix:

--- a/build/ci/one-loc-build.yml
+++ b/build/ci/one-loc-build.yml
@@ -8,8 +8,8 @@ resources:
 - repo: self
   clean: true
 pool:
-  name: NetCorePublic-Pool
-  queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+  name: NetCore1ESPool-Svc-Public
+  demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
   demands: Cmd
   timeoutInMinutes: 15
 variables:

--- a/build/ci/richnav.yml
+++ b/build/ci/richnav.yml
@@ -25,8 +25,8 @@ resources:
 - repo: self
   clean: true
 pool:
-  name: NetCorePublic-Pool
-  queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+  name: NetCore1ESPool-Svc-Public
+  demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
   demands: Cmd
   timeoutInMinutes: 15
 variables:

--- a/build/ci/unit-tests.yml
+++ b/build/ci/unit-tests.yml
@@ -30,21 +30,21 @@ jobs:
     name: Windows_Debug
     configuration: Debug
     pool:
-      name: NetCorePublic-Pool
-      queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+      name: NetCore1ESPool-Svc-Public
+      demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
 
 - template: unit-tests-template.yml
   parameters:
     name: Windows_Release
     configuration: Release
     pool:
-      name: NetCorePublic-Pool
-      queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+      name: NetCore1ESPool-Svc-Public
+      demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
 
 - template: unit-tests-template.yml
   parameters:
     name: Spanish
     configuration: Debug
     pool: 
-      name: NetCorePublic-Pool
-      queue: BuildPool.Windows.Amd64.VS2019.Pre.ES.Open
+      name: NetCore1ESPool-Svc-Public
+      demands: ImageOverride -equals Build.Windows.Amd64.VS2019.Pre.ES.Open


### PR DESCRIPTION
Per https://github.com/dotnet/core-eng/issues/14276.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7690)