### PR TITLE
Remove "under development" references from docs

### DIFF
--- a/docs/repo/property-pages/README.md
+++ b/docs/repo/property-pages/README.md
@@ -2,8 +2,6 @@
 
 This documentation details the updated Project Properties UI and associated back end, added to Visual Studio in 2021.
 
-⚠ This feature is still under development. These documents may talk about features as if they already exist, though they may not yet be available in public builds.
-
 ## Goals
 
 1. Metadata-driven design. The existing property pages are mostly a series of custom WinForms- and/or WPF-based controls, often with custom code for accessing underlying property information. Adding a new page or even a new property is difficult and time-consuming, and properly enforcing visual consistency, theming, accessibility, and extensibility is almost impossible. With the new pages we take the approach of defining pages and properties in a declarative manner, and having the system generate the corresponding UI using metadata on the properties. Similarly, property metadata drives the retrieval and storage of property values.

--- a/docs/repo/property-pages/ui-architecture.md
+++ b/docs/repo/property-pages/ui-architecture.md
@@ -1,7 +1,5 @@
 ﻿# UI Architecture
 
-⚠ This feature is still under development. These documents may talk about features as if they already exist, though they may not yet be available in public builds.
-
 Several components and concepts come together to produce the UI for the new Project Property UI. This document provides an outline of these elements and shows how they relate to one another. Where necessary, links to further information are provided. The source code for the UI is Microsoft internal, so if there are details you believe to be useful that are omitted here, please file an issue in this repo so that clarifications can be made.
 
 ## Editor Factory


### PR DESCRIPTION
These features are now available in public builds, so this comment is no longer helpful.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7777)