### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 981: Build ID 1531874

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
@@ -9,257 +9,257 @@
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
         <source>Adding input reference copy markers:</source>
-        <target state="new">Adding input reference copy markers:</target>
+        <target state="translated">Přidávají se značky kopírování vstupního odkazu:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingNewestImportInput">
         <source>Adding newest import input:</source>
-        <target state="new">Adding newest import input:</target>
+        <target state="translated">Přidává se nejnovější vstup importu:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
         <source>Adding output reference copy marker:</source>
-        <target state="new">Adding output reference copy marker:</target>
+        <target state="translated">Přidává se značka kopírování výstupního odkazu:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingProjectFileInputs">
         <source>Adding project file inputs:</source>
-        <target state="new">Adding project file inputs:</target>
+        <target state="translated">Přidávají se vstupy souborů projektů:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
-        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <target state="translated">Přidávají se vstupy {0} v sadě="{1}":</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputs_1">
         <source>Adding {0} inputs:</source>
-        <target state="new">Adding {0} inputs:</target>
+        <target state="translated">Přidávají se vstupy {0}:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
         <source>Adding {0} outputs in Set="{1}":</source>
-        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <target state="translated">Přidávají se výstupy {0} v sadě="{1}":</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputs_1">
         <source>Adding {0} outputs:</source>
-        <target state="new">Adding {0} outputs:</target>
+        <target state="translated">Přidávají se výstupy {0}:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">Položka {0} přidána – {1} (CopyType={2}, TargetPath={3})</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">Položka {0} odebrána – {1} (CopyType={2}, TargetPath={3})</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
-        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <target state="translated">Probíhá kontrola zkopírovaného výstupního souboru (UpToDateCheckBuilt s vlastností Original):</target>
         <note>Do not translate UpToDateCheckBuilt or Original.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
         <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <target state="translated">Cíl {0} pro kopírování z {1} neexistuje. Není aktuální.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
         <source>Source is newer than build output destination, not up-to-date.</source>
-        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <target state="translated">Zdroj je novější než výstupní cíl sestavení. Není aktuální.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
         <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <target state="translated">Zdroj {0} pro kopírování do {1} neexistuje. Není aktuální.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Cíl {0} neexistuje. Není aktuální.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Zdroj {0} neexistuje. Není aktuální.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
         <source>Checking PreserveNewest file '{0}':</source>
-        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <target state="translated">Kontroluje se souboru PreserveNetf {0}:</target>
         <note>Do not translate PreserveNewest. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
         <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
-        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <target state="translated">Zdroj PreserveNewest {0} je novější než cíl {1}. Není aktuální.</target>
         <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
         <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
-        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <target state="translated">Porovnávají se časová razítka vstupů a výstupů v sadě="{0}":</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_Completed">
         <source>Up-to-date check completed in {0:N1} ms</source>
-        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <target state="translated">Kontrola aktuálnosti dokončena za {0:N1} ms</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_1">
         <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
-        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <target state="translated">Položka {0} má vlastnost CopyToOutputDirectory nastavenou na hodnotu Always. Není aktuální.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
         <source>Critical build tasks are running, not up-to-date.</source>
-        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <target state="translated">Kritické úlohy sestavení jsou spuštěné. Není aktuální.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
         <source>Destination {0}: '{1}'</source>
-        <target state="new">Destination {0}: '{1}'</target>
+        <target state="translated">Cíl {0}: {1}</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
         <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
-        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <target state="translated">Vlastnost DisableFastUpToDateCheck je true. Není aktuální.</target>
         <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_Exception_1">
         <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
-        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <target state="translated">Kontrola aktuálnosti vyvolala výjimku. Není aktuální. {0}</target>
         <note>{0} is the exception message.</note>
       </trans-unit>
       <trans-unit id="FUTD_FirstRun">
         <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
-        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <target state="translated">Pro tento projekt ještě neběží kontrola aktuálnosti. Není aktuální.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_IgnoringKinds_1">
         <source>Ignoring up-to-date check items with Kind="{0}"</source>
-        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <target state="translated">Ignorují se položky kontroly aktuálnosti s prvkem Kind="{0}".</target>
         <note>Do not translate Kind. {0} is the kind name.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
         <source>Input marker is newer than output marker, not up-to-date.</source>
-        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <target state="translated">Vstupní značka je novější než výstupní značka. Není aktuální.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
         <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">Vstup {0} ({1}) byla od poslední kontroly aktuálnosti ({2}) změněna. Není aktuální.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
         <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">Vstup {0} je novější ({1}) než nejstarší výstup {2} ({3}). Není aktuální.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
         <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
-        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <target state="translated">Nejnovější časové razítko zápisu na vstupní značce je {0} v cestě {1}.</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefined">
         <source>No build outputs defined.</source>
-        <target state="new">No build outputs defined.</target>
+        <target state="translated">Nejsou definovány žádné výstupy sestavení.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
         <source>No build outputs defined in Set="{0}".</source>
-        <target state="new">No build outputs defined in Set="{0}".</target>
+        <target state="translated">V sadě="{0}" nejsou definované žádné výstupy sestavení.</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputMarkersExist">
         <source>No input markers exist, skipping marker check.</source>
-        <target state="new">No input markers exist, skipping marker check.</target>
+        <target state="translated">Neexistují žádné vstupní značky. Kontrola značek se přeskočí.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefined">
         <source>No inputs defined.</source>
-        <target state="new">No inputs defined.</target>
+        <target state="translated">Nejsou definované žádné vstupy.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefinedInSet_1">
         <source>No inputs defined in Set="{0}".</source>
-        <target state="new">No inputs defined in Set="{0}".</target>
+        <target state="translated">V sadě="{0}" nejsou definovány žádné vstupy.</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
         <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">V sadě="{4}" nejsou žádné vstupy novější než nejstarší výstup {0} ({1}). Nejnovější vstup je {2} ({3}).</target>
         <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
         <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">Žádné vstupy nejsou novější než nejstarší výstup {0} ({1}). Nejnovější vstup je {2} ({3}).</target>
         <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoOutputMarkerExists_1">
         <source>Output marker '{0}' does not exist, skipping marker check.</source>
-        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <target state="translated">Výstupní značka {0} neexistuje. Kontrola značek se přeskočí.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredInputNotFound_1">
         <source>Input '{0}' does not exist, but is not required.</source>
-        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <target state="translated">Vstup {0} neexistuje, ale není povinný.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
-        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <target state="translated">Vstupní položka {1} {0} neexistuje, i když je povinná.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Výstup {0} neexistuje. Není aktuální.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredInputNotFound_1">
         <source>Input '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">Vstup {0} neexistuje, i když je povinný. Není aktuální.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">Vstupní položka {1} {0} neexistuje, i když je povinná. Není aktuální.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
         <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <target state="translated">Sada položek projektu byla změněna v nedávnější době ({0}), než odpovídá nejstaršímu výstupu {1} ({2}). Není aktuální.</target>
         <note>{0} and {2} are datetimes. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
-        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <target state="translated">Přeskočí se {0} s ignorovaným prvkem Kind="{1}".</target>
         <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
       </trans-unit>
       <trans-unit id="FUTD_SourceFileTimeAndPath_2">
         <source>Source {0}: '{1}'</source>
-        <target state="new">Source {0}: '{1}'</target>
+        <target state="translated">Zdroj {0}: {1}</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
         <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">Vstupní položka {3} {0} ({1}) byla od poslední kontroly aktuálnosti ({2}) změněna. Není aktuální.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
         <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">Vstupní položka {4} {0} je novější ({1}) než nejstarší výstup {2} ({3}). Není aktuální.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_UpToDate">
         <source>Project is up-to-date.</source>
-        <target state="new">Project is up-to-date.</target>
+        <target state="translated">Projekt je aktuální.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
         <source>Write timestamp on output marker is {0} on '{1}'.</source>
-        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <target state="translated">Časové razítko zápisu na výstupní značce je {0} v cestě {1}.</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="ImportsTreeNodeName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
@@ -9,257 +9,257 @@
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
         <source>Adding input reference copy markers:</source>
-        <target state="new">Adding input reference copy markers:</target>
+        <target state="translated">Ausgabeverweiskopiemarker wird hinzugefügt:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingNewestImportInput">
         <source>Adding newest import input:</source>
-        <target state="new">Adding newest import input:</target>
+        <target state="translated">Die neueste Importeingabe wird hinzugefügt:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
         <source>Adding output reference copy marker:</source>
-        <target state="new">Adding output reference copy marker:</target>
+        <target state="translated">Ausgabeverweiskopiemarker wird hinzugefügt:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingProjectFileInputs">
         <source>Adding project file inputs:</source>
-        <target state="new">Adding project file inputs:</target>
+        <target state="translated">Projektdateieingaben werden hinzugefügt:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
-        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <target state="translated">In Set="{1}" werden {0} Eingaben hinzugefügt:</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputs_1">
         <source>Adding {0} inputs:</source>
-        <target state="new">Adding {0} inputs:</target>
+        <target state="translated">Eingaben {0} werden hinzugefügt:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
         <source>Adding {0} outputs in Set="{1}":</source>
-        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <target state="translated">In Set="{1}" werden {0} Ausgaben hinzugefügt:</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputs_1">
         <source>Adding {0} outputs:</source>
-        <target state="new">Adding {0} outputs:</target>
+        <target state="translated">{0} Ausgaben werden hinzugefügt:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} Element wurde hinzugefügt "{1}" (CopyType={2}, TargetPath="{3}")</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} Element wurde entfernt "{1}" (CopyType={2}, TargetPath="{3}")</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
-        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <target state="translated">Die kopierte Ausgabedatei (UpToDateCheckBuilt mit originaler Eigenschaft) wird überprüft:</target>
         <note>Do not translate UpToDateCheckBuilt or Original.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
         <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <target state="translated">Das Ziel "{0}" ist für das Kopieren von "{1}" nicht vorhanden, nicht aktuell.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
         <source>Source is newer than build output destination, not up-to-date.</source>
-        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <target state="translated">Die Quelle ist neuer als das Buildausgabeziel und nicht aktuell.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
         <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <target state="translated">Die Quelle "{0}" ist für das Kopieren nach "{1}" nicht vorhanden, nicht aktuell.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Das Ziel "{0}" ist nicht vorhanden, nicht aktuell.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Die Quelle "{0}" ist nicht vorhanden, nicht aktuell.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
         <source>Checking PreserveNewest file '{0}':</source>
-        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <target state="translated">PreserveNewest-Datei "{0}" wird überprüft:</target>
         <note>Do not translate PreserveNewest. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
         <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
-        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <target state="translated">Die PreserveNewest-Quelle "{0}" ist neuer als das Ziel "{1}", nicht aktuell.</target>
         <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
         <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
-        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <target state="translated">Zeitstempel von Eingaben und Ausgaben in Set="{0}" werden verglichen:</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_Completed">
         <source>Up-to-date check completed in {0:N1} ms</source>
-        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <target state="translated">Die aktuelle Überprüfung wurde in {0:N1} ms abgeschlossen.</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_1">
         <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
-        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <target state="translated">Für das Element "{0}" ist CopyToOutputDirectory auf "Always" festgelegt, nicht auf dem neuesten Stand.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
         <source>Critical build tasks are running, not up-to-date.</source>
-        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <target state="translated">Wichtige Buildtasks werden ausgeführt und sind nicht auf dem neuesten Stand.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
         <source>Destination {0}: '{1}'</source>
-        <target state="new">Destination {0}: '{1}'</target>
+        <target state="translated">Ziel {0}: "{1}"</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
         <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
-        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <target state="translated">Die Eigenschaft 'DisableFastUpToDateCheck' ist 'true', nicht aktuell.</target>
         <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_Exception_1">
         <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
-        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <target state="translated">Bei der aktuellen Überprüfung wurde eine Ausnahme ausgelöst. Nicht aktuell. {0}</target>
         <note>{0} is the exception message.</note>
       </trans-unit>
       <trans-unit id="FUTD_FirstRun">
         <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
-        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <target state="translated">Die aktuelle Überprüfung wurde für dieses Projekt noch nicht ausgeführt. Nicht aktuell.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_IgnoringKinds_1">
         <source>Ignoring up-to-date check items with Kind="{0}"</source>
-        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <target state="translated">Aktuelle Prüfelemente mit Kind="{0}" werden ignoriert.</target>
         <note>Do not translate Kind. {0} is the kind name.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
         <source>Input marker is newer than output marker, not up-to-date.</source>
-        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <target state="translated">Der Eingabemarker ist neuer als der Ausgabemarker und nicht aktuell.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
         <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">Die Eingabe "{0}" ({1}) wurde seit der letzten Aktuellen Überprüfung ({2}) geändert und ist nicht auf dem neuesten Stand.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
         <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">Die Eingabe "{0}" ist neuer ({1}) als die früheste Ausgabe "{2}" ({3}), nicht aktuell.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
         <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
-        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <target state="translated">Der letzte Schreibzeitstempel für den Eingabemarker wird auf "{1}" {0}.</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefined">
         <source>No build outputs defined.</source>
-        <target state="new">No build outputs defined.</target>
+        <target state="translated">Es wurden keine Buildausgaben definiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
         <source>No build outputs defined in Set="{0}".</source>
-        <target state="new">No build outputs defined in Set="{0}".</target>
+        <target state="translated">In Set="{0}" sind keine Buildausgaben definiert.</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputMarkersExist">
         <source>No input markers exist, skipping marker check.</source>
-        <target state="new">No input markers exist, skipping marker check.</target>
+        <target state="translated">Es sind keine Eingabemarker vorhanden, die Markerüberprüfung wird übersprungen.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefined">
         <source>No inputs defined.</source>
-        <target state="new">No inputs defined.</target>
+        <target state="translated">Keine Eingaben definiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefinedInSet_1">
         <source>No inputs defined in Set="{0}".</source>
-        <target state="new">No inputs defined in Set="{0}".</target>
+        <target state="translated">In Set="{0}" sind keine Eingaben definiert.</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
         <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">In Set="{4}"sind keine Eingaben neuer als die früheste Ausgabe '{0}' ({1}). Die neueste Eingabe ist "{2}" ({3}).</target>
         <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
         <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">Keine Eingaben sind neuer als die früheste Ausgabe "{0}" ({1}). Die neueste Eingabe ist "{2}" ({3}).</target>
         <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoOutputMarkerExists_1">
         <source>Output marker '{0}' does not exist, skipping marker check.</source>
-        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <target state="translated">Der Ausgabemarker "{0}" ist nicht vorhanden, die Markerüberprüfung wird übersprungen.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredInputNotFound_1">
         <source>Input '{0}' does not exist, but is not required.</source>
-        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <target state="translated">Die Eingabe "{0}" ist nicht vorhanden, aber nicht erforderlich.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
-        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <target state="translated">Die Eingabe {1}-Element "{0}" ist nicht vorhanden, aber nicht erforderlich.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Die Ausgabe "{0}" ist nicht vorhanden, nicht aktuell.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredInputNotFound_1">
         <source>Input '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">Eingabe "{0}" ist nicht vorhanden und erforderlich, nicht aktuell.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">Eingabe {1}-Element "{0}" ist nicht vorhanden und erforderlich, nicht aktuell.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
         <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <target state="translated">Der Satz von Projektelementen wurde vor kurzem geändert ({0}) als die früheste Ausgabe "{1}" ({2}), nicht aktuell.</target>
         <note>{0} and {2} are datetimes. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
-        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <target state="translated">"{0}" wird mit ignoriertem Kind="{1}" übersprungen.</target>
         <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
       </trans-unit>
       <trans-unit id="FUTD_SourceFileTimeAndPath_2">
         <source>Source {0}: '{1}'</source>
-        <target state="new">Source {0}: '{1}'</target>
+        <target state="translated">Quelle {0}: "{1}"</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
         <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">Die Eingabe {3}-Element "{0}" ({1}) wurde seit der letzten aktuellen Überprüfung ({2}) geändert und ist nicht auf dem neuesten Stand.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
         <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">Die Eingabe {4}-Element "{0}" ist neuer ({1}) als früheste Ausgabe "{2}" ({3}), nicht aktuell.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_UpToDate">
         <source>Project is up-to-date.</source>
-        <target state="new">Project is up-to-date.</target>
+        <target state="translated">Das Projekt ist auf dem neuesten Stand.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
         <source>Write timestamp on output marker is {0} on '{1}'.</source>
-        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <target state="translated">Der Schreibzeitstempel für den Ausgabemarker ist auf "{1}" {0}.</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="ImportsTreeNodeName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
@@ -9,257 +9,257 @@
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
         <source>Adding input reference copy markers:</source>
-        <target state="new">Adding input reference copy markers:</target>
+        <target state="translated">Agregando marcadores de copia de referencia de entrada:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingNewestImportInput">
         <source>Adding newest import input:</source>
-        <target state="new">Adding newest import input:</target>
+        <target state="translated">Agregando una nueva entrada de importación:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
         <source>Adding output reference copy marker:</source>
-        <target state="new">Adding output reference copy marker:</target>
+        <target state="translated">Agregar marcador de copia de referencia de salida:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingProjectFileInputs">
         <source>Adding project file inputs:</source>
-        <target state="new">Adding project file inputs:</target>
+        <target state="translated">Agregando entradas de archivos de proyecto:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
-        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <target state="translated">Agregando {0} entradas en Set="{1}":</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputs_1">
         <source>Adding {0} inputs:</source>
-        <target state="new">Adding {0} inputs:</target>
+        <target state="translated">Agregando {0} entradas:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
         <source>Adding {0} outputs in Set="{1}":</source>
-        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <target state="translated">Agregando {0} salidas en Set="{1}":</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputs_1">
         <source>Adding {0} outputs:</source>
-        <target state="new">Adding {0} outputs:</target>
+        <target state="translated">Agregando salidas de {0}:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} elemento agregado "{1}" (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} elemento eliminado "{1}" (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
-        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <target state="translated">Comprobación del archivo de salida copiado (UpToDateCheckBuilt con la propiedad original):</target>
         <note>Do not translate UpToDateCheckBuilt or Original.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
         <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <target state="translated">El destino "{0}" no existe para copiar desde "{1}", no está actualizado.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
         <source>Source is newer than build output destination, not up-to-date.</source>
-        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <target state="translated">El origen es más reciente que el destino de la construcción, no está actualizado.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
         <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <target state="translated">La fuente "{0}" no existe para copiar en "{1}", no está actualizada..</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">El destino "{0}" no existe, no está actualizado.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">La fuente "{0}" no existe, no está actualizada.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
         <source>Checking PreserveNewest file '{0}':</source>
-        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <target state="translated">Comprobando el archivo PreserveNewest "{0}":</target>
         <note>Do not translate PreserveNewest. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
         <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
-        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <target state="translated">El origen PreserveNewest "{0}" es más reciente que el destino "{1}", no está actualizado.</target>
         <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
         <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
-        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <target state="translated">Comparación de las marcas de tiempo de las entradas y salidas en Set="{0}":</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_Completed">
         <source>Up-to-date check completed in {0:N1} ms</source>
-        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <target state="translated">Comprobación actualizada completada en {0:N1} ms</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_1">
         <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
-        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <target state="translated">El elemento "{0}" tiene CopyToOutputDirectory establecido en "Always", no está actualizado.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
         <source>Critical build tasks are running, not up-to-date.</source>
-        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <target state="translated">Las tareas críticas de construcción se están ejecutando, no están actualizadas.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
         <source>Destination {0}: '{1}'</source>
-        <target state="new">Destination {0}: '{1}'</target>
+        <target state="translated">Destino {0}: "{1}"</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
         <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
-        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <target state="translated">La propiedad "DisableFastUpToDateCheck" es "true", no está actualizada.</target>
         <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_Exception_1">
         <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
-        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <target state="translated">La comprobación de la actualización produjo una excepción. No está actualizado. {0}</target>
         <note>{0} is the exception message.</note>
       </trans-unit>
       <trans-unit id="FUTD_FirstRun">
         <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
-        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <target state="translated">La comprobación de actualización aún no se ha ejecutado para este proyecto. No está actualizado.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_IgnoringKinds_1">
         <source>Ignoring up-to-date check items with Kind="{0}"</source>
-        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <target state="translated">Ignorar los elementos de control actualizados con Kind="{0}"</target>
         <note>Do not translate Kind. {0} is the kind name.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
         <source>Input marker is newer than output marker, not up-to-date.</source>
-        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <target state="translated">El marcador de entrada es más reciente que el de salida, no está actualizado.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
         <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">La entrada "{0}" ({1}) ha sido modificada desde la última comprobación de actualización ({2}), no está actualizada.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
         <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">La entrada "{0}" es más reciente ({1}) que la primera salida "{2}" ({3}), no está actualizada.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
         <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
-        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <target state="translated">La marca de tiempo más reciente de escritura en el marcador de entrada es {0} en "{1}".</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefined">
         <source>No build outputs defined.</source>
-        <target state="new">No build outputs defined.</target>
+        <target state="translated">No se han definido salidas de construcción.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
         <source>No build outputs defined in Set="{0}".</source>
-        <target state="new">No build outputs defined in Set="{0}".</target>
+        <target state="translated">No hay resultados de compilación definidos en Set="{0}".</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputMarkersExist">
         <source>No input markers exist, skipping marker check.</source>
-        <target state="new">No input markers exist, skipping marker check.</target>
+        <target state="translated">No existen marcadores de entrada, omitiendo la comprobación de marcadores.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefined">
         <source>No inputs defined.</source>
-        <target state="new">No inputs defined.</target>
+        <target state="translated">No se definió ninguna entrada.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefinedInSet_1">
         <source>No inputs defined in Set="{0}".</source>
-        <target state="new">No inputs defined in Set="{0}".</target>
+        <target state="translated">No hay entradas definidas en Set="{0}".</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
         <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">En Set="{4}", ninguna entrada es más reciente que la primera salida "{0}" ({1}). La entrada más reciente es "{2}" ({3}).</target>
         <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
         <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">Ninguna entrada es más reciente que la primera salida "{0}" ({1}). La entrada más reciente es "{2}" ({3}).</target>
         <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoOutputMarkerExists_1">
         <source>Output marker '{0}' does not exist, skipping marker check.</source>
-        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <target state="translated">El marcador de salida "{0}" no existe, saltándose la comprobación del marcador.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredInputNotFound_1">
         <source>Input '{0}' does not exist, but is not required.</source>
-        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <target state="translated">La entrada "{0}" no existe, pero no es necesaria.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
-        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <target state="translated">El elemento {1} de entrada "{0}" no existe, pero no es necesario.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">La salida "{0}" no existe, no está actualizada.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredInputNotFound_1">
         <source>Input '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">La entrada "{0}" no existe y es necesaria, no está actualizada.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">El elemento {1} de entrada "{0}" no existe y es necesario, no está actualizado.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
         <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <target state="translated">El conjunto de elementos del proyecto se modificó más recientemente ({0}) que la salida más antigua "{1}" ({2}), no actualizada</target>
         <note>{0} and {2} are datetimes. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
-        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <target state="translated">Omitiendo "{0}" con Kind="{1}" omitido</target>
         <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
       </trans-unit>
       <trans-unit id="FUTD_SourceFileTimeAndPath_2">
         <source>Source {0}: '{1}'</source>
-        <target state="new">Source {0}: '{1}'</target>
+        <target state="translated">Origen {0}: "{1}"</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
         <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">El elemento {3} de entrada "{0}" ({1}) ha sido modificado desde la última comprobación de actualización ({2}), no está actualizado.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
         <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">El elemento {4} de entrada "{0}" es más nuevo ({1}) que el de salida más antiguo "{2}" ({3}), no está actualizado.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_UpToDate">
         <source>Project is up-to-date.</source>
-        <target state="new">Project is up-to-date.</target>
+        <target state="translated">El proyecto está al día.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
         <source>Write timestamp on output marker is {0} on '{1}'.</source>
-        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <target state="translated">Escribir marca de tiempo en el marcador de salida es {0} en "{1}".</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
@@ -348,7 +348,7 @@ Este proyecto se cargó con el tipo de proyecto incorrecto, probablemente como r
       </trans-unit>
       <trans-unit id="Property_NoneValue">
         <source>(None)</source>
-        <target state="new">(None)</target>
+        <target state="translated">(Ninguno)</target>
         <note>Special value to show in the project property pages when a property has no value.</note>
       </trans-unit>
       <trans-unit id="SdkNodeName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
@@ -9,257 +9,257 @@
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
         <source>Adding input reference copy markers:</source>
-        <target state="new">Adding input reference copy markers:</target>
+        <target state="translated">Ajout des marqueurs de copie de référence d’entrée :</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingNewestImportInput">
         <source>Adding newest import input:</source>
-        <target state="new">Adding newest import input:</target>
+        <target state="translated">Ajout de l’entrée d’importation la plus récente :</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
         <source>Adding output reference copy marker:</source>
-        <target state="new">Adding output reference copy marker:</target>
+        <target state="translated">Ajout du marqueur de copie de référence de sortie :</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingProjectFileInputs">
         <source>Adding project file inputs:</source>
-        <target state="new">Adding project file inputs:</target>
+        <target state="translated">Ajout d’entrées de fichier projet :</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
-        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <target state="translated">Ajout d’entrées {0} dans Set="{1}" :</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputs_1">
         <source>Adding {0} inputs:</source>
-        <target state="new">Adding {0} inputs:</target>
+        <target state="translated">Ajout d’entrées {0} :</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
         <source>Adding {0} outputs in Set="{1}":</source>
-        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <target state="translated">Ajout de sorties {0} dans Set="{1}" :</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputs_1">
         <source>Adding {0} outputs:</source>
-        <target state="new">Adding {0} outputs:</target>
+        <target state="translated">Ajout de sorties {0} :</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} élément ajouté '{1}' (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} élément supprimé '{1}' (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
-        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <target state="translated">Vérification de la sortie copiée (UpToDateCheckBuilt avec la propriété Original) du fichier :</target>
         <note>Do not translate UpToDateCheckBuilt or Original.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
         <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <target state="translated">La '{0}' de destination n’existe pas pour la copie à partir de '{1}', elle n’est pas à jour.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
         <source>Source is newer than build output destination, not up-to-date.</source>
-        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <target state="translated">La source est plus récente que la destination de sortie de build, et n’est pas à jour.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
         <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <target state="translated">Le '{0}' source n’existe pas pour la copie vers '{1}', pas à jour.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">La destination '{0}' n’existe pas, elle n’est pas à jour.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">La '{0}' source n’existe pas, elle n’est pas à jour.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
         <source>Checking PreserveNewest file '{0}':</source>
-        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <target state="translated">Vérification de l''{0}' du fichier PreserveNe '{0}' :</target>
         <note>Do not translate PreserveNewest. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
         <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
-        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <target state="translated">Le '{0}' source PreserveNe '{0}' est plus récent que le '{1}' de destination, et n’est pas à jour.</target>
         <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
         <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
-        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <target state="translated">Comparaison des horodatages des entrées et sorties dans Set="{0}" :</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_Completed">
         <source>Up-to-date check completed in {0:N1} ms</source>
-        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <target state="translated">Vérification à jour effectuée en {0:N1} ms</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_1">
         <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
-        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <target state="translated">CopyToOutputDirectory est défini sur « Always », ce qui n’est pas à jour pour l’élément '{0}'.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
         <source>Critical build tasks are running, not up-to-date.</source>
-        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <target state="translated">Des tâches de build critiques sont en cours d’exécution et ne sont pas à jour.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
         <source>Destination {0}: '{1}'</source>
-        <target state="new">Destination {0}: '{1}'</target>
+        <target state="translated">Destination {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
         <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
-        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <target state="translated">La propriété « DisableFastUpToDateCheck » a la valeur « true » et n’est pas à jour.</target>
         <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_Exception_1">
         <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
-        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <target state="translated">Une vérification à jour a levé une exception. Pas à jour. {0}</target>
         <note>{0} is the exception message.</note>
       </trans-unit>
       <trans-unit id="FUTD_FirstRun">
         <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
-        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <target state="translated">La vérification à jour n’a pas encore été exécutée pour ce projet. Pas à jour.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_IgnoringKinds_1">
         <source>Ignoring up-to-date check items with Kind="{0}"</source>
-        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <target state="translated">Éléments de vérification à jour avec Kind="{0}" ignorés</target>
         <note>Do not translate Kind. {0} is the kind name.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
         <source>Input marker is newer than output marker, not up-to-date.</source>
-        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <target state="translated">Le marqueur d’entrée est plus récent que le marqueur de sortie, pas à jour.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
         <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">L''{0}' d’entrée ({1}) a été modifiée depuis la dernière vérification à jour ({2}), et non à jour.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
         <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">Le '{0}' d’entrée est plus récent ({1}) que le '{2}' de sortie le plus ancien ({3}). Il n’est pas à jour.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
         <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
-        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <target state="translated">L’horodatage d’écriture le plus récent sur le marqueur d’entrée est {0} sur '{1}'.</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefined">
         <source>No build outputs defined.</source>
-        <target state="new">No build outputs defined.</target>
+        <target state="translated">||Aucune sortie de build définie</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
         <source>No build outputs defined in Set="{0}".</source>
-        <target state="new">No build outputs defined in Set="{0}".</target>
+        <target state="translated">Aucune sortie de build définie dans Set="{0}".</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputMarkersExist">
         <source>No input markers exist, skipping marker check.</source>
-        <target state="new">No input markers exist, skipping marker check.</target>
+        <target state="translated">Aucun marqueur d’entrée n’existe. La vérification des marqueurs est ignorée.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefined">
         <source>No inputs defined.</source>
-        <target state="new">No inputs defined.</target>
+        <target state="translated">Aucune entrée définie</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefinedInSet_1">
         <source>No inputs defined in Set="{0}".</source>
-        <target state="new">No inputs defined in Set="{0}".</target>
+        <target state="translated">Aucune entrée définie dans Set="{0}"</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
         <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">Dans Set="{4}", aucune entrée n’est plus récente que la sortie la plus ancienne '{0}' ({1}). L’entrée la plus récente est '{2}' ({3}).</target>
         <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
         <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">Aucune entrée n’est plus récente que la sortie la plus ancienne '{0}' ({1}). L’entrée la plus récente est '{2}' ({3}).</target>
         <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoOutputMarkerExists_1">
         <source>Output marker '{0}' does not exist, skipping marker check.</source>
-        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <target state="translated">Le '{0}' de marqueur de sortie n’existe pas. La vérification du marqueur est ignorée.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredInputNotFound_1">
         <source>Input '{0}' does not exist, but is not required.</source>
-        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <target state="translated">Le '{0}' d’entrée n’existe pas, mais n’est pas obligatoire.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
-        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <target state="translated">L''{0}' d’élément de {1} d’entrée n’existe pas, mais n’est pas obligatoire.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">La sortie '{0}' n’existe pas, elle n’est pas à jour.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredInputNotFound_1">
         <source>Input '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">L'entrée '{0}' n’existe pas et est obligatoire et n’est pas à jour.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">L'élément '{0}' de {1} d’entrée n’existe pas et est obligatoire et n’est pas à jour.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
         <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <target state="translated">L’ensemble d’éléments de projet a été modifié plus récemment ({0}) que le '{1}' de sortie le plus ancien ({2}). Il n’est pas à jour.</target>
         <note>{0} and {2} are datetimes. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
-        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <target state="translated">Ignorer '{0}' avec kind="{1}" ignoré</target>
         <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
       </trans-unit>
       <trans-unit id="FUTD_SourceFileTimeAndPath_2">
         <source>Source {0}: '{1}'</source>
-        <target state="new">Source {0}: '{1}'</target>
+        <target state="translated">Source {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
         <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">L''{0}' d’élément de {3} d’entrée ({1}) a été modifiée depuis la dernière vérification à jour ({2}), et non à jour.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
         <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">L’élément {4} de '{0}' d’entrée est plus récent ({1}) que le '{2}' de sortie le plus ancien ({3}). Il n’est pas à jour.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_UpToDate">
         <source>Project is up-to-date.</source>
-        <target state="new">Project is up-to-date.</target>
+        <target state="translated">Le projet est à jour.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
         <source>Write timestamp on output marker is {0} on '{1}'.</source>
-        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <target state="translated">L’horodatage d’écriture sur le marqueur de sortie est {0} sur '{1}'.</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="ImportsTreeNodeName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
@@ -9,257 +9,257 @@
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
         <source>Adding input reference copy markers:</source>
-        <target state="new">Adding input reference copy markers:</target>
+        <target state="translated">Aggiunta di marcatori di copia di riferimento di input:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingNewestImportInput">
         <source>Adding newest import input:</source>
-        <target state="new">Adding newest import input:</target>
+        <target state="translated">Aggiunta dell'input di importazione più recente:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
         <source>Adding output reference copy marker:</source>
-        <target state="new">Adding output reference copy marker:</target>
+        <target state="translated">Aggiunta del marcatore di copia del riferimento di output:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingProjectFileInputs">
         <source>Adding project file inputs:</source>
-        <target state="new">Adding project file inputs:</target>
+        <target state="translated">Aggiunta degli input del file di progetto:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
-        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <target state="translated">Aggiunta di input {0} in Set="{1}":</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputs_1">
         <source>Adding {0} inputs:</source>
-        <target state="new">Adding {0} inputs:</target>
+        <target state="translated">Aggiunta di input {0}:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
         <source>Adding {0} outputs in Set="{1}":</source>
-        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <target state="translated">Aggiunta degli output {0} in Set="{1}":</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputs_1">
         <source>Adding {0} outputs:</source>
-        <target state="new">Adding {0} outputs:</target>
+        <target state="translated">Aggiunta di output {0}:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} elemento aggiunto '{1}' (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} elemento rimosso '{1}' (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
-        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <target state="translated">Controllo del file di output copiato (UpToDateCheckBuilt con proprietà Original):</target>
         <note>Do not translate UpToDateCheckBuilt or Original.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
         <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <target state="translated">La destinazione '{0}' non esiste per la copia da '{1}', non aggiornata.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
         <source>Source is newer than build output destination, not up-to-date.</source>
-        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <target state="translated">L'origine è più recente della destinazione dell'output di compilazione, non aggiornata.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
         <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <target state="translated">L'origine '{0}' non esiste per la copia in '{1}', non aggiornata.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">La destinazione '{0}' non esiste, non è aggiornata.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">L'origine '{0}' non esiste, non è aggiornata.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
         <source>Checking PreserveNewest file '{0}':</source>
-        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <target state="translated">Controllo del file PreserveNewest '{0}':</target>
         <note>Do not translate PreserveNewest. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
         <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
-        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <target state="translated">L'origine PreserveNewest '{0}' è più recente della destinazione '{1}', non aggiornata.</target>
         <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
         <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
-        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <target state="translated">Confronto dei timestamp di input e output in Set="{0}":</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_Completed">
         <source>Up-to-date check completed in {0:N1} ms</source>
-        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <target state="translated">Controllo aggiornato completato in {0:N1} ms</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_1">
         <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
-        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <target state="translated">L'elemento '{0}' ha CopyToOutputDirectory impostato su 'Always', non aggiornato.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
         <source>Critical build tasks are running, not up-to-date.</source>
-        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <target state="translated">Le attività di compilazione critiche sono in esecuzione, non aggiornate.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
         <source>Destination {0}: '{1}'</source>
-        <target state="new">Destination {0}: '{1}'</target>
+        <target state="translated">{0} di destinazione: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
         <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
-        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <target state="translated">La proprietà 'DisableFastUpToDateCheck' è 'true', non aggiornata.</target>
         <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_Exception_1">
         <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
-        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <target state="translated">Il controllo aggiornato ha generato un'eccezione. Non aggiornato. {0}</target>
         <note>{0} is the exception message.</note>
       </trans-unit>
       <trans-unit id="FUTD_FirstRun">
         <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
-        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <target state="translated">Il controllo aggiornato non è ancora stato eseguito per questo progetto. Non aggiornato.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_IgnoringKinds_1">
         <source>Ignoring up-to-date check items with Kind="{0}"</source>
-        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <target state="translated">Gli elementi di controllo aggiornati verranno ignorati con Kind="{0}"</target>
         <note>Do not translate Kind. {0} is the kind name.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
         <source>Input marker is newer than output marker, not up-to-date.</source>
-        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <target state="translated">Il marcatore di input è più recente del marcatore di output, non aggiornato.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
         <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">L'input '{0}' ({1}) è stato modificato dopo l'ultimo controllo aggiornato ({2}), non aggiornato.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
         <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">L'input '{0}' è più recente ({1}) del primo output '{2}' ({3}), non aggiornato.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
         <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
-        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <target state="translated">Il timestamp di scrittura più recente sul marcatore di input è {0} su '{1}'.</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefined">
         <source>No build outputs defined.</source>
-        <target state="new">No build outputs defined.</target>
+        <target state="translated">Nessun output di compilazione definito.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
         <source>No build outputs defined in Set="{0}".</source>
-        <target state="new">No build outputs defined in Set="{0}".</target>
+        <target state="translated">Nessun output di compilazione definito in Set="{0}".</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputMarkersExist">
         <source>No input markers exist, skipping marker check.</source>
-        <target state="new">No input markers exist, skipping marker check.</target>
+        <target state="translated">Non esistono marcatori di input. Il controllo dei marcatori verrà ignorato.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefined">
         <source>No inputs defined.</source>
-        <target state="new">No inputs defined.</target>
+        <target state="translated">Nessun input definito.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefinedInSet_1">
         <source>No inputs defined in Set="{0}".</source>
-        <target state="new">No inputs defined in Set="{0}".</target>
+        <target state="translated">Nessun input definito in Set="{0}".</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
         <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">In Set="{4}", nessun input è più recente del primo output '{0}' ({1}). L'input più recente è '{2}' ({3}).</target>
         <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
         <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">Nessun input è più recente del primo output '{0}' ({1}). L'input più recente è '{2}' ({3}).</target>
         <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoOutputMarkerExists_1">
         <source>Output marker '{0}' does not exist, skipping marker check.</source>
-        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <target state="translated">Il marcatore di output '{0}' non esiste. Il controllo del marcatore verrà ignorato.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredInputNotFound_1">
         <source>Input '{0}' does not exist, but is not required.</source>
-        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <target state="translated">L'input '{0}' non esiste, ma non è obbligatorio.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
-        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <target state="translated">L'input {1} 'elemento '{0}' non esiste, ma non è obbligatorio.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">L'output '{0}' non esiste, non è aggiornato.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredInputNotFound_1">
         <source>Input '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">L'input '{0}' non esiste ed è obbligatorio, non aggiornato.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">L'input {1} 'elemento '{0}' non esiste ed è obbligatorio, non aggiornato.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
         <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <target state="translated">Il set di elementi del progetto è stato modificato più di recente ({0}) rispetto al primo output '{1}' ({2}), non aggiornato.</target>
         <note>{0} and {2} are datetimes. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
-        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <target state="translated">'{0}' ignorato con Kind="{1}" ignorato</target>
         <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
       </trans-unit>
       <trans-unit id="FUTD_SourceFileTimeAndPath_2">
         <source>Source {0}: '{1}'</source>
-        <target state="new">Source {0}: '{1}'</target>
+        <target state="translated">{0} di origine: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
         <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">L'elemento di input {3} '{0}' ({1}) è stato modificato dopo l'ultimo controllo aggiornato ({2}), non aggiornato.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
         <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">L'elemento {4} di input '{0}' è più recente ({1}) dell'output meno recente '{2}' ({3}), non aggiornato.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_UpToDate">
         <source>Project is up-to-date.</source>
-        <target state="new">Project is up-to-date.</target>
+        <target state="translated">Il progetto è aggiornato.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
         <source>Write timestamp on output marker is {0} on '{1}'.</source>
-        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <target state="translated">Il timestamp di scrittura sul marcatore di output è {0} su '{1}'.</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
@@ -348,7 +348,7 @@ Questo progetto è stato caricato con il tipo di progetto non corretto, probabil
       </trans-unit>
       <trans-unit id="Property_NoneValue">
         <source>(None)</source>
-        <target state="new">(None)</target>
+        <target state="translated">(Nessuno)</target>
         <note>Special value to show in the project property pages when a property has no value.</note>
       </trans-unit>
       <trans-unit id="SdkNodeName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
@@ -9,257 +9,257 @@
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
         <source>Adding input reference copy markers:</source>
-        <target state="new">Adding input reference copy markers:</target>
+        <target state="translated">入力参照コピー マーカーの追加:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingNewestImportInput">
         <source>Adding newest import input:</source>
-        <target state="new">Adding newest import input:</target>
+        <target state="translated">最新のインポート入力の追加:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
         <source>Adding output reference copy marker:</source>
-        <target state="new">Adding output reference copy marker:</target>
+        <target state="translated">出力参照コピー マーカーの追加:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingProjectFileInputs">
         <source>Adding project file inputs:</source>
-        <target state="new">Adding project file inputs:</target>
+        <target state="translated">プロジェクト ファイル入力の追加:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
-        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <target state="translated">Set="{1}" で {0} 個の入力の追加:</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputs_1">
         <source>Adding {0} inputs:</source>
-        <target state="new">Adding {0} inputs:</target>
+        <target state="translated">{0} 入力の追加:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
         <source>Adding {0} outputs in Set="{1}":</source>
-        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <target state="translated">Set="{1}" での {0} 出力の追加:</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputs_1">
         <source>Adding {0} outputs:</source>
-        <target state="new">Adding {0} outputs:</target>
+        <target state="translated">{0} 出力の追加:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} 個の項目が追加された '{1}' (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} アイテムが削除された '{1}' (CopyType={2}、TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
-        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <target state="translated">コピー済み出力 (Original プロパティ を使用した UpToDateCheckBuilt) ファイルの確認:</target>
         <note>Do not translate UpToDateCheckBuilt or Original.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
         <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <target state="translated">宛先 '{0}' は '{1}' からコピーするために存在せず、最新ではありません。</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
         <source>Source is newer than build output destination, not up-to-date.</source>
-        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <target state="translated">ソースは、ビルド出力先よりも新しく、最新ではありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
         <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <target state="translated">ソース '{0}' は '{1}' にコピーするために存在せず、最新ではありません。</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">宛先 '{0}' が存在せず、最新ではありません。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">ソース '{0}' が存在せず、最新ではありません。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
         <source>Checking PreserveNewest file '{0}':</source>
-        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <target state="translated">PreserveNewest ファイル '{0}' の確認:</target>
         <note>Do not translate PreserveNewest. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
         <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
-        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <target state="translated">PreserveNewest ソース '{0}'は宛先 '{1}' よりも新しく、最新ではありません。</target>
         <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
         <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
-        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <target state="translated">Set="{0}" での入力と出力のタイムスタンプの比較:</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_Completed">
         <source>Up-to-date check completed in {0:N1} ms</source>
-        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <target state="translated">{0:N1} ミリ秒で最新チェックが完了しました</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_1">
         <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
-        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <target state="translated">項目 '{0}' に '常時' に設定された CopyToOutputDirectory があり、最新ではありません。</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
         <source>Critical build tasks are running, not up-to-date.</source>
-        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <target state="translated">重要なビルド タスクを実行中ですが、最新ではありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
         <source>Destination {0}: '{1}'</source>
-        <target state="new">Destination {0}: '{1}'</target>
+        <target state="translated">宛先 {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
         <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
-        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <target state="translated">'DisableFastUpToDateCheck' プロパティは 'true' で、最新ではありません。</target>
         <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_Exception_1">
         <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
-        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <target state="translated">最新のチェックで例外が発生しました。最新ではありません。{0}</target>
         <note>{0} is the exception message.</note>
       </trans-unit>
       <trans-unit id="FUTD_FirstRun">
         <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
-        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <target state="translated">このプロジェクト用の最新チェックはまだ実行されていません。最新ではありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_IgnoringKinds_1">
         <source>Ignoring up-to-date check items with Kind="{0}"</source>
-        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <target state="translated">Kind="{0}" を含む最新のチェック項目を無視します</target>
         <note>Do not translate Kind. {0} is the kind name.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
         <source>Input marker is newer than output marker, not up-to-date.</source>
-        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <target state="translated">入力マーカーは出力マーカーよりも新しく、最新ではありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
         <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">入力 '{0}' ({1}) は、前回の最新のチェック ({2}) 以降に変更されており、最新ではありません。</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
         <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">入力 '{0}' は、最も前の出力'{2}' ({3}) よりも新しい ({1}) で、最新ではありません。</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
         <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
-        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <target state="translated">入力マーカーの最新の書き込みタイムスタンプは '{1}' の {0} です。</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefined">
         <source>No build outputs defined.</source>
-        <target state="new">No build outputs defined.</target>
+        <target state="translated">定義されたビルド出力はありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
         <source>No build outputs defined in Set="{0}".</source>
-        <target state="new">No build outputs defined in Set="{0}".</target>
+        <target state="translated">Set="{0}" に定義されたビルド出力はありません。</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputMarkersExist">
         <source>No input markers exist, skipping marker check.</source>
-        <target state="new">No input markers exist, skipping marker check.</target>
+        <target state="translated">入力マーカーが存在せず、マーカーの確認をスキップしています。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefined">
         <source>No inputs defined.</source>
-        <target state="new">No inputs defined.</target>
+        <target state="translated">入力が定義されていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefinedInSet_1">
         <source>No inputs defined in Set="{0}".</source>
-        <target state="new">No inputs defined in Set="{0}".</target>
+        <target state="translated">Set="{0}" で入力が定義されていません。</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
         <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">Set="{4}" では、最初の出力 '{0}' ({1}) よりも新しい入力はありません。最新の入力は '{2}' ({3}) です。</target>
         <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
         <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">最初の出力 '{0}' ({1}) よりも新しい入力はありません。最新の入力は '{2}' ({3}) です。</target>
         <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoOutputMarkerExists_1">
         <source>Output marker '{0}' does not exist, skipping marker check.</source>
-        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <target state="translated">出力マーカー '{0}' が存在せず、マーカーの確認をスキップしています。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredInputNotFound_1">
         <source>Input '{0}' does not exist, but is not required.</source>
-        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <target state="translated">入力 '{0}' は存在しませんが、必須ではありません。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
-        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <target state="translated">入力 {1} の項目 '{0}' は存在しませんが、必須ではありません。</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">出力 '{0}' が存在せず、最新ではありません。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredInputNotFound_1">
         <source>Input '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">入力 '{0}' が存在せず、最新ではないことが必須です。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">入力 {1} の項目 '{0}' が存在せず、最新ではないことが必須です。</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
         <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <target state="translated">プロジェクト項目のセットは、最も前の出力 '{1}' ({2}) よりも最近 ({0}) に変更され、最新ではありませんでした。</target>
         <note>{0} and {2} are datetimes. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
-        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <target state="translated">Kind="{1}" を無視して '{0}' をスキップしています</target>
         <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
       </trans-unit>
       <trans-unit id="FUTD_SourceFileTimeAndPath_2">
         <source>Source {0}: '{1}'</source>
-        <target state="new">Source {0}: '{1}'</target>
+        <target state="translated">ソース {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
         <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">入力 {3} 項目 '{0}' ({1}) は、前回の最新のチェック ({2}) 以降に変更されており、最新ではありません。</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
         <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">入力 {4} 項目 '{0}' は、最も前の出力 '{2}' ({3}) よりも新しい ({1}) で、最新ではありません。</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_UpToDate">
         <source>Project is up-to-date.</source>
-        <target state="new">Project is up-to-date.</target>
+        <target state="translated">プロジェクトは最新のものです。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
         <source>Write timestamp on output marker is {0} on '{1}'.</source>
-        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <target state="translated">'{1}' で出力マーカーが {0} の書き込みタイムスタンプ。</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="ImportsTreeNodeName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
@@ -9,257 +9,257 @@
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
         <source>Adding input reference copy markers:</source>
-        <target state="new">Adding input reference copy markers:</target>
+        <target state="translated">입력 참고자료 복사 마커 추가:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingNewestImportInput">
         <source>Adding newest import input:</source>
-        <target state="new">Adding newest import input:</target>
+        <target state="translated">최신 가져오기 입력 추가:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
         <source>Adding output reference copy marker:</source>
-        <target state="new">Adding output reference copy marker:</target>
+        <target state="translated">출력 참고자료 복사 마커 추가:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingProjectFileInputs">
         <source>Adding project file inputs:</source>
-        <target state="new">Adding project file inputs:</target>
+        <target state="translated">프로젝트 파일 입력 추가:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
-        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <target state="translated">Set="{1}"에 {0} 입력 추가:</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputs_1">
         <source>Adding {0} inputs:</source>
-        <target state="new">Adding {0} inputs:</target>
+        <target state="translated">{0} 입력 추가:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
         <source>Adding {0} outputs in Set="{1}":</source>
-        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <target state="translated">Set="{1}"에 {0} 출력 추가:</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputs_1">
         <source>Adding {0} outputs:</source>
-        <target state="new">Adding {0} outputs:</target>
+        <target state="translated">{0} 출력 추가:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} 항목이 '{1}' 추가됨(CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} 항목이 '{1}'을(를) 제거함(CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
-        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <target state="translated">복사된 출력(Original 속성이 있는 UpToDateCheckBuilt) 파일 확인:</target>
         <note>Do not translate UpToDateCheckBuilt or Original.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
         <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <target state="translated">'{1}'의 복사본에 대한 대상 '{0}'이(가) 존재하지 않으며 최신 상태가 아닙니다.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
         <source>Source is newer than build output destination, not up-to-date.</source>
-        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <target state="translated">원본이 최신이 아니라 빌드 출력 대상보다 최신입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
         <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <target state="translated">'{1}'(으)로 복사할 원본 '{0}'이(가) 존재하지 않으며 최신 상태가 아닙니다.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">대상 '{0}'이(가) 존재하지 않으며 최신 상태가 아닙니다.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">원본 '{0}'이(가) 존재하지 않으며 최신 상태가 아닙니다.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
         <source>Checking PreserveNewest file '{0}':</source>
-        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <target state="translated">PreserveNewest 파일 '{0}' 확인:</target>
         <note>Do not translate PreserveNewest. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
         <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
-        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <target state="translated">PreserveNewest 원본 '{0}'이(가) 대상 '{1}'보다 최신이며 최신 상태가 아닙니다.</target>
         <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
         <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
-        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <target state="translated">Set="{0}"에서 입력 및 출력의 타임스탬프 비교:</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_Completed">
         <source>Up-to-date check completed in {0:N1} ms</source>
-        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <target state="translated">{0:N1}ms 후에 최신 확인 완료</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_1">
         <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
-        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <target state="translated">항목 '{0}'의 CopyToOutputDirectory가 최신 상태가 아닌 '항상'으로 설정되어 있습니다.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
         <source>Critical build tasks are running, not up-to-date.</source>
-        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <target state="translated">중요한 빌드 작업이 최신 상태가 아닌 실행 중입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
         <source>Destination {0}: '{1}'</source>
-        <target state="new">Destination {0}: '{1}'</target>
+        <target state="translated">대상 {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
         <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
-        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <target state="translated">'DisableFastUpToDateCheck' 속성은 최신이 아닌 'true'입니다.</target>
         <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_Exception_1">
         <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
-        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <target state="translated">최신 검사에서 예외가 발생했습니다. 최신 정보가 아닙니다. {0}</target>
         <note>{0} is the exception message.</note>
       </trans-unit>
       <trans-unit id="FUTD_FirstRun">
         <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
-        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <target state="translated">이 프로젝트에 대한 최신 확인이 아직 실행되지 않았습니다. 최신 정보가 아닙니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_IgnoringKinds_1">
         <source>Ignoring up-to-date check items with Kind="{0}"</source>
-        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <target state="translated">Kind="{0}"인 최신 확인 항목 무시</target>
         <note>Do not translate Kind. {0} is the kind name.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
         <source>Input marker is newer than output marker, not up-to-date.</source>
-        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <target state="translated">입력 마커가 최신이 아니라 출력 마커보다 최신입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
         <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">입력 '{0}'({1})이(가) 최신이 아닌 마지막 최신 확인({2}) 이후 수정되었습니다.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
         <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">입력 '{0}'이(가) 최신이 아니라 가장 오래된 출력 '{2}'({3})보다 최신({1})입니다.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
         <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
-        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <target state="translated">입력 마커의 최신 쓰기 타임스탬프는 '{1}'의 {0}입니다.</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefined">
         <source>No build outputs defined.</source>
-        <target state="new">No build outputs defined.</target>
+        <target state="translated">빌드 출력이 정의되지 않았습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
         <source>No build outputs defined in Set="{0}".</source>
-        <target state="new">No build outputs defined in Set="{0}".</target>
+        <target state="translated">Set="{0}"에 정의된 빌드 출력이 없습니다.</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputMarkersExist">
         <source>No input markers exist, skipping marker check.</source>
-        <target state="new">No input markers exist, skipping marker check.</target>
+        <target state="translated">마커 확인을 건너뛰는 입력 마커가 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefined">
         <source>No inputs defined.</source>
-        <target state="new">No inputs defined.</target>
+        <target state="translated">정의된 입력이 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefinedInSet_1">
         <source>No inputs defined in Set="{0}".</source>
-        <target state="new">No inputs defined in Set="{0}".</target>
+        <target state="translated">Set="{0}"에 정의된 입력이 없습니다.</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
         <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">Set="{4}"에서 가장 빠른 출력 '{0}'({1})보다 최신 입력이 없습니다. 최신 입력은 '{2}'({3})입니다.</target>
         <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
         <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">가장 빠른 출력 '{0}'({1})보다 최신 입력이 없습니다. 최신 입력은 '{2}'({3})입니다.</target>
         <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoOutputMarkerExists_1">
         <source>Output marker '{0}' does not exist, skipping marker check.</source>
-        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <target state="translated">출력 마커 '{0}'이(가) 존재하지 않아 마커 검사를 건너뜁니다.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredInputNotFound_1">
         <source>Input '{0}' does not exist, but is not required.</source>
-        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <target state="translated">입력 '{0}'이(가) 존재하지 않지만 필수는 아닙니다.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
-        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <target state="translated">입력 {1} 항목 '{0}'이(가) 존재하지 않지만 필수는 아닙니다.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">출력 '{0}'이(가) 존재하지 않으며 최신 상태가 아닙니다.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredInputNotFound_1">
         <source>Input '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">입력 '{0}'이(가) 존재하지 않으며 필수 항목이며 최신 정보가 아닙니다.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">입력 {1} 항목 '{0}'이(가) 존재하지 않으며 필수 항목이며 최신 상태가 아닙니다.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
         <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <target state="translated">프로젝트 항목 집합이 최신이 아닌 가장 이른 출력 '{1}'({2})보다 최근에({0}) 변경되었습니다.</target>
         <note>{0} and {2} are datetimes. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
-        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <target state="translated">무시된 Kind="{1}"(으)로 '{0}' 건너뛰기</target>
         <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
       </trans-unit>
       <trans-unit id="FUTD_SourceFileTimeAndPath_2">
         <source>Source {0}: '{1}'</source>
-        <target state="new">Source {0}: '{1}'</target>
+        <target state="translated">원본 {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
         <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">입력 {3} 항목 '{0}'({1})은(는) 최신이 아닌 마지막 최신 확인({2}) 이후에 수정되었습니다.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
         <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">입력 {4} 항목 '{0}'이(가) 최신 출력 '{2}'({3})보다 최신({1})이며 최신 상태가 아닙니다.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_UpToDate">
         <source>Project is up-to-date.</source>
-        <target state="new">Project is up-to-date.</target>
+        <target state="translated">프로젝트가 최신 상태입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
         <source>Write timestamp on output marker is {0} on '{1}'.</source>
-        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <target state="translated">출력 마커의 쓰기 타임스탬프는 '{1}'의 {0}입니다.</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="ImportsTreeNodeName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
@@ -9,257 +9,257 @@
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
         <source>Adding input reference copy markers:</source>
-        <target state="new">Adding input reference copy markers:</target>
+        <target state="translated">Dodawanie znaczników kopiowania odwołań wejściowych:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingNewestImportInput">
         <source>Adding newest import input:</source>
-        <target state="new">Adding newest import input:</target>
+        <target state="translated">Dodawanie najnowszych danych wejściowych importu:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
         <source>Adding output reference copy marker:</source>
-        <target state="new">Adding output reference copy marker:</target>
+        <target state="translated">Dodawanie znacznika kopiowania odwołań wyjściowych:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingProjectFileInputs">
         <source>Adding project file inputs:</source>
-        <target state="new">Adding project file inputs:</target>
+        <target state="translated">Dodawanie danych wejściowych pliku projektu:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
-        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <target state="translated">Dodawanie {0} danych wejściowych w zestawie Set=„{1}”:</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputs_1">
         <source>Adding {0} inputs:</source>
-        <target state="new">Adding {0} inputs:</target>
+        <target state="translated">Dodawanie {0} danych wejściowych:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
         <source>Adding {0} outputs in Set="{1}":</source>
-        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <target state="translated">Dodawanie {0} danych wyjściowych w zestawie Set=„{1}”:</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputs_1">
         <source>Adding {0} outputs:</source>
-        <target state="new">Adding {0} outputs:</target>
+        <target state="translated">Dodawanie {0} danych wyjściowych:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} dodano element „{1}” (CopyType={2}, TargetPath=„{3}”)</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} usunięto element „{1}” (CopyType={2}, TargetPath=”{3}”)</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
-        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <target state="translated">Sprawdzanie skopiowanego pliku wyjściowego (UpToDateCheckBuilt z właściwością Original):</target>
         <note>Do not translate UpToDateCheckBuilt or Original.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
         <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <target state="translated">Miejsce docelowe „{0}” nie istnieje dla kopii z elementu „{1}”, nieaktualne.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
         <source>Source is newer than build output destination, not up-to-date.</source>
-        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <target state="translated">Źródło jest nowsze niż miejsce docelowe danych wyjściowych kompilacji, nieaktualne.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
         <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <target state="translated">Źródło „{0}” nie istnieje dla kopii do „{1}”, nieaktualne.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Miejsce docelowe „{0}” nie istnieje, nie jest aktualne.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Źródło „{0}” nie istnieje, nie jest aktualne.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
         <source>Checking PreserveNewest file '{0}':</source>
-        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <target state="translated">Sprawdzanie pliku PreserveNewest „{0}”:</target>
         <note>Do not translate PreserveNewest. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
         <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
-        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <target state="translated">Źródło PreserveNewest „{0}” jest nowsze niż docelowe „{1}”, nieaktualne.</target>
         <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
         <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
-        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <target state="translated">Porównywanie sygnatur czasowych danych wejściowych i wyjściowych w zestawie Set=„{0}”:</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_Completed">
         <source>Up-to-date check completed in {0:N1} ms</source>
-        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <target state="translated">Sprawdzanie aktualności zostało ukończone w {0:N1} ms</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_1">
         <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
-        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <target state="translated">Element „{0}” ma właściwość CopyToOutputDirectory ustawioną na wartość „Always”, nieaktualne.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
         <source>Critical build tasks are running, not up-to-date.</source>
-        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <target state="translated">Krytyczne zadania kompilacji są uruchomione, nieaktualne.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
         <source>Destination {0}: '{1}'</source>
-        <target state="new">Destination {0}: '{1}'</target>
+        <target state="translated">Lokalizacja docelowa {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
         <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
-        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <target state="translated">Właściwość "DisableFastUpToDateCheck" ma wartość „true”, nieaktualne.</target>
         <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_Exception_1">
         <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
-        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <target state="translated">Aktualne sprawdzanie zgłosiło wyjątek. Nieaktualne. {0}</target>
         <note>{0} is the exception message.</note>
       </trans-unit>
       <trans-unit id="FUTD_FirstRun">
         <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
-        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <target state="translated">Sprawdzanie aktualności nie zostało jeszcze uruchomione dla tego projektu. Nieaktualne.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_IgnoringKinds_1">
         <source>Ignoring up-to-date check items with Kind="{0}"</source>
-        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <target state="translated">Ignorowanie aktualnych elementów sprawdzania za pomocą Kind=„{0}”</target>
         <note>Do not translate Kind. {0} is the kind name.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
         <source>Input marker is newer than output marker, not up-to-date.</source>
-        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <target state="translated">Znacznik wejściowy jest nowszy niż znacznik wyjściowy, nieaktualny.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
         <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">Dane wejściowe „{0}” ({1}) zostały zmodyfikowane od czasu ostatniego sprawdzenia aktualności ({2}), nieaktualne.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
         <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">Dane wejściowe „{0}” są nowsze ({1}) niż najwcześniejsze dane wyjściowe „{2}” ({3}), nieaktualne.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
         <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
-        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <target state="translated">Najnowszy znacznik czasu zapisu w znaczniku wejściowym to {0} na „{1}”.</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefined">
         <source>No build outputs defined.</source>
-        <target state="new">No build outputs defined.</target>
+        <target state="translated">Nie zdefiniowano żadnych danych wyjściowych kompilacji.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
         <source>No build outputs defined in Set="{0}".</source>
-        <target state="new">No build outputs defined in Set="{0}".</target>
+        <target state="translated">Nie zdefiniowano żadnych danych wyjściowych kompilacji w elemencie Set=„{0}”.</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputMarkersExist">
         <source>No input markers exist, skipping marker check.</source>
-        <target state="new">No input markers exist, skipping marker check.</target>
+        <target state="translated">Nie istnieją znaczniki wejściowe, pomijanie sprawdzania znaczników.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefined">
         <source>No inputs defined.</source>
-        <target state="new">No inputs defined.</target>
+        <target state="translated">Nie zdefiniowano danych wejściowych.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefinedInSet_1">
         <source>No inputs defined in Set="{0}".</source>
-        <target state="new">No inputs defined in Set="{0}".</target>
+        <target state="translated">Nie zdefiniowano żadnych danych wejściowych w zestawie Set=„{0}”.</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
         <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">W zestawie Set=„{4}” żadne dane wejściowe nie są nowsze niż najwcześniejsze dane wyjściowe „{0}” ({1}). Najnowsze dane wejściowe to „{2}” ({3}).</target>
         <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
         <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">Żadne dane wejściowe nie są nowsze niż najwcześniejsze dane wyjściowe „{0}” ({1}). Najnowsze dane wejściowe to „{2}” ({3}).</target>
         <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoOutputMarkerExists_1">
         <source>Output marker '{0}' does not exist, skipping marker check.</source>
-        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <target state="translated">Znacznik danych wyjściowych „{0}” nie istnieje, pomijanie sprawdzania znacznika.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredInputNotFound_1">
         <source>Input '{0}' does not exist, but is not required.</source>
-        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <target state="translated">Dane wejściowe „{0}” nie istnieją, ale nie są wymagane.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
-        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <target state="translated">Wejściowy {1} element „{0}” nie istnieje, ale nie jest wymagany.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Dane wyjściowe „{0}’ nie istnieją, nie są aktualne.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredInputNotFound_1">
         <source>Input '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">Dane wejściowe „{0}” nie istnieją i są wymagane, nie są aktualne.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">Wejściowy {1} element „{0}” nie istnieje i jest wymagany, nie jest aktualny.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
         <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <target state="translated">Zestaw elementów projektu został zmieniony wcześniej ({0}) niż najwcześniejsze dane wyjściowe „{1}” ({2}), nieaktualne.</target>
         <note>{0} and {2} are datetimes. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
-        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <target state="translated">Pomijanie elementu „{0}” z zignorowanym rodzajem Kind=„{1}”</target>
         <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
       </trans-unit>
       <trans-unit id="FUTD_SourceFileTimeAndPath_2">
         <source>Source {0}: '{1}'</source>
-        <target state="new">Source {0}: '{1}'</target>
+        <target state="translated">Źródło {0}: „{1}”</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
         <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">Dane {3} wejściowe „{0}” ({1}) zostały zmodyfikowane od czasu ostatniego sprawdzenia aktualności ({2}), nieaktualne.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
         <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">Dane {4} wejściowe „{0}” są nowsze ({1}) niż najwcześniejsze dane wyjściowe „{2}” ({3}), nieaktualne.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_UpToDate">
         <source>Project is up-to-date.</source>
-        <target state="new">Project is up-to-date.</target>
+        <target state="translated">Projekt jest aktualny.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
         <source>Write timestamp on output marker is {0} on '{1}'.</source>
-        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <target state="translated">Sygnatura czasowa zapisu w znaczniku danych wyjściowych jest {0} na „{1}”.</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
@@ -348,7 +348,7 @@ Ten projekt został załadowany przy użyciu nieprawidłowego typu projektu, pra
       </trans-unit>
       <trans-unit id="Property_NoneValue">
         <source>(None)</source>
-        <target state="new">(None)</target>
+        <target state="translated">(Brak)</target>
         <note>Special value to show in the project property pages when a property has no value.</note>
       </trans-unit>
       <trans-unit id="SdkNodeName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
@@ -9,257 +9,257 @@
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
         <source>Adding input reference copy markers:</source>
-        <target state="new">Adding input reference copy markers:</target>
+        <target state="translated">Adicionando marcadores de cópia de referência de entrada:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingNewestImportInput">
         <source>Adding newest import input:</source>
-        <target state="new">Adding newest import input:</target>
+        <target state="translated">Adicionando entrada de importação mais recente:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
         <source>Adding output reference copy marker:</source>
-        <target state="new">Adding output reference copy marker:</target>
+        <target state="translated">Adicionando marcador de cópia de referência de saída:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingProjectFileInputs">
         <source>Adding project file inputs:</source>
-        <target state="new">Adding project file inputs:</target>
+        <target state="translated">Adicionando entradas de arquivo de projeto:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
-        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <target state="translated">Adicionando {0} entradas em Set="{1}":</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputs_1">
         <source>Adding {0} inputs:</source>
-        <target state="new">Adding {0} inputs:</target>
+        <target state="translated">Adicionando {0} entradas:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
         <source>Adding {0} outputs in Set="{1}":</source>
-        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <target state="translated">Adicionando saídas {0} em Set="{1}":</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputs_1">
         <source>Adding {0} outputs:</source>
-        <target state="new">Adding {0} outputs:</target>
+        <target state="translated">Adicionando {0} saídas:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} item adicionado '{1}' (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} item removido '{1}' (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
-        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <target state="translated">Verificando o arquivo de saída copiado (UpToDateCheckBuilt com propriedade Original):</target>
         <note>Do not translate UpToDateCheckBuilt or Original.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
         <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <target state="translated">O destino '{0}' não existe para a cópia de '{1}', não atualizado.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
         <source>Source is newer than build output destination, not up-to-date.</source>
-        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <target state="translated">A origem é mais recente do que o destino de saída do build, não atualizada.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
         <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <target state="translated">A origem '{0}' não existe para copiar para '{1}', não atualizado.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">O destino '{0}' não existe, não atualizado.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">A origem '{0}' não existe, não atualizada.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
         <source>Checking PreserveNewest file '{0}':</source>
-        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <target state="translated">Verificando o arquivo PreserveNewest '{0}':</target>
         <note>Do not translate PreserveNewest. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
         <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
-        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <target state="translated">A origem PreserveNewest '{0}' é mais recente do que o destino '{1}', não atualizada.</target>
         <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
         <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
-        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <target state="translated">Comparando carimbos de data/hora de entradas e saídas em Set="{0}":</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_Completed">
         <source>Up-to-date check completed in {0:N1} ms</source>
-        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <target state="translated">Verificação de atualização concluída em {0:N1} ms</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_1">
         <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
-        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <target state="translated">O item '{0}' tem CopyToOutputDirectory definido como 'Always', não atualizado.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
         <source>Critical build tasks are running, not up-to-date.</source>
-        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <target state="translated">Tarefas críticas de build estão em execução, não atualizadas.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
         <source>Destination {0}: '{1}'</source>
-        <target state="new">Destination {0}: '{1}'</target>
+        <target state="translated">Destino {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
         <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
-        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <target state="translated">A propriedade 'DisableFastUpToDateCheck' é 'true', não atualizada.</target>
         <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_Exception_1">
         <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
-        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <target state="translated">A verificação de atualização a gerou uma exceção. Não atualizada. {0}</target>
         <note>{0} is the exception message.</note>
       </trans-unit>
       <trans-unit id="FUTD_FirstRun">
         <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
-        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <target state="translated">A verificação de atualização ainda não foi executada para este projeto. Não atualizada.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_IgnoringKinds_1">
         <source>Ignoring up-to-date check items with Kind="{0}"</source>
-        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <target state="translated">Ignorando itens de verificação atualizados com Kind="{0}”</target>
         <note>Do not translate Kind. {0} is the kind name.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
         <source>Input marker is newer than output marker, not up-to-date.</source>
-        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <target state="translated">O marcador de entrada é mais recente do que o marcador de saída, não atualizado.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
         <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">A entrada '{0}' ({1}) foi modificada desde a última verificação de atualização ({2}), não atualizada.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
         <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">A entrada '{0}' é mais recente ({1}) do que a saída mais antiga '{2}' ({3}), não atualizada.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
         <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
-        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <target state="translated">O carimbo de data/hora no marcador de entrada é {0} em '{1}'.</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefined">
         <source>No build outputs defined.</source>
-        <target state="new">No build outputs defined.</target>
+        <target state="translated">Nenhuma saída de build definida.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
         <source>No build outputs defined in Set="{0}".</source>
-        <target state="new">No build outputs defined in Set="{0}".</target>
+        <target state="translated">Nenhuma saída de build definida em Set="{0}”.</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputMarkersExist">
         <source>No input markers exist, skipping marker check.</source>
-        <target state="new">No input markers exist, skipping marker check.</target>
+        <target state="translated">Não há marcadores de entrada, ignorando a verificação de marcador.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefined">
         <source>No inputs defined.</source>
-        <target state="new">No inputs defined.</target>
+        <target state="translated">Nenhuma entrada definida.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefinedInSet_1">
         <source>No inputs defined in Set="{0}".</source>
-        <target state="new">No inputs defined in Set="{0}".</target>
+        <target state="translated">Nenhuma entrada definida em Set="{0}”.</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
         <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">Em Set="{4}", nenhuma entrada é mais recente do que a saída mais antiga '{0}' ({1}). A entrada mais recente é '{2}' ({3}).</target>
         <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
         <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">Nenhuma entrada é mais recente do que a saída mais antiga '{0}' ({1}). A entrada mais recente é '{2}' ({3}).</target>
         <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoOutputMarkerExists_1">
         <source>Output marker '{0}' does not exist, skipping marker check.</source>
-        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <target state="translated">O marcador de saída '{0}' não existe, ignorando a verificação de marcador.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredInputNotFound_1">
         <source>Input '{0}' does not exist, but is not required.</source>
-        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <target state="translated">A entrada '{0}' não existe, mas não é necessária.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
-        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <target state="translated">O item '{0}' de entrada {1} não existe, mas não é necessário.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">A saída '{0}' não existe, não atualizada.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredInputNotFound_1">
         <source>Input '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">A entrada '{0}' e é necessária, não atualizada.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">O item '{0}' de entrada {1} não existe e é necessário, não atualizado.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
         <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <target state="translated">O conjunto de itens de projeto foi alterado mais recentemente ({0}) do que a saída mais antiga '{1}' ({2}), não atualizada.</target>
         <note>{0} and {2} are datetimes. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
-        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <target state="translated">Ignorando '{0}' com Kind="{1}"</target>
         <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
       </trans-unit>
       <trans-unit id="FUTD_SourceFileTimeAndPath_2">
         <source>Source {0}: '{1}'</source>
-        <target state="new">Source {0}: '{1}'</target>
+        <target state="translated">Origem {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
         <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">O item '{0}' de entrada {3} ({1}) foi modificado desde a última verificação de atualização ({2}), não atualizado.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
         <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">O item '{0}' de entrada {4} é mais recente ({1}) do que a saída mais antiga '{2}' ({3}), não atualizado.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_UpToDate">
         <source>Project is up-to-date.</source>
-        <target state="new">Project is up-to-date.</target>
+        <target state="translated">O projeto está atualizado.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
         <source>Write timestamp on output marker is {0} on '{1}'.</source>
-        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <target state="translated">O carimbo de data/hora de gravação no marcador de saída é {0} em '{1}'.</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="ImportsTreeNodeName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
@@ -9,257 +9,257 @@
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
         <source>Adding input reference copy markers:</source>
-        <target state="new">Adding input reference copy markers:</target>
+        <target state="translated">Добавление маркеров копирования ссылок на входные данные:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingNewestImportInput">
         <source>Adding newest import input:</source>
-        <target state="new">Adding newest import input:</target>
+        <target state="translated">Добавление новейших входных данных импорта:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
         <source>Adding output reference copy marker:</source>
-        <target state="new">Adding output reference copy marker:</target>
+        <target state="translated">Добавление маркера копирования ссылок на выходные данные:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingProjectFileInputs">
         <source>Adding project file inputs:</source>
-        <target state="new">Adding project file inputs:</target>
+        <target state="translated">Добавление входных данных файла проекта:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
-        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <target state="translated">Добавление входных данных {0} в Set="{1}":</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputs_1">
         <source>Adding {0} inputs:</source>
-        <target state="new">Adding {0} inputs:</target>
+        <target state="translated">Добавление входных данных {0}:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
         <source>Adding {0} outputs in Set="{1}":</source>
-        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <target state="translated">Добавление выходных данных {0} в Set="{1}":</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputs_1">
         <source>Adding {0} outputs:</source>
-        <target state="new">Adding {0} outputs:</target>
+        <target state="translated">Добавление выходных данных {0}:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">Элемент {0} добавил "{1}" (CopyType={2}, TargetPath="{3}")</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">Элемент {0} удалил "{1}" (CopyType={2}, TargetPath="{3}")</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
-        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <target state="translated">Проверка скопированного выходного файла (UpToDateCheckBuilt со свойством Original):</target>
         <note>Do not translate UpToDateCheckBuilt or Original.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
         <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <target state="translated">Назначение "{0}" не существует для копирования из "{1}". Обновление не выполнено.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
         <source>Source is newer than build output destination, not up-to-date.</source>
-        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <target state="translated">Источник новее, чем целевой выходной объект сборки. Обновление не выполнено.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
         <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <target state="translated">Источник "{0}" не существует для копирования в "{1}". Обновление не выполнено.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Назначение "{0}" не существует. Обновление не выполнено.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Источник "{0}" не существует. Обновление не выполнено.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
         <source>Checking PreserveNewest file '{0}':</source>
-        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <target state="translated">Проверка файла PreserveNewest "{0}":</target>
         <note>Do not translate PreserveNewest. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
         <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
-        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <target state="translated">Источник PreserveNewest "{0}" новее, чем назначение "{1}". Обновление не выполнено.</target>
         <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
         <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
-        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <target state="translated">Сравнение меток времени входных и выходных данных в Set="{0}":</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_Completed">
         <source>Up-to-date check completed in {0:N1} ms</source>
-        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <target state="translated">Проверка актуальности завершена за {0:N1} мс</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_1">
         <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
-        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <target state="translated">Параметру CopyToOutputDirectory элемента "{0}" присвоено значение Always. Обновление не выполнено.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
         <source>Critical build tasks are running, not up-to-date.</source>
-        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <target state="translated">Критические задачи сборки запущены. Обновление не выполнено.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
         <source>Destination {0}: '{1}'</source>
-        <target state="new">Destination {0}: '{1}'</target>
+        <target state="translated">Назначение {0}: "{1}"</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
         <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
-        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <target state="translated">Свойству DisableFastUpToDateCheck присвоено значение true. Обновление не выполнено.</target>
         <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_Exception_1">
         <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
-        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <target state="translated">При проверке актуальности возникло исключение. Обновление не выполнено. {0}</target>
         <note>{0} is the exception message.</note>
       </trans-unit>
       <trans-unit id="FUTD_FirstRun">
         <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
-        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <target state="translated">Для этого проекта еще не запускалась проверка актуальности. Обновление не выполнено.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_IgnoringKinds_1">
         <source>Ignoring up-to-date check items with Kind="{0}"</source>
-        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <target state="translated">Пропуск элементов проверки актуальности с Kind="{0}"</target>
         <note>Do not translate Kind. {0} is the kind name.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
         <source>Input marker is newer than output marker, not up-to-date.</source>
-        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <target state="translated">Входной маркер новее выходного маркера. Обновление не выполнено.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
         <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">Входные данные "{0}" ({1}) были изменены с момента последней проверки актуальности ({2}). Обновление не выполнено.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
         <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">Входные данные "{0}" новее ({1}), чем самые ранние выходные данные "{2}" ({3}). Обновление не выполнено.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
         <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
-        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <target state="translated">Последняя метка времени записи в маркере входных данных — {0} в "{1}".</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefined">
         <source>No build outputs defined.</source>
-        <target state="new">No build outputs defined.</target>
+        <target state="translated">Выходные данные сборки не определены.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
         <source>No build outputs defined in Set="{0}".</source>
-        <target state="new">No build outputs defined in Set="{0}".</target>
+        <target state="translated">Выходные данные сборки не определены в Set="{0}".</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputMarkersExist">
         <source>No input markers exist, skipping marker check.</source>
-        <target state="new">No input markers exist, skipping marker check.</target>
+        <target state="translated">Входные маркеры не существуют. Проверка маркера пропускается.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefined">
         <source>No inputs defined.</source>
-        <target state="new">No inputs defined.</target>
+        <target state="translated">Входные данные не заданы.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefinedInSet_1">
         <source>No inputs defined in Set="{0}".</source>
-        <target state="new">No inputs defined in Set="{0}".</target>
+        <target state="translated">Входные данные не заданы в Set="{0}".</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
         <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">В Set="{4}" нет входных данных новее, чем самые ранние выходные данные "{0}" ({1}). Самые новые входные данные: "{2}" ({3}).</target>
         <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
         <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">Отсутствуют входные данные новее, чем самые ранние выходные данные "{0}" ({1}). Самые новые входные данные: "{2}" ({3}).</target>
         <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoOutputMarkerExists_1">
         <source>Output marker '{0}' does not exist, skipping marker check.</source>
-        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <target state="translated">Выходной маркер "{0}" не существует. Проверка маркера пропускается.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredInputNotFound_1">
         <source>Input '{0}' does not exist, but is not required.</source>
-        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <target state="translated">Входные данные "{0}" не существуют и не являются обязательными.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
-        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <target state="translated">Элемент "{0}" входных данных {1} не существует и не является обязательным.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Выходные данные "{0}" не существуют. Обновление не выполнено.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredInputNotFound_1">
         <source>Input '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">Входные данные "{0}" не существуют и являются обязательными. Обновление не выполнено.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">Элемент "{0}" входных данных {1} не существует и является обязательным. Обновление не выполнено.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
         <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <target state="translated">Набор элементов проекта изменен позднее ({0}) самых ранних выходных данных "{1}" ({2}). Обновление не выполнено.</target>
         <note>{0} and {2} are datetimes. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
-        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <target state="translated">Пропуск "{0}" с пропущенным Kind="{1}"</target>
         <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
       </trans-unit>
       <trans-unit id="FUTD_SourceFileTimeAndPath_2">
         <source>Source {0}: '{1}'</source>
-        <target state="new">Source {0}: '{1}'</target>
+        <target state="translated">Источник {0}: "{1}"</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
         <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">Элемент "{0}" ({1}) входных данных {3} был изменен с момента последней проверки актуальности ({2}). Обновление не выполнено.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
         <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">Элемент "{0}" входных данных {4} новее ({1}), чем самые ранние выходные данные "{2}" ({3}). Обновление не выполнено.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_UpToDate">
         <source>Project is up-to-date.</source>
-        <target state="new">Project is up-to-date.</target>
+        <target state="translated">Проект обновлен.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
         <source>Write timestamp on output marker is {0} on '{1}'.</source>
-        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <target state="translated">Метка времени записи в выходном маркере {0} в "{1}".</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="ImportsTreeNodeName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
@@ -9,257 +9,257 @@
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
         <source>Adding input reference copy markers:</source>
-        <target state="new">Adding input reference copy markers:</target>
+        <target state="translated">Giriş başvurusu kopyalama işaretçileri ekleniyor:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingNewestImportInput">
         <source>Adding newest import input:</source>
-        <target state="new">Adding newest import input:</target>
+        <target state="translated">En yeni içeri aktarma girişi ekleniyor:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
         <source>Adding output reference copy marker:</source>
-        <target state="new">Adding output reference copy marker:</target>
+        <target state="translated">Çıkış başvurusu kopyalama işaretçisi ekleniyor:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingProjectFileInputs">
         <source>Adding project file inputs:</source>
-        <target state="new">Adding project file inputs:</target>
+        <target state="translated">Proje dosyası girişleri ekleniyor:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
-        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <target state="translated">{0} girişleri Set="{1}" içine ekleniyor:</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputs_1">
         <source>Adding {0} inputs:</source>
-        <target state="new">Adding {0} inputs:</target>
+        <target state="translated">{0} girişleri ekleniyor:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
         <source>Adding {0} outputs in Set="{1}":</source>
-        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <target state="translated">Set="{1}" içine {0} çıkışları ekleniyor:</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputs_1">
         <source>Adding {0} outputs:</source>
-        <target state="new">Adding {0} outputs:</target>
+        <target state="translated">{0} çıkışları ekleniyor:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} öğesi '{1}' ekledi (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} öğesi '{1}' dosya yolunu kaldırdı (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
-        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <target state="translated">Kopyalanan çıkış (Original özelliğine sahip UpToDateCheckBuilt) dosyası denetleniyor:</target>
         <note>Do not translate UpToDateCheckBuilt or Original.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
         <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <target state="translated">'{1}' dosya yolundan kopyalama için '{0}' hedefi yok ve güncel değil.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
         <source>Source is newer than build output destination, not up-to-date.</source>
-        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <target state="translated">Kaynak, derleme çıkışı hedefinden daha yeni ancak güncel değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
         <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <target state="translated">'{1}' yoluna kopyalama için '{0}' kaynağı yok ve güncel değil.</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">'{0}' hedefi yok ve güncel değil.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">'{0}' kaynağı yok ve güncel değil.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
         <source>Checking PreserveNewest file '{0}':</source>
-        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <target state="translated">PreserveNewest dosya boyutu ('{0}') denetleniyor:</target>
         <note>Do not translate PreserveNewest. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
         <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
-        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <target state="translated">'{0}' PreserveNewest kaynağı, '{1}' hedefinden daha yeni ancak güncel değil.</target>
         <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
         <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
-        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <target state="translated">Set="{0}" içinde giriş ve çıkışların zaman damgaları karşılaştırılıyor:</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_Completed">
         <source>Up-to-date check completed in {0:N1} ms</source>
-        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <target state="translated">Güncel denetim {0:N1} ms içinde tamamlandı</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_1">
         <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
-        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <target state="translated">'{0}' öğesi 'Always' olarak ayarlanmış CopyToOutputDirectory’e sahip ancak güncel değil.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
         <source>Critical build tasks are running, not up-to-date.</source>
-        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <target state="translated">Kritik derleme görevleri çalışıyor ancak güncel değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
         <source>Destination {0}: '{1}'</source>
-        <target state="new">Destination {0}: '{1}'</target>
+        <target state="translated">{0} hedefi: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
         <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
-        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <target state="translated">'DisableFastUpToDateCheck' özelliği 'true' ancak güncel değil.</target>
         <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_Exception_1">
         <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
-        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <target state="translated">Güncel denetim bir özel durum oluşturdu ancak güncel değil. {0}</target>
         <note>{0} is the exception message.</note>
       </trans-unit>
       <trans-unit id="FUTD_FirstRun">
         <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
-        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <target state="translated">Bu proje için henüz güncel denetim çalıştırılmadı. Güncel değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_IgnoringKinds_1">
         <source>Ignoring up-to-date check items with Kind="{0}"</source>
-        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <target state="translated">Kind="{0}" ile güncel denetim öğeleri yoksayılıyor</target>
         <note>Do not translate Kind. {0} is the kind name.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
         <source>Input marker is newer than output marker, not up-to-date.</source>
-        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <target state="translated">Giriş işaretçisi, çıkış işaretçisinden daha yeni ancak güncel değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
         <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">'{0}' girişi ({1}) son güncelleştirme denetiminden ({2}) bu yana değiştirildi ancak güncel değil.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
         <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">'{0}' girişi, en erken '{2}' ({3}) çıkışından daha yeni ({1}) ancak güncel değil.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
         <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
-        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <target state="translated">Giriş işaretçisindeki en son yazma zaman damgası '{1}' üzerindeki {0}.</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefined">
         <source>No build outputs defined.</source>
-        <target state="new">No build outputs defined.</target>
+        <target state="translated">Derleme çıkışı tanımlanmadı.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
         <source>No build outputs defined in Set="{0}".</source>
-        <target state="new">No build outputs defined in Set="{0}".</target>
+        <target state="translated">Set="{0}" içinde derleme çıkışı tanımlanmadı.</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputMarkersExist">
         <source>No input markers exist, skipping marker check.</source>
-        <target state="new">No input markers exist, skipping marker check.</target>
+        <target state="translated">Giriş işaretçisi yok, işaretçi denetimi atlanıyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefined">
         <source>No inputs defined.</source>
-        <target state="new">No inputs defined.</target>
+        <target state="translated">Giriş tanımlanmadı.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefinedInSet_1">
         <source>No inputs defined in Set="{0}".</source>
-        <target state="new">No inputs defined in Set="{0}".</target>
+        <target state="translated">Set="{0}" içinde giriş tanımlanmadı.</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
         <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">Set="{4}" içinde, en erken '{0}' ({1}) çıkışından daha yeni giriş yok. En yeni giriş '{2}' ({3}).</target>
         <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
         <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">En erken '{0}' ({1}) çıkışından daha yeni giriş yok. En yeni giriş '{2}' ({3}).</target>
         <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoOutputMarkerExists_1">
         <source>Output marker '{0}' does not exist, skipping marker check.</source>
-        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <target state="translated">'{0}' çıkış işaretçisi yok, işaretçi denetimi atlanıyor.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredInputNotFound_1">
         <source>Input '{0}' does not exist, but is not required.</source>
-        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <target state="translated">'{0}' girişi yok ancak gerekli değil.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
-        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <target state="translated">{1} girişinin '{0}' öğesi yok ancak gerekli değil.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">'{0}' çıkışı yok ve güncel değil.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredInputNotFound_1">
         <source>Input '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">'{0}' girişi yok ve gerekiyor ancak güncel değil.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">{1} girişinin '{0}' öğesi yok ve gerekiyor ancak güncel değil.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
         <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <target state="translated">Proje öğeleri grubu, en eski '{1}' ({2}) çıkışından daha yakın zamanda ({0}) değiştirildi ancak güncel değil.</target>
         <note>{0} and {2} are datetimes. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
-        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <target state="translated">Yoksayılan Kind="{1}" ile '{0}' atlanıyor</target>
         <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
       </trans-unit>
       <trans-unit id="FUTD_SourceFileTimeAndPath_2">
         <source>Source {0}: '{1}'</source>
-        <target state="new">Source {0}: '{1}'</target>
+        <target state="translated">{0} kaynağı: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
         <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">{3} girişinin '{0}' ({1}) öğesi son güncelleştirme denetiminden ({2}) bu yana değiştirildi ancak güncel değil.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
         <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">{4} girişinin '{0}' öğesi en erken '{2}' ({3}) çıkışından daha yeni ({1}) ancak güncel değil.</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_UpToDate">
         <source>Project is up-to-date.</source>
-        <target state="new">Project is up-to-date.</target>
+        <target state="translated">Proje güncel.</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
         <source>Write timestamp on output marker is {0} on '{1}'.</source>
-        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <target state="translated">Çıkış işaretçisindeki yazma zaman damgası '{1}' üzerinde {0}.</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
@@ -348,7 +348,7 @@ Bu proje, muhtemelen proje uzantısının Visual Studio dışında yeniden adlan
       </trans-unit>
       <trans-unit id="Property_NoneValue">
         <source>(None)</source>
-        <target state="new">(None)</target>
+        <target state="translated">(Hiçbiri)</target>
         <note>Special value to show in the project property pages when a property has no value.</note>
       </trans-unit>
       <trans-unit id="SdkNodeName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
@@ -9,257 +9,257 @@
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
         <source>Adding input reference copy markers:</source>
-        <target state="new">Adding input reference copy markers:</target>
+        <target state="translated">正在添加输入引用副本标记：</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingNewestImportInput">
         <source>Adding newest import input:</source>
-        <target state="new">Adding newest import input:</target>
+        <target state="translated">正在添加最新的导入输入：</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
         <source>Adding output reference copy marker:</source>
-        <target state="new">Adding output reference copy marker:</target>
+        <target state="translated">正在添加输出引用副本标记：</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingProjectFileInputs">
         <source>Adding project file inputs:</source>
-        <target state="new">Adding project file inputs:</target>
+        <target state="translated">正在添加项目文件输入：</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
-        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <target state="translated">正在 Set="{1}" 中添加 {0} 个输入：</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputs_1">
         <source>Adding {0} inputs:</source>
-        <target state="new">Adding {0} inputs:</target>
+        <target state="translated">正在添加 {0} 个输入：</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
         <source>Adding {0} outputs in Set="{1}":</source>
-        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <target state="translated">正在 Set="{1}" 中添加 {0} 个输出：</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputs_1">
         <source>Adding {0} outputs:</source>
-        <target state="new">Adding {0} outputs:</target>
+        <target state="translated">正在添加 {0} 个输出：</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} 项已添加 '{1}' (CopyType={2}，TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} 项已删除'{1}' (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
-        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <target state="translated">正在检查复制的输出（使用原始属性生成 UpToDateCheckBuilt）文件：</target>
         <note>Do not translate UpToDateCheckBuilt or Original.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
         <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <target state="translated">从'{1}'复制的目标'{0}'不存在，不是最新的。</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
         <source>Source is newer than build output destination, not up-to-date.</source>
-        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <target state="translated">源比生成输出目标新，不是最新的。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
         <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <target state="translated">源 '{0}' 不存在，无法复制到 '{1}'，不是最新的。</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">目标 '{0}' 不存在，不是最新的。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">源 '{0}' 不存在，不是最新的。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
         <source>Checking PreserveNewest file '{0}':</source>
-        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <target state="translated">正在检查 PreserveNewest 文件'{0}'：</target>
         <note>Do not translate PreserveNewest. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
         <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
-        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <target state="translated">PreserveNewest 源 '{0}' 比目标 '{1}' 新，不是最新的。</target>
         <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
         <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
-        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <target state="translated">比较 Set="{0}" 中的输入和输出时间戳：</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_Completed">
         <source>Up-to-date check completed in {0:N1} ms</source>
-        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <target state="translated">最新检查已在 {0:N1} 毫秒内完成</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_1">
         <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
-        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <target state="translated">项 '{0}' 已将 CopyToOutputDirectory 设置为 'Always'，不是最新的。</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
         <source>Critical build tasks are running, not up-to-date.</source>
-        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <target state="translated">关键生成任务正在运行，不是最新的。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
         <source>Destination {0}: '{1}'</source>
-        <target state="new">Destination {0}: '{1}'</target>
+        <target state="translated">目标 {0}： '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
         <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
-        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <target state="translated">'DisableFastUpToDateCheck' 属性为 'true'，不是最新的。</target>
         <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_Exception_1">
         <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
-        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <target state="translated">最新检查引发了异常。不是最新的。{0}</target>
         <note>{0} is the exception message.</note>
       </trans-unit>
       <trans-unit id="FUTD_FirstRun">
         <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
-        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <target state="translated">尚未为此项目运行最新检查。不是最新的。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_IgnoringKinds_1">
         <source>Ignoring up-to-date check items with Kind="{0}"</source>
-        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <target state="translated">正在忽略 Kind="{0}" 的最新检查项</target>
         <note>Do not translate Kind. {0} is the kind name.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
         <source>Input marker is newer than output marker, not up-to-date.</source>
-        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <target state="translated">输入标记比输出标记新，不是最新的。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
         <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">自上次最新检查 ({1})以来，已修改输入'{0}' ({2})，不是最新的。</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
         <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">输入 '{0}' 比最早的输出 '{2}' ({3}) 新 ({1}) ，不是最新的。</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
         <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
-        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <target state="translated">输入标记上的最新写入时间戳是 '{1}' 上的 {0}。</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefined">
         <source>No build outputs defined.</source>
-        <target state="new">No build outputs defined.</target>
+        <target state="translated">未定义生成输出。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
         <source>No build outputs defined in Set="{0}".</source>
-        <target state="new">No build outputs defined in Set="{0}".</target>
+        <target state="translated">Set="{0}" 中未定义生成输出。</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputMarkersExist">
         <source>No input markers exist, skipping marker check.</source>
-        <target state="new">No input markers exist, skipping marker check.</target>
+        <target state="translated">不存在输入标记，正在跳过标记检查。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefined">
         <source>No inputs defined.</source>
-        <target state="new">No inputs defined.</target>
+        <target state="translated">未定义输入。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefinedInSet_1">
         <source>No inputs defined in Set="{0}".</source>
-        <target state="new">No inputs defined in Set="{0}".</target>
+        <target state="translated">Set="{0}" 中未定义任何输入。</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
         <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">在 Set="{4}" 中，没有比最早输出'{0}' ({1})更新的输入。最新的输入为'{2}' ({3})。</target>
         <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
         <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">输入不早于最早输出'{0}' ({1})。最新的输入为 '{2}' ({3})。</target>
         <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoOutputMarkerExists_1">
         <source>Output marker '{0}' does not exist, skipping marker check.</source>
-        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <target state="translated">输出标记 '{0}' 不存在，正在跳过标记检查。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredInputNotFound_1">
         <source>Input '{0}' does not exist, but is not required.</source>
-        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <target state="translated">输入'{0}'不存在，但不需要。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
-        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <target state="translated">输入{1}项'{0}'不存在，但不需要。</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">输出 '{0}' 不存在，不是最新的。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredInputNotFound_1">
         <source>Input '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">输入 '{0}' 不存在并且是必需的，不是最新的。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">输入 {1} 项'{0}'不存在且是必需的，不是最新的。</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
         <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <target state="translated">项目项集最近更改的 ({0})早于最早输出'{1}' ({2})，不是最新的。</target>
         <note>{0} and {2} are datetimes. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
-        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <target state="translated">正在跳过已忽略 Kind="{1}" 的'{0}'</target>
         <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
       </trans-unit>
       <trans-unit id="FUTD_SourceFileTimeAndPath_2">
         <source>Source {0}: '{1}'</source>
-        <target state="new">Source {0}: '{1}'</target>
+        <target state="translated">源 {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
         <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">输入{3}项'{0}' ({1}) 自上次最新检查 ({2})以来已修改，不是最新的。</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
         <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">输入{4}项 '{0}' 比最早输出'{1}' ({2})新 ({3})，不是最新的。</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_UpToDate">
         <source>Project is up-to-date.</source>
-        <target state="new">Project is up-to-date.</target>
+        <target state="translated">项目已是最新。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
         <source>Write timestamp on output marker is {0} on '{1}'.</source>
-        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <target state="translated">输出标记上写入时间戳为 '{1}'上的 {0}。</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="ImportsTreeNodeName">
@@ -348,7 +348,7 @@ This project was loaded using the wrong project type, likely as a result of rena
       </trans-unit>
       <trans-unit id="Property_NoneValue">
         <source>(None)</source>
-        <target state="new">(None)</target>
+        <target state="translated">(无)</target>
         <note>Special value to show in the project property pages when a property has no value.</note>
       </trans-unit>
       <trans-unit id="SdkNodeName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
@@ -9,257 +9,257 @@
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
         <source>Adding input reference copy markers:</source>
-        <target state="new">Adding input reference copy markers:</target>
+        <target state="translated">正在新增輸入參考複製標記:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingNewestImportInput">
         <source>Adding newest import input:</source>
-        <target state="new">Adding newest import input:</target>
+        <target state="translated">正在新增最新的匯入輸入:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingOutputReferenceCopyMarker">
         <source>Adding output reference copy marker:</source>
-        <target state="new">Adding output reference copy marker:</target>
+        <target state="translated">正在新增輸出參考複製標記:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingProjectFileInputs">
         <source>Adding project file inputs:</source>
-        <target state="new">Adding project file inputs:</target>
+        <target state="translated">正在新增專案檔案輸入:</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
-        <target state="new">Adding {0} inputs in Set="{1}":</target>
+        <target state="translated">正在 Set="{1}" 中新增 {0} 輸入:</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputs_1">
         <source>Adding {0} inputs:</source>
-        <target state="new">Adding {0} inputs:</target>
+        <target state="translated">正在新增 {0} 輸入:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputsInSet_2">
         <source>Adding {0} outputs in Set="{1}":</source>
-        <target state="new">Adding {0} outputs in Set="{1}":</target>
+        <target state="translated">正在在 Set="{1}" 中新增 {0} 輸出:</target>
         <note>{0} is an MSBuild item type. {1} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingTypedOutputs_1">
         <source>Adding {0} outputs:</source>
-        <target state="new">Adding {0} outputs:</target>
+        <target state="translated">正在新增 {0} 輸入:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} 項目已新增 '{1}' (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyType={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} 項目已移除 '{1}' (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
-        <target state="new">Checking copied output (UpToDateCheckBuilt with Original property) file:</target>
+        <target state="translated">正在檢查複製的輸出 (具有原始屬性的 UpToDateCheckBuilt) 檔案:</target>
         <note>Do not translate UpToDateCheckBuilt or Original.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileDestinationNotFound_2">
         <source>Destination '{0}' does not exist for copy from '{1}', not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist for copy from '{1}', not up-to-date.</target>
+        <target state="translated">目的地 '{0}' 不存在，無法從 '{1}' 複製，不是最新狀態。</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNewer">
         <source>Source is newer than build output destination, not up-to-date.</source>
-        <target state="new">Source is newer than build output destination, not up-to-date.</target>
+        <target state="translated">來源比組建輸出目的地更新，不是最新狀態。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFileSourceNotFound_2">
         <source>Source '{0}' does not exist for copy to '{1}', not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist for copy to '{1}', not up-to-date.</target>
+        <target state="translated">來源 '{0}' 不存在，無法複製到 '{1}'，不是最新狀態。</target>
         <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">目的地 '{0}' 不存在，不是最新狀態。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFileSourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">來源 '{0}' 不存在，不是最新狀態。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestFile_1">
         <source>Checking PreserveNewest file '{0}':</source>
-        <target state="new">Checking PreserveNewest file '{0}':</target>
+        <target state="translated">正在檢查 PreserveNewest 檔案 '{0}'：</target>
         <note>Do not translate PreserveNewest. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingPreserveNewestSourceNewerThanDestination_2">
         <source>PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</source>
-        <target state="new">PreserveNewest source '{0}' is newer than destination '{1}', not up-to-date.</target>
+        <target state="translated">PreserveNewest 來源 '{0}' 比目的地 '{1}' 新，不是最新狀態。</target>
         <note>Do not translate PreserveNewest. {0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
         <source>Comparing timestamps of inputs and outputs in Set="{0}":</source>
-        <target state="new">Comparing timestamps of inputs and outputs in Set="{0}":</target>
+        <target state="translated">正在比較 Set="{0}" 中輸入和輸出的時間戳記:</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_Completed">
         <source>Up-to-date check completed in {0:N1} ms</source>
-        <target state="new">Up-to-date check completed in {0:N1} ms</target>
+        <target state="translated">已在 {0:N1} 毫秒内完成最新的檢查</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_1">
         <source>Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</source>
-        <target state="new">Item '{0}' has CopyToOutputDirectory set to 'Always', not up-to-date.</target>
+        <target state="translated">項目 '{0}' 的 CopyToOutputDirectory 設定為 'Always'，不是最新狀態。</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always'. {0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
         <source>Critical build tasks are running, not up-to-date.</source>
-        <target state="new">Critical build tasks are running, not up-to-date.</target>
+        <target state="translated">重要的組建工作正在執行，不是最新狀態。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_DestinationFileTimeAndPath_2">
         <source>Destination {0}: '{1}'</source>
-        <target state="new">Destination {0}: '{1}'</target>
+        <target state="translated">目的地 {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_DisableFastUpToDateCheckTrue">
         <source>The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</source>
-        <target state="new">The 'DisableFastUpToDateCheck' property is 'true', not up-to-date.</target>
+        <target state="translated">'DisableFastUpToDateCheck' 屬性為 'true'，不是最新狀態。</target>
         <note>Do not translate 'DisableFastUpToDateCheck' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_Exception_1">
         <source>Up-to-date check threw an exception. Not up-to-date. {0}</source>
-        <target state="new">Up-to-date check threw an exception. Not up-to-date. {0}</target>
+        <target state="translated">最新檢查擲出例外狀況。不是最新狀態。{0}</target>
         <note>{0} is the exception message.</note>
       </trans-unit>
       <trans-unit id="FUTD_FirstRun">
         <source>The up-to-date check has not yet run for this project. Not up-to-date.</source>
-        <target state="new">The up-to-date check has not yet run for this project. Not up-to-date.</target>
+        <target state="translated">此專案尚未執行最新檢查。不是最新狀態。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_IgnoringKinds_1">
         <source>Ignoring up-to-date check items with Kind="{0}"</source>
-        <target state="new">Ignoring up-to-date check items with Kind="{0}"</target>
+        <target state="translated">正在略過 Kind="{0}" 的最新檢查項目</target>
         <note>Do not translate Kind. {0} is the kind name.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputMarkerNewerThanOutputMarker">
         <source>Input marker is newer than output marker, not up-to-date.</source>
-        <target state="new">Input marker is newer than output marker, not up-to-date.</target>
+        <target state="translated">輸入標記比輸出標記新，不是最新狀態。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
         <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">自上次最新檢查 ({2}) 以來，輸入 '{0}' ({1}) 已被修改，不是最新狀態。</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
         <source>Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">輸入 '{0}' 比最早的輸出 '{2}' ({3}) 新 ({1})，不是最新狀態。</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_LatestWriteTimeOnInputMarker_2">
         <source>Latest write timestamp on input marker is {0} on '{1}'.</source>
-        <target state="new">Latest write timestamp on input marker is {0} on '{1}'.</target>
+        <target state="translated">輸入標記上的最新寫入時間戳記是 {0}，'{1}'。</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefined">
         <source>No build outputs defined.</source>
-        <target state="new">No build outputs defined.</target>
+        <target state="translated">未定義任何組建輸出。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoBuildOutputDefinedInSet_1">
         <source>No build outputs defined in Set="{0}".</source>
-        <target state="new">No build outputs defined in Set="{0}".</target>
+        <target state="translated">Set="{0}" 中未定義任何組建輸出。</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputMarkersExist">
         <source>No input markers exist, skipping marker check.</source>
-        <target state="new">No input markers exist, skipping marker check.</target>
+        <target state="translated">沒有輸入標記存在，正在略過標記檢查。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefined">
         <source>No inputs defined.</source>
-        <target state="new">No inputs defined.</target>
+        <target state="translated">未定義任何輸入。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_NoInputsDefinedInSet_1">
         <source>No inputs defined in Set="{0}".</source>
-        <target state="new">No inputs defined in Set="{0}".</target>
+        <target state="translated">Set="{0}" 中未定義任何輸入</target>
         <note>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutputInSet_5">
         <source>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">在 Set="{4}" 中，沒有輸入比最早的輸出 '{0}' ({1}) 新。最新輸入是 '{2}' ({3})。</target>
         <note>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoInputsNewerThanEarliestOutput_4">
         <source>No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</source>
-        <target state="new">No inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</target>
+        <target state="translated">沒有輸入比最早的輸出 '{0}' ({1}) 新。最新輸入是 '{2}' ({3})。</target>
         <note>{0} and {2} are file paths. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_NoOutputMarkerExists_1">
         <source>Output marker '{0}' does not exist, skipping marker check.</source>
-        <target state="new">Output marker '{0}' does not exist, skipping marker check.</target>
+        <target state="translated">輸出標記 '{0}' 不存在，正在略過標記檢查。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredInputNotFound_1">
         <source>Input '{0}' does not exist, but is not required.</source>
-        <target state="new">Input '{0}' does not exist, but is not required.</target>
+        <target state="translated">輸入 '{0}' 不存在，但並非必要項目。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_NonRequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
-        <target state="new">Input {1} item '{0}' does not exist, but is not required.</target>
+        <target state="translated">輸入 {1} 項目 '{0}' 不存在，但並非必要項目。</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Output '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">輸出 '{0}' 不存在，不是最新狀態。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredInputNotFound_1">
         <source>Input '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">輸入 '{0}' 不存在且為必要項目，不是最新狀態。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_RequiredTypedInputNotFound_2">
         <source>Input {1} item '{0}' does not exist and is required, not up-to-date.</source>
-        <target state="new">Input {1} item '{0}' does not exist and is required, not up-to-date.</target>
+        <target state="translated">輸入 {1} 項目 '{0}' 不存在且為必要項目，不是最新狀態。</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
         <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="new">The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</target>
+        <target state="translated">專案項目集的變更時間 ({0}) 比最早的輸出 '{1}' ({2}) 更近，不是最新狀態。</target>
         <note>{0} and {2} are datetimes. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
-        <target state="new">Skipping '{0}' with ignored Kind="{1}"</target>
+        <target state="translated">在忽略 Kind="{1}" 的情況下略過 '{0}'</target>
         <note>Do not translate 'Kind' as this name is used in code. {0} is a file path. {2} is the name of the kind.</note>
       </trans-unit>
       <trans-unit id="FUTD_SourceFileTimeAndPath_2">
         <source>Source {0}: '{1}'</source>
-        <target state="new">Source {0}: '{1}'</target>
+        <target state="translated">來源 {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
         <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</target>
+        <target state="translated">自上次最新檢查 ({2}) 以來，輸入 {3} 項目 '{0}' ({1}) 已被修改，不是最新狀態。</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">
         <source>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</source>
-        <target state="new">Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</target>
+        <target state="translated">輸入 {4} 項目 '{0}' 比最早的輸出 '{2}' ({3}) 新 ({1})，不是最新狀態。</target>
         <note>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_UpToDate">
         <source>Project is up-to-date.</source>
-        <target state="new">Project is up-to-date.</target>
+        <target state="translated">專案是最新狀態。</target>
         <note />
       </trans-unit>
       <trans-unit id="FUTD_WriteTimeOnOutputMarker_2">
         <source>Write timestamp on output marker is {0} on '{1}'.</source>
-        <target state="new">Write timestamp on output marker is {0} on '{1}'.</target>
+        <target state="translated">輸出標記上的寫入時間戳記是 {0}，'{1}'。</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="ImportsTreeNodeName">


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/ceLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7833)