### PR TITLE
Remove unused extension method

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ImmutableCollectionLinqExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ImmutableCollectionLinqExtensions.cs
@@ -41,17 +41,6 @@ namespace Microsoft.VisualStudio
             return false;
         }
 
-        public static bool Any<T>(this ImmutableArray<T> source, Func<T, bool> predicate)
-        {
-            foreach (T obj in source)
-            {
-                if (predicate(obj))
-                    return true;
-            }
-
-            return false;
-        }
-
         public static T? FirstOrDefault<T, TArg>(this ImmutableArray<T> source, Func<T, TArg, bool> predicate, TArg arg)
         {
             foreach (T obj in source)


### PR DESCRIPTION
This method is provided by the `ImmutableArrayExtensions` class in the immutable collections library itself. We don't need to duplicate it here.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7778)