### PR TITLE
Make analyzer package assets private and remove some package references

### DIFF
--- a/build/import/HostAgnostic.props
+++ b/build/import/HostAgnostic.props
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Query" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Analyzers" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK.Tools" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
 
@@ -50,7 +50,7 @@
     <PackageReference Include="Microsoft.CSharp" />
 
     <!-- Analyzers-->
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" PrivateAssets="all" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" PrivateAssets="all" Condition="'$(IsTestProject)' != 'true'" />

--- a/build/import/HostAgnostic.props
+++ b/build/import/HostAgnostic.props
@@ -37,7 +37,6 @@
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Query" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK.Tools" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
 
@@ -50,10 +49,12 @@
     <PackageReference Include="Microsoft.CSharp" />
 
     <!-- Analyzers-->
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" PrivateAssets="all" />
-    <PackageReference Include="Roslyn.Diagnostics.Analyzers" PrivateAssets="all" Condition="'$(IsTestProject)' != 'true'" />
+    <!-- Set PrivateAssets="all" to prevent consumers of our packages from picking up these analyzers transitively. -->
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Analyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers"               PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle"        PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"   PrivateAssets="all" />
+    <PackageReference Include="Roslyn.Diagnostics.Analyzers"                   PrivateAssets="all" Condition="'$(IsTestProject)' != 'true'" />
 
     <!-- Framework packages -->
     <PackageReference Include="Microsoft.IO.Redist" />

--- a/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
+++ b/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
@@ -17,6 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Remove="Microsoft.VisualStudio.ProjectSystem*" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="..\Common\ManagedCodeMarkers.vb">
       <Link>ManagedCodeMarkers.vb</Link>
     </Compile>


### PR DESCRIPTION
Follows from an internal email chain.

This makes our analyzer package references use private assets, so that consumers of those packages do not transitively take on dependencies on those analyzers too.

This PR also removes the `Microsoft.VisualStudio.ProjectSystem*` package references from the App Designer projects, where they are not needed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7857)