### PR TITLE
Don't track context changes

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
@@ -146,14 +145,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var registration = IDataProgressTrackerServiceRegistrationFactory.Create();
             var activeConfiguredProject = ConfiguredProjectFactory.Create();
             var update = IProjectVersionedValueFactory.CreateEmpty();
-            var lastContextState = new StrongBox<ContextState?>();
 
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
             {
                 return instance.OnProjectChangedAsync(
                     registration,
                     activeConfiguredProject,
-                    lastContextState,
                     update,
                     hasChange: _ => true,
                     applyFunc: (_, _, _, token) =>
@@ -173,14 +170,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var registration = IDataProgressTrackerServiceRegistrationFactory.Create();
             var activeConfiguredProject = ConfiguredProjectFactory.Create();
             var update = IProjectVersionedValueFactory.CreateEmpty();
-            var lastContextState = new StrongBox<ContextState?>();
 
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
             {
                 return instance.OnProjectChangedAsync(
                     registration,
                     activeConfiguredProject,
-                    lastContextState,
                     update,
                     hasChange: _ => true,
                     applyFunc: (_, _, state, token) =>
@@ -207,43 +202,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var update1 = IProjectVersionedValueFactory.Create(versions1);
             var update2 = IProjectVersionedValueFactory.Create(versions2);
             var update3 = IProjectVersionedValueFactory.Create(versions3);
-            var lastContextState = new StrongBox<ContextState?>();
             var callCount = 0;
 
-            // Apply func will be called here as the last context state differs
+            // Apply func not called as no change
             await instance.OnProjectChangedAsync(
                 registration,
                 activeConfiguredProject,
-                lastContextState,
                 update1,
                 hasChange: _ => false, // no change
                 applyFunc: (_, _, state, token) => callCount++);
 
-            Assert.Equal(1, callCount);
+            Assert.Equal(0, callCount);
             Assert.Same(versions1, seenVersions);
-
-            // Apply func will NOT be called here as the context state is unchanged, and we claim to change to other data items
-            await instance.OnProjectChangedAsync(
-                registration,
-                activeConfiguredProject,
-                lastContextState,
-                update2,
-                hasChange: _ => false, // no change
-                applyFunc: (_, _, state, token) => callCount++);
-
-            Assert.Equal(1, callCount);
-            Assert.Same(versions2, seenVersions);
 
             // Apply func will be called as hasChange returns true, despite the context state being unchanged
             await instance.OnProjectChangedAsync(
                 registration,
                 activeConfiguredProject,
-                lastContextState,
-                update3,
+                update2,
                 hasChange: _ => true, // change
                 applyFunc: (_, _, state, token) => callCount++);
 
-            Assert.Equal(2, callCount);
+            Assert.Equal(1, callCount);
+            Assert.Same(versions2, seenVersions);
+
+            // Apply func not called as no change
+            await instance.OnProjectChangedAsync(
+                registration,
+                activeConfiguredProject,
+                update3,
+                hasChange: _ => false, // no change
+                applyFunc: (_, _, state, token) => callCount++);
+
+            Assert.Equal(1, callCount);
             Assert.Same(versions3, seenVersions);
         }
 
@@ -260,14 +251,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var registration = IDataProgressTrackerServiceRegistrationFactory.Create();
             var update = IProjectVersionedValueFactory.CreateEmpty();
-            var lastContextState = new StrongBox<ContextState?>();
 
             ContextState? observedState = null;
 
             await instance.OnProjectChangedAsync(
                 registration,
                 activeConfiguredProject,
-                lastContextState,
                 update,
                 hasChange: _ => true,
                 applyFunc: (_, _, state, token) => observedState = state);


### PR DESCRIPTION
Fixes #7860.

The previous code was tracking the active project/active editor state and notifying Roslyn when these changed. However, the individual "apply to workspace" implementations were not taking this change into account, so this change tracking would lead to redundant batch updates.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7862)