### PR TITLE
Make DebugType config-dependent

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -152,7 +152,7 @@
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2173089"
                 Category="General">
     <EnumProperty.DataSource>
-      <DataSource HasConfigurationCondition="False"
+      <DataSource HasConfigurationCondition="True"
                   Persistence="ProjectFileWithInterception" />
     </EnumProperty.DataSource>
     <EnumProperty.Metadata>


### PR DESCRIPTION
Fixes [AB#1470720](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1470720).

As with most of the other settings on the "Build" property page, the `DebugType` property is meant to be configuration-dependent. While the default for .NET Core projects is to always produce a portable PDB, this supports the common practice of producing a PDB for debug builds and no PDB for release builds.

We also need this property value to go through interception (see the `DebugTypeValueProvider` for details) and so we need to add a property-specific `DataSource` and set the `Persistence` to "ProjectFileWithInterception". When we add a property-specific `DataSource` we typically set the `HasConfigurationCondition` value again as we are no longer inheriting it from the `Rule`-level `DataSource` and the default value is often wrong.

In this case we made a mistake when initially creating BuildPropertyPage.xaml, and set `HasConfigurationCondition` to "False". This means the UI will not let you set different values in different configurations. The fix here is to change it to "True".

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7879)