### PR TITLE
Don't detect incremental build failure on clean 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.IProjectChecker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.IProjectChecker.cs
@@ -23,8 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
             /// <summary>
             /// Checks for incremental build failure.
             /// </summary>
-            /// <param name="buildAction">The build action being requested.</param>
-            void OnProjectBuildCompleted(BuildAction buildAction);
+            void OnProjectBuildCompleted();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.ProjectChecker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.ProjectChecker.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
                 Reporters = new OrderPrecedenceImportCollection<IIncrementalBuildFailureReporter>(projectCapabilityCheckProvider: project);
             }
 
-            public void OnProjectBuildCompleted(BuildAction buildAction)
+            public void OnProjectBuildCompleted()
             {
                 IBuildUpToDateCheckValidator? validator = _upToDateCheckValidator.Value;
 
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
                         return;
                     }
 
-                    (bool isUpToDate, string? failureReason) = await validator.ValidateUpToDateAsync(buildAction, cancellationToken);
+                    (bool isUpToDate, string? failureReason) = await validator.ValidateUpToDateAsync(cancellationToken);
 
                     if (isUpToDate)
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.cs
@@ -4,7 +4,6 @@ using System;
 using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.ProjectSystem.Build;
 using Microsoft.VisualStudio.ProjectSystem.UpToDate;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -118,26 +117,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
                     return HResult.OK;
                 }
 
-                IProjectChecker? checker = pHierProj.AsUnconfiguredProject()?.Services.ExportProvider.GetExportedValueOrDefault<IProjectChecker>();
+                if (IsRelevantBuild(dwAction))
+                {
+                    IProjectChecker? checker = pHierProj.AsUnconfiguredProject()?.Services.ExportProvider.GetExportedValueOrDefault<IProjectChecker>();
 
-                checker?.OnProjectBuildCompleted(buildAction: GetBuildActionFromUpToDateOptions(dwAction));
+                    checker?.OnProjectBuildCompleted();
+                }
             }
 
             return HResult.OK;
 
-            static BuildAction GetBuildActionFromUpToDateOptions(uint options)
+            static bool IsRelevantBuild(uint options)
             {
-                if ((options & VSConstants.VSUTDCF_PACKAGE) == VSConstants.VSUTDCF_PACKAGE)
+                var operation = (VSSOLNBUILDUPDATEFLAGS)options;
+
+                if ((operation & VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD) == VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD)
                 {
-                    return BuildAction.Package;
+                    return true;
                 }
 
-                if ((options & VSConstants.VSUTDCF_REBUILD) == VSConstants.VSUTDCF_REBUILD)
-                {
-                    return BuildAction.Rebuild;
-                }
-
-                return BuildAction.Build;
+                return false;
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -668,9 +668,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             return IsUpToDateAsync(buildAction, logWriter, ImmutableDictionary<string, string>.Empty, cancellationToken);
         }
 
-        async Task<(bool IsUpToDate, string? FailureReason)> IBuildUpToDateCheckValidator.ValidateUpToDateAsync(
-            BuildAction buildAction,
-            CancellationToken cancellationToken)
+        async Task<(bool IsUpToDate, string? FailureReason)> IBuildUpToDateCheckValidator.ValidateUpToDateAsync(CancellationToken cancellationToken)
         {
             bool isUpToDate = await IsUpToDateInternalAsync(TextWriter.Null, _lastGlobalProperties, updateLastCheckedAt: false, cancellationToken);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/IBuildUpToDateCheckValidator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/IBuildUpToDateCheckValidator.cs
@@ -18,11 +18,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// that this method will not mutate any internal state. If in future that method is made idempotent, then
         /// this method (and probably the whole interface) could be removed.
         /// </remarks>
-        /// <param name="buildAction">The build action to perform.</param>
         /// <param name="cancellationToken">A token that is cancelled if the caller loses interest in the result.</param>
         /// <returns></returns>
-        Task<(bool IsUpToDate, string? FailureReason)> ValidateUpToDateAsync(
-            BuildAction buildAction,
-            CancellationToken cancellationToken = default);
+        Task<(bool IsUpToDate, string? FailureReason)> ValidateUpToDateAsync(CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
Fixes #7746 

The previous code was incorrectly identifying the build type, then not conditioning behaviour on the value anyway. This fixes the check and ensures we don't run the check when performing a clean.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7750)