### PR TITLE
Fix dupe demands node

### DIFF
--- a/build/ci/richnav.yml
+++ b/build/ci/richnav.yml
@@ -27,7 +27,6 @@ resources:
 pool:
   name: NetCore1ESPool-Public
   demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
-  demands: Cmd
   timeoutInMinutes: 15
 variables:
   BuildConfiguration: Debug


### PR DESCRIPTION
From: https://github.com/dotnet/project-system/pull/7686

When the new pools were added, `demands` is required for these pools to resolve the specific image to be used. However, we had a `demands` node here already. It was missed in the PR review. This has been causing the RichNav build to fail for about 10 days now.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7718)