### PR TITLE
Don't rethrow exception

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.ProjectRestoreInfoSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.ProjectRestoreInfoSource.cs
@@ -86,14 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 #pragma warning disable RS0030 // Do not used banned APIs
             var registerRestoreInfoSourceTask = Task.Run(async () =>
             {
-                try
-                {
-                    await _solutionRestoreService4.RegisterRestoreInfoSourceAsync(this, _projectAsynchronousTasksService.UnloadCancellationToken);
-                }
-                catch (Exception ex)
-                {
-                    throw ex;
-                }
+                await _solutionRestoreService4.RegisterRestoreInfoSourceAsync(this, _projectAsynchronousTasksService.UnloadCancellationToken);
             });
 #pragma warning restore RS0030 // Do not used banned APIs
 


### PR DESCRIPTION
The previous code would lose the original stack trace, making it harder to debug the root cause of any exception raised in this code path.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7794)