### PR TITLE
Revert "Use VS platform's IVsService"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     {
         private readonly UnconfiguredProject _project;
         private readonly IUnconfiguredProjectTasksService _projectTasksService;
-        private readonly IVsService<IVsStartupProjectsListService> _startupProjectsListService;
+        private readonly IVsService<IVsStartupProjectsListService?> _startupProjectsListService;
         private readonly IProjectThreadingService _threadingService;
         private readonly ISafeProjectGuidService _projectGuidService;
         private readonly IActiveConfiguredProjectSubscriptionService _projectSubscriptionService;
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public StartupProjectRegistrar(
             UnconfiguredProject project,
             IUnconfiguredProjectTasksService projectTasksService,
-            IVsService<SVsStartupProjectsListService, IVsStartupProjectsListService> startupProjectsListService,
+            IVsService<SVsStartupProjectsListService, IVsStartupProjectsListService?> startupProjectsListService,
             IProjectThreadingService threadingService,
             ISafeProjectGuidService projectGuidService,
             IActiveConfiguredProjectSubscriptionService projectSubscriptionService,
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             {
                 bool isDebuggable = await IsDebuggableAsync();
 
-                IVsStartupProjectsListService? startupProjectsListService = await _startupProjectsListService.GetValueOrNullAsync();
+                IVsStartupProjectsListService? startupProjectsListService = await _startupProjectsListService.GetValueAsync();
 
                 if (startupProjectsListService == null)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsService`1.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Composition;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    ///     Provides access to a Visual Studio proffered service.
+    /// </summary>
+    /// <typeparam name="T">
+    ///     The type of the service to retrieve and return from <see cref="GetValueAsync"/>.
+    /// </typeparam>
+    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    internal interface IVsService<T>
+        where T : class?
+    {
+        /// <summary>
+        ///     Gets the service object associated with <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///     A token whose cancellation indicates that the caller no longer is interested
+        ///     in the result. The default is <see cref="CancellationToken.None"/>.
+        /// </param>
+        /// <value>
+        ///     The service <see cref="object"/> associated with <typeparamref name="T"/>;
+        ///     otherwise, <see langword="null"/> if it is not present;
+        /// </value>
+        /// <remarks>
+        ///     Note that cancelling <paramref name="cancellationToken"/> will not cancel the
+        ///     creation of the service, but will result in an expedient cancellation of the
+        ///     returned <see cref="Task"/>, and a dis-joining of any <see cref="JoinableTask"/>
+        ///     that may have occurred as a result of this call.
+        /// </remarks>
+        /// <exception cref="OperationCanceledException">
+        ///     The result is awaited and <paramref name="cancellationToken"/> is cancelled.
+        /// </exception>
+        Task<T> GetValueAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsService`2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsService`2.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading;
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    ///     Provides access to a Visual Studio proffered service.
+    /// </summary>
+    /// <typeparam name="TService">
+    ///     The type of the service to retrieve.
+    /// </typeparam>
+    /// <typeparam name="TInterface">
+    ///     The type of the service to return from <see cref="IVsService{T}.GetValueAsync(CancellationToken)"/>
+    /// </typeparam>
+    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    internal interface IVsService<TService, TInterface> : IVsService<TInterface>
+        where TService : class
+        where TInterface : class?
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsService`1.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+#pragma warning disable RS0030 // Do not used banned APIs (wrapping IAsyncServiceProvider/SAsyncServiceProvider)
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    ///     Provides an implementation of <see cref="IVsService{T}"/> that calls into Visual Studio's <see cref="IAsyncServiceProvider"/>.
+    /// </summary>
+    [Export(typeof(IVsService<>))]
+    internal class VsService<T> : IVsService<T>
+        where T : class?
+    {
+        private readonly AsyncLazy<T> _value;
+
+        [ImportingConstructor]
+        public VsService([Import(typeof(SAsyncServiceProvider))]IAsyncServiceProvider serviceProvider, JoinableTaskContext joinableTaskContext)
+        {
+            Requires.NotNull(serviceProvider, nameof(serviceProvider));
+            Requires.NotNull(joinableTaskContext, nameof(joinableTaskContext));
+
+            _value = new AsyncLazy<T>(async () =>
+            {
+                // If the service request requires a package load, GetServiceAsync will 
+                // happily do that on a background thread.
+                object? iunknown = await serviceProvider.GetServiceAsync(ServiceType);
+
+                // We explicitly switch to the UI thread to avoid doing a QueryInterface 
+                // via blocking RPC for STA objects when we cast explicitly to the type
+                await joinableTaskContext.Factory.SwitchToMainThreadAsync();
+
+                return (T)iunknown!;
+            }, joinableTaskContext.Factory);
+        }
+
+        public Task<T> GetValueAsync(CancellationToken cancellationToken = default)
+        {
+            return _value.GetValueAsync(cancellationToken);
+        }
+
+        protected virtual Type ServiceType
+        {
+            get { return typeof(T); }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsService`2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsService`2.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+#pragma warning disable RS0030 // Do not used banned APIs (wrapping IAsyncServiceProvider/SAsyncServiceProvider)
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    ///     Provides an implementation of <see cref="IVsService{TInterfaceType, TServiceType}"/> that calls into Visual Studio's <see cref="SVsServiceProvider"/>.
+    /// </summary>
+    [Export(typeof(IVsService<,>))]
+    internal class VsService<TService, TInterface> : VsService<TInterface>, IVsService<TService, TInterface>
+        where TService : class
+        where TInterface : class?
+    {
+        [ImportingConstructor]
+        public VsService([Import(typeof(SAsyncServiceProvider))]IAsyncServiceProvider serviceProvider, JoinableTaskContext joinableTaskContext)
+            : base(serviceProvider, joinableTaskContext)
+        {
+        }
+
+        protected override Type ServiceType
+        {
+            get { return typeof(TService); }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsShellUtilitiesHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsShellUtilitiesHelper.cs
@@ -14,17 +14,17 @@ namespace Microsoft.VisualStudio.Shell.Interop
         /// <summary>
         /// Returns the version of VS as defined by <see cref="VSAPropID.VSAPROPID_ProductSemanticVersion"/> with the trailing sem version stripped, or <see langword="null"/> on failure.
         /// </summary>
-        Task<Version?> GetVSVersionAsync(IVsService<IVsAppId> vsAppIdService);
+        Task<Version?> GetVSVersionAsync(ProjectSystem.VS.IVsService<IVsAppId> vsAppIdService);
 
         /// <summary>
         /// Returns the local app data folder as defined by <see cref="__VSSPROPID4.VSSPROPID_LocalAppDataDir"/>.
         /// </summary>
-        Task<string?> GetLocalAppDataFolderAsync(IVsService<IVsShell> vsShellService);
+        Task<string?> GetLocalAppDataFolderAsync(ProjectSystem.VS.IVsService<IVsShell> vsShellService);
 
         /// <summary>
         /// Returns the virtual registry root as defined by <see cref="__VSSPROPID.VSSPROPID_VirtualRegistryRoot"/>.
         /// </summary>
-        Task<string?> GetRegistryRootAsync(IVsService<IVsShell> vsShellService);
+        Task<string?> GetRegistryRootAsync(ProjectSystem.VS.IVsService<IVsShell> vsShellService);
 
         /// <summary>
         /// Determines whether Visual Studio was installed from a preview channel.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsShellUtilitiesHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsShellUtilitiesHelper.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
             _threadingService = threadingService;
         }
 
-        public async Task<Version?> GetVSVersionAsync(IVsService<IVsAppId> vsAppIdService)
+        public async Task<Version?> GetVSVersionAsync(ProjectSystem.VS.IVsService<IVsAppId> vsAppIdService)
         {
             await _threadingService.SwitchToUIThread();
 
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
             return null;
         }
 
-        public async Task<string?> GetLocalAppDataFolderAsync(IVsService<IVsShell> vsShellService)
+        public async Task<string?> GetLocalAppDataFolderAsync(ProjectSystem.VS.IVsService<IVsShell> vsShellService)
         {
             await _threadingService.SwitchToUIThread();
 
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
             return null;
         }
 
-        public async Task<string?> GetRegistryRootAsync(IVsService<IVsShell> vsShellService)
+        public async Task<string?> GetRegistryRootAsync(ProjectSystem.VS.IVsService<IVsShell> vsShellService)
         {
             await _threadingService.SwitchToUIThread();
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsServiceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsServiceFactory.cs
@@ -16,13 +16,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             return mock.Object;
         }
 
-        public static IVsService<TService, TInterface> Create<TService, TInterface>(TInterface? value)
-            where TService : class where TInterface : class
+        public static IVsService<TService, TInterface> Create<TService, TInterface>(TInterface value)
+            where TService : class where TInterface : class?
         {
             var mock = new Mock<IVsService<TService, TInterface>>();
             mock.Setup(s => s.GetValueAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(() => value!);
-            mock.Setup(s => s.GetValueOrNullAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => value);
 
             return mock.Object;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
@@ -193,7 +193,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             var instance = new StartupProjectRegistrar(
                 project,
                 IUnconfiguredProjectTasksServiceFactory.Create(),
-                IVsServiceFactory.Create<SVsStartupProjectsListService, IVsStartupProjectsListService>(vsStartupProjectsListService!),
+                IVsServiceFactory.Create<SVsStartupProjectsListService, IVsStartupProjectsListService?>(vsStartupProjectsListService!),
                 threadingService ?? IProjectThreadingServiceFactory.Create(),
                 projectGuidService ?? ISafeProjectGuidServiceFactory.ImplementGetProjectGuidAsync(Guid.NewGuid()),
                 projectSubscriptionService ?? IActiveConfiguredProjectSubscriptionServiceFactory.Create(),

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsServiceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsServiceTests.cs
@@ -1,0 +1,112 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    public class VsServiceTests
+    {
+        [Fact]
+        public void Constructor_NullAsServiceProvider_ThrowsArgumentNull()
+        {
+            var joinableTaskContext = IProjectThreadingServiceFactory.Create().JoinableTaskContext.Context;
+
+            Assert.Throws<ArgumentNullException>("serviceProvider", () =>
+            {
+                return new VsService<string, string>(null!, joinableTaskContext);
+            });
+        }
+
+        [Fact]
+        public void Constructor_NullAsJoinableTaskContext_ThrowsArgumentNull()
+        {
+            var serviceProvider = IAsyncServiceProviderFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("joinableTaskContext", () =>
+            {
+                return new VsService<string, string>(serviceProvider, null!);
+            });
+        }
+
+        [Fact]
+        public async Task GetValueAsync_CancelledToken_ThrowsOperationCanceled()
+        {
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var serviceProvider = IAsyncServiceProviderFactory.ImplementGetServiceAsync(type => null);
+
+            var service = CreateInstance<string, string>(serviceProvider: serviceProvider, threadingService: threadingService);
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            {
+                return service.GetValueAsync(new CancellationToken(true));
+            });
+        }
+
+        [Fact]
+        public async Task GetValueAsync_WhenMissingService_ReturnsNull()
+        {
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var serviceProvider = IAsyncServiceProviderFactory.ImplementGetServiceAsync(type => null);
+
+            var service = CreateInstance<string, string>(serviceProvider: serviceProvider, threadingService: threadingService);
+
+            var result = await service.GetValueAsync();
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task GetValueAsync_ReturnsGetService()
+        {
+            object input = new object();
+
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var serviceProvider = IAsyncServiceProviderFactory.ImplementGetServiceAsync(type =>
+            {
+                if (type == typeof(string))
+                    return input;
+
+                return null;
+            });
+
+            var service = CreateInstance<string, object>(serviceProvider: serviceProvider, threadingService: threadingService);
+
+            var result = await service.GetValueAsync();
+
+            Assert.Same(input, result);
+        }
+
+        [Fact]
+        public async Task GetValueAsync_CachesResult()
+        {
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var serviceProvider = IAsyncServiceProviderFactory.ImplementGetServiceAsync(type =>
+            {
+                return new object();
+            });
+
+            var service = CreateInstance<string, object>(serviceProvider: serviceProvider, threadingService: threadingService);
+
+            var result1 = await service.GetValueAsync();
+            var result2 = await service.GetValueAsync();
+
+            Assert.Same(result1, result2);
+        }
+
+        private static VsService<TService, TInterface> CreateInstance<TService, TInterface>(
+            IAsyncServiceProvider? serviceProvider = null,
+            IProjectThreadingService? threadingService = null)
+            where TService : class
+            where TInterface : class
+        {
+            serviceProvider ??= IAsyncServiceProviderFactory.Create();
+            threadingService ??= IProjectThreadingServiceFactory.Create();
+
+            return new VsService<TService, TInterface>(serviceProvider, threadingService.JoinableTaskContext.Context);
+        }
+    }
+}


### PR DESCRIPTION
This reverts commit 5370595a5e5df3ca9c6e9e7e25ff776660190534 from #7808.

Moving to the platform's implementation of `IVsService<>` caused the issue reported in [AB#1448794](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1448794).

We will temporarily reverts the change. We will reinstate that once safe to do so.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7818)