### PR TITLE
Update property page documentation

### DIFF
--- a/docs/repo/property-pages/how-to-add-a-new-launch-profile-kind.md
+++ b/docs/repo/property-pages/how-to-add-a-new-launch-profile-kind.md
@@ -1,8 +1,21 @@
 ﻿# HOW TO: Add a New Launch Profile UI
 
-Launch Profile UIs are defined by XAML files describing an instance of the [Rule](https://docs.microsoft.com/en-us/dotnet/api/microsoft.build.framework.xamltypes.rule) class. Visual Studio uses these XAML files to dynamically build the UI and bind the controls to launch settings. This HOW TO describes two options for defining and distributing these XAML files. At the end your Launch Profile will look something like this:
+Launch Profile UIs are defined by instances of the [Rule](https://docs.microsoft.com/en-us/dotnet/api/microsoft.build.framework.xamltypes.rule) class. Visual Studio uses these `Rule` objects to dynamically build the UI and bind the controls to launch settings. This HOW TO describes three options for defining and distributing these `Rule` objects:
+
+1. [`Rule` objects read from a .xaml file on disk](#option-1-xaml-file-on-disk)
+2. [`Rule` objects read from an embedded .xaml file resource](#option-2-embedded-xaml-file)
+3. [`Rule` objects defined in code and exposed via `IRuleObjectProvider`](#option-3-iruleobjectprovider)
+
+At the end your Launch Profile will look something like this:
 
 ![New Launch Profile](new-launch-profile.png)
+
+## Further reading
+
+This HOWTO is concerned with how to create a `Rule` that defines a launch profile UI; however, `Rule` objects are used for various purposes in the project system. For a more general discussion of `Rule`s, please see the following:
+
+- [Adding XAML Rules](https://github.com/microsoft/VSProjectSystem/blob/master/doc/extensibility/adding_xaml_rules.md)
+- [Extending XAML Rules](https://github.com/microsoft/VSProjectSystem/blob/master/doc/extensibility/extending_rules.md)
 
 ## Option 1: XAML file on disk
 
@@ -187,5 +200,107 @@ public sealed class MyPackage : AsyncPackage
     ...
 }
 ```
+
+And you're done. This Launch Profile UI will be available in any project with matching capabilities.
+
+## Option 3: `IRuleObjectProvider`
+
+_Note this option is only available starting in VS 2022 Update 1 (Dev17.1)._
+
+In this option, `Rule` objects are defined in code and provided to the project system via MEF-exported implementations of the `IRuleObjectProvider` type. This will be an attractive option if you already have an assembly participating in the VS MEF composition, don't have a .props or .targets file to hold `PropertyPageSchema` items, or prefer to define your `Rule`s in code rather than XAML.
+
+This is also the simplest option if you need to localize your launch profile, as you can read the localized text from .resx files or similar rather than translating the entire .xaml file and distributing the translations.
+
+### Step 1: Add the Project System SDK
+
+Use the NuGet Package Manager to add the Microsoft.VisualStudio.ProjectSystem.Sdk package package to your project.
+
+### Step 2: Define the `IRuleObjectProvider`
+
+Create a new class with the following contents:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace RuleObjectProviderDemo
+{
+    [ExportRuleObjectProvider(name: "MyRuleObjectProvider", context: "Project")]
+    [AppliesTo("MyUniqueProjectCapability")]
+    [Order(0)]
+    public class MyRuleObjectProvider : IRuleObjectProvider
+    {
+        private List<Rule> rules;
+
+        public IReadOnlyCollection<Rule> GetRules()
+        {
+            if (this.rules == null)
+            {
+                this.rules = new List<Rule>();
+
+                Rule rule = new Rule();
+
+                rule.BeginInit();
+
+                rule.Name = "MyLaunchProfile";
+                rule.Description = "Properties associated with launching and debugging a custom debug target.";
+                rule.DisplayName = "My Custom Debug Target";
+                rule.PageTemplate = "commandNameBasedDebugger";
+
+                rule.Metadata["CommandName"] = "MyCustomDebugTarget";
+
+                // KnownImageIds.ImageCatalogGuid
+                rule.Metadata["ImageMonikerGuid"] = Guid.Parse("AE27A6B0-E345-4288-96DF-5EAF394EE369");
+
+                // KnownImageIds.Execute
+                rule.Metadata["ImageMonikerId"] = 1173;
+
+                rule.DataSource = new DataSource
+                {
+                    Persistence = "LaunchProfile",
+                    HasConfigurationCondition = false,
+                    ItemType = "LaunchProfile"
+                };
+
+                rule.Properties.Add(new StringProperty
+                {
+                    Name = "ExecutablePath",
+                    DisplayName = "Executable",
+                    Description = "Path to the executable to run.",
+                    Subtype = "file"
+                });
+
+                rule.EndInit();
+
+                rules.Add(rule);
+            }
+
+            return this.rules;
+        }
+    }
+}
+
+```
+
+Important points:
+- The `Rule.Name` must be unique.
+- The `Rule.PageTemplate` property must have the value `"commandNameBasedDebugger"`.
+- The `Rule.Metadata` dictionary must include a value for `CommandName`: this is the debug command name (also known as a debug target) corresponding to this UI. Debug commands and how they are handled by VS are beyond the scope of this document,
+- The `ImageMonikerGuid` and `ImageMonikerId` in `Rule.Metadata` together define an ImageMoniker designating the icon to show for this Launch Profile UI. These are optional and if they are not defined a default icon will be supplied.
+- The `Rule.DataSource` property must be specified as shown above.
+  - The `ItemType` property indicates that this `Rule` only pertains to launch profiles, as opposed to other types of items that are typically found in a project (`Compile`, `Reference`, etc.).
+  - The `Persistence` property indicates that values for the properties should be read and written through the launch profile persistence mechanism, as opposed to trying to read data from the MSBuild file.
+- The `ExportRuleObjectProvider` attribute exposes the class through MEF and allows the project system to find it.
+  - The `name` parameter must be unique to this `IRuleObjectProvider`. Duplicate names will cause one or the other to be ignored.
+  - The `context` paraemter should always be "Project".
+- The `AppliesTo` attribute is required. The `Rule` will only be available to projects with the matching capability.
+- The `Order` attribute is also required. Generally an `orderPrecedence` of "0" is fine, unless you are going to return a `Rule` object that extends an existing `Rule` from a different `IRuleObjectProvider`. In that case the `Order` of your `IRuleObjectProvider` must be higher than the other one.
+
+### Step 3: Add the assembly as MEF asset
+
+Using the VSIX Manifest designer, ensure the assembly containing your `IRuleObjectProvider` implementation is included as a "MefComponent" asset.
 
 And you're done. This Launch Profile UI will be available in any project with matching capabilities.

--- a/docs/repo/property-pages/how-to-add-a-new-launch-profile-kind.md
+++ b/docs/repo/property-pages/how-to-add-a-new-launch-profile-kind.md
@@ -288,7 +288,7 @@ namespace RuleObjectProviderDemo
 Important points:
 - The `Rule.Name` must be unique.
 - The `Rule.PageTemplate` property must have the value `"commandNameBasedDebugger"`.
-- The `Rule.Metadata` dictionary must include a value for `CommandName`: this is the debug command name (also known as a debug target) corresponding to this UI. Debug commands and how they are handled by VS are beyond the scope of this document,
+- The `Rule.Metadata` dictionary must include a value for `CommandName`: this is the debug command name (also known as a debug target) corresponding to this UI. Debug commands and how they are handled by VS are beyond the scope of this document.
 - The `ImageMonikerGuid` and `ImageMonikerId` in `Rule.Metadata` together define an ImageMoniker designating the icon to show for this Launch Profile UI. These are optional and if they are not defined a default icon will be supplied.
 - The `Rule.DataSource` property must be specified as shown above.
   - The `ItemType` property indicates that this `Rule` only pertains to launch profiles, as opposed to other types of items that are typically found in a project (`Compile`, `Reference`, etc.).
@@ -298,6 +298,8 @@ Important points:
   - The `context` paraemter should always be "Project".
 - The `AppliesTo` attribute is required. The `Rule` will only be available to projects with the matching capability.
 - The `Order` attribute is also required. Generally an `orderPrecedence` of "0" is fine, unless you are going to return a `Rule` object that extends an existing `Rule` from a different `IRuleObjectProvider`. In that case the `Order` of your `IRuleObjectProvider` must be higher than the other one.
+- The set of `Rule` objects and the `Rule`s themselves should not depend on any VS state. That is, _do not_ dynamically generate different sets of `Rule`s, properties, etc., in the `GetRules` method based on the state of your project or any VS setting. They should be static in the same way that `Rule`s loaded from .xaml files are static.
+  - Exception: It is fine for user-facing strings to vary based on the VS locale settings, as the locale cannot change while VS is running.
 
 ### Step 3: Add the assembly as MEF asset
 

--- a/docs/repo/property-pages/how-to-add-a-new-project-property-page.md
+++ b/docs/repo/property-pages/how-to-add-a-new-project-property-page.md
@@ -1,8 +1,21 @@
 ﻿# HOW TO: Add a New Property Page
 
-Property pages are defined by XAML files describing an instance of the [Rule](https://docs.microsoft.com/en-us/dotnet/api/microsoft.build.framework.xamltypes.rule) class. Visual Studio uses these XAML files to dynamically build the UI and bind the controls to properties in your project. This HOW TO describes two options for defining and distributing these XAML files. At the end your property page will look something like this:
+Property pages are defined by instances of the [Rule](https://docs.microsoft.com/en-us/dotnet/api/microsoft.build.framework.xamltypes.rule) class. Visual Studio uses these `Rule` objects to dynamically build the UI and bind the controls to launch settings. This HOW TO describes three options for defining and distributing these `Rule` objects:
+
+1. [`Rule` objects read from a .xaml file on disk](#option-1-xaml-file-on-disk)
+2. [`Rule` objects read from an embedded .xaml file resource](#option-2-embedded-xaml-file)
+3. [`Rule` objects defined in code and exposed via `IRuleObjectProvider`](#option-3-iruleobjectprovider)
+
+ At the end your property page will look something like this:
 
 ![New Property Page](new-property-page.png)
+
+## Further reading
+
+This HOWTO is concerned with how to create a `Rule` that defines a project property page; however, `Rule` objects are used for various purposes in the project system. For a more general discussion of `Rule`s, please see the following:
+
+- [Adding XAML Rules](https://github.com/microsoft/VSProjectSystem/blob/master/doc/extensibility/adding_xaml_rules.md)
+- [Extending XAML Rules](https://github.com/microsoft/VSProjectSystem/blob/master/doc/extensibility/extending_rules.md)
 
 ## Option 1: XAML file on disk
 
@@ -86,3 +99,92 @@ And you're done. Projects that import the .targets file will now show this page 
 In this option the XAML file is embedded in an assembly as a resource and discovered by means of a MEF export. Compared to Option 1 this requires more initial setup but does not require you to distribute an additional file. This may be an attractive option if you are already exporting MEF components for use in Visual Studio.
 
 _Steps to be determined._
+
+## Option 3: `IRuleObjectProvider`
+
+_Note this option is only available starting in VS 2022 Update 1 (Dev17.1)._
+
+In this option, `Rule` objects are defined in code and provided to the project system via MEF-exported implementations of the `IRuleObjectProvider` type. This will be an attractive option if you already have an assembly participating in the VS MEF composition, don't have a .props or .targets file to hold `PropertyPageSchema` items, or prefer to define your `Rule`s in code rather than XAML.
+
+This is also the simplest option if you need to localize your launch profile, as you can read the localized text from .resx files or similar rather than translating the entire .xaml file and distributing the translations.
+
+### Step 1: Add the Project System SDK
+
+Use the NuGet Package Manager to add the Microsoft.VisualStudio.ProjectSystem.Sdk package package to your project.
+
+### Step 2: Define the `IRuleObjectProvider`
+
+Create a new class with the following contents:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace RuleObjectProviderDemo
+{
+    [ExportRuleObjectProvider(name: "MyRuleObjectProvider", context: "Project")]
+    [AppliesTo("MyUniqueProjectCapability")]
+    [Order(0)]
+    public class MyRuleObjectProvider : IRuleObjectProvider
+    {
+        private List<Rule> rules;
+
+        public IReadOnlyCollection<Rule> GetRules()
+        {
+            if (this.rules == null)
+            {
+                this.rules = new List<Rule>();
+
+                Rule rule = new Rule();
+
+                rule.BeginInit();
+
+                rule.Name = "MyPropertyPage";
+                rule.Description = "A description of my project properties page.";
+                rule.DisplayName = "My Properties";
+                rule.PageTemplate = "generic";
+                rule.Order = 500;
+
+                rule.DataSource = new DataSource
+                {
+                    Persistence = "ProjectFile",
+                    HasConfigurationCondition = false,
+                    SourceOfDefaultValue = DefaultValueSourceLocation.AfterContext
+                };
+
+                rule.Properties.Add(new StringProperty
+                {
+                    Name = "MyProperty",
+                    DisplayName = "My property",
+                    Description = "A property that writes to the project file.",
+                });
+
+                rule.EndInit();
+
+                rules.Add(rule);
+            }
+
+            return this.rules;
+        }
+    }
+}
+
+```
+
+Important points:
+- The `Rule.Name` must be unique.
+- The `Rule.PageTemplate` property must have the value `"generic"`.
+- The `ExportRuleObjectProvider` attribute exposes the class through MEF and allows the project system to find it.
+  - The `name` parameter must be unique to this `IRuleObjectProvider`. Duplicate names will cause one or the other to be ignored.
+  - The `context` paraemter should always be "Project".
+- The `AppliesTo` attribute is required. The `Rule` will only be available to projects with the matching capability.
+- The `Order` attribute is also required. Generally an `orderPrecedence` of "0" is fine, unless you are going to return a `Rule` object that extends an existing `Rule` from a different `IRuleObjectProvider`. In that case the `Order` of your `IRuleObjectProvider` must be higher than the other one.
+- The set of `Rule` objects and the `Rule`s themselves should not depend on any VS state. That is, _do not_ dynamically generate different sets of `Rule`s, properties, etc., in the `GetRules` method based on the state of your project or any VS setting. They should be static in the same way that `Rule`s loaded from .xaml files are static.
+  - Exception: It is fine for user-facing strings to vary based on the VS locale settings, as the locale cannot change while VS is running.
+
+### Step 3: Add the assembly as MEF asset
+
+Using the VSIX Manifest designer, ensure the assembly containing your `IRuleObjectProvider` implementation is included as a "MefComponent" asset.


### PR DESCRIPTION
Update our property page and launch profile documentation to explain how to use `IRuleObjectProvider` to define `Rule`s in code.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7773)