### PR TITLE
Remove AdditionalDependentFileTimes from fast up-to-date check

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -222,14 +222,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     return false;
                 }
 
-#if FALSE // https://github.com/dotnet/project-system/issues/6227
-
-                if (_enableAdditionalDependentFile && earliestOutputTime < state.LastAdditionalDependentFileTimesChangedAtUtc)
-                {
-                    return log.Fail("Outputs", "The set of AdditionalDependentFileTimes was changed more recently ({0}) than the earliest output '{1}' ({2}), not up to date.", state.LastAdditionalDependentFileTimesChangedAtUtc, earliestOutputPath, earliestOutputTime);
-                }
-#endif
-
                 (string Path, DateTime? Time)? latestInput = null;
 
                 foreach ((string input, string? itemType, bool isRequired) in inputs)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTestBase.cs
@@ -77,13 +77,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             UpToDateCheckImplicitConfiguredInput priorState,
             Dictionary<string, IProjectRuleSnapshotModel>? projectRuleSnapshot = null,
             Dictionary<string, IProjectRuleSnapshotModel>? sourceRuleSnapshot = null,
-            IImmutableDictionary<string, DateTime>? dependentFileTimes = null,
             bool itemRemovedFromSourceSnapshot = false)
         {
             return priorState.Update(
                 CreateUpdate(projectRuleSnapshot),
                 CreateUpdate(sourceRuleSnapshot, itemRemovedFromSourceSnapshot),
-                IProjectSnapshot2Factory.Create(dependentFileTimes),
                 IProjectItemSchemaFactory.Create(_itemTypes),
                 IProjectCatalogSnapshotFactory.CreateWithDefaultMapping(_itemTypes));
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputTests.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Xunit;
 
@@ -58,32 +57,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 sourceSnapshot2);
 
             Assert.NotEqual(DateTime.MinValue, state.LastItemsChangedAtUtc);
-        }
-
-        [Fact]
-        public void Update_InitialItemDataDoesNotUpdateLastAdditionalDependentFileTimesChangedAtUtc()
-        {
-            var dependentTime = DateTime.UtcNow.AddMinutes(-1);
-            var dependentPath = @"C:\Dev\Solution\Project\Dependent";
-            var dependentTimeFiles = ImmutableDictionary.Create<string, DateTime>(StringComparers.Paths).Add(dependentPath, dependentTime);
-
-            var state = UpToDateCheckImplicitConfiguredInput.Empty;
-            Assert.Equal(DateTime.MinValue, state.LastAdditionalDependentFileTimesChangedAtUtc);
-
-            // Initial change does NOT set LastAdditionalDependentFileTimesChangedAtUtc
-            state = UpdateState(state, dependentFileTimes: dependentTimeFiles);
-
-            Assert.Equal(DateTime.MinValue, state.LastAdditionalDependentFileTimesChangedAtUtc);
-
-            // Broadcasting an update with same Additional Dependent Files does NOT set LastAdditionalDependentFileTimesChangedAtUtc
-            state = UpdateState(state, dependentFileTimes: dependentTimeFiles);
-
-            Assert.Equal(DateTime.MinValue, state.LastAdditionalDependentFileTimesChangedAtUtc);
-
-            // Broadcasting removing Additional Dependent Files DOES set LastAdditionalDependentFileTimesChangedAtUtc
-            state = UpdateState(state, dependentFileTimes: ImmutableDictionary.Create<string, DateTime>(StringComparers.Paths));
-
-            Assert.InRange((DateTime.UtcNow - state.LastAdditionalDependentFileTimesChangedAtUtc).TotalSeconds, 0, 10);
         }
     }
 }


### PR DESCRIPTION
At some point in the history of the fast up-to-date check we used `AdditionalDependentFileTimes` data to track files such as `.editorconfig`, `global.json`, and other similar files.

Currently we do not use this data. This change removes the tracking and storage of this data, along with some commented code and skipped unit tests related to it.

We may wish to revert this PR in future as part of a potential fix for #6227. Until then it is avoidable overhead.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7822)