### PR TITLE
Don't require the UI thread for settings

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/ImplicitlyTriggeredDebugBuildManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/ImplicitlyTriggeredDebugBuildManager.cs
@@ -59,20 +59,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             ErrorHandler.ThrowOnFailure(_solutionBuildManager.AdviseUpdateSolutionEvents3(this, out _cookie3));
 
             _skipAnalyzersForImplicitlyTriggeredBuild = await _options.GetSkipAnalyzersForImplicitlyTriggeredBuildAsync(cancellationToken);
-            _options.RegisterOptionChangedEventHandler(OnOptionChangedAsync);
+            await _options.RegisterOptionChangedEventHandlerAsync(OnOptionChangedAsync);
         }
 
-        protected override Task DisposeCoreAsync(bool initialized)
+        protected override async Task DisposeCoreAsync(bool initialized)
         {
             if (initialized)
             {
                 (_solutionBuildManager as IVsSolutionBuildManager2)?.UnadviseUpdateSolutionEvents(_cookie);
                 _solutionBuildManager!.UnadviseUpdateSolutionEvents3(_cookie3);
 
-                _options.UnregisterOptionChangedEventHandler(OnOptionChangedAsync);
+                await _options.UnregisterOptionChangedEventHandlerAsync(OnOptionChangedAsync);
             }
-
-            return Task.CompletedTask;
         }
 
         private async Task OnOptionChangedAsync(object sender, PropertyChangedEventArgs args)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/ImplicitlyTriggeredDebugBuildManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/ImplicitlyTriggeredDebugBuildManager.cs
@@ -62,15 +62,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             await _options.RegisterOptionChangedEventHandlerAsync(OnOptionChangedAsync);
         }
 
-        protected override async Task DisposeCoreAsync(bool initialized)
+        protected override Task DisposeCoreAsync(bool initialized)
         {
             if (initialized)
             {
                 (_solutionBuildManager as IVsSolutionBuildManager2)?.UnadviseUpdateSolutionEvents(_cookie);
                 _solutionBuildManager!.UnadviseUpdateSolutionEvents3(_cookie3);
 
-                await _options.UnregisterOptionChangedEventHandlerAsync(OnOptionChangedAsync);
+                return _options.UnregisterOptionChangedEventHandlerAsync(OnOptionChangedAsync);
             }
+
+            return Task.CompletedTask;
         }
 
         private async Task OnOptionChangedAsync(object sender, PropertyChangedEventArgs args)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IProjectSystemOptionsWithChanges.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IProjectSystemOptionsWithChanges.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.Settings;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
@@ -12,11 +13,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// <summary>
         /// Registers the given <paramref name="handler"/> as a callback for option changes.
         /// </summary>
-        void RegisterOptionChangedEventHandler(PropertyChangedAsyncEventHandler handler);
+        Task RegisterOptionChangedEventHandlerAsync(PropertyChangedAsyncEventHandler handler);
 
         /// <summary>
         /// Unregsiters the given <paramref name="handler"/> from option change callbacks.
         /// </summary>
-        void UnregisterOptionChangedEventHandler(PropertyChangedAsyncEventHandler handler);
+        Task UnregisterOptionChangedEventHandlerAsync(PropertyChangedAsyncEventHandler handler);
     }
 }


### PR DESCRIPTION
Visual Studio settings are exposed through the `Microsoft.VisualStudio.Settings.ISettingsManager`. We hide this behind our `IProjectSystemOptions` interface, partly so we can access these options in the Microsoft.VisualStudio.ProjectSystem.Managed project (which doesn't depend on VS-specific interfaces). Currently, our implementation of `IProjectSystemOptions` treats `ISettingsManager` as being bound to the UI thread, which means it explicitly transitions to the UI thread before retrieving the service or calling methods on it.

However, this is unnecessarily restrictive, as the `ISettingsManager` documentation explicitly states that its methods may be called on any thread. Here we remove the transitions to the main thread, and access `ISettingsManager` through an `IVsService<T>` instead of `IVsUIService<T>`.

The immediate practical effect of this change is the Fast Up-to-Date Check will no longer need to transition to the main thread once (or more) for every project being built. This will also allow me to simplify the `ImplicitlyTriggeredDebugBuildManager`--it caches a certain setting value and listens for events to reset the value, presumably to avoid a transition to the main thread every time the value is needed. After this change I think we can get rid of all of that.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7865)