### PR TITLE
Fix missing newline in output window

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/HotReloadDiagnosticOutputService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/HotReloadDiagnosticOutputService.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             IVsOutputWindowPane? pane = await _outputWindowPane.GetValueAsync();
             if (pane is not null)
             {
-                pane.OutputStringNoPump(outputMessage + Environment.NewLine);
+                pane.OutputStringNoPump(outputMessage);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsOutputWindowPaneExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsOutputWindowPaneExtensions.cs
@@ -21,11 +21,11 @@ namespace Microsoft.VisualStudio.Shell.Interop
 
             if (pane is IVsOutputWindowPaneNoPump noPumpPane)
             {
-                noPumpPane.OutputStringNoPump(pszOutputString);
+                noPumpPane.OutputStringNoPump(pszOutputString + Environment.NewLine);
             }
             else
             {
-                Verify.HResult(pane.OutputStringThreadSafe(pszOutputString));
+                Verify.HResult(pane.OutputStringThreadSafe(pszOutputString + Environment.NewLine));
             }
         }
     }


### PR DESCRIPTION
In code review for #7681, it was suggested to change from `OutputString` to `OutputStringNoPump`. My testing of that change only involved a single project, so the message printed was the last in the Output Window. However the no-pump version of this method does not include a trailing newline character, meaning that had there been another log message, it would have commenced on the same line that the incremental build failure warning finished on.

The change here makes our `OutputStringNoPump` extension method behave identically to `OutputString` in terms of what it writes to the output pane.

The bug being fixed here manifested in `IncrementalBuildFailureOutputWindowReporter`, which is not present in this diff:

https://github.com/dotnet/project-system/blob/04474df00ebd742e05d31f8e487d6ed4ac83763e/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureOutputWindowReporter.cs#L78

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7733)