### PR TITLE
Move the MissingWorkloadDetector into the Workloads folder

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Workloads/MissingWorkloadDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Workloads/MissingWorkloadDetector.cs
@@ -6,9 +6,8 @@ using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.VS;
-using Microsoft.VisualStudio.ProjectSystem.Workloads;
 
-namespace Microsoft.VisualStudio.ProjectSystem
+namespace Microsoft.VisualStudio.ProjectSystem.Workloads
 {
     /// <summary>
     ///     Tracks the set of missing .NET workloads for a configured project.


### PR DESCRIPTION
Minor cleanup inspired by @MiYanni's point about random files in the top level ProjectSystem folder

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7738)