### PR TITLE
Prevent overbuild for .NET Framework console apps

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -436,9 +436,11 @@
       <!-- app.config -->
       <!-- The property AppConfig, created in PrepareForBuild, is used instead of AppConfigWithTargetPath because GenerateSupportedRuntime
            rewrites AppConfigWithTargetPath to point to the intermediate filename. This is needed because Fast up-to-date needs to compare
-           the timestamp of the source filename (AppConfig) with destination filename. 
-           https://github.com/microsoft/msbuild/blob/64c8e4a18e7cf7f064fbad304ea7ed877cdaa0a1/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1109-L1122 -->
-      <UpToDateCheckBuilt Condition=" '@(AppConfigWithTargetPath)' != '' " Include="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Original="$(AppConfig)"/>
+           the timestamp of the source filename (AppConfig) with destination filename.
+           https://github.com/microsoft/msbuild/blob/64c8e4a18e7cf7f064fbad304ea7ed877cdaa0a1/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1109-L1122
+           We skip this check if AppConfig is empty, which occurs for .NET Framework console apps. See https://github.com/dotnet/project-system/issues/6758.
+      -->
+      <UpToDateCheckBuilt Condition=" '@(AppConfigWithTargetPath)' != '' and '@(AppConfig)' != '' " Include="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Original="$(AppConfig)"/>
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -437,7 +437,7 @@
       <!-- The property AppConfig, created in PrepareForBuild, is used instead of AppConfigWithTargetPath because GenerateSupportedRuntime
            rewrites AppConfigWithTargetPath to point to the intermediate filename. This is needed because Fast up-to-date needs to compare
            the timestamp of the source filename (AppConfig) with destination filename.
-           https://github.com/microsoft/msbuild/blob/64c8e4a18e7cf7f064fbad304ea7ed877cdaa0a1/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1109-L1122
+           https://github.com/dotnet/msbuild/blob/d2f9dbccd913c5612fd3a3cb78b2524fbcb023da/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1152-L1165
            We skip this check if AppConfig is empty, which occurs for .NET Framework console apps. See https://github.com/dotnet/project-system/issues/6758.
       -->
       <UpToDateCheckBuilt Condition=" '@(AppConfigWithTargetPath)' != '' and '@(AppConfig)' != '' " Include="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Original="$(AppConfig)"/>


### PR DESCRIPTION
Fixes #6758

SDK-style console app projects that target .NET Framework create `bin\Debug\net48\MyApp.exe.config` (for example) even when no input `App.config` file exists. If we create an `UpToDateCheckBuilt` item that has empty `Original` metadata, the up-to-date check assumes that every build will produce this file, which is not the case. When the `Original` metadata is present, the up-to-date check assumes the file is copied, and so won't continue scheduling builds. However with empty `Original` metadata, we assume it's produced on every build.

The fix is to exclude this item when the `AppConfig` value (which would populate the `Original` metadata) is empty.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7810)