### PR TITLE
Uncover source of NullReferenceException

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
@@ -65,6 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             ContextState state,
             CancellationToken cancellationToken)
         {
+            Requires.NotNull(buildSnapshot, nameof(buildSnapshot));
             Requires.NotNull(update, nameof(update));
 
             VerifyInitializedAndNotDisposed();
@@ -85,9 +86,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             Assumes.NotNull(_context);
 
-            buildSnapshot.TargetOutputs.TryGetValue(
+            Assumes.True(buildSnapshot.TargetOutputs.TryGetValue(
                 "CompileDesignTime",
-                out IImmutableList<KeyValuePair<string, IImmutableDictionary<string, string>>> targetOutputs);
+                out IImmutableList<KeyValuePair<string, IImmutableDictionary<string, string>>> targetOutputs));
 
             var options = ImmutableArray.CreateBuilder<string>(targetOutputs.Count);
 


### PR DESCRIPTION
In the CPS NFE report we have an item with stack:

```
Microsoft.VisualStudio.ProjectSystem.LanguageServices.ApplyChangesToWorkspaceContext.ProcessOptions(IProjectBuildSnapshot)
Microsoft.VisualStudio.ProjectSystem.LanguageServices.ApplyChangesToWorkspaceContext.<ApplyProjectBuildAsync>d__11.MoveNext()
```

There are a few places where a null value could creep in. This change will allow us to better root cause the issue, in the absence of a repro.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7851)