### PR TITLE
Fix exception when fast up-to-date check is disabled

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
@@ -119,11 +119,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     projectItemSchema: e.Value.Item4,
                     projectCatalogSnapshot: e.Value.Item5);
 
-                if (_persistentState != null && (priorItemHash != state.ItemHash || priorLastItemsChangedAtUtc != state.LastItemsChangedAtUtc))
+                if (state.ItemHash is not null && _persistentState is not null && (priorItemHash != state.ItemHash || priorLastItemsChangedAtUtc != state.LastItemsChangedAtUtc))
                 {
-                    // The input hash is always non-null after calling Update.
-                    Assumes.NotNull(state.ItemHash);
-
                     _persistentState.StoreState(_configuredProject.UnconfiguredProject.FullPath, _configuredProject.ProjectConfiguration.Dimensions, state.ItemHash.Value, state.LastItemsChangedAtUtc);
                 }
 


### PR DESCRIPTION
The change in #7687 optimised the fast up-to-date check in the case that the check is disabled, but introduced a logic bug. When disabled, the state hash will be null. Here we convert the assertion to a check, to allow for that case.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7742)