### PR TITLE
Declare a prerequisite

### DIFF
--- a/setup/ProjectSystemSetup/source.extension.vsixmanifest
+++ b/setup/ProjectSystemSetup/source.extension.vsixmanifest
@@ -15,7 +15,8 @@
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />   
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.HotReload.Components" Version="[6.0.0,)" DisplayName="Hot Reload components" />
   </Prerequisites>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />


### PR DESCRIPTION
In 17.0 we've seen a number of reports where users try to start a project with F5/Ctrl+F5. When I've looked into these I've found that the VS components related to Hot Reload (i.e. Microsoft.VisualStudio.HotReload.Components) are not installed. This leads to a short chain of MEF composition errors that results in us being unable to instantiate a `ProjectLaunchTargetsProvider`, which in turn means we don't know how to handle launch profiles using the "Project" or "Executable" command.

It is not entirely clear how we get into this situation as I have not yet been able to create a VS installation that _doesn't_ include Microsoft.VisualStudio.HotReload.Components, either through choosing workloads in the UI or by importing a .vsconfig file.

This is a low-cost attempt to fix the problem by specifying Microsoft.VisualStudio.HotReload.Components as a prerequisite in our .vsixmanifest file. While this is correct (we do depend on this component) I've found very few .vsixmanifest files with any prerequisite other than Microsoft.VisualStudio.Component.CoreEditor, and I'm not entirely convinced the VS installer makes use of this information.

If this does not work, there are other changes I can try on the VS side.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7819)