### PR TITLE
Notify operation progress even when we skip batches

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
@@ -203,6 +203,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 // Avoid starting a batch when nothing has actually changed
                 if (!hasChange)
                 {
+                    // Even though we will skip the batch, we must still notify operation progress of the
+                    // version we are up to. Without this, operation progress might not complete.
+                    UpdateProgressRegistration();
                     return;
                 }
 
@@ -236,6 +239,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 {
                     await context.EndBatchAsync();
 
+                    UpdateProgressRegistration();
+                }
+
+                void UpdateProgressRegistration()
+                {
                     // Notify operation progress that we've now processed these versions of our input, if they are
                     // up-to-date with the latest version that produced, then we no longer considered "in progress".
                     IDataProgressTrackerServiceRegistration? registration = handlerType switch


### PR DESCRIPTION
In #7848 we introduced a mechanism to skip sending empty batches to the language service. That change introduced a bug where a skipped batch would also fail to provide operation progress with the data source versions.

This could result in a case where the last language service update was empty, we wouldn't notify operation progress of that update's version, and operation progress would run indefinitely.

This change ensures we always notify operation progress.

Note that this code is going to change in the next PR (already submitted as #7855). I will rebase that PR on this change once merged, and add unit tests to cover this scenario.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7856)