### PR TITLE
Populate LaunchProfileValue.DisplayName

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -11,7 +11,7 @@
       https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
-      https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
 

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -12,6 +12,7 @@
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json;
+      https://pkgs.dev.azure.com/devdiv/_packaging/VSIDE-RealSigned-Release/nuget/v3/index.json
     </RestoreSources>
   </PropertyGroup>
 
@@ -71,10 +72,10 @@
     <PackageReference Include="StreamJsonRpc"                                                         Version="2.8.28" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.1.111-pre-g765e5baae0" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.1.111-pre-g765e5baae0" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.1.111-pre-g765e5baae0" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.1.111-pre-g765e5baae0" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.1.122-pre-g4a40630e36" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.1.122-pre-g4a40630e36" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.1.122-pre-g4a40630e36" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.1.122-pre-g4a40630e36" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.1.0-2.21558.8" />

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -71,10 +71,10 @@
     <PackageReference Include="StreamJsonRpc"                                                         Version="2.8.28" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.0.1304-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.0.1304-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.0.1304-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.0.1304-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.1.111-pre-g765e5baae0" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.1.111-pre-g765e5baae0" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.1.111-pre-g765e5baae0" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.1.111-pre-g765e5baae0" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.1.0-2.21558.8" />

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -11,8 +11,7 @@
       https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
-      https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json;
-      https://pkgs.dev.azure.com/devdiv/_packaging/VSIDE-RealSigned-Release/nuget/v3/index.json
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json
     </RestoreSources>
   </PropertyGroup>
 
@@ -72,10 +71,10 @@
     <PackageReference Include="StreamJsonRpc"                                                         Version="2.8.28" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.1.122-pre-g4a40630e36" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.1.122-pre-g4a40630e36" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.1.122-pre-g4a40630e36" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.1.122-pre-g4a40630e36" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.1.221-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.1.221-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.1.221-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.1.221-pre" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.1.0-2.21558.8" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/ProjectLaunchProfileHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/ProjectLaunchProfileHandler.cs
@@ -239,6 +239,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 newLaunchProfile.Name = propertiesContext.ItemName;
             }
 
+            if (properties.DisplayName)
+            {
+                newLaunchProfile.DisplayName = propertiesContext.ItemName;
+            }
+
             if (properties.CommandName)
             {
                 if (rule.Metadata.TryGetValue(s_commandNameMetadataName, out object? commandNameObj)


### PR DESCRIPTION
Move to a newer version of CPS that includes the new `LaunchProfileValue.DisplayName` property and populate it. For the moment it will be the same as the `Name` property, but a future change will make `Name` a unique, persistent identifier for a launch profile.

Note this is the second step of a set of staged changes. CPS now defines the `LaunchProfileValue.DisplayName` property but can't take a dependency on it because the .NET Project System doesn't populate it at all. And since CPS can't depend on it, the project system can't be updated to make `Name` a persistent, unique value and handle renames as expected. This interim change allows CPS to move forward without a user-visible break or change in behavior.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7811)