### PR TITLE
Move to new build pool

### DIFF
--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -10,7 +10,7 @@ resources:
 - repo: self
   clean: true
 queue:
-  name: VSEngSS-MicroBuild2019
+  name: VSEngSS-MicroBuild2019-1ES
   demands: Cmd
   timeoutInMinutes: 90
 variables:


### PR DESCRIPTION
Move our 16.11.x builds to the proper build pool; the one we're using is
being retired.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7798)