### PR TITLE
Remove unused "external" feeds

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -11,7 +11,6 @@
     <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
     <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
     <add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
-    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -10,7 +10,6 @@
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json;
-      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json;
     </RestoreSources>


### PR DESCRIPTION
This makes all our feeds come from blessed internal sources, which resolves the Azure Artifacts Configuration Check as described in https://docs.opensource.microsoft.com/tools/nuget_security_analysis/azure_artifacts_checks/

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7766)