### PR TITLE
Enable external "related items" to use the interaction pattern

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AttachedCollectionItemBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AttachedCollectionItemBase.cs
@@ -27,7 +27,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     {
         // Other patterns we may wish to utilise in future are:
         //
-        // - IInvocationPattern
         // - ISupportExpansionEvents
         // - ISupportExpansionState
         // - IDragDropSourcePattern
@@ -43,7 +42,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         {
             typeof(ITreeDisplayItem),
             typeof(IBrowsablePattern),
-            typeof(IContextMenuPattern)
+            typeof(IContextMenuPattern),
+            typeof(IInvocationPattern)
         };
 
         public event PropertyChangedEventHandler? PropertyChanged;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AttachedCollectionItemBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AttachedCollectionItemBase.cs
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         protected virtual IContextMenuController? ContextMenuController => null;
 
-        TPattern IInteractionPatternProvider.GetPattern<TPattern>() where TPattern : class
+        public virtual TPattern? GetPattern<TPattern>() where TPattern : class
         {
             if (s_supportedPatterns.Contains(typeof(TPattern)))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AttachedCollectionItemBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AttachedCollectionItemBase.cs
@@ -101,14 +101,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         TPattern IInteractionPatternProvider.GetPattern<TPattern>() where TPattern : class
         {
-#pragma warning disable CS8603 // Possible null reference return. (https://github.com/dotnet/roslyn/issues/43619)
             if (s_supportedPatterns.Contains(typeof(TPattern)))
             {
                 return this as TPattern;
             }
 
             return null;
-#pragma warning restore CS8603 // Possible null reference return.
         }
 
         public virtual int CompareTo(object obj)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Shipped.txt
@@ -414,3 +414,4 @@ abstract Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColle
 abstract Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.RelationBase<TParent, TChild>.UpdateContainsCollection(TParent! parent, Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AggregateContainsRelationCollectionSpan! span) -> void
 ~static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.JSWebView2DebuggingAdditionalText.get -> string
 ~static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.chkJSWebView2DebuggingText.get -> string
+virtual Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AttachedCollectionItemBase.GetPattern<TPattern>() -> TPattern?


### PR DESCRIPTION
I am working to show `.props` and `.targets` files within NuGet package nodes in the Dependencies tree (#7838). It feels natural to want to double-click these to open them in the editor.

Currently that is not possible on the NuGet side as the explicit implementation of `IInteractionPatternProvider.GetPattern` could not be overridden. This PR changes that, however it will take a while for code to flow through to where I can consume it on the NuGet side. To avoid that delay, this PR also adds `IInvocationPattern` to the set of supported patterns. At runtime there is no behaviour change for types that do not actually implement IInvocationPattern. However those that do will now work correctly, meaning the NuGet scenario becomes unblocked.

The "interaction pattern" here means support for double-clicking nodes in the Dependencies tree.




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7837)