### PR TITLE
Add SkipOptimize runtime parameter

### DIFF
--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -58,7 +58,7 @@ steps:
     DropNamePrefix: 'OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)'
     AccessToken: '$(System.AccessToken)'
     feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-    ShouldSkipOptimize: false
+    ShouldSkipOptimize: true
     NumberCommitsToSearch: '100'
 
 ###################################################################################################################################################################

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -29,6 +29,10 @@ parameters:
   values:
   - real
   - test
+- name: SkipOptimize
+  displayName: Skip OptProf Optimization
+  type: boolean
+  default: false
 
 ###################################################################################################################################################################
 # INSTALLATION
@@ -58,7 +62,7 @@ steps:
     DropNamePrefix: 'OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)'
     AccessToken: '$(System.AccessToken)'
     feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-    ShouldSkipOptimize: true
+    ShouldSkipOptimize: ${{ parameters.SkipOptimize }}
     NumberCommitsToSearch: '100'
 
 ###################################################################################################################################################################


### PR DESCRIPTION
The build is currently failing because the optimization data doesn't exist with the current history in `main`. Basically, merging the OptProf PR with `Squash and Merge` meant that the history is different. Why does that matter? Because OptProf looks up to a certain amount of commits away from the current commit to find the optimization data. It was working fine on my separate branch, but the history changed on main and it has no context of where to find the optimization data now.
 
The branch in this PR already has a set of optimization data with this history. So, the build when merging this PR should succeed. Additionally, I've made the ability to skip optimization a runtime parameter. This means that if you manually queue a build in CI, you can skip optimization if this issue ever arises again in this future.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7871)