### PR TITLE
Remove IWaitContext.AllowCancel

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitContext.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.VisualStudio.ProjectSystem.Waiting;
@@ -37,8 +36,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
         private IVsThreadedWaitDialog3 CreateDialog(IVsThreadedWaitDialogFactory dialogFactory)
         {
             Marshal.ThrowExceptionForHR(dialogFactory.CreateInstance(out IVsThreadedWaitDialog2 dialog2));
-            if (dialog2 == null)
-                throw new ArgumentNullException(nameof(dialog2));
+
+            Assumes.NotNull(dialog2);
 
             var dialog3 = (IVsThreadedWaitDialog3)dialog2;
             var callback = new Callback(this);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitContext.cs
@@ -72,9 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
             }
         }
 
-        public CancellationToken CancellationToken => _cancellationTokenSource is null
-                                                    ? CancellationToken.None
-                                                    : _cancellationTokenSource.Token;
+        public CancellationToken CancellationToken => _cancellationTokenSource?.Token ?? CancellationToken.None;
 
         public string Message
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitContext.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
             Assumes.NotNull(dialog2);
 
             var dialog3 = (IVsThreadedWaitDialog3)dialog2;
-            var callback = new Callback(this);
+            var callback = new Callback(_cancellationTokenSource);
 
             dialog3.StartWaitDialogWithCallback(
                 szWaitCaption: _title,
@@ -59,16 +59,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
 
         private class Callback : IVsThreadedWaitDialogCallback
         {
-            private readonly VisualStudioWaitContext _waitContext;
+            private readonly CancellationTokenSource? _cancellationTokenSource;
 
-            public Callback(VisualStudioWaitContext waitContext)
+            public Callback(CancellationTokenSource? cancellationTokenSource)
             {
-                _waitContext = waitContext;
+                _cancellationTokenSource = cancellationTokenSource;
             }
 
             public void OnCanceled()
             {
-                _waitContext.OnCanceled();
+                _cancellationTokenSource?.Cancel();
             }
         }
 
@@ -100,11 +100,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
         {
             _dialog.EndWaitDialog(out _);
             _cancellationTokenSource?.Dispose();
-        }
-
-        private void OnCanceled()
-        {
-            _cancellationTokenSource?.Cancel();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitContext.cs
@@ -13,7 +13,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
 
         private readonly string _title;
         private string _message;
-        private bool _allowCancel;
         private readonly CancellationTokenSource? _cancellationTokenSource;
         private readonly IVsThreadedWaitDialog3 _dialog;
 
@@ -24,8 +23,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
         {
             _title = title;
             _message = message;
-            _allowCancel = allowCancel;
-            if (_allowCancel)
+
+            if (allowCancel)
             {
                 _cancellationTokenSource = new CancellationTokenSource();
             }
@@ -48,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
                 szProgressText: null,
                 varStatusBmpAnim: null,
                 szStatusBarText: null,
-                fIsCancelable: _allowCancel,
+                fIsCancelable: _cancellationTokenSource is not null,
                 iDelayToShowDialog: DelayToShowDialogSecs,
                 fShowProgress: false,
                 iTotalSteps: 0,
@@ -77,16 +76,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
                                                     ? CancellationToken.None
                                                     : _cancellationTokenSource.Token;
 
-        public bool AllowCancel
-        {
-            get => _allowCancel;
-            set
-            {
-                _allowCancel = value;
-                UpdateDialog();
-            }
-        }
-
         public string Message
         {
             get => _message;
@@ -105,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
                 szStatusBarText: null,
                 iCurrentStep: 0,
                 iTotalSteps: 0,
-                fDisableCancel: !_allowCancel,
+                fDisableCancel: _cancellationTokenSource is null,
                 pfCanceled: out _);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/IWaitContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/IWaitContext.cs
@@ -8,7 +8,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Waiting
     internal interface IWaitContext : IDisposable
     {
         CancellationToken CancellationToken { get; }
-        bool AllowCancel { get; set; }
         string Message { get; set; }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitContextTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitContextTests.cs
@@ -10,15 +10,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
     public static class VisualStudioWaitContextTests
     {
         [Fact]
-        public static void SetPropertyAllowCancel_Test()
+        public static void CancellationToken()
         {
-            string title = "Test001";
-            string message = "Testing001";
-            bool isCancelable = true;
-            var context = Create(title, message, isCancelable);
-            Assert.True(context.AllowCancel);
-            context.AllowCancel = false;
-            Assert.False(context.AllowCancel);
+            var cancellable = Create("Title", "Message", allowCancel: true);
+
+            Assert.True(cancellable.CancellationToken.CanBeCanceled);
+
+            var nonCancellable = Create("Title", "Message", allowCancel: false);
+
+            Assert.False(nonCancellable.CancellationToken.CanBeCanceled);
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitContextTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitContextTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
         [Fact]
         public static void CreateWrongType_Test()
         {
-            Assert.Throws<ArgumentNullException>(() => _ = CreateWrongType(string.Empty, string.Empty, false));
+            Assert.ThrowsAny<Exception>(() => _ = CreateWrongType(string.Empty, string.Empty, false));
         }
 
         private delegate void CreateInstanceCallback(out IVsThreadedWaitDialog2 ppIVsThreadedWaitDialog);


### PR DESCRIPTION
#7816 made me curious about how we handle threaded wait dialogs in the .NET Project System.

While looking at our code for that, I noticed buggy and unused code. This PR removes it, and tidies.

The `IWaitContext.AllowCancel` property is unused and will not work correctly. If a dialog was created that did not allow cancellation, then this property is later set to true, the backing cancellation token will not be updated. Further, it's unlikely that a consumer of this type would re-query the token after setting the property. It feels like a safer design, and a cleaner implementation, to remove this unused property and avoid potential future bugs.

Note that we don't use the `IWaitContext.Message` property either, but the implementation of that property appears to be correct so I left it in.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7817)