### PR TITLE
Remove assertion

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
@@ -66,7 +66,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             IProjectChangeDescription projectChange = update.Value.ProjectUpdate.ProjectChanges[ProjectBuildRuleName];
 
             // There should always be some change to publish, as we have already called BeginBatch by this point
-            Assumes.True(projectChange.Difference.AnyChanges && update.Value.CommandLineArgumentsSnapshot.IsChanged);
+            // TODO understand why the CLA snapshot's changed state differs from the project update, as they are supposed to travel together in sync
+            //Assumes.True(projectChange.Difference.AnyChanges && update.Value.CommandLineArgumentsSnapshot.IsChanged);
 
             IComparable version = GetConfiguredProjectVersion(update);
 


### PR DESCRIPTION
This assertion seems logically sound but is failing in practice in some cases. I will investigate the reason for this in future. For now, it is harmless to continue in such cases. The only downside might be redundant batches being sent to Roslyn, but we had many more such updates only a week ago, so even if some of these slip through we are still in a much better state than before.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7863)