### PR TITLE
Revert "Don't track context changes"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
@@ -3,6 +3,7 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
@@ -79,6 +80,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 _evaluationProgressRegistration = _dataProgressTrackerService.RegisterForIntelliSense(this, _project, nameof(WorkspaceProjectContextHostInstance) + ".Evaluation");
                 _projectBuildProgressRegistration = _dataProgressTrackerService.RegisterForIntelliSense(this, _project, nameof(WorkspaceProjectContextHostInstance) + ".ProjectBuild");
 
+                StrongBox<ContextState?> lastEvaluationContextState = new();
+                StrongBox<ContextState?> lastBuildContextState = new();
+
                 _disposables = new DisposableBag
                 {
                     _applyChangesToWorkspaceContext,
@@ -125,6 +129,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     return OnProjectChangedAsync(
                         _evaluationProgressRegistration,
                         e.Value.ActiveConfiguredProject,
+                        lastEvaluationContextState,
                         e,
                         hasChange: static e => e.Value.ProjectUpdate.ProjectChanges.HasChange() || e.Value.SourceItemsUpdate.ProjectChanges.HasChange(),
                         applyFunc: static (e, applyChangesToWorkspaceContext, contextState, token) => applyChangesToWorkspaceContext.ApplyProjectEvaluation(e.Derive(v => (v.ProjectUpdate, v.SourceItemsUpdate)), contextState, token));
@@ -135,6 +140,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     return OnProjectChangedAsync(
                         _projectBuildProgressRegistration,
                         e.Value.ActiveConfiguredProject,
+                        lastBuildContextState,
                         e,
                         hasChange: static e => e.Value.BuildUpdate.ProjectChanges.HasChange() || e.Value.CommandLineArgumentsUpdate.IsChanged,
                         applyFunc: static (e, applyChangesToWorkspaceContext, contextState, token) => applyChangesToWorkspaceContext.ApplyProjectBuild(e.Derive(v => (v.BuildUpdate, v.CommandLineArgumentsUpdate)), contextState, token));
@@ -190,6 +196,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             internal Task OnProjectChangedAsync<T>(
                 IDataProgressTrackerServiceRegistration registration,
                 ConfiguredProject activeConfiguredProject,
+                StrongBox<ContextState?> lastContextState,
                 IProjectVersionedValue<T> update,
                 Func<IProjectVersionedValue<T>, bool> hasChange,
                 Action<IProjectVersionedValue<T>, IApplyChangesToWorkspaceContext, ContextState, CancellationToken> applyFunc)
@@ -202,7 +209,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     Assumes.NotNull(_contextAccessor);
                     Assumes.NotNull(_applyChangesToWorkspaceContext);
 
-                    if (!hasChange(update))
+                    (ContextState contextState, bool stateChanged) = GetContextState(lastContextState);
+
+                    if (!stateChanged && !hasChange(update))
                     {
                         // No change since the last update. We must still update operation progress, but can skip creating a batch.
                         UpdateProgressRegistration();
@@ -213,10 +222,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                     async Task ApplyInBatchAsync()
                     {
-                        ContextState contextState = new(
-                            isActiveEditorContext: _activeWorkspaceProjectContextTracker.IsActiveEditorContext(_contextAccessor.ContextId),
-                            isActiveConfiguration: activeConfiguredProject == _project);
-
                         IWorkspaceProjectContext context = _contextAccessor.Context;
 
                         context.StartBatch();
@@ -231,6 +236,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                             UpdateProgressRegistration();
                         }
+                    }
+
+                    (ContextState ContextState, bool StateChanged) GetContextState(StrongBox<ContextState?> lastContextState)
+                    {
+                        bool isActiveConfiguration = activeConfiguredProject == _project;
+                        bool isActiveEditorContext = _activeWorkspaceProjectContextTracker.IsActiveEditorContext(_contextAccessor.ContextId);
+                        
+                        ContextState newState = new(isActiveEditorContext, isActiveConfiguration);
+
+                        bool stateChanged = false;
+
+                        if (lastContextState.Value is null ||
+                            lastContextState.Value.Value.IsActiveConfiguration != newState.IsActiveConfiguration ||
+                            lastContextState.Value.Value.IsActiveEditorContext != newState.IsActiveEditorContext)
+                        {
+                            // The state has changed
+                            lastContextState.Value = newState;
+                            stateChanged = true;
+                        }
+
+                        return (newState, stateChanged);
                     }
 
                     void UpdateProgressRegistration()


### PR DESCRIPTION
Reverts dotnet/project-system#7862

Turns out that change causes an issue when opening `.razor` files in a new Blazor WebAssembly project, for example.

Thanks to @ryanbrandenburg for finding and doing the initial diagnosis.

cc @davkean who was interested in this change.

I'll re-open #7860 too.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7876)