### PR TITLE
Use in-process Framework

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
@@ -98,7 +98,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ' job is to translate the .NET Framework 4.x types known to VS into .NET Framework
         ' 2.x/3.x types to be persisted into the .resx file for use by the application at
         ' run time. It largely assumes that VS is running on the newest .NET Framework,
-        ' and thus will inherently understand (thanks to type forwarding) and 2.x/3.x
+        ' and thus will inherently understand (thanks to type forwarding) any 2.x/3.x
         ' types it comes across.
         ' This completely falls over when the project is targeting anything newer than
         ' .NET Framework 4.x. The service will translate the Framework types known to VS


### PR DESCRIPTION
Related to #5629, #7715.

The Resource Designer assumes that it is using the latest version of the framework. If the project containing the .resx file is targeting an earlier framework, the designer uses the `MultiTargetService` to translate types into the correct (assembly-qualified) type names to persist into the file for use by the application at run time.

This completely falls over for projects targeting .NET Core. The `MultiTargetService` will end up translating a .NET Framework 4.7.2 `Type` (which is what the designer understands) into the name of the type in .NET Core. This is fine, until the designer tries to read it back and is unable to find and instantiate the type.

The fix here is to avoid translating the type to begin with, and use the .NET Framework 4.7.2 name as-is. The designer will of course understand this type, and thanks to type forwarding, the .NET Core application will understand it at run time, as well.

The WinForms designer is already doing something similar when it needs to write to .resx files in projects targeting .NET Core. By matching their behavior, we avoid failures in both designers.

When VS moves off of .NET Framework we will need to revisit this with a more robust solution, but this will work for the Dev17 release cycle.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7726)