### PR TITLE
Fix WAPPROJ do not appear in Startup Project combo-box (16.11)

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -109,12 +109,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
         private async Task<bool> IsDebuggableAsync()
         {
+            var foundStartupProjectProvider = false;
+
             foreach (Lazy<IDebugLaunchProvider> provider in _launchProviders.Values)
             {
-                if (provider.Value is IStartupProjectProvider startupProjectProvider &&
-                    await startupProjectProvider.CanBeStartupProjectAsync(DebugLaunchOptions.DesignTimeExpressionEvaluation))
+                if (provider.Value is IStartupProjectProvider startupProjectProvider)
                 {
-                    return true;
+                    foundStartupProjectProvider = true;
+                    if (await startupProjectProvider.CanBeStartupProjectAsync(DebugLaunchOptions.DesignTimeExpressionEvaluation))
+                    {
+                        return true;
+                    }
+                } 
+            }
+
+            if (!foundStartupProjectProvider)
+            {
+                foreach (Lazy<IDebugLaunchProvider> provider in _launchProviders.Values)
+                {
+                    if (await provider.Value.CanLaunchAsync(DebugLaunchOptions.DesignTimeExpressionEvaluation))
+                    {
+                        return true;
+                    }
                 }
             }
 


### PR DESCRIPTION
This is the fix for #7587, originally submitted in #7588 but back-ported to 16.11.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7721)