### PR TITLE
Up-to-date check ignores None and Content items

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ProjectItemsSchema.xaml
@@ -109,8 +109,8 @@
     DisplayName="Resource"
     ItemType="Resource" />
 
-  <ItemType Name="None" DisplayName="None"/>
-  <ItemType Name="Content" DisplayName="Content" />
+  <ItemType Name="None" DisplayName="None" UpToDateCheckInput="False" />
+  <ItemType Name="Content" DisplayName="Content" UpToDateCheckInput="False" />
   <ItemType Name="EmbeddedResource" DisplayName="Embedded resource" />
   <ItemType Name="Page" DisplayName="Page" />
   <ItemType Name="ApplicationDefinition" DisplayName="Application definition" />


### PR DESCRIPTION
Fixes #7700 

This change fixes a potential overbuild issue where adding or removing a `None` or `Content` item in the project would mark the items as changed at that point in time, with the expectation that a subsequent build would produce newer outputs. This is not the case for `None` and `Content` items. If any such items do behave that way in a given project, they should be modelled as `UpToDateCheckInput` or `UpToDateCheckBuilt` items instead.

This change will also cause the up-to-date check to hold on to less in-memory data. For projects with a lot of `None` or `Content` items, this may have a positive effect.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7703)