### PR TITLE
Improve up-to-date check logging of file copies

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -572,7 +572,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 }
                 else
                 {
-                    return log.Fail("CopySourceNotFound", "Source '{0}' does not exist, not up to date.", source);
+                    return log.Fail("CopySourceNotFound", "Source '{0}' does not exist for copy to '{1}', not up to date.", source, destination);
                 }
 
                 DateTime? destinationTime = timestampCache.GetTimestampUtc(destination);
@@ -583,7 +583,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 }
                 else
                 {
-                    return log.Fail("CopyDestinationNotFound", "Destination '{0}' does not exist, not up to date.", destination);
+                    return log.Fail("CopyDestinationNotFound", "Destination '{0}' does not exist for copy from '{1}', not up to date.", destination, source);
                 }
 
                 if (destinationTime < sourceTime)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -1067,7 +1067,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     "No build outputs defined.",
                     $"Checking copied output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file '{sourcePath}':",
-                    $"Source '{sourcePath}' does not exist, not up to date."
+                    $"Source '{sourcePath}' does not exist for copy to '{destinationPath}', not up to date."
                 },
                 "CopySourceNotFound");
         }
@@ -1100,7 +1100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     "No build outputs defined.",
                     $"Checking copied output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file '{sourcePath}':",
                     $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
-                    $"Destination '{destinationPath}' does not exist, not up to date."
+                    $"Destination '{destinationPath}' does not exist for copy from '{sourcePath}', not up to date."
                 },
                 "CopyDestinationNotFound");
         }


### PR DESCRIPTION
The up-to-date check tests several file copy operations. In cases where either the source or destination of a copy is not found, the project is not up-to-date.

Previously logging when we missed a source or destination file would log the missing file. With this change we log both files each way.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7694)