### PR TITLE
Impove up-to-date check logging for multi-targeting projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectConfigurationExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectConfigurationExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
@@ -51,6 +53,52 @@ namespace Microsoft.VisualStudio.ProjectSystem
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Produces a string containing each dimension's value, in idiomatic order (configuration, platform, then any targets),
+        /// such as <c>Debug|AnyCPU|net7.0</c>.
+        /// </summary>
+        /// <remarks>
+        /// Calling <c>ToString</c> on <see cref="ProjectConfiguration"/> excludes the target framework from the first configuration,
+        /// meaning it is not suitable when the full set of dimensions is needed.
+        /// </remarks>
+        /// <param name="projectConfiguration"></param>
+        /// <returns></returns>
+        internal static string GetDisplayString(this ProjectConfiguration projectConfiguration)
+        {
+            // ImmutableDictionary does not preserve order, so we manually produce the idiomatic order
+
+            IImmutableDictionary<string, string> dims = projectConfiguration.Dimensions;
+
+            var sb = new StringBuilder();
+
+            // Configuration and platform are always first
+            if (dims.TryGetValue(ConfigurationGeneral.ConfigurationProperty, out string? configuration))
+                Append(configuration);
+            if (dims.TryGetValue(ConfigurationGeneral.PlatformProperty, out string? platform))
+                Append(platform);
+
+            // Any other dimensions later
+            foreach ((string name, string value) in dims)
+            {
+                if (StringComparers.ConfigurationDimensionNames.Equals(name, ConfigurationGeneral.ConfigurationProperty) ||
+                    StringComparers.ConfigurationDimensionNames.Equals(name, ConfigurationGeneral.PlatformProperty))
+                {
+                    continue;
+                }
+
+                Append(value);
+            }
+
+            return sb.ToString();
+
+            void Append(string s)
+            {
+                if (sb.Length != 0)
+                    sb.Append('|');
+                sb.Append(s);
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
@@ -46,6 +46,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 };
             }
 
+            private static string GetResourceString(string resourceName)
+            {
+                string? message = Resources.ResourceManager.GetString(resourceName, Resources.Culture);
+
+                if (message is null)
+                {
+                    Assumes.Fail($"Resource with name '{resourceName}' not found.");
+                }
+
+                return message;
+            }
+
             private void Write(LogLevel level, string resourceName, object arg0)
             {
                 if (level <= Level)
@@ -54,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     // they correspond with dates/times that Explorer, etc shows
                     ConvertToLocalTime(ref arg0);
 
-                    string message = Resources.ResourceManager.GetString(resourceName, Resources.Culture);
+                    string message = GetResourceString(resourceName);
 
                     _writer.WriteLine($"{Preamble()}{string.Format(message, arg0)} ({_fileName})");
                 }
@@ -69,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     ConvertToLocalTime(ref arg0);
                     ConvertToLocalTime(ref arg1);
 
-                    string message = Resources.ResourceManager.GetString(resourceName, Resources.Culture);
+                    string message = GetResourceString(resourceName);
 
                     _writer.WriteLine($"{Preamble()}{string.Format(message, arg0, arg1)} ({_fileName})");
                 }
@@ -83,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     // they correspond with dates/times that Explorer, etc shows
                     ConvertToLocalTimes(values);
 
-                    string message = Resources.ResourceManager.GetString(resourceName, Resources.Culture);
+                    string message = GetResourceString(resourceName);
 
                     _writer.WriteLine($"{Preamble()}{string.Format(message, values)} ({_fileName})");
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -781,8 +781,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         }
                     }
 
+                    bool logConfigurations = state.ImplicitInputs.Length > 1 && logger.Level >= LogLevel.Info;
+
                     foreach (UpToDateCheckImplicitConfiguredInput implicitState in state.ImplicitInputs)
                     {
+                        if (logConfigurations)
+                        {
+                            // Only null when the FUTD check is disabled. If we get here, we are not disabled.
+                            Assumes.NotNull(implicitState.ProjectConfiguration);
+
+                            logger.Info(nameof(Resources.FUTD_CheckingConfiguration_1), implicitState.ProjectConfiguration.GetDisplayString());
+                            logger.Indent++;
+                        }
+
                         if (!CheckGlobalConditions(logger, lastCheckedAtUtc, validateFirstRun: !isValidationRun, implicitState) ||
                             !CheckInputsAndOutputs(logger, lastCheckedAtUtc, timestampCache, implicitState, ignoreKinds, token) ||
                             !CheckMarkers(logger, timestampCache, implicitState) ||
@@ -790,6 +801,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                             !CheckCopiedOutputFiles(logger, timestampCache, implicitState, token))
                         {
                             return false;
+                        }
+
+                        if (logConfigurations)
+                        {
+                            logger.Indent--;
                         }
                     }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -17,9 +17,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
     /// </remarks>
     internal sealed class UpToDateCheckImplicitConfiguredInput
     {
-        public static UpToDateCheckImplicitConfiguredInput Empty { get; } = new();
+        public static UpToDateCheckImplicitConfiguredInput CreateEmpty(ProjectConfiguration projectConfiguration)
+        {
+            return new UpToDateCheckImplicitConfiguredInput(projectConfiguration);
+        }
 
         public static UpToDateCheckImplicitConfiguredInput Disabled { get; } = new UpToDateCheckImplicitConfiguredInput(
+            projectConfiguration:                         null,
             msBuildProjectFullPath:                       null,
             msBuildProjectDirectory:                      null,
             copyUpToDateMarkerItem:                       null,
@@ -39,6 +43,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             lastItemChanges:                              ImmutableArray<(bool IsAdd, string ItemType, UpToDateCheckInputItem)>.Empty,
             itemHash:                                     null,
             wasStateRestored:                             false);
+
+        /// <summary>
+        /// Gets the project configuration for this configured data snapshot.
+        /// </summary>
+        /// <remarks>
+        /// Useful when a project multi-targets and we want to differentiate targets in log output.
+        /// <see langword="null"/> when the up-to-date check is disabled.
+        /// </remarks>
+        public ProjectConfiguration? ProjectConfiguration { get; }
 
         public string? MSBuildProjectFullPath { get; }
 
@@ -119,10 +132,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// </summary>
         public ImmutableArray<string> CopyReferenceInputs { get; }
 
-        private UpToDateCheckImplicitConfiguredInput()
+        private UpToDateCheckImplicitConfiguredInput(ProjectConfiguration? projectConfiguration)
         {
             var emptyItemBySetName = ImmutableDictionary.Create<string, ImmutableDictionary<string, ImmutableArray<string>>>(BuildUpToDateCheck.SetNameComparer);
 
+            ProjectConfiguration = projectConfiguration;
             LastItemsChangedAtUtc = DateTime.MinValue;
             InputSourceItemTypes = ImmutableArray<string>.Empty;
             InputSourceItemsByItemType = ImmutableDictionary.Create<string, ImmutableArray<UpToDateCheckInputItem>>(StringComparers.ItemTypes);
@@ -138,6 +152,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         }
 
         private UpToDateCheckImplicitConfiguredInput(
+            ProjectConfiguration? projectConfiguration,
             string? msBuildProjectFullPath,
             string? msBuildProjectDirectory,
             string? copyUpToDateMarkerItem,
@@ -158,6 +173,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             int? itemHash,
             bool wasStateRestored)
         {
+            ProjectConfiguration = projectConfiguration;
             MSBuildProjectFullPath = msBuildProjectFullPath;
             MSBuildProjectDirectory = msBuildProjectDirectory;
             CopyUpToDateMarkerItem = copyUpToDateMarkerItem;
@@ -322,6 +338,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             (ImmutableArray<string> resolvedCompilationReferencePaths, ImmutableArray<string> copyReferenceInputs) = UpdateResolvedCompilationReferences();
 
             return new(
+                ProjectConfiguration,
                 msBuildProjectFullPath,
                 msBuildProjectDirectory,
                 copyUpToDateMarkerItem: UpdateCopyUpToDateMarkerItem(),
@@ -513,6 +530,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         internal UpToDateCheckImplicitConfiguredInput WithLastItemsChangedAtUtc(DateTime lastItemsChangedAtUtc)
         {
             return new(
+                ProjectConfiguration,
                 MSBuildProjectFullPath,
                 MSBuildProjectDirectory,
                 CopyUpToDateMarkerItem,
@@ -537,6 +555,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         public UpToDateCheckImplicitConfiguredInput WithRestoredState(int itemHash, DateTime lastInputsChangedAtUtc)
         {
             return new(
+                ProjectConfiguration,
                 MSBuildProjectFullPath,
                 MSBuildProjectDirectory,
                 CopyUpToDateMarkerItem,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             // Initial state is empty. We will evolve this reference over time, updating it iteratively
             // on each new data update.
-            UpToDateCheckImplicitConfiguredInput state = UpToDateCheckImplicitConfiguredInput.Empty;
+            UpToDateCheckImplicitConfiguredInput state = UpToDateCheckImplicitConfiguredInput.CreateEmpty(_configuredProject.ProjectConfiguration);
 
             IPropagatorBlock<IProjectVersionedValue<UpdateValues>, IProjectVersionedValue<UpToDateCheckImplicitConfiguredInput>> transformBlock
                 = DataflowBlockSlim.CreateTransformBlock<IProjectVersionedValue<UpdateValues>, IProjectVersionedValue<UpToDateCheckImplicitConfiguredInput>>(TransformAsync);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
@@ -214,6 +214,15 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Checking configuration {0}:.
+        /// </summary>
+        internal static string FUTD_CheckingConfiguration_1 {
+            get {
+                return ResourceManager.GetString("FUTD_CheckingConfiguration_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Checking copied output (UpToDateCheckBuilt with Original property) file:.
         /// </summary>
         internal static string FUTD_CheckingCopiedOutputFile {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
@@ -386,4 +386,8 @@ This project was loaded using the wrong project type, likely as a result of rena
     <value>Up-to-date check completed in {0:N1} ms</value>
     <comment>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</comment>
   </data>
+  <data name="FUTD_CheckingConfiguration_1" xml:space="preserve">
+    <value>Checking configuration {0}:</value>
+    <comment>{0} is a description of the project's configuration, such as "Debug|AnyCPU|net6.0".</comment>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Položka {0} odebrána – {1} (CopyType={2}, TargetPath={3})</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingConfiguration_1">
+        <source>Checking configuration {0}:</source>
+        <target state="new">Checking configuration {0}:</target>
+        <note>{0} is a description of the project's configuration, such as "Debug|AnyCPU|net6.0".</note>
+      </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
         <target state="translated">Probíhá kontrola zkopírovaného výstupního souboru (UpToDateCheckBuilt s vlastností Original):</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
@@ -57,6 +57,11 @@
         <target state="translated">{0} Element wurde entfernt "{1}" (CopyType={2}, TargetPath="{3}")</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingConfiguration_1">
+        <source>Checking configuration {0}:</source>
+        <target state="new">Checking configuration {0}:</target>
+        <note>{0} is a description of the project's configuration, such as "Debug|AnyCPU|net6.0".</note>
+      </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
         <target state="translated">Die kopierte Ausgabedatei (UpToDateCheckBuilt mit originaler Eigenschaft) wird überprüft:</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
@@ -57,6 +57,11 @@
         <target state="translated">{0} elemento eliminado "{1}" (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingConfiguration_1">
+        <source>Checking configuration {0}:</source>
+        <target state="new">Checking configuration {0}:</target>
+        <note>{0} is a description of the project's configuration, such as "Debug|AnyCPU|net6.0".</note>
+      </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
         <target state="translated">Comprobación del archivo de salida copiado (UpToDateCheckBuilt con la propiedad original):</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">{0} élément supprimé '{1}' (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingConfiguration_1">
+        <source>Checking configuration {0}:</source>
+        <target state="new">Checking configuration {0}:</target>
+        <note>{0} is a description of the project's configuration, such as "Debug|AnyCPU|net6.0".</note>
+      </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
         <target state="translated">Vérification de la sortie copiée (UpToDateCheckBuilt avec la propriété Original) du fichier :</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
@@ -57,6 +57,11 @@
         <target state="translated">{0} elemento rimosso '{1}' (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingConfiguration_1">
+        <source>Checking configuration {0}:</source>
+        <target state="new">Checking configuration {0}:</target>
+        <note>{0} is a description of the project's configuration, such as "Debug|AnyCPU|net6.0".</note>
+      </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
         <target state="translated">Controllo del file di output copiato (UpToDateCheckBuilt con proprietà Original):</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
@@ -57,6 +57,11 @@
         <target state="translated">{0} アイテムが削除された '{1}' (CopyType={2}、TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingConfiguration_1">
+        <source>Checking configuration {0}:</source>
+        <target state="new">Checking configuration {0}:</target>
+        <note>{0} is a description of the project's configuration, such as "Debug|AnyCPU|net6.0".</note>
+      </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
         <target state="translated">コピー済み出力 (Original プロパティ を使用した UpToDateCheckBuilt) ファイルの確認:</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
@@ -57,6 +57,11 @@
         <target state="translated">{0} 항목이 '{1}'을(를) 제거함(CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingConfiguration_1">
+        <source>Checking configuration {0}:</source>
+        <target state="new">Checking configuration {0}:</target>
+        <note>{0} is a description of the project's configuration, such as "Debug|AnyCPU|net6.0".</note>
+      </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
         <target state="translated">복사된 출력(Original 속성이 있는 UpToDateCheckBuilt) 파일 확인:</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
@@ -57,6 +57,11 @@
         <target state="translated">{0} usunięto element „{1}” (CopyType={2}, TargetPath=”{3}”)</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingConfiguration_1">
+        <source>Checking configuration {0}:</source>
+        <target state="new">Checking configuration {0}:</target>
+        <note>{0} is a description of the project's configuration, such as "Debug|AnyCPU|net6.0".</note>
+      </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
         <target state="translated">Sprawdzanie skopiowanego pliku wyjściowego (UpToDateCheckBuilt z właściwością Original):</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
@@ -57,6 +57,11 @@
         <target state="translated">{0} item removido '{1}' (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingConfiguration_1">
+        <source>Checking configuration {0}:</source>
+        <target state="new">Checking configuration {0}:</target>
+        <note>{0} is a description of the project's configuration, such as "Debug|AnyCPU|net6.0".</note>
+      </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
         <target state="translated">Verificando o arquivo de saída copiado (UpToDateCheckBuilt com propriedade Original):</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Элемент {0} удалил "{1}" (CopyType={2}, TargetPath="{3}")</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingConfiguration_1">
+        <source>Checking configuration {0}:</source>
+        <target state="new">Checking configuration {0}:</target>
+        <note>{0} is a description of the project's configuration, such as "Debug|AnyCPU|net6.0".</note>
+      </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
         <target state="translated">Проверка скопированного выходного файла (UpToDateCheckBuilt со свойством Original):</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">{0} öğesi '{1}' dosya yolunu kaldırdı (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingConfiguration_1">
+        <source>Checking configuration {0}:</source>
+        <target state="new">Checking configuration {0}:</target>
+        <note>{0} is a description of the project's configuration, such as "Debug|AnyCPU|net6.0".</note>
+      </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
         <target state="translated">Kopyalanan çıkış (Original özelliğine sahip UpToDateCheckBuilt) dosyası denetleniyor:</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
@@ -57,6 +57,11 @@
         <target state="translated">{0} 项已删除'{1}' (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingConfiguration_1">
+        <source>Checking configuration {0}:</source>
+        <target state="new">Checking configuration {0}:</target>
+        <note>{0} is a description of the project's configuration, such as "Debug|AnyCPU|net6.0".</note>
+      </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
         <target state="translated">正在检查复制的输出（使用原始属性生成 UpToDateCheckBuilt）文件：</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
@@ -57,6 +57,11 @@
         <target state="translated">{0} 項目已移除 '{1}' (CopyType={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyType' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingConfiguration_1">
+        <source>Checking configuration {0}:</source>
+        <target state="new">Checking configuration {0}:</target>
+        <note>{0} is a description of the project's configuration, such as "Debug|AnyCPU|net6.0".</note>
+      </trans-unit>
       <trans-unit id="FUTD_CheckingCopiedOutputFile">
         <source>Checking copied output (UpToDateCheckBuilt with Original property) file:</source>
         <target state="translated">正在檢查複製的輸出 (具有原始屬性的 UpToDateCheckBuilt) 檔案:</target>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ProjectConfigurationExtensionsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ProjectConfigurationExtensionsTests.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    public sealed class ProjectConfigurationExtensionsTests
+    {
+        [Theory]
+        [InlineData("Debug|AnyCPU")]
+        [InlineData("Release|AnyCPU")]
+        [InlineData("Debug|AnyCPU|net48")]
+        [InlineData("Debug|AnyCPU|net6.0")]
+        public void GetDisplayString(string pattern)
+        {
+            Assert.Equal(pattern, ProjectConfigurationFactory.Create(pattern).GetDisplayString());
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             UpToDateCheckImplicitConfiguredInput? upToDateCheckImplicitConfiguredInput = null,
             bool itemRemovedFromSourceSnapshot = false)
         {
-            upToDateCheckImplicitConfiguredInput ??= UpToDateCheckImplicitConfiguredInput.Empty;
+            upToDateCheckImplicitConfiguredInput ??= UpToDateCheckImplicitConfiguredInput.CreateEmpty(ProjectConfigurationFactory.Create("testConfiguration"));
 
             _lastCheckTimeAtUtc = lastCheckTimeAtUtc ?? DateTime.MinValue;
             

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 [Compile.SchemaName] = SimpleItems("ItemPath1", "ItemPath2")
             };
 
-            var state = UpToDateCheckImplicitConfiguredInput.Empty;
+            var state = UpToDateCheckImplicitConfiguredInput.CreateEmpty(ProjectConfigurationFactory.Create("testConfiguration"));
 
             Assert.Equal(DateTime.MinValue, state.LastItemsChangedAtUtc);
 


### PR DESCRIPTION
Fixes #7839 

Now as the check cycles through the various target frameworks in the project, the log specifies each target in its own section.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7841)