### PR TITLE
Use asynchronous batch disposal

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -45,7 +45,7 @@
     <PackageReference Update="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.0.0-preview-2-31223-026"/>
     <PackageReference Update="Microsoft.VisualStudio.Data.Services"                                   Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.DataTools.Interop"                               Version="17.0.0-preview-2-31223-026" />
-    <PackageReference Update="Microsoft.VisualStudio.Debugger.Contracts"                              Version="17.2.0-beta.21378.1" />
+    <PackageReference Update="Microsoft.VisualStudio.Debugger.Contracts"                              Version="17.2.0" />
     <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces"                             Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.0.0-previews-2-31421-281" />
     <PackageReference Update="Microsoft.VisualStudio.Interop"                                         Version="17.0.0-previews-2-31423-289"/>
@@ -77,8 +77,8 @@
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.0.1304-pre" />
 
     <!-- Roslyn -->
-    <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.0.0-2.21302.13" />
-    <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="4.0.0-2.21302.13" />
+    <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.1.0-2.21558.8" />
+    <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="4.1.0-2.21558.8" />
     <PackageReference Update="Microsoft.VisualStudio.IntegrationTest.Utilities"                       Version="2.6.0-beta1-62113-02" />
     <PackageReference Update="Microsoft.CSharp"                                                       Version="4.7.0" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
@@ -217,7 +217,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 }
                 finally
                 {
-                    context.EndBatch();
+                    await context.EndBatchAsync();
 
                     NotifyOutputDataCalculated(change.DataSourceVersions, handlerType);
                 }


### PR DESCRIPTION
Contributes to [AB#1370097](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1370097).
Replaces #7713, which was reverted in #7748 over concerns about insertion synchronisation.

The previous `EndBatch` method internally uses blocking locks to protect access to its solution-level workspace data. When opening a solution with many projects, each project make requests to update workspaces. Those updates pass through this interface so that we can serialize them in order to reduce blocking lock contention on the thread pool from concurrent update requests.

Using the `EndBatchAsync` allows calling threadpool threads to make progress on other useful work while waiting for this shared resource.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7757)