### PR TITLE
Revert "Use asynchronous batch disposal"

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -45,7 +45,7 @@
     <PackageReference Update="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.0.0-preview-2-31223-026"/>
     <PackageReference Update="Microsoft.VisualStudio.Data.Services"                                   Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.DataTools.Interop"                               Version="17.0.0-preview-2-31223-026" />
-    <PackageReference Update="Microsoft.VisualStudio.Debugger.Contracts"                              Version="17.2.0" />
+    <PackageReference Update="Microsoft.VisualStudio.Debugger.Contracts"                              Version="17.2.0-beta.21378.1" />
     <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces"                             Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.0.0-previews-2-31421-281" />
     <PackageReference Update="Microsoft.VisualStudio.Interop"                                         Version="17.0.0-previews-2-31423-289"/>
@@ -77,8 +77,8 @@
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.0.1304-pre" />
 
     <!-- Roslyn -->
-    <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.1.0-2.21558.8" />
-    <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="4.1.0-2.21558.8" />
+    <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.0.0-2.21302.13" />
+    <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="4.0.0-2.21302.13" />
     <PackageReference Update="Microsoft.VisualStudio.IntegrationTest.Utilities"                       Version="2.6.0-beta1-62113-02" />
     <PackageReference Update="Microsoft.CSharp"                                                       Version="4.7.0" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
@@ -217,7 +217,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 }
                 finally
                 {
-                    await context.EndBatchAsync();
+                    context.EndBatch();
 
                     NotifyOutputDataCalculated(change.DataSourceVersions, handlerType);
                 }


### PR DESCRIPTION
Reverts dotnet/project-system#7713

The Roslyn side of this does not actually appear to have been inserted. I am seeing:

```
System.MissingMethodException: Method not found: 'System.Threading.Tasks.ValueTask Microsoft.VisualStudio.LanguageServices.ProjectSystem.IWorkspaceProjectContext.EndBatchAsync()'.
   at Microsoft.VisualStudio.ProjectSystem.LanguageServices.WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.<ApplyProjectChangesUnderLockAsync>d__24.MoveNext()
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[TStateMachine](TStateMachine& stateMachine)
   at Microsoft.VisualStudio.ProjectSystem.LanguageServices.WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.ApplyProjectChangesUnderLockAsync(ProjectChange change, WorkspaceContextHandlerType handlerType, CancellationToken cancellationToken)
   at Microsoft.VisualStudio.ProjectSystem.LanguageServices.WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.<>c__DisplayClass23_0.<OnProjectChangedAsync>b__0(CancellationToken ct)
   at Microsoft.VisualStudio.ProjectSystem.OnceInitializedOnceDisposedUnderLockAsync.<>c__DisplayClass7_0.<ExecuteUnderLockCoreAsync>b__0()
   at Microsoft.VisualStudio.Threading.ReentrantSemaphore.StackSemaphore.<>c__DisplayClass3_0.<<ExecuteAsync>b__0>d.MoveNext()
```

I'll revert the change for now and reinstate once it's safe to do so. I'll merge this without review so that any overnight insertion doesn't accidentally break the main channel for internal users.

cc @jasonmalinowski. Note that my local clean/restore/build tests with version `4.1.0-2.21558.8` of `Microsoft.VisualStudio.LanguageServices` showed `EndBatchAsync` as present, but bumping the minor number by one to `4.1.0-2.21558.9` made it disappear again.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7748)