### PR TITLE
17.0 manual merge to main

### DIFF
--- a/build/ci/integration-tests.yml
+++ b/build/ci/integration-tests.yml
@@ -11,7 +11,7 @@ jobs:
 - job: Visual_Studio
   pool:
     name: NetCore1ESPool-Public
-    demands: ImageOverride -equals build.windows.10.amd64.vs2019.pre.open
+    demands: ImageOverride -equals Build.windows.10.amd64.vs2019.pre.open
   strategy:
     maxParallel: 2
     matrix:


### PR DESCRIPTION
Related: https://github.com/dotnet/roslyn-tools/pull/1116

We have to do these manually when the pool is changed so that the history has the right information about the pool name. ☹
After this is merged, I can re-enable auto-merging. I also fixed the casing on the one image name to match the others. Otherwise, no code changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7736)