### PR TITLE
Flush Unshipped API contents into Shipped on build

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -2,4 +2,13 @@
 <Project>
   <Import Project="..\Directory.Build.targets" />
   <Import Project="..\build\import\VisualStudio.XamlRules.targets"/>
+
+  <!--
+    Copies the contents of PublicAPI.Unshipped.txt into PublicAPI.Shipped.txt on build.
+    It assumes that the project directory contains these files (PublicApiAnalyzers also makes this assumption).
+    Uses AppendAllText instead of Add-Content since that cmdlet adds an empty line at the end of the file.
+  -->
+  <Target Name="FlushUnshippedAPI" AfterTargets="Build">
+    <Exec Command="powershell.exe -NonInteractive -NoLogo -NoProfile -Command &quot;$unshipped = '$(MSBuildProjectDirectory)\PublicAPI.Unshipped.txt'; $content = Get-Content $unshipped -Raw; if(-Not [String]::IsNullOrWhiteSpace($content)) { [IO.File]::AppendAllText('$(MSBuildProjectDirectory)\PublicAPI.Shipped.txt', [Environment]::NewLine + $content); Clear-Content $unshipped }&quot;" />
+  </Target>
 </Project>


### PR DESCRIPTION
Added an after-build target to flush the Unshipped API contents into Shipped. This applies to projects in the `src` directory. This means we no longer need to manually flush these files.

Originally, I wanted to deleted the `PublicAPI.Unshipped.txt` file. Unfortunately, the analyzer (PublicApiAnalyzers) requires the file to be there:
```
1>------ Rebuild All started: Project: Microsoft.VisualStudio.ProjectSystem.Managed, Configuration: Debug Any CPU ------
1>CSC : warning AD0001: Analyzer 'Microsoft.CodeAnalysis.PublicApiAnalyzers.DeclarePublicApiAnalyzer' threw an exception of type 'System.NullReferenceException' with message 'Object reference not set to an instance of an object.'.
1>CSC : error CS2001: Source file 'C:\Code\project-system\src\Microsoft.VisualStudio.ProjectSystem.Managed\PublicAPI.Unshipped.txt' could not be found.
1>Done building project "Microsoft.VisualStudio.ProjectSystem.Managed.csproj" -- FAILED.
```
Instead, we just clear the contents of the file.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7745)