### PR TITLE
Add AppliesToProject attribute to DependenciesTreeSearchProvider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeSearchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeSearchProvider.cs
@@ -43,6 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     /// Search results for top-level dependencies occurs via the hierarchy, so those items need not be included here.
     /// </para>
     /// </remarks>
+    [AppliesToProject(ProjectCapability.DependenciesTree)]
     [Export(typeof(ISearchProvider))]
     [Name("DependenciesTreeSearchProvider")]
     [VisualStudio.Utilities.Order(Before = "GraphSearchProvider")]


### PR DESCRIPTION
For 17.1 Preview 2, I've implemented the ability to delay instantiation of solution explorer search providers based on project capabilities or UI context.

Similar functionality already existed for attached collection source providers (which you already take advantage of), and it is now available for search providers.

So with this change here, if you load a solution that has no project with DependenciesTree capability, when you do a search in solution explorer we will not instantiate this provider, which means we avoid loading the managed project system assemblies.

Comparison of loaded assemblies after doing a solution explorer search of a solution with a python project:

Before this change:

![image](https://user-images.githubusercontent.com/1696845/143320108-1eb98138-feca-45c6-a1fd-45df555f13fd.png)

After this change:

![image](https://user-images.githubusercontent.com/1696845/143320122-9e749a8e-a38f-41aa-ab11-80d879ffaf3d.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7799)