### PR TITLE
Use capabilities to filter exports

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
           IActiveConfigurationComponent,
           IDisposable
     {
-        internal const string AppliesToExpression = ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject;
+        internal const string AppliesToExpression = ProjectCapability.DotNet + " + !" + ProjectCapabilities.SharedAssetsProject;
 
         internal const string FastUpToDateCheckIgnoresKindsGlobalPropertyName = "FastUpToDateCheckIgnoresKinds";
 


### PR DESCRIPTION
In #7749 a `NullReferenceException` was fixed by checking for a null export.

A better solution is to filter the calling MEF component such that it is not created for projects that do not themselves have the .NET Project System's up-to-date check. This is more idiomatic, and avoids a small allocation for each project to which the check does not apply.

Includes #7750 so only review 302c821b58d11c86023ae71a1906edf22d184d52.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7752)