### PR TITLE
Update moq package to 4.16.1

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -101,7 +101,7 @@
     <PackageReference Update="Newtonsoft.Json"                                                        Version="13.0.1"/>
 
     <!-- Tests -->
-    <PackageReference Update="Moq"                                                                    Version="4.12.0"/>
+    <PackageReference Update="Moq"                                                                    Version="4.16.1"/>
     <PackageReference Update="xunit"                                                                  Version="2.4.2-pre.13" />
     <PackageReference Update="xunit.assert"                                                           Version="2.4.2-pre.13" />
     <PackageReference Update="xunit.combinatorial"                                                    Version="1.4.1" />


### PR DESCRIPTION
We see intermittent `AccessViolationException`s during CI builds on stacks related to Moq codegen.

For example:

```
System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
   at System.Reflection.Internal.MemoryBlock.PeekCompressedInteger(Int32 offset, Int32& numberOfBytesRead)
   at System.Reflection.Metadata.BlobReader.ReadCompressedIntegerOrInvalid()
   at System.Reflection.Metadata.Ecma335.BlobHeap.GetDocumentName(DocumentNameBlobHandle handle)
   at System.Diagnostics.StackTraceSymbols.GetSourceLineInfoWithoutCasAssert(String assemblyPath, IntPtr loadedPeAddress, Int32 loadedPeSize, IntPtr inMemoryPdbAddress, Int32 inMemoryPdbSize, Int32 methodToken, Int32 ilOffset, String& sourceFile, Int32& sourceLine, Int32& sourceColumn)
   at System.Diagnostics.StackFrameHelper.InitializeSourceInfo(Int32 iSkip, Boolean fNeedFileInfo, Exception exception)
   at System.Diagnostics.StackTrace.CaptureStackTrace(Int32 iSkip, Boolean fNeedFileInfo, Thread targetThread, Exception e)
   at System.Diagnostics.StackTrace..ctor(Boolean fNeedFileInfo)
   at Moq.MethodCall.GetUserCodeCallSite()
   at Moq.MethodCall..ctor(Mock mock, Condition condition, InvocationShape expectation)
   at Moq.Mock.<>c__DisplayClass62_0.<Setup>b__0(InvocationShape part, Mock targetMock)
   at Moq.Mock.SetupRecursive[TSetup](Mock mock, LambdaExpression expression, Stack`1 parts, Func`3 setupLast)
   at Moq.Mock.Setup(Mock mock, LambdaExpression expression, Condition condition)
   at Moq.Mock.SetupGet(Mock mock, LambdaExpression expression, Condition condition)
   at Moq.Mock`1.SetupGet[TProperty](Expression`1 expression)
   at Microsoft.VisualStudio.LanguageServices.ProjectSystem.IWorkspaceProjectContextMockFactory.CreateForDynamicFiles(UnconfiguredProject project, Action`1 addDynamicFile)
   at Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers.DynamicItemHandlerTests.Handle_RazorAndCshtmlFiles_AddsToContext()
```

This change upgrades the `Moq` package in the hope of fixing these errors.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7759)