### PR TITLE
Switch IDE0005 from warning to error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -372,7 +372,7 @@ dotnet_diagnostic.RS0010.severity = warning
                                                   # Name:                                         Before:                                             After:
 dotnet_diagnostic.IDE0001.severity = warning      # Simplify names                                System.Version version;                             Version version;
 dotnet_diagnostic.IDE0002.severity = warning      # Simplify (member access)                      System.Version.Equals("1", "2");                    Version.Equals("1", "2");
-dotnet_diagnostic.IDE0005.severity = warning      # Using directive is unnecessary                using System.Text;
+dotnet_diagnostic.IDE0005.severity = error        # Using directive is unnecessary                using System.Text;
 dotnet_diagnostic.IDE0030.severity = warning      # Use coalesce expression (nullable)            int? y = x.HasValue ? x.Value : 0                   int? y = x ?? 0;
 dotnet_diagnostic.IDE0030WithoutSuggestion.severity = error
 dotnet_diagnostic.IDE0079.severity = warning      # Unused suppresion


### PR DESCRIPTION
CI builds will fail due to that error so the .editorconfig should match that behavior. For a sample failure, see https://github.com/dotnet/project-system/pull/7719/checks?check_run_id=3981355521

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7720)