### PR TITLE
Localise fast up-to-date check logging

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -357,20 +357,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         }
                     }
                 }
-
-#if FALSE // https://github.com/dotnet/project-system/issues/6227
-
-                if (_enableAdditionalDependentFile && state.AdditionalDependentFileTimes.Count != 0)
-                {
-                    log.Verbose("Adding " + nameof(state.AdditionalDependentFileTimes) + " inputs:");
-                    foreach ((string path, DateTime _) in state.AdditionalDependentFileTimes)
-                    {
-                        System.Diagnostics.Debug.Assert(Path.IsPathRooted(path), "AdditionalDependentFileTimes path should be rooted");
-                        log.Verbose("    '{0}'", path);
-                        yield return (Path: path, IsRequired: false);
-                    }
-                }
-#endif
             }
 
             IEnumerable<string> CollectDefaultOutputs()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -112,19 +112,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         {
             if (!_tasksService.IsTaskQueueEmpty(ProjectCriticalOperation.Build))
             {
-                return log.Fail("CriticalTasks", "Critical build tasks are running, not up to date.");
+                return log.Fail("CriticalTasks", nameof(Resources.FUTD_CriticalBuildTasksRunning));
             }
 
             if (state.IsDisabled)
             {
-                return log.Fail("Disabled", "The 'DisableFastUpToDateCheck' property is true, not up to date.");
+                return log.Fail("Disabled", nameof(Resources.FUTD_DisableFastUpToDateCheckTrue));
             }
 
             if (validateFirstRun && !state.WasStateRestored && lastCheckedAtUtc == DateTime.MinValue)
             {
                 // We had no persisted state, and this is the first run. We cannot know if the project is up-to-date
                 // or not, so schedule a build.
-                return log.Fail("FirstRun", "The up-to-date check has not yet run for this project. Not up-to-date.");
+                return log.Fail("FirstRun", nameof(Resources.FUTD_FirstRun));
             }
 
             foreach ((_, ImmutableArray<UpToDateCheckInputItem> items) in state.InputSourceItemsByItemType)
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     if (item.CopyType == CopyType.CopyAlways)
                     {
-                        return log.Fail("CopyAlwaysItemExists", "Item '{0}' has CopyToOutputDirectory set to 'Always', not up to date.", _configuredProject.UnconfiguredProject.MakeRooted(item.Path));
+                        return log.Fail("CopyAlwaysItemExists", nameof(Resources.FUTD_CopyAlwaysItemExists_1), _configuredProject.UnconfiguredProject.MakeRooted(item.Path));
                     }
                 }
             }
@@ -156,11 +156,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             // Second, validate the relationships between inputs and outputs in specific sets, if any.
             foreach (string setName in state.SetNames)
             {
-                log.Verbose("Comparing timestamps of inputs and outputs in set '{0}':", setName);
+                if (log.Level >= LogLevel.Verbose)
+                {
+                    log.Verbose(nameof(Resources.FUTD_ComparingInputOutputTimestamps_1), setName);
+                    log.Indent++;
+                }
 
                 if (!CheckInputsAndOutputs(CollectSetInputs(setName), CollectSetOutputs(setName), timestampCache, setName))
                 {
                     return false;
+                }
+
+                if (log.Level >= LogLevel.Verbose)
+                {
+                    log.Indent--;
                 }
             }
 
@@ -183,7 +192,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                     if (outputTime == null)
                     {
-                        return log.Fail("OutputNotFound", "Output '{0}' does not exist, not up to date.", output);
+                        return log.Fail("OutputNotFound", nameof(Resources.FUTD_OutputDoesNotExist_1), output);
                     }
 
                     if (outputTime < earliestOutputTime)
@@ -197,7 +206,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 if (!hasOutput)
                 {
-                    log.Info(setName == DefaultSetName ? "No build outputs defined." : "No build outputs defined in set '{0}'.", setName);
+                    log.Info(setName == DefaultSetName ? nameof(Resources.FUTD_NoBuildOutputDefined) : nameof(Resources.FUTD_NoBuildOutputDefinedInSet_1), setName);
 
                     return true;
                 }
@@ -206,17 +215,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 if (earliestOutputTime < state.LastItemsChangedAtUtc)
                 {
-                    log.Fail("ProjectItemsChangedSinceEarliestOutput", "The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up to date.", state.LastItemsChangedAtUtc, earliestOutputPath, earliestOutputTime);
+                    log.Fail("ProjectItemsChangedSinceEarliestOutput", nameof(Resources.FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3), state.LastItemsChangedAtUtc, earliestOutputPath, earliestOutputTime);
 
                     if (log.Level >= LogLevel.Info)
                     {
+                        log.Indent++;
+
                         foreach ((bool isAdd, string itemType, UpToDateCheckInputItem item) in state.LastItemChanges.OrderBy(change => change.ItemType).ThenBy(change => change.Item.Path))
                         {
-                            if (Strings.IsNullOrEmpty(item.TargetPath))
-                                log.Info("    {0} item {1} '{2}' (CopyType={3})", itemType, isAdd ? "added" : "removed", item.Path, item.CopyType);
-                            else
-                                log.Info("    {0} item {1} '{2}' (CopyType={3}, TargetPath='{4}')", itemType, isAdd ? "added" : "removed", item.Path, item.CopyType, item.TargetPath);
+                            log.Info(isAdd ? nameof(Resources.FUTD_ChangedItemsAddition_4) : nameof(Resources.FUTD_ChangedItemsRemoval_4), itemType, item.Path, item.CopyType, item.TargetPath ?? "");
                         }
+
+                        log.Indent--;
                     }
 
                     return false;
@@ -234,26 +244,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {
                         if (isRequired)
                         {
-                            string prefix = itemType is null ? "Input " : $"Input {itemType} item ";
-                            return log.Fail("InputNotFound", "{0}'{1}' does not exist and is required, not up to date.", prefix, input);
+                            return log.Fail("InputNotFound", itemType is null ? nameof(Resources.FUTD_RequiredInputNotFound_1) : nameof(Resources.FUTD_RequiredTypedInputNotFound_2), input, itemType ?? "");
                         }
                         else
                         {
-                            log.Verbose("Input '{0}' does not exist, but is not required.", input);
+                            log.Verbose(itemType is null ? nameof(Resources.FUTD_NonRequiredInputNotFound_1) : nameof(Resources.FUTD_NonRequiredTypedInputNotFound_2), input, itemType ?? "");
                         }
                     }
 
                     if (inputTime > earliestOutputTime)
                     {
-                        string prefix = itemType is null ? "Input " : $"Input {itemType} item ";
-                        return log.Fail("InputNewerThanEarliestOutput", "{0}'{1}' is newer ({2}) than earliest output '{3}' ({4}), not up to date.", prefix, input, inputTime.Value, earliestOutputPath, earliestOutputTime);
+                        return log.Fail("InputNewerThanEarliestOutput", itemType is null ? nameof(Resources.FUTD_InputNewerThanOutput_4) : nameof(Resources.FUTD_TypedInputNewerThanOutput_5), input, inputTime.Value, earliestOutputPath, earliestOutputTime, itemType ?? "");
                     }
 
                     if (inputTime > lastCheckedAtUtc && lastCheckedAtUtc != DateTime.MinValue)
                     {
                         // Bypass this test if no check has yet been performed. We handle that in CheckGlobalConditions.
-                        string prefix = itemType is null ? "Input " : $"Input {itemType} item ";
-                        return log.Fail("InputModifiedSinceLastCheck", "{0}'{1}' ({2}) has been modified since the last up-to-date check ({3}), not up to date.", prefix, input, inputTime.Value, lastCheckedAtUtc);
+                        return log.Fail("InputModifiedSinceLastCheck", itemType is null ? nameof(Resources.FUTD_InputModifiedSinceLastCheck_3) : nameof(Resources.FUTD_TypedInputModifiedSinceLastCheck_4), input, inputTime.Value, lastCheckedAtUtc, itemType ?? "");
                     }
 
                     if (latestInput is null || inputTime > latestInput.Value.Time)
@@ -266,15 +273,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     if (latestInput is null)
                     {
-                        log.Info(setName == DefaultSetName ? "No inputs defined." : "No inputs defined in set '{0}'.", setName);
-                    }
-                    else if (setName == DefaultSetName)
-                    {
-                        log.Info("No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).", earliestOutputPath, earliestOutputTime, latestInput.Value.Path, latestInput.Value.Time ?? (object)"null");
+                        log.Info(setName == DefaultSetName ? nameof(Resources.FUTD_NoInputsDefined) : nameof(Resources.FUTD_NoInputsDefinedInSet_1), setName);
                     }
                     else
                     {
-                        log.Info("In set '{0}', no inputs are newer than earliest output '{1}' ({2}). Newest input is '{3}' ({4}).", setName, earliestOutputPath, earliestOutputTime, latestInput.Value.Path, latestInput.Value.Time ?? (object)"null");
+                        log.Info(setName == DefaultSetName ? nameof(Resources.FUTD_NoInputsNewerThanEarliestOutput_4) : nameof(Resources.FUTD_NoInputsNewerThanEarliestOutputInSet_5), earliestOutputPath, earliestOutputTime, latestInput.Value.Path, latestInput.Value.Time ?? (object)"null", setName);
                     }
                 }
 
@@ -285,15 +288,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 if (state.MSBuildProjectFullPath != null)
                 {
-                    log.Verbose("Adding project file inputs:");
-                    log.Verbose("    '{0}'", state.MSBuildProjectFullPath);
+                    log.Verbose(nameof(Resources.FUTD_AddingProjectFileInputs));
+                    log.Indent++;
+                    log.VerboseLiteral(state.MSBuildProjectFullPath);
+                    log.Indent--;
                     yield return (Path: state.MSBuildProjectFullPath, ItemType: null, IsRequired: true);
                 }
 
                 if (state.NewestImportInput != null)
                 {
-                    log.Verbose("Adding newest import input:");
-                    log.Verbose("    '{0}'", state.NewestImportInput);
+                    log.Verbose(nameof(Resources.FUTD_AddingNewestImportInput));
+                    log.Indent++;
+                    log.VerboseLiteral(state.NewestImportInput);
+                    log.Indent--;
                     yield return (Path: state.NewestImportInput, ItemType: null, IsRequired: true);
                 }
 
@@ -306,42 +313,55 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     // The need to schedule a build in order to copy files is handled separately.
                     if (!NonCompilationItemTypes.Contains(itemType))
                     {
-                        log.Verbose("Adding {0} inputs:", itemType);
+                        log.Verbose(nameof(Resources.FUTD_AddingTypedInputs_1), itemType);
+                        log.Indent++;
 
                         foreach (UpToDateCheckInputItem item in items)
                         {
                             string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(item.Path);
-                            log.Verbose("    '{0}'", absolutePath);
+                            log.VerboseLiteral(absolutePath);
                             yield return (Path: absolutePath, itemType, IsRequired: true);
                         }
+
+                        log.Indent--;
                     }
                 }
 
                 if (!state.ResolvedAnalyzerReferencePaths.IsEmpty)
                 {
-                    log.Verbose("Adding " + ResolvedAnalyzerReference.SchemaName + " inputs:");
+                    log.Verbose(nameof(Resources.FUTD_AddingTypedInputs_1), ResolvedAnalyzerReference.SchemaName);
+                    log.Indent++;
+
                     foreach (string path in state.ResolvedAnalyzerReferencePaths)
                     {
                         string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
-                        log.Verbose("    '{0}'", absolutePath);
+                        log.VerboseLiteral(absolutePath);
                         yield return (Path: absolutePath, ItemType: ResolvedAnalyzerReference.SchemaName, IsRequired: true);
                     }
+
+                    log.Indent--;
                 }
 
                 if (!state.ResolvedCompilationReferencePaths.IsEmpty)
                 {
-                    log.Verbose("Adding " + ResolvedCompilationReference.SchemaName + " inputs:");
+                    log.Verbose(nameof(Resources.FUTD_AddingTypedInputs_1), ResolvedCompilationReference.SchemaName);
+                    log.Indent++;
+
                     foreach (string path in state.ResolvedCompilationReferencePaths)
                     {
                         System.Diagnostics.Debug.Assert(Path.IsPathRooted(path), "ResolvedCompilationReference path should be rooted");
-                        log.Verbose("    '{0}'", path);
+                        log.VerboseLiteral(path);
                         yield return (Path: path, ItemType: ResolvedCompilationReference.SchemaName, IsRequired: true);
                     }
+
+                    log.Indent--;
                 }
 
                 if (state.UpToDateCheckInputItemsByKindBySetName.TryGetValue(DefaultSetName, out ImmutableDictionary<string, ImmutableArray<string>>? upToDateCheckInputItems))
                 {
-                    log.Verbose("Adding " + UpToDateCheckInput.SchemaName + " inputs:");
+                    log.Verbose(nameof(Resources.FUTD_AddingTypedInputs_1), UpToDateCheckInput.SchemaName);
+                    log.Indent++;
+
                     foreach ((string kind, ImmutableArray<string> items) in upToDateCheckInputItems)
                     {
                         if (ShouldIgnoreItems(kind, items))
@@ -352,10 +372,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         foreach (string path in items)
                         {
                             string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
-                            log.Verbose("    '{0}'", absolutePath);
+                            log.VerboseLiteral(absolutePath);
                             yield return (Path: absolutePath, ItemType: UpToDateCheckInput.SchemaName, IsRequired: true);
                         }
                     }
+
+                    log.Indent--;
                 }
             }
 
@@ -363,7 +385,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 if (state.UpToDateCheckOutputItemsByKindBySetName.TryGetValue(DefaultSetName, out ImmutableDictionary<string, ImmutableArray<string>>? upToDateCheckOutputItems))
                 {
-                    log.Verbose("Adding " + UpToDateCheckOutput.SchemaName + " outputs:");
+                    log.Verbose(nameof(Resources.FUTD_AddingTypedOutputs_1), UpToDateCheckOutput.SchemaName);
+                    log.Indent++;
 
                     foreach ((string kind, ImmutableArray<string> items) in upToDateCheckOutputItems)
                     {
@@ -375,15 +398,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         foreach (string path in items)
                         {
                             string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
-                            log.Verbose("    '{0}'", absolutePath);
+                            log.VerboseLiteral(absolutePath);
                             yield return absolutePath;
                         }
                     }
+
+                    log.Indent--;
                 }
 
                 if (state.UpToDateCheckBuiltItemsByKindBySetName.TryGetValue(DefaultSetName, out ImmutableDictionary<string, ImmutableArray<string>>? upToDateCheckBuiltItems))
                 {
-                    log.Verbose("Adding " + UpToDateCheckBuilt.SchemaName + " outputs:");
+                    log.Verbose(nameof(Resources.FUTD_AddingTypedOutputs_1), UpToDateCheckBuilt.SchemaName);
+                    log.Indent++;
 
                     foreach ((string kind, ImmutableArray<string> items) in upToDateCheckBuiltItems)
                     {
@@ -395,10 +421,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         foreach (string path in items)
                         {
                             string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
-                            log.Verbose("    '{0}'", absolutePath);
+                            log.VerboseLiteral(absolutePath);
                             yield return absolutePath;
                         }
                     }
+
+                    log.Indent--;
                 }
             }
 
@@ -406,7 +434,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 if (state.UpToDateCheckInputItemsByKindBySetName.TryGetValue(setName, out ImmutableDictionary<string, ImmutableArray<string>>? upToDateCheckInputItems))
                 {
-                    log.Verbose("Adding " + UpToDateCheckInput.SchemaName + " inputs in set '{0}':", setName);
+                    log.Verbose(nameof(Resources.FUTD_AddingTypedInputsInSet_2), UpToDateCheckInput.SchemaName, setName);
+                    log.Indent++;
+
                     foreach ((string kind, ImmutableArray<string> items) in upToDateCheckInputItems)
                     {
                         if (ShouldIgnoreItems(kind, items))
@@ -417,10 +447,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         foreach (string path in items)
                         {
                             string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
-                            log.Verbose("    '{0}'", absolutePath);
+                            log.VerboseLiteral(absolutePath);
                             yield return (Path: absolutePath, ItemType: UpToDateCheckInput.SchemaName, IsRequired: true);
                         }
                     }
+
+                    log.Indent--;
                 }
             }
 
@@ -428,7 +460,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 if (state.UpToDateCheckOutputItemsByKindBySetName.TryGetValue(setName, out ImmutableDictionary<string, ImmutableArray<string>>? upToDateCheckOutputItems))
                 {
-                    log.Verbose("Adding " + UpToDateCheckOutput.SchemaName + " outputs in set '{0}':", setName);
+                    log.Verbose(nameof(Resources.FUTD_AddingTypedOutputsInSet_2), UpToDateCheckOutput.SchemaName, setName);
+                    log.Indent++;
 
                     foreach ((string kind, ImmutableArray<string> items) in upToDateCheckOutputItems)
                     {
@@ -440,15 +473,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         foreach (string path in items)
                         {
                             string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
-                            log.Verbose("    '{0}'", absolutePath);
+                            log.VerboseLiteral(absolutePath);
                             yield return absolutePath;
                         }
                     }
+
+                    log.Indent--;
                 }
 
                 if (state.UpToDateCheckBuiltItemsByKindBySetName.TryGetValue(setName, out ImmutableDictionary<string, ImmutableArray<string>>? upToDateCheckBuiltItems))
                 {
-                    log.Verbose("Adding " + UpToDateCheckBuilt.SchemaName + " outputs in set '{0}':", setName);
+                    log.Verbose(nameof(Resources.FUTD_AddingTypedOutputsInSet_2), UpToDateCheckBuilt.SchemaName, setName);
+                    log.Indent++;
 
                     foreach ((string kind, ImmutableArray<string> items) in upToDateCheckBuiltItems)
                     {
@@ -460,10 +496,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         foreach (string path in items)
                         {
                             string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
-                            log.Verbose("    '{0}'", absolutePath);
+                            log.VerboseLiteral(absolutePath);
                             yield return absolutePath;
                         }
                     }
+
+                    log.Indent--;
                 }
             }
 
@@ -476,11 +514,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 if (log.Level >= LogLevel.Verbose)
                 {
+                    log.Indent++;
+                   
                     foreach (string path in items)
                     {
                         string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
-                        log.Verbose("    Skipping '{0}' with ignored kind '{1}'", absolutePath, kind);
+                        log.Verbose(nameof(Resources.FUTD_SkippingIgnoredKindItem_2), absolutePath, kind);
                     }
+
+                    log.Indent--;
                 }
 
                 return true;
@@ -505,24 +547,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             if (log.Level >= LogLevel.Verbose)
             {
-                log.Verbose("Adding input reference copy markers:");
+                log.Verbose(nameof(Resources.FUTD_AddingInputReferenceCopyMarkers));
+
+                log.Indent++;
 
                 foreach (string referenceMarkerFile in state.CopyReferenceInputs)
                 {
-                    log.Verbose("    '{0}'", referenceMarkerFile);
+                    log.VerboseLiteral(referenceMarkerFile);
                 }
 
-                log.Verbose("Adding output reference copy marker:");
-                log.Verbose("    '{0}'", markerFile);
+                log.Indent--;
+
+                log.Verbose(nameof(Resources.FUTD_AddingOutputReferenceCopyMarker));
+                log.Indent++;
+                log.VerboseLiteral(markerFile);
+                log.Indent--;
             }
 
             if (timestampCache.TryGetLatestInput(state.CopyReferenceInputs, out string? latestInputMarkerPath, out DateTime latestInputMarkerTime))
             {
-                log.Info("Latest write timestamp on input marker is {0} on '{1}'.", latestInputMarkerTime, latestInputMarkerPath);
+                log.Info(nameof(Resources.FUTD_LatestWriteTimeOnInputMarker_2), latestInputMarkerTime, latestInputMarkerPath);
             }
             else
             {
-                log.Info("No input markers exist, skipping marker check.");
+                log.Info(nameof(Resources.FUTD_NoInputMarkersExist));
                 return true;
             }
 
@@ -530,17 +578,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             if (outputMarkerTime != null)
             {
-                log.Info("Write timestamp on output marker is {0} on '{1}'.", outputMarkerTime, markerFile);
+                log.Info(nameof(Resources.FUTD_WriteTimeOnOutputMarker_2), outputMarkerTime, markerFile);
             }
             else
             {
-                log.Info("Output marker '{0}' does not exist, skipping marker check.", markerFile);
+                log.Info(nameof(Resources.FUTD_NoOutputMarkerExists_1), markerFile);
                 return true;
             }
 
             if (outputMarkerTime < latestInputMarkerTime)
             {
-                return log.Fail("InputMarkerNewerThanOutputMarker", "Input marker is newer than output marker, not up to date.");
+                return log.Fail("InputMarkerNewerThanOutputMarker", nameof(Resources.FUTD_InputMarkerNewerThanOutputMarker));
             }
 
             return true;
@@ -555,33 +603,37 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 string source = _configuredProject.UnconfiguredProject.MakeRooted(sourceRelative);
                 string destination = _configuredProject.UnconfiguredProject.MakeRooted(destinationRelative);
 
-                log.Info("Checking copied output (" + UpToDateCheckBuilt.SchemaName + " with " + UpToDateCheckBuilt.OriginalProperty + " property) file '{0}':", source);
+                log.Info(nameof(Resources.FUTD_CheckingCopiedOutputFile), source);
 
                 DateTime? sourceTime = timestampCache.GetTimestampUtc(source);
 
                 if (sourceTime != null)
                 {
-                    log.Info("    Source {0}: '{1}'.", sourceTime, source);
+                    log.Indent++;
+                    log.Info(nameof(Resources.FUTD_SourceFileTimeAndPath_2), sourceTime, source);
+                    log.Indent--;
                 }
                 else
                 {
-                    return log.Fail("CopySourceNotFound", "Source '{0}' does not exist for copy to '{1}', not up to date.", source, destination);
+                    return log.Fail("CopySourceNotFound", nameof(Resources.FUTD_CheckingCopiedOutputFileSourceNotFound_2), source, destination);
                 }
 
                 DateTime? destinationTime = timestampCache.GetTimestampUtc(destination);
 
                 if (destinationTime != null)
                 {
-                    log.Info("    Destination {0}: '{1}'.", destinationTime, destination);
+                    log.Indent++;
+                    log.Info(nameof(Resources.FUTD_DestinationFileTimeAndPath_2), destinationTime, destination);
+                    log.Indent--;
                 }
                 else
                 {
-                    return log.Fail("CopyDestinationNotFound", "Destination '{0}' does not exist for copy from '{1}', not up to date.", destination, source);
+                    return log.Fail("CopyDestinationNotFound", nameof(Resources.FUTD_CheckingCopiedOutputFileDestinationNotFound_2), destination, source);
                 }
 
                 if (destinationTime < sourceTime)
                 {
-                    return log.Fail("CopySourceNewer", "Source is newer than build output destination, not up to date.");
+                    return log.Fail("CopySourceNewer", nameof(Resources.FUTD_CheckingCopiedOutputFileSourceNewer));
                 }
             }
 
@@ -596,7 +648,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 foreach (UpToDateCheckInputItem item in items)
                 {
-                    // Only consider items with CopyType of CopyIfNewer
+                    // Only consider items with CopyType of CopyIfNewer (PreserveNewest)
                     if (item.CopyType != CopyType.CopyIfNewer)
                     {
                         continue;
@@ -614,17 +666,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                     filename = _configuredProject.UnconfiguredProject.MakeRelative(filename);
 
-                    log.Info("Checking PreserveNewest file '{0}':", rootedPath);
+                    log.Info(nameof(Resources.FUTD_CheckingPreserveNewestFile_1), rootedPath);
 
                     DateTime? itemTime = timestampCache.GetTimestampUtc(rootedPath);
 
                     if (itemTime != null)
                     {
-                        log.Info("    Source {0}: '{1}'.", itemTime, rootedPath);
+                        log.Indent++;
+                        log.Info(nameof(Resources.FUTD_SourceFileTimeAndPath_2), itemTime, rootedPath);
+                        log.Indent--;
                     }
                     else
                     {
-                        return log.Fail("CopyToOutputDirectorySourceNotFound", "Source '{0}' does not exist, not up to date.", rootedPath);
+                        return log.Fail("CopyToOutputDirectorySourceNotFound", nameof(Resources.FUTD_CheckingPreserveNewestFileSourceNotFound_1), rootedPath);
                     }
 
                     string destination = Path.Combine(outputFullPath, filename);
@@ -632,16 +686,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                     if (destinationTime != null)
                     {
-                        log.Info("    Destination {0}: '{1}'.", destinationTime, destination);
+                        log.Indent++;
+                        log.Info(nameof(Resources.FUTD_DestinationFileTimeAndPath_2), destinationTime, destination);
+                        log.Indent--;
                     }
                     else
                     {
-                        return log.Fail("CopyToOutputDirectoryDestinationNotFound", "Destination '{0}' does not exist, not up to date.", destination);
+                        return log.Fail("CopyToOutputDirectoryDestinationNotFound", nameof(Resources.FUTD_CheckingPreserveNewestFileDestinationNotFound_1), destination);
                     }
 
                     if (destinationTime < itemTime)
                     {
-                        return log.Fail("CopyToOutputDirectorySourceNewer", "PreserveNewest source '{0}' is newer than destination '{1}', not up to date.", rootedPath, destination);
+                        return log.Fail("CopyToOutputDirectorySourceNewer", nameof(Resources.FUTD_CheckingPreserveNewestSourceNewerThanDestination_2), rootedPath, destination);
                     }
                 }
             }
@@ -721,7 +777,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                         if (requestedLogLevel >= LogLevel.Info && ignoreKinds.Count != 0)
                         {
-                            logger.Info("Ignoring up-to-date check items with kinds: {0}", ignoreKindsString);
+                            logger.Info(nameof(Resources.FUTD_IgnoringKinds_1), ignoreKindsString);
                         }
                     }
 
@@ -742,11 +798,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 }
                 catch (Exception ex)
                 {
-                    return logger.Fail("Exception", "Up-to-date check threw an exception. Not up-to-date. {0}", ex);
+                    return logger.Fail("Exception", nameof(Resources.FUTD_Exception_1), ex);
                 }
                 finally
                 {
-                    logger.Verbose("Up to date check completed in {0:N1} ms", sw.Elapsed.TotalMilliseconds);
+                    logger.Verbose(nameof(Resources.FUTD_Completed), sw.Elapsed.TotalMilliseconds);
 
                     _lastFailureReason = logger.FailureReason ?? "";
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -120,6 +120,465 @@ namespace Microsoft.VisualStudio {
         internal static string FrameworkNodeName {
             get {
                 return ResourceManager.GetString("FrameworkNodeName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Adding input reference copy markers:.
+        /// </summary>
+        internal static string FUTD_AddingInputReferenceCopyMarkers {
+            get {
+                return ResourceManager.GetString("FUTD_AddingInputReferenceCopyMarkers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Adding newest import input:.
+        /// </summary>
+        internal static string FUTD_AddingNewestImportInput {
+            get {
+                return ResourceManager.GetString("FUTD_AddingNewestImportInput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Adding output reference copy marker:.
+        /// </summary>
+        internal static string FUTD_AddingOutputReferenceCopyMarker {
+            get {
+                return ResourceManager.GetString("FUTD_AddingOutputReferenceCopyMarker", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Adding project file inputs:.
+        /// </summary>
+        internal static string FUTD_AddingProjectFileInputs {
+            get {
+                return ResourceManager.GetString("FUTD_AddingProjectFileInputs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Adding {0} inputs:.
+        /// </summary>
+        internal static string FUTD_AddingTypedInputs_1 {
+            get {
+                return ResourceManager.GetString("FUTD_AddingTypedInputs_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Adding {0} inputs in Set=&quot;{1}&quot;:.
+        /// </summary>
+        internal static string FUTD_AddingTypedInputsInSet_2 {
+            get {
+                return ResourceManager.GetString("FUTD_AddingTypedInputsInSet_2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Adding {0} outputs:.
+        /// </summary>
+        internal static string FUTD_AddingTypedOutputs_1 {
+            get {
+                return ResourceManager.GetString("FUTD_AddingTypedOutputs_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Adding {0} outputs in Set=&quot;{1}&quot;:.
+        /// </summary>
+        internal static string FUTD_AddingTypedOutputsInSet_2 {
+            get {
+                return ResourceManager.GetString("FUTD_AddingTypedOutputsInSet_2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} item added &apos;{1}&apos; (CopyType={2}, TargetPath=&apos;{3}&apos;).
+        /// </summary>
+        internal static string FUTD_ChangedItemsAddition_4 {
+            get {
+                return ResourceManager.GetString("FUTD_ChangedItemsAddition_4", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} item removed &apos;{1}&apos; (CopyType={2}, TargetPath=&apos;{3}&apos;).
+        /// </summary>
+        internal static string FUTD_ChangedItemsRemoval_4 {
+            get {
+                return ResourceManager.GetString("FUTD_ChangedItemsRemoval_4", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Checking copied output (UpToDateCheckBuilt with Original property) file:.
+        /// </summary>
+        internal static string FUTD_CheckingCopiedOutputFile {
+            get {
+                return ResourceManager.GetString("FUTD_CheckingCopiedOutputFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Destination &apos;{0}&apos; does not exist for copy from &apos;{1}&apos;, not up-to-date..
+        /// </summary>
+        internal static string FUTD_CheckingCopiedOutputFileDestinationNotFound_2 {
+            get {
+                return ResourceManager.GetString("FUTD_CheckingCopiedOutputFileDestinationNotFound_2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Source is newer than build output destination, not up-to-date..
+        /// </summary>
+        internal static string FUTD_CheckingCopiedOutputFileSourceNewer {
+            get {
+                return ResourceManager.GetString("FUTD_CheckingCopiedOutputFileSourceNewer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Source &apos;{0}&apos; does not exist for copy to &apos;{1}&apos;, not up-to-date..
+        /// </summary>
+        internal static string FUTD_CheckingCopiedOutputFileSourceNotFound_2 {
+            get {
+                return ResourceManager.GetString("FUTD_CheckingCopiedOutputFileSourceNotFound_2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Checking PreserveNewest file &apos;{0}&apos;:.
+        /// </summary>
+        internal static string FUTD_CheckingPreserveNewestFile_1 {
+            get {
+                return ResourceManager.GetString("FUTD_CheckingPreserveNewestFile_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Destination &apos;{0}&apos; does not exist, not up-to-date..
+        /// </summary>
+        internal static string FUTD_CheckingPreserveNewestFileDestinationNotFound_1 {
+            get {
+                return ResourceManager.GetString("FUTD_CheckingPreserveNewestFileDestinationNotFound_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Source &apos;{0}&apos; does not exist, not up-to-date..
+        /// </summary>
+        internal static string FUTD_CheckingPreserveNewestFileSourceNotFound_1 {
+            get {
+                return ResourceManager.GetString("FUTD_CheckingPreserveNewestFileSourceNotFound_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PreserveNewest source &apos;{0}&apos; is newer than destination &apos;{1}&apos;, not up-to-date..
+        /// </summary>
+        internal static string FUTD_CheckingPreserveNewestSourceNewerThanDestination_2 {
+            get {
+                return ResourceManager.GetString("FUTD_CheckingPreserveNewestSourceNewerThanDestination_2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Comparing timestamps of inputs and outputs in Set=&quot;{0}&quot;:.
+        /// </summary>
+        internal static string FUTD_ComparingInputOutputTimestamps_1 {
+            get {
+                return ResourceManager.GetString("FUTD_ComparingInputOutputTimestamps_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Up-to-date check completed in {0:N1} ms.
+        /// </summary>
+        internal static string FUTD_Completed {
+            get {
+                return ResourceManager.GetString("FUTD_Completed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Item &apos;{0}&apos; has CopyToOutputDirectory set to &apos;Always&apos;, not up-to-date..
+        /// </summary>
+        internal static string FUTD_CopyAlwaysItemExists_1 {
+            get {
+                return ResourceManager.GetString("FUTD_CopyAlwaysItemExists_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Critical build tasks are running, not up-to-date..
+        /// </summary>
+        internal static string FUTD_CriticalBuildTasksRunning {
+            get {
+                return ResourceManager.GetString("FUTD_CriticalBuildTasksRunning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Destination {0}: &apos;{1}&apos;.
+        /// </summary>
+        internal static string FUTD_DestinationFileTimeAndPath_2 {
+            get {
+                return ResourceManager.GetString("FUTD_DestinationFileTimeAndPath_2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The &apos;DisableFastUpToDateCheck&apos; property is &apos;true&apos;, not up-to-date..
+        /// </summary>
+        internal static string FUTD_DisableFastUpToDateCheckTrue {
+            get {
+                return ResourceManager.GetString("FUTD_DisableFastUpToDateCheckTrue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Up-to-date check threw an exception. Not up-to-date. {0}.
+        /// </summary>
+        internal static string FUTD_Exception_1 {
+            get {
+                return ResourceManager.GetString("FUTD_Exception_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The up-to-date check has not yet run for this project. Not up-to-date..
+        /// </summary>
+        internal static string FUTD_FirstRun {
+            get {
+                return ResourceManager.GetString("FUTD_FirstRun", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ignoring up-to-date check items with Kind=&quot;{0}&quot;.
+        /// </summary>
+        internal static string FUTD_IgnoringKinds_1 {
+            get {
+                return ResourceManager.GetString("FUTD_IgnoringKinds_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Input marker is newer than output marker, not up-to-date..
+        /// </summary>
+        internal static string FUTD_InputMarkerNewerThanOutputMarker {
+            get {
+                return ResourceManager.GetString("FUTD_InputMarkerNewerThanOutputMarker", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Input &apos;{0}&apos; ({1}) has been modified since the last up-to-date check ({2}), not up-to-date..
+        /// </summary>
+        internal static string FUTD_InputModifiedSinceLastCheck_3 {
+            get {
+                return ResourceManager.GetString("FUTD_InputModifiedSinceLastCheck_3", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Input &apos;{0}&apos; is newer ({1}) than earliest output &apos;{2}&apos; ({3}), not up-to-date..
+        /// </summary>
+        internal static string FUTD_InputNewerThanOutput_4 {
+            get {
+                return ResourceManager.GetString("FUTD_InputNewerThanOutput_4", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Latest write timestamp on input marker is {0} on &apos;{1}&apos;..
+        /// </summary>
+        internal static string FUTD_LatestWriteTimeOnInputMarker_2 {
+            get {
+                return ResourceManager.GetString("FUTD_LatestWriteTimeOnInputMarker_2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No build outputs defined..
+        /// </summary>
+        internal static string FUTD_NoBuildOutputDefined {
+            get {
+                return ResourceManager.GetString("FUTD_NoBuildOutputDefined", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No build outputs defined in Set=&quot;{0}&quot;..
+        /// </summary>
+        internal static string FUTD_NoBuildOutputDefinedInSet_1 {
+            get {
+                return ResourceManager.GetString("FUTD_NoBuildOutputDefinedInSet_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No input markers exist, skipping marker check..
+        /// </summary>
+        internal static string FUTD_NoInputMarkersExist {
+            get {
+                return ResourceManager.GetString("FUTD_NoInputMarkersExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No inputs defined..
+        /// </summary>
+        internal static string FUTD_NoInputsDefined {
+            get {
+                return ResourceManager.GetString("FUTD_NoInputsDefined", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No inputs defined in Set=&quot;{0}&quot;..
+        /// </summary>
+        internal static string FUTD_NoInputsDefinedInSet_1 {
+            get {
+                return ResourceManager.GetString("FUTD_NoInputsDefinedInSet_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No inputs are newer than earliest output &apos;{0}&apos; ({1}). Newest input is &apos;{2}&apos; ({3})..
+        /// </summary>
+        internal static string FUTD_NoInputsNewerThanEarliestOutput_4 {
+            get {
+                return ResourceManager.GetString("FUTD_NoInputsNewerThanEarliestOutput_4", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to In Set=&quot;{4}&quot;, no inputs are newer than earliest output &apos;{0}&apos; ({1}). Newest input is &apos;{2}&apos; ({3})..
+        /// </summary>
+        internal static string FUTD_NoInputsNewerThanEarliestOutputInSet_5 {
+            get {
+                return ResourceManager.GetString("FUTD_NoInputsNewerThanEarliestOutputInSet_5", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Input &apos;{0}&apos; does not exist, but is not required..
+        /// </summary>
+        internal static string FUTD_NonRequiredInputNotFound_1 {
+            get {
+                return ResourceManager.GetString("FUTD_NonRequiredInputNotFound_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Input {1} item &apos;{0}&apos; does not exist, but is not required..
+        /// </summary>
+        internal static string FUTD_NonRequiredTypedInputNotFound_2 {
+            get {
+                return ResourceManager.GetString("FUTD_NonRequiredTypedInputNotFound_2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Output marker &apos;{0}&apos; does not exist, skipping marker check..
+        /// </summary>
+        internal static string FUTD_NoOutputMarkerExists_1 {
+            get {
+                return ResourceManager.GetString("FUTD_NoOutputMarkerExists_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Output &apos;{0}&apos; does not exist, not up-to-date..
+        /// </summary>
+        internal static string FUTD_OutputDoesNotExist_1 {
+            get {
+                return ResourceManager.GetString("FUTD_OutputDoesNotExist_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Input &apos;{0}&apos; does not exist and is required, not up-to-date..
+        /// </summary>
+        internal static string FUTD_RequiredInputNotFound_1 {
+            get {
+                return ResourceManager.GetString("FUTD_RequiredInputNotFound_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Input {1} item &apos;{0}&apos; does not exist and is required, not up-to-date..
+        /// </summary>
+        internal static string FUTD_RequiredTypedInputNotFound_2 {
+            get {
+                return ResourceManager.GetString("FUTD_RequiredTypedInputNotFound_2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The set of project items was changed more recently ({0}) than the earliest output &apos;{1}&apos; ({2}), not up-to-date..
+        /// </summary>
+        internal static string FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3 {
+            get {
+                return ResourceManager.GetString("FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Skipping &apos;{0}&apos; with ignored Kind=&quot;{1}&quot;.
+        /// </summary>
+        internal static string FUTD_SkippingIgnoredKindItem_2 {
+            get {
+                return ResourceManager.GetString("FUTD_SkippingIgnoredKindItem_2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Source {0}: &apos;{1}&apos;.
+        /// </summary>
+        internal static string FUTD_SourceFileTimeAndPath_2 {
+            get {
+                return ResourceManager.GetString("FUTD_SourceFileTimeAndPath_2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Input {3} item &apos;{0}&apos; ({1}) has been modified since the last up-to-date check ({2}), not up-to-date..
+        /// </summary>
+        internal static string FUTD_TypedInputModifiedSinceLastCheck_4 {
+            get {
+                return ResourceManager.GetString("FUTD_TypedInputModifiedSinceLastCheck_4", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Input {4} item &apos;{0}&apos; is newer ({1}) than earliest output &apos;{2}&apos; ({3}), not up-to-date..
+        /// </summary>
+        internal static string FUTD_TypedInputNewerThanOutput_5 {
+            get {
+                return ResourceManager.GetString("FUTD_TypedInputNewerThanOutput_5", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Project is up-to-date..
+        /// </summary>
+        internal static string FUTD_UpToDate {
+            get {
+                return ResourceManager.GetString("FUTD_UpToDate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Write timestamp on output marker is {0} on &apos;{1}&apos;..
+        /// </summary>
+        internal static string FUTD_WriteTimeOnOutputMarker_2 {
+            get {
+                return ResourceManager.GetString("FUTD_WriteTimeOnOutputMarker_2", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
@@ -194,4 +194,196 @@ This project was loaded using the wrong project type, likely as a result of rena
     <value>(None)</value>
     <comment>Special value to show in the project property pages when a property has no value.</comment>
   </data>
+  <data name="FUTD_UpToDate" xml:space="preserve">
+    <value>Project is up-to-date.</value>
+  </data>
+  <data name="FUTD_CriticalBuildTasksRunning" xml:space="preserve">
+    <value>Critical build tasks are running, not up-to-date.</value>
+  </data>
+  <data name="FUTD_DisableFastUpToDateCheckTrue" xml:space="preserve">
+    <value>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</value>
+    <comment>Do not translate 'DisableFastUpToDateCheck' or 'true'.</comment>
+  </data>
+  <data name="FUTD_FirstRun" xml:space="preserve">
+    <value>The up-to-date check has not yet run for this project. Not up-to-date.</value>
+  </data>
+  <data name="FUTD_CopyAlwaysItemExists_1" xml:space="preserve">
+    <value>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</value>
+    <comment>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</comment>
+  </data>
+  <data name="FUTD_ComparingInputOutputTimestamps_1" xml:space="preserve">
+    <value>Comparing timestamps of inputs and outputs in Set="{0}":</value>
+    <comment>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</comment>
+  </data>
+  <data name="FUTD_OutputDoesNotExist_1" xml:space="preserve">
+    <value>Output '{0}' does not exist, not up-to-date.</value>
+    <comment>{0} is a file path.</comment>
+  </data>
+  <data name="FUTD_NoBuildOutputDefined" xml:space="preserve">
+    <value>No build outputs defined.</value>
+  </data>
+  <data name="FUTD_NoBuildOutputDefinedInSet_1" xml:space="preserve">
+    <value>No build outputs defined in Set="{0}".</value>
+    <comment>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</comment>
+  </data>
+  <data name="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3" xml:space="preserve">
+    <value>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</value>
+    <comment>{0} and {2} are datetimes. {1} is a file path.</comment>
+  </data>
+  <data name="FUTD_ChangedItemsAddition_4" xml:space="preserve">
+    <value>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</value>
+    <comment>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</comment>
+  </data>
+  <data name="FUTD_ChangedItemsRemoval_4" xml:space="preserve">
+    <value>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</value>
+    <comment>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</comment>
+  </data>
+  <data name="FUTD_RequiredInputNotFound_1" xml:space="preserve">
+    <value>Input '{0}' does not exist and is required, not up-to-date.</value>
+    <comment>{0} is a file path.</comment>
+  </data>
+  <data name="FUTD_RequiredTypedInputNotFound_2" xml:space="preserve">
+    <value>Input {1} item '{0}' does not exist and is required, not up-to-date.</value>
+    <comment>{0} is a file path. {1} is an MSBuild item type.</comment>
+  </data>
+  <data name="FUTD_NonRequiredInputNotFound_1" xml:space="preserve">
+    <value>Input '{0}' does not exist, but is not required.</value>
+    <comment>{0} is a file path.</comment>
+  </data>
+  <data name="FUTD_NonRequiredTypedInputNotFound_2" xml:space="preserve">
+    <value>Input {1} item '{0}' does not exist, but is not required.</value>
+    <comment>{0} is a file path. {1} is an MSBuild item type.</comment>
+  </data>
+  <data name="FUTD_InputNewerThanOutput_4" xml:space="preserve">
+    <value>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</value>
+    <comment>{0} and {2} are file paths. {1} and {3} are datetimes.</comment>
+  </data>
+  <data name="FUTD_TypedInputNewerThanOutput_5" xml:space="preserve">
+    <value>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</value>
+    <comment>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</comment>
+  </data>
+  <data name="FUTD_InputModifiedSinceLastCheck_3" xml:space="preserve">
+    <value>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</value>
+    <comment>{0} is a file path. {1} and {2} are datetimes.</comment>
+  </data>
+  <data name="FUTD_TypedInputModifiedSinceLastCheck_4" xml:space="preserve">
+    <value>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</value>
+    <comment>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</comment>
+  </data>
+  <data name="FUTD_NoInputsDefined" xml:space="preserve">
+    <value>No inputs defined.</value>
+  </data>
+  <data name="FUTD_NoInputsDefinedInSet_1" xml:space="preserve">
+    <value>No inputs defined in Set="{0}".</value>
+    <comment>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</comment>
+  </data>
+  <data name="FUTD_NoInputsNewerThanEarliestOutput_4" xml:space="preserve">
+    <value>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</value>
+    <comment>{0} and {2} are file paths. {1} and {2} are datetimes.</comment>
+  </data>
+  <data name="FUTD_NoInputsNewerThanEarliestOutputInSet_5" xml:space="preserve">
+    <value>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</value>
+    <comment>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</comment>
+  </data>
+  <data name="FUTD_AddingProjectFileInputs" xml:space="preserve">
+    <value>Adding project file inputs:</value>
+  </data>
+  <data name="FUTD_AddingNewestImportInput" xml:space="preserve">
+    <value>Adding newest import input:</value>
+  </data>
+  <data name="FUTD_AddingTypedInputs_1" xml:space="preserve">
+    <value>Adding {0} inputs:</value>
+    <comment>{0} is an MSBuild item type.</comment>
+  </data>
+  <data name="FUTD_AddingTypedInputsInSet_2" xml:space="preserve">
+    <value>Adding {0} inputs in Set="{1}":</value>
+    <comment>{0} is an MSBuild item type. {1} is the name of the set.</comment>
+  </data>
+  <data name="FUTD_AddingTypedOutputs_1" xml:space="preserve">
+    <value>Adding {0} outputs:</value>
+    <comment>{0} is an MSBuild item type.</comment>
+  </data>
+  <data name="FUTD_AddingTypedOutputsInSet_2" xml:space="preserve">
+    <value>Adding {0} outputs in Set="{1}":</value>
+    <comment>{0} is an MSBuild item type. {1} is the name of the set.</comment>
+  </data>
+  <data name="FUTD_SkippingIgnoredKindItem_2" xml:space="preserve">
+    <value>Skipping '{0}' with ignored Kind="{1}"</value>
+    <comment>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</comment>
+  </data>
+  <data name="FUTD_AddingInputReferenceCopyMarkers" xml:space="preserve">
+    <value>Adding input reference copy markers:</value>
+  </data>
+  <data name="FUTD_AddingOutputReferenceCopyMarker" xml:space="preserve">
+    <value>Adding output reference copy marker:</value>
+  </data>
+  <data name="FUTD_LatestWriteTimeOnInputMarker_2" xml:space="preserve">
+    <value>Latest write timestamp on input marker is {0} on '{1}'.</value>
+    <comment>{0} is a datetime. {1} is a file path.</comment>
+  </data>
+  <data name="FUTD_NoInputMarkersExist" xml:space="preserve">
+    <value>No input markers exist, skipping marker check.</value>
+  </data>
+  <data name="FUTD_WriteTimeOnOutputMarker_2" xml:space="preserve">
+    <value>Write timestamp on output marker is {0} on '{1}'.</value>
+    <comment>{0} is a datetime. {1} is a file path.</comment>
+  </data>
+  <data name="FUTD_NoOutputMarkerExists_1" xml:space="preserve">
+    <value>Output marker '{0}' does not exist, skipping marker check.</value>
+    <comment>{0} is a file path.</comment>
+  </data>
+  <data name="FUTD_InputMarkerNewerThanOutputMarker" xml:space="preserve">
+    <value>Input marker is newer than output marker, not up-to-date.</value>
+  </data>
+  <data name="FUTD_SourceFileTimeAndPath_2" xml:space="preserve">
+    <value>Source {0}: '{1}'</value>
+    <comment>{0} is a datetime. {1} is a file path.</comment>
+  </data>
+  <data name="FUTD_DestinationFileTimeAndPath_2" xml:space="preserve">
+    <value>Destination {0}: '{1}'</value>
+    <comment>{0} is a datetime. {1} is a file path.</comment>
+  </data>
+  <data name="FUTD_CheckingCopiedOutputFile" xml:space="preserve">
+    <value>Checking copied output (UpToDateCheckBuilt with Original property) file:</value>
+    <comment>Do not translate UpToDateCheckBuilt or Original.</comment>
+  </data>
+  <data name="FUTD_CheckingCopiedOutputFileSourceNotFound_2" xml:space="preserve">
+    <value>Source '{0}' does not exist for copy to '{1}', not up-to-date.</value>
+    <comment>{0} and {1} are file paths.</comment>
+  </data>
+  <data name="FUTD_CheckingCopiedOutputFileDestinationNotFound_2" xml:space="preserve">
+    <value>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</value>
+    <comment>{0} and {1} are file paths.</comment>
+  </data>
+  <data name="FUTD_CheckingCopiedOutputFileSourceNewer" xml:space="preserve">
+    <value>Source is newer than build output destination, not up-to-date.</value>
+  </data>
+  <data name="FUTD_CheckingPreserveNewestFile_1" xml:space="preserve">
+    <value>Checking PreserveNewest file '{0}':</value>
+    <comment>Do not translate PreserveNewest. {0} is a file path.</comment>
+  </data>
+  <data name="FUTD_CheckingPreserveNewestFileSourceNotFound_1" xml:space="preserve">
+    <value>Source '{0}' does not exist, not up-to-date.</value>
+    <comment>{0} is a file path.</comment>
+  </data>
+  <data name="FUTD_CheckingPreserveNewestFileDestinationNotFound_1" xml:space="preserve">
+    <value>Destination '{0}' does not exist, not up-to-date.</value>
+    <comment>{0} is a file path.</comment>
+  </data>
+  <data name="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2" xml:space="preserve">
+    <value>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</value>
+    <comment>Do not translate PreserveNewest. {0} and {1} are file paths.</comment>
+  </data>
+  <data name="FUTD_IgnoringKinds_1" xml:space="preserve">
+    <value>Ignoring up-to-date check items with Kind="{0}"</value>
+    <comment>Do not translate Kind. {0} is the kind name.</comment>
+  </data>
+  <data name="FUTD_Exception_1" xml:space="preserve">
+    <value>Up-to-date check threw an exception. Not up-to-date. {0}</value>
+    <comment>{0} is the exception message.</comment>
+  </data>
+  <data name="FUTD_Completed" xml:space="preserve">
+    <value>Up-to-date check completed in {0:N1} ms</value>
+    <comment>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</comment>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
@@ -7,6 +7,261 @@
         <target state="translated">Tok systémových dat projektu {0} se uzavřel z důvodu výjimky: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
+        <source>Adding input reference copy markers:</source>
+        <target state="new">Adding input reference copy markers:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingNewestImportInput">
+        <source>Adding newest import input:</source>
+        <target state="new">Adding newest import input:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
+        <source>Adding output reference copy marker:</source>
+        <target state="new">Adding output reference copy marker:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingProjectFileInputs">
+        <source>Adding project file inputs:</source>
+        <target state="new">Adding project file inputs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputsInSet_2">
+        <source>Adding {0} inputs in Set="{1}":</source>
+        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputs_1">
+        <source>Adding {0} inputs:</source>
+        <target state="new">Adding {0} inputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
+        <source>Adding {0} outputs in Set="{1}":</source>
+        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputs_1">
+        <source>Adding {0} outputs:</source>
+        <target state="new">Adding {0} outputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsAddition_4">
+        <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsRemoval_4">
+        <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFile">
+        <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
+        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <note>Do not translate UpToDateCheckBuilt or Original.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
+        <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
+        <source>Source is newer than build output destination, not up-to-date.</source>
+        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
+        <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
+        <source>Destination '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
+        <source>Source '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
+        <source>Checking PreserveNewest file '{0}':</source>
+        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <note>Do not translate PreserveNewest. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
+        <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
+        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
+        <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
+        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Completed">
+        <source>Up-to-date check completed in {0:N1} ms</source>
+        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CopyAlwaysItemExists_1">
+        <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
+        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CriticalBuildTasksRunning">
+        <source>Critical build tasks are running, not up-to-date.</source>
+        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
+        <source>Destination {0}: '{1}'</source>
+        <target state="new">Destination {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
+        <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
+        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Exception_1">
+        <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
+        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <note>{0} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_FirstRun">
+        <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
+        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_IgnoringKinds_1">
+        <source>Ignoring up-to-date check items with Kind="{0}"</source>
+        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <note>Do not translate Kind. {0} is the kind name.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
+        <source>Input marker is newer than output marker, not up-to-date.</source>
+        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
+        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputNewerThanOutput_4">
+        <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
+        <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
+        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefined">
+        <source>No build outputs defined.</source>
+        <target state="new">No build outputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
+        <source>No build outputs defined in Set="{0}".</source>
+        <target state="new">No build outputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputMarkersExist">
+        <source>No input markers exist, skipping marker check.</source>
+        <target state="new">No input markers exist, skipping marker check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefined">
+        <source>No inputs defined.</source>
+        <target state="new">No inputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefinedInSet_1">
+        <source>No inputs defined in Set="{0}".</source>
+        <target state="new">No inputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
+        <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
+        <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoOutputMarkerExists_1">
+        <source>Output marker '{0}' does not exist, skipping marker check.</source>
+        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredInputNotFound_1">
+        <source>Input '{0}' does not exist, but is not required.</source>
+        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist, but is not required.</source>
+        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_OutputDoesNotExist_1">
+        <source>Output '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredInputNotFound_1">
+        <source>Input '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
+        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
+        <source>Skipping '{0}' with ignored Kind="{1}"</source>
+        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SourceFileTimeAndPath_2">
+        <source>Source {0}: '{1}'</source>
+        <target state="new">Source {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
+        <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_UpToDate">
+        <source>Project is up-to-date.</source>
+        <target state="new">Project is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
+        <source>Write timestamp on output marker is {0} on '{1}'.</source>
+        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
         <source>Imports</source>
         <target state="translated">Importy</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
@@ -7,6 +7,261 @@
         <target state="translated">Projektsystem-Datenfluss "{0}" aufgrund einer Ausnahme geschlossen: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
+        <source>Adding input reference copy markers:</source>
+        <target state="new">Adding input reference copy markers:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingNewestImportInput">
+        <source>Adding newest import input:</source>
+        <target state="new">Adding newest import input:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
+        <source>Adding output reference copy marker:</source>
+        <target state="new">Adding output reference copy marker:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingProjectFileInputs">
+        <source>Adding project file inputs:</source>
+        <target state="new">Adding project file inputs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputsInSet_2">
+        <source>Adding {0} inputs in Set="{1}":</source>
+        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputs_1">
+        <source>Adding {0} inputs:</source>
+        <target state="new">Adding {0} inputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
+        <source>Adding {0} outputs in Set="{1}":</source>
+        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputs_1">
+        <source>Adding {0} outputs:</source>
+        <target state="new">Adding {0} outputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsAddition_4">
+        <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsRemoval_4">
+        <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFile">
+        <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
+        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <note>Do not translate UpToDateCheckBuilt or Original.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
+        <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
+        <source>Source is newer than build output destination, not up-to-date.</source>
+        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
+        <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
+        <source>Destination '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
+        <source>Source '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
+        <source>Checking PreserveNewest file '{0}':</source>
+        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <note>Do not translate PreserveNewest. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
+        <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
+        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
+        <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
+        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Completed">
+        <source>Up-to-date check completed in {0:N1} ms</source>
+        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CopyAlwaysItemExists_1">
+        <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
+        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CriticalBuildTasksRunning">
+        <source>Critical build tasks are running, not up-to-date.</source>
+        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
+        <source>Destination {0}: '{1}'</source>
+        <target state="new">Destination {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
+        <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
+        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Exception_1">
+        <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
+        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <note>{0} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_FirstRun">
+        <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
+        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_IgnoringKinds_1">
+        <source>Ignoring up-to-date check items with Kind="{0}"</source>
+        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <note>Do not translate Kind. {0} is the kind name.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
+        <source>Input marker is newer than output marker, not up-to-date.</source>
+        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
+        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputNewerThanOutput_4">
+        <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
+        <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
+        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefined">
+        <source>No build outputs defined.</source>
+        <target state="new">No build outputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
+        <source>No build outputs defined in Set="{0}".</source>
+        <target state="new">No build outputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputMarkersExist">
+        <source>No input markers exist, skipping marker check.</source>
+        <target state="new">No input markers exist, skipping marker check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefined">
+        <source>No inputs defined.</source>
+        <target state="new">No inputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefinedInSet_1">
+        <source>No inputs defined in Set="{0}".</source>
+        <target state="new">No inputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
+        <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
+        <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoOutputMarkerExists_1">
+        <source>Output marker '{0}' does not exist, skipping marker check.</source>
+        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredInputNotFound_1">
+        <source>Input '{0}' does not exist, but is not required.</source>
+        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist, but is not required.</source>
+        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_OutputDoesNotExist_1">
+        <source>Output '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredInputNotFound_1">
+        <source>Input '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
+        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
+        <source>Skipping '{0}' with ignored Kind="{1}"</source>
+        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SourceFileTimeAndPath_2">
+        <source>Source {0}: '{1}'</source>
+        <target state="new">Source {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
+        <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_UpToDate">
+        <source>Project is up-to-date.</source>
+        <target state="new">Project is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
+        <source>Write timestamp on output marker is {0} on '{1}'.</source>
+        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
         <source>Imports</source>
         <target state="translated">Importe</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
@@ -7,6 +7,261 @@
         <target state="translated">Flujo de datos del sistema de proyectos "{0}" cerrado debido a una excepción: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
+        <source>Adding input reference copy markers:</source>
+        <target state="new">Adding input reference copy markers:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingNewestImportInput">
+        <source>Adding newest import input:</source>
+        <target state="new">Adding newest import input:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
+        <source>Adding output reference copy marker:</source>
+        <target state="new">Adding output reference copy marker:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingProjectFileInputs">
+        <source>Adding project file inputs:</source>
+        <target state="new">Adding project file inputs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputsInSet_2">
+        <source>Adding {0} inputs in Set="{1}":</source>
+        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputs_1">
+        <source>Adding {0} inputs:</source>
+        <target state="new">Adding {0} inputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
+        <source>Adding {0} outputs in Set="{1}":</source>
+        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputs_1">
+        <source>Adding {0} outputs:</source>
+        <target state="new">Adding {0} outputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsAddition_4">
+        <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsRemoval_4">
+        <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFile">
+        <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
+        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <note>Do not translate UpToDateCheckBuilt or Original.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
+        <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
+        <source>Source is newer than build output destination, not up-to-date.</source>
+        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
+        <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
+        <source>Destination '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
+        <source>Source '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
+        <source>Checking PreserveNewest file '{0}':</source>
+        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <note>Do not translate PreserveNewest. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
+        <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
+        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
+        <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
+        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Completed">
+        <source>Up-to-date check completed in {0:N1} ms</source>
+        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CopyAlwaysItemExists_1">
+        <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
+        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CriticalBuildTasksRunning">
+        <source>Critical build tasks are running, not up-to-date.</source>
+        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
+        <source>Destination {0}: '{1}'</source>
+        <target state="new">Destination {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
+        <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
+        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Exception_1">
+        <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
+        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <note>{0} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_FirstRun">
+        <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
+        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_IgnoringKinds_1">
+        <source>Ignoring up-to-date check items with Kind="{0}"</source>
+        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <note>Do not translate Kind. {0} is the kind name.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
+        <source>Input marker is newer than output marker, not up-to-date.</source>
+        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
+        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputNewerThanOutput_4">
+        <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
+        <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
+        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefined">
+        <source>No build outputs defined.</source>
+        <target state="new">No build outputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
+        <source>No build outputs defined in Set="{0}".</source>
+        <target state="new">No build outputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputMarkersExist">
+        <source>No input markers exist, skipping marker check.</source>
+        <target state="new">No input markers exist, skipping marker check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefined">
+        <source>No inputs defined.</source>
+        <target state="new">No inputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefinedInSet_1">
+        <source>No inputs defined in Set="{0}".</source>
+        <target state="new">No inputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
+        <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
+        <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoOutputMarkerExists_1">
+        <source>Output marker '{0}' does not exist, skipping marker check.</source>
+        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredInputNotFound_1">
+        <source>Input '{0}' does not exist, but is not required.</source>
+        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist, but is not required.</source>
+        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_OutputDoesNotExist_1">
+        <source>Output '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredInputNotFound_1">
+        <source>Input '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
+        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
+        <source>Skipping '{0}' with ignored Kind="{1}"</source>
+        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SourceFileTimeAndPath_2">
+        <source>Source {0}: '{1}'</source>
+        <target state="new">Source {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
+        <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_UpToDate">
+        <source>Project is up-to-date.</source>
+        <target state="new">Project is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
+        <source>Write timestamp on output marker is {0} on '{1}'.</source>
+        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
         <source>Imports</source>
         <target state="translated">Importaciones</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
@@ -7,6 +7,261 @@
         <target state="translated">Le flux de données '{0}' du système de projet s'est fermé en raison d'une exception : {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
+        <source>Adding input reference copy markers:</source>
+        <target state="new">Adding input reference copy markers:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingNewestImportInput">
+        <source>Adding newest import input:</source>
+        <target state="new">Adding newest import input:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
+        <source>Adding output reference copy marker:</source>
+        <target state="new">Adding output reference copy marker:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingProjectFileInputs">
+        <source>Adding project file inputs:</source>
+        <target state="new">Adding project file inputs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputsInSet_2">
+        <source>Adding {0} inputs in Set="{1}":</source>
+        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputs_1">
+        <source>Adding {0} inputs:</source>
+        <target state="new">Adding {0} inputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
+        <source>Adding {0} outputs in Set="{1}":</source>
+        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputs_1">
+        <source>Adding {0} outputs:</source>
+        <target state="new">Adding {0} outputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsAddition_4">
+        <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsRemoval_4">
+        <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFile">
+        <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
+        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <note>Do not translate UpToDateCheckBuilt or Original.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
+        <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
+        <source>Source is newer than build output destination, not up-to-date.</source>
+        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
+        <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
+        <source>Destination '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
+        <source>Source '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
+        <source>Checking PreserveNewest file '{0}':</source>
+        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <note>Do not translate PreserveNewest. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
+        <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
+        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
+        <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
+        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Completed">
+        <source>Up-to-date check completed in {0:N1} ms</source>
+        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CopyAlwaysItemExists_1">
+        <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
+        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CriticalBuildTasksRunning">
+        <source>Critical build tasks are running, not up-to-date.</source>
+        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
+        <source>Destination {0}: '{1}'</source>
+        <target state="new">Destination {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
+        <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
+        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Exception_1">
+        <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
+        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <note>{0} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_FirstRun">
+        <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
+        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_IgnoringKinds_1">
+        <source>Ignoring up-to-date check items with Kind="{0}"</source>
+        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <note>Do not translate Kind. {0} is the kind name.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
+        <source>Input marker is newer than output marker, not up-to-date.</source>
+        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
+        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputNewerThanOutput_4">
+        <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
+        <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
+        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefined">
+        <source>No build outputs defined.</source>
+        <target state="new">No build outputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
+        <source>No build outputs defined in Set="{0}".</source>
+        <target state="new">No build outputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputMarkersExist">
+        <source>No input markers exist, skipping marker check.</source>
+        <target state="new">No input markers exist, skipping marker check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefined">
+        <source>No inputs defined.</source>
+        <target state="new">No inputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefinedInSet_1">
+        <source>No inputs defined in Set="{0}".</source>
+        <target state="new">No inputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
+        <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
+        <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoOutputMarkerExists_1">
+        <source>Output marker '{0}' does not exist, skipping marker check.</source>
+        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredInputNotFound_1">
+        <source>Input '{0}' does not exist, but is not required.</source>
+        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist, but is not required.</source>
+        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_OutputDoesNotExist_1">
+        <source>Output '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredInputNotFound_1">
+        <source>Input '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
+        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
+        <source>Skipping '{0}' with ignored Kind="{1}"</source>
+        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SourceFileTimeAndPath_2">
+        <source>Source {0}: '{1}'</source>
+        <target state="new">Source {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
+        <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_UpToDate">
+        <source>Project is up-to-date.</source>
+        <target state="new">Project is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
+        <source>Write timestamp on output marker is {0} on '{1}'.</source>
+        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
         <source>Imports</source>
         <target state="translated">Importations</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
@@ -7,6 +7,261 @@
         <target state="translated">Il flusso di dati di sistema '{0}' del progetto è stato chiuso a causa di un'eccezione: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
+        <source>Adding input reference copy markers:</source>
+        <target state="new">Adding input reference copy markers:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingNewestImportInput">
+        <source>Adding newest import input:</source>
+        <target state="new">Adding newest import input:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
+        <source>Adding output reference copy marker:</source>
+        <target state="new">Adding output reference copy marker:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingProjectFileInputs">
+        <source>Adding project file inputs:</source>
+        <target state="new">Adding project file inputs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputsInSet_2">
+        <source>Adding {0} inputs in Set="{1}":</source>
+        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputs_1">
+        <source>Adding {0} inputs:</source>
+        <target state="new">Adding {0} inputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
+        <source>Adding {0} outputs in Set="{1}":</source>
+        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputs_1">
+        <source>Adding {0} outputs:</source>
+        <target state="new">Adding {0} outputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsAddition_4">
+        <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsRemoval_4">
+        <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFile">
+        <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
+        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <note>Do not translate UpToDateCheckBuilt or Original.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
+        <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
+        <source>Source is newer than build output destination, not up-to-date.</source>
+        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
+        <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
+        <source>Destination '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
+        <source>Source '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
+        <source>Checking PreserveNewest file '{0}':</source>
+        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <note>Do not translate PreserveNewest. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
+        <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
+        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
+        <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
+        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Completed">
+        <source>Up-to-date check completed in {0:N1} ms</source>
+        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CopyAlwaysItemExists_1">
+        <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
+        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CriticalBuildTasksRunning">
+        <source>Critical build tasks are running, not up-to-date.</source>
+        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
+        <source>Destination {0}: '{1}'</source>
+        <target state="new">Destination {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
+        <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
+        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Exception_1">
+        <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
+        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <note>{0} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_FirstRun">
+        <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
+        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_IgnoringKinds_1">
+        <source>Ignoring up-to-date check items with Kind="{0}"</source>
+        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <note>Do not translate Kind. {0} is the kind name.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
+        <source>Input marker is newer than output marker, not up-to-date.</source>
+        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
+        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputNewerThanOutput_4">
+        <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
+        <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
+        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefined">
+        <source>No build outputs defined.</source>
+        <target state="new">No build outputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
+        <source>No build outputs defined in Set="{0}".</source>
+        <target state="new">No build outputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputMarkersExist">
+        <source>No input markers exist, skipping marker check.</source>
+        <target state="new">No input markers exist, skipping marker check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefined">
+        <source>No inputs defined.</source>
+        <target state="new">No inputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefinedInSet_1">
+        <source>No inputs defined in Set="{0}".</source>
+        <target state="new">No inputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
+        <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
+        <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoOutputMarkerExists_1">
+        <source>Output marker '{0}' does not exist, skipping marker check.</source>
+        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredInputNotFound_1">
+        <source>Input '{0}' does not exist, but is not required.</source>
+        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist, but is not required.</source>
+        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_OutputDoesNotExist_1">
+        <source>Output '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredInputNotFound_1">
+        <source>Input '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
+        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
+        <source>Skipping '{0}' with ignored Kind="{1}"</source>
+        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SourceFileTimeAndPath_2">
+        <source>Source {0}: '{1}'</source>
+        <target state="new">Source {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
+        <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_UpToDate">
+        <source>Project is up-to-date.</source>
+        <target state="new">Project is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
+        <source>Write timestamp on output marker is {0} on '{1}'.</source>
+        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
         <source>Imports</source>
         <target state="translated">Importazioni</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
@@ -7,6 +7,261 @@
         <target state="translated">例外 {1} が発生したため、プロジェクトのシステム データ フロー '{0}' が終了しました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
+        <source>Adding input reference copy markers:</source>
+        <target state="new">Adding input reference copy markers:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingNewestImportInput">
+        <source>Adding newest import input:</source>
+        <target state="new">Adding newest import input:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
+        <source>Adding output reference copy marker:</source>
+        <target state="new">Adding output reference copy marker:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingProjectFileInputs">
+        <source>Adding project file inputs:</source>
+        <target state="new">Adding project file inputs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputsInSet_2">
+        <source>Adding {0} inputs in Set="{1}":</source>
+        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputs_1">
+        <source>Adding {0} inputs:</source>
+        <target state="new">Adding {0} inputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
+        <source>Adding {0} outputs in Set="{1}":</source>
+        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputs_1">
+        <source>Adding {0} outputs:</source>
+        <target state="new">Adding {0} outputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsAddition_4">
+        <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsRemoval_4">
+        <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFile">
+        <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
+        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <note>Do not translate UpToDateCheckBuilt or Original.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
+        <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
+        <source>Source is newer than build output destination, not up-to-date.</source>
+        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
+        <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
+        <source>Destination '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
+        <source>Source '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
+        <source>Checking PreserveNewest file '{0}':</source>
+        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <note>Do not translate PreserveNewest. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
+        <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
+        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
+        <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
+        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Completed">
+        <source>Up-to-date check completed in {0:N1} ms</source>
+        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CopyAlwaysItemExists_1">
+        <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
+        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CriticalBuildTasksRunning">
+        <source>Critical build tasks are running, not up-to-date.</source>
+        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
+        <source>Destination {0}: '{1}'</source>
+        <target state="new">Destination {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
+        <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
+        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Exception_1">
+        <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
+        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <note>{0} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_FirstRun">
+        <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
+        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_IgnoringKinds_1">
+        <source>Ignoring up-to-date check items with Kind="{0}"</source>
+        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <note>Do not translate Kind. {0} is the kind name.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
+        <source>Input marker is newer than output marker, not up-to-date.</source>
+        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
+        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputNewerThanOutput_4">
+        <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
+        <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
+        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefined">
+        <source>No build outputs defined.</source>
+        <target state="new">No build outputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
+        <source>No build outputs defined in Set="{0}".</source>
+        <target state="new">No build outputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputMarkersExist">
+        <source>No input markers exist, skipping marker check.</source>
+        <target state="new">No input markers exist, skipping marker check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefined">
+        <source>No inputs defined.</source>
+        <target state="new">No inputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefinedInSet_1">
+        <source>No inputs defined in Set="{0}".</source>
+        <target state="new">No inputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
+        <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
+        <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoOutputMarkerExists_1">
+        <source>Output marker '{0}' does not exist, skipping marker check.</source>
+        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredInputNotFound_1">
+        <source>Input '{0}' does not exist, but is not required.</source>
+        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist, but is not required.</source>
+        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_OutputDoesNotExist_1">
+        <source>Output '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredInputNotFound_1">
+        <source>Input '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
+        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
+        <source>Skipping '{0}' with ignored Kind="{1}"</source>
+        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SourceFileTimeAndPath_2">
+        <source>Source {0}: '{1}'</source>
+        <target state="new">Source {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
+        <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_UpToDate">
+        <source>Project is up-to-date.</source>
+        <target state="new">Project is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
+        <source>Write timestamp on output marker is {0} on '{1}'.</source>
+        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
         <source>Imports</source>
         <target state="translated">インポート</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
@@ -7,6 +7,261 @@
         <target state="translated">프로젝트 시스템 데이터 흐름 '{0}'이(가) {1} 예외로 인해 닫혔습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
+        <source>Adding input reference copy markers:</source>
+        <target state="new">Adding input reference copy markers:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingNewestImportInput">
+        <source>Adding newest import input:</source>
+        <target state="new">Adding newest import input:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
+        <source>Adding output reference copy marker:</source>
+        <target state="new">Adding output reference copy marker:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingProjectFileInputs">
+        <source>Adding project file inputs:</source>
+        <target state="new">Adding project file inputs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputsInSet_2">
+        <source>Adding {0} inputs in Set="{1}":</source>
+        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputs_1">
+        <source>Adding {0} inputs:</source>
+        <target state="new">Adding {0} inputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
+        <source>Adding {0} outputs in Set="{1}":</source>
+        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputs_1">
+        <source>Adding {0} outputs:</source>
+        <target state="new">Adding {0} outputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsAddition_4">
+        <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsRemoval_4">
+        <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFile">
+        <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
+        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <note>Do not translate UpToDateCheckBuilt or Original.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
+        <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
+        <source>Source is newer than build output destination, not up-to-date.</source>
+        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
+        <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
+        <source>Destination '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
+        <source>Source '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
+        <source>Checking PreserveNewest file '{0}':</source>
+        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <note>Do not translate PreserveNewest. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
+        <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
+        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
+        <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
+        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Completed">
+        <source>Up-to-date check completed in {0:N1} ms</source>
+        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CopyAlwaysItemExists_1">
+        <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
+        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CriticalBuildTasksRunning">
+        <source>Critical build tasks are running, not up-to-date.</source>
+        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
+        <source>Destination {0}: '{1}'</source>
+        <target state="new">Destination {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
+        <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
+        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Exception_1">
+        <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
+        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <note>{0} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_FirstRun">
+        <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
+        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_IgnoringKinds_1">
+        <source>Ignoring up-to-date check items with Kind="{0}"</source>
+        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <note>Do not translate Kind. {0} is the kind name.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
+        <source>Input marker is newer than output marker, not up-to-date.</source>
+        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
+        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputNewerThanOutput_4">
+        <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
+        <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
+        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefined">
+        <source>No build outputs defined.</source>
+        <target state="new">No build outputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
+        <source>No build outputs defined in Set="{0}".</source>
+        <target state="new">No build outputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputMarkersExist">
+        <source>No input markers exist, skipping marker check.</source>
+        <target state="new">No input markers exist, skipping marker check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefined">
+        <source>No inputs defined.</source>
+        <target state="new">No inputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefinedInSet_1">
+        <source>No inputs defined in Set="{0}".</source>
+        <target state="new">No inputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
+        <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
+        <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoOutputMarkerExists_1">
+        <source>Output marker '{0}' does not exist, skipping marker check.</source>
+        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredInputNotFound_1">
+        <source>Input '{0}' does not exist, but is not required.</source>
+        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist, but is not required.</source>
+        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_OutputDoesNotExist_1">
+        <source>Output '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredInputNotFound_1">
+        <source>Input '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
+        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
+        <source>Skipping '{0}' with ignored Kind="{1}"</source>
+        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SourceFileTimeAndPath_2">
+        <source>Source {0}: '{1}'</source>
+        <target state="new">Source {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
+        <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_UpToDate">
+        <source>Project is up-to-date.</source>
+        <target state="new">Project is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
+        <source>Write timestamp on output marker is {0} on '{1}'.</source>
+        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
         <source>Imports</source>
         <target state="translated">가져오기</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
@@ -7,6 +7,261 @@
         <target state="translated">Przepływ danych systemu projektu „{0}” został zamknięty z powodu wyjątku: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
+        <source>Adding input reference copy markers:</source>
+        <target state="new">Adding input reference copy markers:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingNewestImportInput">
+        <source>Adding newest import input:</source>
+        <target state="new">Adding newest import input:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
+        <source>Adding output reference copy marker:</source>
+        <target state="new">Adding output reference copy marker:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingProjectFileInputs">
+        <source>Adding project file inputs:</source>
+        <target state="new">Adding project file inputs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputsInSet_2">
+        <source>Adding {0} inputs in Set="{1}":</source>
+        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputs_1">
+        <source>Adding {0} inputs:</source>
+        <target state="new">Adding {0} inputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
+        <source>Adding {0} outputs in Set="{1}":</source>
+        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputs_1">
+        <source>Adding {0} outputs:</source>
+        <target state="new">Adding {0} outputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsAddition_4">
+        <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsRemoval_4">
+        <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFile">
+        <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
+        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <note>Do not translate UpToDateCheckBuilt or Original.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
+        <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
+        <source>Source is newer than build output destination, not up-to-date.</source>
+        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
+        <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
+        <source>Destination '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
+        <source>Source '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
+        <source>Checking PreserveNewest file '{0}':</source>
+        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <note>Do not translate PreserveNewest. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
+        <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
+        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
+        <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
+        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Completed">
+        <source>Up-to-date check completed in {0:N1} ms</source>
+        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CopyAlwaysItemExists_1">
+        <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
+        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CriticalBuildTasksRunning">
+        <source>Critical build tasks are running, not up-to-date.</source>
+        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
+        <source>Destination {0}: '{1}'</source>
+        <target state="new">Destination {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
+        <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
+        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Exception_1">
+        <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
+        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <note>{0} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_FirstRun">
+        <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
+        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_IgnoringKinds_1">
+        <source>Ignoring up-to-date check items with Kind="{0}"</source>
+        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <note>Do not translate Kind. {0} is the kind name.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
+        <source>Input marker is newer than output marker, not up-to-date.</source>
+        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
+        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputNewerThanOutput_4">
+        <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
+        <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
+        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefined">
+        <source>No build outputs defined.</source>
+        <target state="new">No build outputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
+        <source>No build outputs defined in Set="{0}".</source>
+        <target state="new">No build outputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputMarkersExist">
+        <source>No input markers exist, skipping marker check.</source>
+        <target state="new">No input markers exist, skipping marker check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefined">
+        <source>No inputs defined.</source>
+        <target state="new">No inputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefinedInSet_1">
+        <source>No inputs defined in Set="{0}".</source>
+        <target state="new">No inputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
+        <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
+        <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoOutputMarkerExists_1">
+        <source>Output marker '{0}' does not exist, skipping marker check.</source>
+        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredInputNotFound_1">
+        <source>Input '{0}' does not exist, but is not required.</source>
+        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist, but is not required.</source>
+        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_OutputDoesNotExist_1">
+        <source>Output '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredInputNotFound_1">
+        <source>Input '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
+        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
+        <source>Skipping '{0}' with ignored Kind="{1}"</source>
+        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SourceFileTimeAndPath_2">
+        <source>Source {0}: '{1}'</source>
+        <target state="new">Source {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
+        <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_UpToDate">
+        <source>Project is up-to-date.</source>
+        <target state="new">Project is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
+        <source>Write timestamp on output marker is {0} on '{1}'.</source>
+        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
         <source>Imports</source>
         <target state="translated">Importy</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
@@ -7,6 +7,261 @@
         <target state="translated">Fluxo de dados do sistema do projeto '{0}' fechado devido a uma exceção: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
+        <source>Adding input reference copy markers:</source>
+        <target state="new">Adding input reference copy markers:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingNewestImportInput">
+        <source>Adding newest import input:</source>
+        <target state="new">Adding newest import input:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
+        <source>Adding output reference copy marker:</source>
+        <target state="new">Adding output reference copy marker:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingProjectFileInputs">
+        <source>Adding project file inputs:</source>
+        <target state="new">Adding project file inputs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputsInSet_2">
+        <source>Adding {0} inputs in Set="{1}":</source>
+        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputs_1">
+        <source>Adding {0} inputs:</source>
+        <target state="new">Adding {0} inputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
+        <source>Adding {0} outputs in Set="{1}":</source>
+        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputs_1">
+        <source>Adding {0} outputs:</source>
+        <target state="new">Adding {0} outputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsAddition_4">
+        <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsRemoval_4">
+        <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFile">
+        <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
+        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <note>Do not translate UpToDateCheckBuilt or Original.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
+        <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
+        <source>Source is newer than build output destination, not up-to-date.</source>
+        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
+        <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
+        <source>Destination '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
+        <source>Source '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
+        <source>Checking PreserveNewest file '{0}':</source>
+        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <note>Do not translate PreserveNewest. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
+        <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
+        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
+        <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
+        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Completed">
+        <source>Up-to-date check completed in {0:N1} ms</source>
+        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CopyAlwaysItemExists_1">
+        <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
+        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CriticalBuildTasksRunning">
+        <source>Critical build tasks are running, not up-to-date.</source>
+        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
+        <source>Destination {0}: '{1}'</source>
+        <target state="new">Destination {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
+        <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
+        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Exception_1">
+        <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
+        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <note>{0} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_FirstRun">
+        <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
+        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_IgnoringKinds_1">
+        <source>Ignoring up-to-date check items with Kind="{0}"</source>
+        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <note>Do not translate Kind. {0} is the kind name.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
+        <source>Input marker is newer than output marker, not up-to-date.</source>
+        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
+        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputNewerThanOutput_4">
+        <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
+        <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
+        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefined">
+        <source>No build outputs defined.</source>
+        <target state="new">No build outputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
+        <source>No build outputs defined in Set="{0}".</source>
+        <target state="new">No build outputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputMarkersExist">
+        <source>No input markers exist, skipping marker check.</source>
+        <target state="new">No input markers exist, skipping marker check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefined">
+        <source>No inputs defined.</source>
+        <target state="new">No inputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefinedInSet_1">
+        <source>No inputs defined in Set="{0}".</source>
+        <target state="new">No inputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
+        <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
+        <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoOutputMarkerExists_1">
+        <source>Output marker '{0}' does not exist, skipping marker check.</source>
+        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredInputNotFound_1">
+        <source>Input '{0}' does not exist, but is not required.</source>
+        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist, but is not required.</source>
+        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_OutputDoesNotExist_1">
+        <source>Output '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredInputNotFound_1">
+        <source>Input '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
+        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
+        <source>Skipping '{0}' with ignored Kind="{1}"</source>
+        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SourceFileTimeAndPath_2">
+        <source>Source {0}: '{1}'</source>
+        <target state="new">Source {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
+        <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_UpToDate">
+        <source>Project is up-to-date.</source>
+        <target state="new">Project is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
+        <source>Write timestamp on output marker is {0} on '{1}'.</source>
+        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
         <source>Imports</source>
         <target state="translated">Importações</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
@@ -7,6 +7,261 @@
         <target state="translated">Поток системных данных проекта "{0}" закрыт из-за исключения: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
+        <source>Adding input reference copy markers:</source>
+        <target state="new">Adding input reference copy markers:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingNewestImportInput">
+        <source>Adding newest import input:</source>
+        <target state="new">Adding newest import input:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
+        <source>Adding output reference copy marker:</source>
+        <target state="new">Adding output reference copy marker:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingProjectFileInputs">
+        <source>Adding project file inputs:</source>
+        <target state="new">Adding project file inputs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputsInSet_2">
+        <source>Adding {0} inputs in Set="{1}":</source>
+        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputs_1">
+        <source>Adding {0} inputs:</source>
+        <target state="new">Adding {0} inputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
+        <source>Adding {0} outputs in Set="{1}":</source>
+        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputs_1">
+        <source>Adding {0} outputs:</source>
+        <target state="new">Adding {0} outputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsAddition_4">
+        <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsRemoval_4">
+        <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFile">
+        <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
+        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <note>Do not translate UpToDateCheckBuilt or Original.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
+        <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
+        <source>Source is newer than build output destination, not up-to-date.</source>
+        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
+        <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
+        <source>Destination '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
+        <source>Source '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
+        <source>Checking PreserveNewest file '{0}':</source>
+        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <note>Do not translate PreserveNewest. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
+        <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
+        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
+        <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
+        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Completed">
+        <source>Up-to-date check completed in {0:N1} ms</source>
+        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CopyAlwaysItemExists_1">
+        <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
+        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CriticalBuildTasksRunning">
+        <source>Critical build tasks are running, not up-to-date.</source>
+        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
+        <source>Destination {0}: '{1}'</source>
+        <target state="new">Destination {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
+        <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
+        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Exception_1">
+        <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
+        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <note>{0} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_FirstRun">
+        <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
+        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_IgnoringKinds_1">
+        <source>Ignoring up-to-date check items with Kind="{0}"</source>
+        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <note>Do not translate Kind. {0} is the kind name.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
+        <source>Input marker is newer than output marker, not up-to-date.</source>
+        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
+        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputNewerThanOutput_4">
+        <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
+        <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
+        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefined">
+        <source>No build outputs defined.</source>
+        <target state="new">No build outputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
+        <source>No build outputs defined in Set="{0}".</source>
+        <target state="new">No build outputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputMarkersExist">
+        <source>No input markers exist, skipping marker check.</source>
+        <target state="new">No input markers exist, skipping marker check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefined">
+        <source>No inputs defined.</source>
+        <target state="new">No inputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefinedInSet_1">
+        <source>No inputs defined in Set="{0}".</source>
+        <target state="new">No inputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
+        <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
+        <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoOutputMarkerExists_1">
+        <source>Output marker '{0}' does not exist, skipping marker check.</source>
+        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredInputNotFound_1">
+        <source>Input '{0}' does not exist, but is not required.</source>
+        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist, but is not required.</source>
+        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_OutputDoesNotExist_1">
+        <source>Output '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredInputNotFound_1">
+        <source>Input '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
+        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
+        <source>Skipping '{0}' with ignored Kind="{1}"</source>
+        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SourceFileTimeAndPath_2">
+        <source>Source {0}: '{1}'</source>
+        <target state="new">Source {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
+        <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_UpToDate">
+        <source>Project is up-to-date.</source>
+        <target state="new">Project is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
+        <source>Write timestamp on output marker is {0} on '{1}'.</source>
+        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
         <source>Imports</source>
         <target state="translated">Импортирует</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
@@ -7,6 +7,261 @@
         <target state="translated">Proje sistem veri akışı '{0}', bir özel durum nedeniyle kapatıldı: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
+        <source>Adding input reference copy markers:</source>
+        <target state="new">Adding input reference copy markers:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingNewestImportInput">
+        <source>Adding newest import input:</source>
+        <target state="new">Adding newest import input:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
+        <source>Adding output reference copy marker:</source>
+        <target state="new">Adding output reference copy marker:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingProjectFileInputs">
+        <source>Adding project file inputs:</source>
+        <target state="new">Adding project file inputs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputsInSet_2">
+        <source>Adding {0} inputs in Set="{1}":</source>
+        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputs_1">
+        <source>Adding {0} inputs:</source>
+        <target state="new">Adding {0} inputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
+        <source>Adding {0} outputs in Set="{1}":</source>
+        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputs_1">
+        <source>Adding {0} outputs:</source>
+        <target state="new">Adding {0} outputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsAddition_4">
+        <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsRemoval_4">
+        <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFile">
+        <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
+        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <note>Do not translate UpToDateCheckBuilt or Original.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
+        <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
+        <source>Source is newer than build output destination, not up-to-date.</source>
+        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
+        <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
+        <source>Destination '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
+        <source>Source '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
+        <source>Checking PreserveNewest file '{0}':</source>
+        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <note>Do not translate PreserveNewest. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
+        <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
+        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
+        <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
+        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Completed">
+        <source>Up-to-date check completed in {0:N1} ms</source>
+        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CopyAlwaysItemExists_1">
+        <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
+        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CriticalBuildTasksRunning">
+        <source>Critical build tasks are running, not up-to-date.</source>
+        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
+        <source>Destination {0}: '{1}'</source>
+        <target state="new">Destination {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
+        <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
+        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Exception_1">
+        <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
+        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <note>{0} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_FirstRun">
+        <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
+        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_IgnoringKinds_1">
+        <source>Ignoring up-to-date check items with Kind="{0}"</source>
+        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <note>Do not translate Kind. {0} is the kind name.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
+        <source>Input marker is newer than output marker, not up-to-date.</source>
+        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
+        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputNewerThanOutput_4">
+        <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
+        <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
+        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefined">
+        <source>No build outputs defined.</source>
+        <target state="new">No build outputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
+        <source>No build outputs defined in Set="{0}".</source>
+        <target state="new">No build outputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputMarkersExist">
+        <source>No input markers exist, skipping marker check.</source>
+        <target state="new">No input markers exist, skipping marker check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefined">
+        <source>No inputs defined.</source>
+        <target state="new">No inputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefinedInSet_1">
+        <source>No inputs defined in Set="{0}".</source>
+        <target state="new">No inputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
+        <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
+        <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoOutputMarkerExists_1">
+        <source>Output marker '{0}' does not exist, skipping marker check.</source>
+        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredInputNotFound_1">
+        <source>Input '{0}' does not exist, but is not required.</source>
+        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist, but is not required.</source>
+        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_OutputDoesNotExist_1">
+        <source>Output '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredInputNotFound_1">
+        <source>Input '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
+        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
+        <source>Skipping '{0}' with ignored Kind="{1}"</source>
+        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SourceFileTimeAndPath_2">
+        <source>Source {0}: '{1}'</source>
+        <target state="new">Source {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
+        <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_UpToDate">
+        <source>Project is up-to-date.</source>
+        <target state="new">Project is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
+        <source>Write timestamp on output marker is {0} on '{1}'.</source>
+        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
         <source>Imports</source>
         <target state="translated">Almalar</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
@@ -7,6 +7,261 @@
         <target state="translated">由于出现异常 {1}，已关闭项目系统数据流“{0}”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
+        <source>Adding input reference copy markers:</source>
+        <target state="new">Adding input reference copy markers:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingNewestImportInput">
+        <source>Adding newest import input:</source>
+        <target state="new">Adding newest import input:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
+        <source>Adding output reference copy marker:</source>
+        <target state="new">Adding output reference copy marker:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingProjectFileInputs">
+        <source>Adding project file inputs:</source>
+        <target state="new">Adding project file inputs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputsInSet_2">
+        <source>Adding {0} inputs in Set="{1}":</source>
+        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputs_1">
+        <source>Adding {0} inputs:</source>
+        <target state="new">Adding {0} inputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
+        <source>Adding {0} outputs in Set="{1}":</source>
+        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputs_1">
+        <source>Adding {0} outputs:</source>
+        <target state="new">Adding {0} outputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsAddition_4">
+        <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsRemoval_4">
+        <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFile">
+        <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
+        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <note>Do not translate UpToDateCheckBuilt or Original.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
+        <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
+        <source>Source is newer than build output destination, not up-to-date.</source>
+        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
+        <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
+        <source>Destination '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
+        <source>Source '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
+        <source>Checking PreserveNewest file '{0}':</source>
+        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <note>Do not translate PreserveNewest. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
+        <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
+        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
+        <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
+        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Completed">
+        <source>Up-to-date check completed in {0:N1} ms</source>
+        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CopyAlwaysItemExists_1">
+        <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
+        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CriticalBuildTasksRunning">
+        <source>Critical build tasks are running, not up-to-date.</source>
+        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
+        <source>Destination {0}: '{1}'</source>
+        <target state="new">Destination {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
+        <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
+        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Exception_1">
+        <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
+        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <note>{0} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_FirstRun">
+        <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
+        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_IgnoringKinds_1">
+        <source>Ignoring up-to-date check items with Kind="{0}"</source>
+        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <note>Do not translate Kind. {0} is the kind name.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
+        <source>Input marker is newer than output marker, not up-to-date.</source>
+        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
+        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputNewerThanOutput_4">
+        <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
+        <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
+        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefined">
+        <source>No build outputs defined.</source>
+        <target state="new">No build outputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
+        <source>No build outputs defined in Set="{0}".</source>
+        <target state="new">No build outputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputMarkersExist">
+        <source>No input markers exist, skipping marker check.</source>
+        <target state="new">No input markers exist, skipping marker check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefined">
+        <source>No inputs defined.</source>
+        <target state="new">No inputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefinedInSet_1">
+        <source>No inputs defined in Set="{0}".</source>
+        <target state="new">No inputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
+        <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
+        <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoOutputMarkerExists_1">
+        <source>Output marker '{0}' does not exist, skipping marker check.</source>
+        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredInputNotFound_1">
+        <source>Input '{0}' does not exist, but is not required.</source>
+        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist, but is not required.</source>
+        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_OutputDoesNotExist_1">
+        <source>Output '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredInputNotFound_1">
+        <source>Input '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
+        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
+        <source>Skipping '{0}' with ignored Kind="{1}"</source>
+        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SourceFileTimeAndPath_2">
+        <source>Source {0}: '{1}'</source>
+        <target state="new">Source {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
+        <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_UpToDate">
+        <source>Project is up-to-date.</source>
+        <target state="new">Project is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
+        <source>Write timestamp on output marker is {0} on '{1}'.</source>
+        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
         <source>Imports</source>
         <target state="translated">导入</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
@@ -7,6 +7,261 @@
         <target state="translated">因為發生下列例外狀況，而導致專案系統資料流程 '{0}' 關閉: {1}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
+        <source>Adding input reference copy markers:</source>
+        <target state="new">Adding input reference copy markers:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingNewestImportInput">
+        <source>Adding newest import input:</source>
+        <target state="new">Adding newest import input:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
+        <source>Adding output reference copy marker:</source>
+        <target state="new">Adding output reference copy marker:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingProjectFileInputs">
+        <source>Adding project file inputs:</source>
+        <target state="new">Adding project file inputs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputsInSet_2">
+        <source>Adding {0} inputs in Set="{1}":</source>
+        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedInputs_1">
+        <source>Adding {0} inputs:</source>
+        <target state="new">Adding {0} inputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
+        <source>Adding {0} outputs in Set="{1}":</source>
+        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_AddingTypedOutputs_1">
+        <source>Adding {0} outputs:</source>
+        <target state="new">Adding {0} outputs:</target>
+        <note>{0} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsAddition_4">
+        <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ChangedItemsRemoval_4">
+        <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
+        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFile">
+        <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
+        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <note>Do not translate UpToDateCheckBuilt or Original.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
+        <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
+        <source>Source is newer than build output destination, not up-to-date.</source>
+        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
+        <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <note>{0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
+        <source>Destination '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
+        <source>Source '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
+        <source>Checking PreserveNewest file '{0}':</source>
+        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <note>Do not translate PreserveNewest. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
+        <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
+        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
+        <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
+        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Completed">
+        <source>Up-to-date check completed in {0:N1} ms</source>
+        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CopyAlwaysItemExists_1">
+        <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
+        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_CriticalBuildTasksRunning">
+        <source>Critical build tasks are running, not up-to-date.</source>
+        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
+        <source>Destination {0}: '{1}'</source>
+        <target state="new">Destination {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
+        <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
+        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_Exception_1">
+        <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
+        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <note>{0} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_FirstRun">
+        <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
+        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_IgnoringKinds_1">
+        <source>Ignoring up-to-date check items with Kind="{0}"</source>
+        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <note>Do not translate Kind. {0} is the kind name.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
+        <source>Input marker is newer than output marker, not up-to-date.</source>
+        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
+        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_InputNewerThanOutput_4">
+        <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
+        <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
+        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefined">
+        <source>No build outputs defined.</source>
+        <target state="new">No build outputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
+        <source>No build outputs defined in Set="{0}".</source>
+        <target state="new">No build outputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputMarkersExist">
+        <source>No input markers exist, skipping marker check.</source>
+        <target state="new">No input markers exist, skipping marker check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefined">
+        <source>No inputs defined.</source>
+        <target state="new">No inputs defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsDefinedInSet_1">
+        <source>No inputs defined in Set="{0}".</source>
+        <target state="new">No inputs defined in Set="{0}".</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
+        <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
+        <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
+        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NoOutputMarkerExists_1">
+        <source>Output marker '{0}' does not exist, skipping marker check.</source>
+        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredInputNotFound_1">
+        <source>Input '{0}' does not exist, but is not required.</source>
+        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist, but is not required.</source>
+        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_OutputDoesNotExist_1">
+        <source>Output '{0}' does not exist, not up-to-date.</source>
+        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredInputNotFound_1">
+        <source>Input '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
+        <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
+        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <note>{0} is a file path. {1} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
+        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
+        <source>Skipping '{0}' with ignored Kind="{1}"</source>
+        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_SourceFileTimeAndPath_2">
+        <source>Source {0}: '{1}'</source>
+        <target state="new">Source {0}: '{1}'</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
+        <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
+        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_UpToDate">
+        <source>Project is up-to-date.</source>
+        <target state="new">Project is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
+        <source>Write timestamp on output marker is {0} on '{1}'.</source>
+        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <note>{0} is a datetime. {1} is a file path.</note>
+      </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
         <source>Imports</source>
         <target state="translated">匯入</target>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -205,7 +205,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _isTaskQueueEmpty = false;
 
             await AssertNotUpToDateAsync(
-                "Critical build tasks are running, not up to date.",
+                "Critical build tasks are running, not up-to-date.",
                 "CriticalTasks");
         }
 
@@ -237,9 +237,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertNotUpToDateAsync(
                 new[]
                 {
-                    $"The set of project items was changed more recently ({itemChangedTime.ToLocalTime()}) than the earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({outputTime.ToLocalTime()}), not up to date.",
-                    "    Content item added 'ItemPath1' (CopyType=CopyNever)",
-                    "    Content item added 'ItemPath2' (CopyType=CopyNever)",
+                    $"The set of project items was changed more recently ({itemChangedTime.ToLocalTime()}) than the earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({outputTime.ToLocalTime()}), not up-to-date.",
+                    "    Content item added 'ItemPath1' (CopyType=CopyNever, TargetPath='')",
+                    "    Content item added 'ItemPath2' (CopyType=CopyNever, TargetPath='')",
                 },
                 "ProjectItemsChangedSinceEarliestOutput");
         }
@@ -250,7 +250,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await SetupAsync(disableFastUpToDateCheck: true);
 
             await AssertNotUpToDateAsync(
-                "The 'DisableFastUpToDateCheck' property is true, not up to date.",
+                "The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.",
                 "Disabled");
         }
 
@@ -275,7 +275,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await SetupAsync(sourceSnapshot: sourceSnapshot, lastCheckTimeAtUtc: lastCheckTime);
 
             await AssertNotUpToDateAsync(
-                "Item 'C:\\Dev\\Solution\\Project\\ItemPath1' has CopyToOutputDirectory set to 'Always', not up to date.",
+                "Item 'C:\\Dev\\Solution\\Project\\ItemPath1' has CopyToOutputDirectory set to 'Always', not up-to-date.",
                 "CopyAlwaysItemExists");
         }
 
@@ -292,7 +292,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await SetupAsync(projectSnapshot: projectSnapshot, lastCheckTimeAtUtc: lastCheckTime);
 
             await AssertNotUpToDateAsync(
-                "Output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' does not exist, not up to date.",
+                "Output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' does not exist, not up-to-date.",
                 "OutputNotFound");
         }
 
@@ -338,8 +338,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 itemRemovedFromSourceSnapshot: true);
 
             await AssertNotUpToDateAsync(new[] {
-                $"The set of project items was changed more recently ({itemChangeTime.ToLocalTime()}) than the earliest output 'C:\\Dev\\Solution\\Project\\BuildDefault' ({buildTime.ToLocalTime()}), not up to date.",
-                "    Compile item removed \'ItemPath1\' (CopyType=CopyNever)"},
+                $"The set of project items was changed more recently ({itemChangeTime.ToLocalTime()}) than the earliest output 'C:\\Dev\\Solution\\Project\\BuildDefault' ({buildTime.ToLocalTime()}), not up-to-date.",
+                "    Compile item removed \'ItemPath1\' (CopyType=CopyNever, TargetPath='')"},
                 "ProjectItemsChangedSinceEarliestOutput");
         }
 
@@ -369,7 +369,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\BuiltOutputPath1", outputTime);
 
             await AssertNotUpToDateAsync(
-                "Input Compile item 'C:\\Dev\\Solution\\Project\\ItemPath1' does not exist and is required, not up to date.",
+                "Input Compile item 'C:\\Dev\\Solution\\Project\\ItemPath1' does not exist and is required, not up-to-date.",
                 "InputNotFound");
         }
 
@@ -401,7 +401,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\ItemPath1", inputTime);
 
             await AssertNotUpToDateAsync(
-                $"Input Compile item 'C:\\Dev\\Solution\\Project\\ItemPath1' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({outputTime.ToLocalTime()}), not up to date.",
+                $"Input Compile item 'C:\\Dev\\Solution\\Project\\ItemPath1' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({outputTime.ToLocalTime()}), not up-to-date.",
                 "InputNewerThanEarliestOutput");
         }
 
@@ -411,10 +411,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             // This test covers a race condition described in https://github.com/dotnet/project-system/issues/4014
             //
             // t0 Modify input file
-            // t1 Check up to date (false) so start a build
+            // t1 Check up-to-date (false) so start a build
             // t2 Modify input file (during build)
             // t3 Produce first (earliest) output DLL (from t0 input)
-            // t4 Check incorrectly claims everything up to date, as t3 > t2
+            // t4 Check incorrectly claims everything up-to-date, as t3 > t2
 
             var projectSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
             {
@@ -438,7 +438,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await SetupAsync(projectSnapshot, sourceSnapshot, lastCheckTimeAtUtc: lastCheckTime);
 
             await AssertNotUpToDateAsync(
-                $"Input Compile item '{itemPath}' is newer ({t0.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({t0.AddMinutes(-1).ToLocalTime()}), not up to date.",
+                $"Input Compile item '{itemPath}' is newer ({t0.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({t0.AddMinutes(-1).ToLocalTime()}), not up-to-date.",
                 "InputNewerThanEarliestOutput");
 
             await Task.Delay(50);
@@ -457,7 +457,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             // Run check again (t4)
             await AssertNotUpToDateAsync(
-                $"Input Compile item 'C:\\Dev\\Solution\\Project\\ItemPath1' ({t2.ToLocalTime()}) has been modified since the last up-to-date check ({_lastCheckTimeAtUtc.ToLocalTime()}), not up to date.",
+                $"Input Compile item 'C:\\Dev\\Solution\\Project\\ItemPath1' ({t2.ToLocalTime()}) has been modified since the last up-to-date check ({_lastCheckTimeAtUtc.ToLocalTime()}), not up-to-date.",
                 "InputModifiedSinceLastCheck");
         }
 
@@ -489,7 +489,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\ItemPath1", compileItemTime);
 
             await AssertNotUpToDateAsync(
-                $"Input Compile item 'C:\\Dev\\Solution\\Project\\ItemPath1' is newer ({compileItemTime.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\CustomOutputPath1' ({outputTime.ToLocalTime()}), not up to date.",
+                $"Input Compile item 'C:\\Dev\\Solution\\Project\\ItemPath1' is newer ({compileItemTime.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\CustomOutputPath1' ({outputTime.ToLocalTime()}), not up-to-date.",
                 "InputNewerThanEarliestOutput");
         }
 
@@ -529,7 +529,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     "No build outputs defined.",
                     $"Latest write timestamp on input marker is {originalTime.ToLocalTime()} on 'Reference1OriginalPath'.",
                     $"Write timestamp on output marker is {outputTime.ToLocalTime()} on 'C:\\Dev\\Solution\\Project\\Marker'.",
-                    "Input marker is newer than output marker, not up to date."
+                    "Input marker is newer than output marker, not up-to-date."
                 },
                 "InputMarkerNewerThanOutputMarker");
         }
@@ -560,7 +560,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _fileSystem.AddFile(analyzerItem, inputTime);
 
             await AssertNotUpToDateAsync(
-                $"Input ResolvedAnalyzerReference item '{analyzerItem}' is newer ({inputTime.ToLocalTime()}) than earliest output '{outputItem}' ({outputTime.ToLocalTime()}), not up to date.",
+                $"Input ResolvedAnalyzerReference item '{analyzerItem}' is newer ({inputTime.ToLocalTime()}) than earliest output '{outputItem}' ({outputTime.ToLocalTime()}), not up-to-date.",
                 "InputNewerThanEarliestOutput");
         }
 
@@ -594,7 +594,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\Reference1ResolvedPath", inputTime);
 
             await AssertNotUpToDateAsync(
-                $"Input ResolvedCompilationReference item 'C:\\Dev\\Solution\\Project\\Reference1ResolvedPath' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({outputTime.ToLocalTime()}), not up to date.",
+                $"Input ResolvedCompilationReference item 'C:\\Dev\\Solution\\Project\\Reference1ResolvedPath' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({outputTime.ToLocalTime()}), not up-to-date.",
                 "InputNewerThanEarliestOutput");
         }
 
@@ -622,7 +622,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\Item2", outputTime);
 
             await AssertNotUpToDateAsync(
-                $"Input UpToDateCheckInput item 'C:\\Dev\\Solution\\Project\\Item1' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({outputTime.ToLocalTime()}), not up to date.",
+                $"Input UpToDateCheckInput item 'C:\\Dev\\Solution\\Project\\Item1' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({outputTime.ToLocalTime()}), not up-to-date.",
                 "InputNewerThanEarliestOutput");
         }
 
@@ -654,7 +654,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 new[]
                 {
                     $"No inputs are newer than earliest output 'C:\\Dev\\Solution\\Project\\BuildDefault' ({outputTime.ToLocalTime()}). Newest input is '{_msBuildProjectFullPath}' ({_projectFileTimeUtc.ToLocalTime()}).",
-                    $"Input UpToDateCheckInput item 'C:\\Dev\\Solution\\Project\\Input1' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\Output1' ({outputTime.ToLocalTime()}), not up to date."
+                    $"Input UpToDateCheckInput item 'C:\\Dev\\Solution\\Project\\Input1' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\Output1' ({outputTime.ToLocalTime()}), not up-to-date."
                 },
                 "InputNewerThanEarliestOutput");
         }
@@ -689,8 +689,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertUpToDateAsync(
                 $"No inputs are newer than earliest output 'C:\\Dev\\Solution\\Project\\BuildDefault' ({outputTime1.ToLocalTime()}). Newest input is '{_msBuildProjectFullPath}' ({_projectFileTimeUtc.ToLocalTime()}).",
-                $"In set 'Set1', no inputs are newer than earliest output 'C:\\Dev\\Solution\\Project\\Output1' ({outputTime1.ToLocalTime()}). Newest input is 'C:\\Dev\\Solution\\Project\\Input1' ({inputTime1.ToLocalTime()}).",
-                $"In set 'Set2', no inputs are newer than earliest output 'C:\\Dev\\Solution\\Project\\Output2' ({outputTime2.ToLocalTime()}). Newest input is 'C:\\Dev\\Solution\\Project\\Input2' ({inputTime2.ToLocalTime()}).");
+                $"In Set=\"Set1\", no inputs are newer than earliest output 'C:\\Dev\\Solution\\Project\\Output1' ({outputTime1.ToLocalTime()}). Newest input is 'C:\\Dev\\Solution\\Project\\Input1' ({inputTime1.ToLocalTime()}).",
+                $"In Set=\"Set2\", no inputs are newer than earliest output 'C:\\Dev\\Solution\\Project\\Output2' ({outputTime2.ToLocalTime()}). Newest input is 'C:\\Dev\\Solution\\Project\\Input2' ({inputTime2.ToLocalTime()}).");
         }
 
         [Fact]
@@ -725,8 +725,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 new[]
                 {
                     $"No inputs are newer than earliest output 'C:\\Dev\\Solution\\Project\\BuildDefault' ({outputTime1.ToLocalTime()}). Newest input is '{_msBuildProjectFullPath}' ({_projectFileTimeUtc.ToLocalTime()}).",
-                    $"In set 'Set1', no inputs are newer than earliest output 'C:\\Dev\\Solution\\Project\\Output1' ({outputTime1.ToLocalTime()}). Newest input is 'C:\\Dev\\Solution\\Project\\Input1' ({inputTime1.ToLocalTime()}).",
-                    $"Input UpToDateCheckInput item 'C:\\Dev\\Solution\\Project\\Input2' is newer ({inputTime2.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\Output2' ({outputTime2.ToLocalTime()}), not up to date."
+                    $"In Set=\"Set1\", no inputs are newer than earliest output 'C:\\Dev\\Solution\\Project\\Output1' ({outputTime1.ToLocalTime()}). Newest input is 'C:\\Dev\\Solution\\Project\\Input1' ({inputTime1.ToLocalTime()}).",
+                    $"Input UpToDateCheckInput item 'C:\\Dev\\Solution\\Project\\Input2' is newer ({inputTime2.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\Output2' ({outputTime2.ToLocalTime()}), not up-to-date."
                 },
                 "InputNewerThanEarliestOutput");
         }
@@ -760,8 +760,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 new[]
                 {
                     $"No inputs are newer than earliest output 'C:\\Dev\\Solution\\Project\\BuildDefault' ({outputTime1.ToLocalTime()}). Newest input is '{_msBuildProjectFullPath}' ({_projectFileTimeUtc.ToLocalTime()}).",
-                    $"In set 'Set1', no inputs are newer than earliest output 'C:\\Dev\\Solution\\Project\\Output1' ({outputTime1.ToLocalTime()}). Newest input is 'C:\\Dev\\Solution\\Project\\Input' ({inputTime.ToLocalTime()}).",
-                    $"Input UpToDateCheckInput item 'C:\\Dev\\Solution\\Project\\Input' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\Output2' ({outputTime2.ToLocalTime()}), not up to date."
+                    $"In Set=\"Set1\", no inputs are newer than earliest output 'C:\\Dev\\Solution\\Project\\Output1' ({outputTime1.ToLocalTime()}). Newest input is 'C:\\Dev\\Solution\\Project\\Input' ({inputTime.ToLocalTime()}).",
+                    $"Input UpToDateCheckInput item 'C:\\Dev\\Solution\\Project\\Input' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\Output2' ({outputTime2.ToLocalTime()}), not up-to-date."
                 },
                 "InputNewerThanEarliestOutput");
         }
@@ -790,7 +790,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertUpToDateAsync(
                 $"No inputs are newer than earliest output 'C:\\Dev\\Solution\\Project\\BuildDefault' ({buildTime.ToLocalTime()}). Newest input is '{_msBuildProjectFullPath}' ({_projectFileTimeUtc.ToLocalTime()}).",
-                "No build outputs defined in set 'Set1'.");
+                "No build outputs defined in Set=\"Set1\".");
         }
 
         [Fact]
@@ -816,7 +816,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertUpToDateAsync(
                 $"No inputs are newer than earliest output 'C:\\Dev\\Solution\\Project\\BuildDefault' ({outputTime.ToLocalTime()}). Newest input is '{_msBuildProjectFullPath}' ({_projectFileTimeUtc.ToLocalTime()}).",
-                "No inputs defined in set 'Set1'.");
+                "No inputs defined in Set=\"Set1\".");
         }
 
         [Fact]
@@ -846,8 +846,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertNotUpToDateAsync(
                 new[]
                 {
-                    "Ignoring up-to-date check items with kinds: Ignored",
-                    $"Input UpToDateCheckInput item 'C:\\Dev\\Solution\\Project\\Input' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\Output' ({outputTime.ToLocalTime()}), not up to date.",
+                    "Ignoring up-to-date check items with Kind=\"Ignored\"",
+                    $"Input UpToDateCheckInput item 'C:\\Dev\\Solution\\Project\\Input' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\Output' ({outputTime.ToLocalTime()}), not up-to-date.",
                 },
                 "InputNewerThanEarliestOutput",
                 ignoreKinds: "Ignored");
@@ -883,7 +883,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\TaggedBuilt",  output2Time);
 
             await AssertNotUpToDateAsync(
-                $"Input UpToDateCheckInput item 'C:\\Dev\\Solution\\Project\\Input' is newer ({input1Time.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\Output' ({output1Time.ToLocalTime()}), not up to date.",
+                $"Input UpToDateCheckInput item 'C:\\Dev\\Solution\\Project\\Input' is newer ({input1Time.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\Output' ({output1Time.ToLocalTime()}), not up-to-date.",
                 "InputNewerThanEarliestOutput",
                 ignoreKinds: "");
         }
@@ -915,7 +915,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertUpToDateAsync(
                 new[]
                 {
-                    "Ignoring up-to-date check items with kinds: Ignored",
+                    "Ignoring up-to-date check items with Kind=\"Ignored\"",
                     $"No inputs are newer than earliest output 'C:\\Dev\\Solution\\Project\\Output' ({outputTime.ToLocalTime()}). Newest input is 'C:\\Dev\\Solution\\Project\\Input' ({inputTime.ToLocalTime()})."
                 },
                 ignoreKinds: "Ignored");
@@ -984,10 +984,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 new[]
                 {
                     "No build outputs defined.",
-                    $"Checking copied output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file '{sourcePath}':",
-                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
-                    $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'.",
-                    "Source is newer than build output destination, not up to date."
+                    $"Checking copied output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file:",
+                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'",
+                    $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'",
+                    "Source is newer than build output destination, not up-to-date."
                 },
                 "CopySourceNewer");
         }
@@ -1026,9 +1026,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     "No build outputs defined.",
                     $"Checking PreserveNewest file '{sourcePath}':",
-                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
-                    $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'.",
-                    $"PreserveNewest source '{sourcePath}' is newer than destination '{destinationPath}', not up to date."
+                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'",
+                    $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'",
+                    $"PreserveNewest source '{sourcePath}' is newer than destination '{destinationPath}', not up-to-date."
                 },
                 "CopyToOutputDirectorySourceNewer");
         }
@@ -1054,8 +1054,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 new[]
                 {
                     "No build outputs defined.",
-                    $"Checking copied output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file '{sourcePath}':",
-                    $"Source '{sourcePath}' does not exist for copy to '{destinationPath}', not up to date."
+                    $"Checking copied output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file:",
+                    $"Source '{sourcePath}' does not exist for copy to '{destinationPath}', not up-to-date."
                 },
                 "CopySourceNotFound");
         }
@@ -1086,9 +1086,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 new[]
                 {
                     "No build outputs defined.",
-                    $"Checking copied output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file '{sourcePath}':",
-                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
-                    $"Destination '{destinationPath}' does not exist for copy from '{sourcePath}', not up to date."
+                    $"Checking copied output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file:",
+                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'",
+                    $"Destination '{destinationPath}' does not exist for copy from '{sourcePath}', not up-to-date."
                 },
                 "CopyDestinationNotFound");
         }
@@ -1122,9 +1122,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     "No build outputs defined.",
                     $"Checking PreserveNewest file '{sourcePath}':",
-                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
-                    $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'.",
-                    $"PreserveNewest source '{sourcePath}' is newer than destination '{destinationPath}', not up to date."
+                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'",
+                    $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'",
+                    $"PreserveNewest source '{sourcePath}' is newer than destination '{destinationPath}', not up-to-date."
                 },
                 "CopyToOutputDirectorySourceNewer");
         }
@@ -1158,9 +1158,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     "No build outputs defined.",
                     $"Checking PreserveNewest file '{sourcePath}':",
-                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
-                    $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'.",
-                    $"PreserveNewest source '{sourcePath}' is newer than destination '{destinationPath}', not up to date."
+                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'",
+                    $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'",
+                    $"PreserveNewest source '{sourcePath}' is newer than destination '{destinationPath}', not up-to-date."
                 },
                 "CopyToOutputDirectorySourceNewer");
         }
@@ -1194,9 +1194,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     "No build outputs defined.",
                     $"Checking PreserveNewest file '{sourcePath}':",
-                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
-                    $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'.",
-                    $"PreserveNewest source '{sourcePath}' is newer than destination '{destinationPath}', not up to date."
+                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'",
+                    $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'",
+                    $"PreserveNewest source '{sourcePath}' is newer than destination '{destinationPath}', not up-to-date."
                 },
                 "CopyToOutputDirectorySourceNewer");
         }
@@ -1232,9 +1232,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     "No build outputs defined.",
                     $"Checking PreserveNewest file '{sourcePath}':",
-                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
-                    $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'.",
-                    $"PreserveNewest source '{sourcePath}' is newer than destination '{destinationPath}', not up to date."
+                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'",
+                    $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'",
+                    $"PreserveNewest source '{sourcePath}' is newer than destination '{destinationPath}', not up-to-date."
                 },
                 "CopyToOutputDirectorySourceNewer");
         }
@@ -1266,7 +1266,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     "No build outputs defined.",
                     $"Checking PreserveNewest file '{sourcePath}':",
-                    $"Source '{sourcePath}' does not exist, not up to date."
+                    $"Source '{sourcePath}' does not exist, not up-to-date."
                 },
                 "CopyToOutputDirectorySourceNotFound");
         }
@@ -1298,8 +1298,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     "No build outputs defined.",
                     $"Checking PreserveNewest file '{sourcePath}':",
-                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
-                    $"Destination '{destinationPath}' does not exist, not up to date."
+                    $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'",
+                    $"Destination '{destinationPath}' does not exist, not up-to-date."
                 },
                 "CopyToOutputDirectoryDestinationNotFound");
         }
@@ -1379,7 +1379,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 writer.Add(logMessage);
             }
 
-            writer.Add("Project is up to date.");
+            writer.Add("Project is up-to-date.");
 
             Assert.True(await _buildUpToDateCheck.IsUpToDateAsync(BuildAction.Build, writer, CreateGlobalProperties(ignoreKinds)));
             AssertTelemetrySuccessEvent();


### PR DESCRIPTION
Fixes #7820

Moves all strings to resource dictionaries. A few strings were slightly modified to be more likely to succeed in other languages.

The lack of indentation for items within sets in verbose logging was also addressed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7827)