### PR TITLE
Fix broken source item reporting

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
@@ -92,6 +92,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             IComparable version = GetConfiguredProjectVersion(update);
 
             ProcessProjectEvaluationHandlers(version, update.Value.ProjectUpdate, state, cancellationToken);
+            ProcessSourceItemsHandlers(version, update.Value.SourceItemsUpdate, state, cancellationToken);
         }
 
         public IEnumerable<string> GetProjectEvaluationRules()
@@ -194,6 +195,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                     evaluationHandler.Handle(version, projectChange, state, _logger);
                 }
+            }
+        }
+
+        private void ProcessSourceItemsHandlers(IComparable version, IProjectSubscriptionUpdate update, ContextState state, CancellationToken cancellationToken)
+        {
+            foreach (ExportLifetimeContext<IWorkspaceContextHandler> handler in _handlers)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
 
                 if (handler.Value is ISourceItemsHandler sourceItemsHandler)
                 {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ISourceItemsHandlerFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ISourceItemsHandlerFactory.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.VisualStudio.ProjectSystem.VS;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    internal static class ISourceItemsHandlerFactory
+    {
+        public static ISourceItemsHandler ImplementHandle(Action<IComparable, IImmutableDictionary<string, IProjectChangeDescription>, ContextState, IProjectDiagnosticOutputService> action)
+        {
+            var mock = new Mock<ISourceItemsHandler>();
+
+            mock.Setup(h => h.Handle(It.IsAny<IComparable>(), It.IsAny<IImmutableDictionary<string, IProjectChangeDescription>>(), It.IsAny<ContextState>(), It.IsAny<IProjectDiagnosticOutputService>()))
+                .Callback(action);
+
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
@@ -146,14 +145,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var registration = IDataProgressTrackerServiceRegistrationFactory.Create();
             var activeConfiguredProject = ConfiguredProjectFactory.Create();
             var update = IProjectVersionedValueFactory.CreateEmpty();
-            var lastContextState = new StrongBox<ContextState?>();
 
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
             {
                 return instance.OnProjectChangedAsync(
                     registration,
                     activeConfiguredProject,
-                    lastContextState,
                     update,
                     hasChange: _ => true,
                     applyFunc: (_, _, _, token) =>
@@ -173,14 +170,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var registration = IDataProgressTrackerServiceRegistrationFactory.Create();
             var activeConfiguredProject = ConfiguredProjectFactory.Create();
             var update = IProjectVersionedValueFactory.CreateEmpty();
-            var lastContextState = new StrongBox<ContextState?>();
 
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
             {
                 return instance.OnProjectChangedAsync(
                     registration,
                     activeConfiguredProject,
-                    lastContextState,
                     update,
                     hasChange: _ => true,
                     applyFunc: (_, _, state, token) =>
@@ -207,43 +202,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var update1 = IProjectVersionedValueFactory.Create(versions1);
             var update2 = IProjectVersionedValueFactory.Create(versions2);
             var update3 = IProjectVersionedValueFactory.Create(versions3);
-            var lastContextState = new StrongBox<ContextState?>();
             var callCount = 0;
 
-            // Apply func will be called here as the last context state differs
+            // Apply func not called as no change
             await instance.OnProjectChangedAsync(
                 registration,
                 activeConfiguredProject,
-                lastContextState,
                 update1,
                 hasChange: _ => false, // no change
                 applyFunc: (_, _, state, token) => callCount++);
 
-            Assert.Equal(1, callCount);
+            Assert.Equal(0, callCount);
             Assert.Same(versions1, seenVersions);
-
-            // Apply func will NOT be called here as the context state is unchanged, and we claim to change to other data items
-            await instance.OnProjectChangedAsync(
-                registration,
-                activeConfiguredProject,
-                lastContextState,
-                update2,
-                hasChange: _ => false, // no change
-                applyFunc: (_, _, state, token) => callCount++);
-
-            Assert.Equal(1, callCount);
-            Assert.Same(versions2, seenVersions);
 
             // Apply func will be called as hasChange returns true, despite the context state being unchanged
             await instance.OnProjectChangedAsync(
                 registration,
                 activeConfiguredProject,
-                lastContextState,
-                update3,
+                update2,
                 hasChange: _ => true, // change
                 applyFunc: (_, _, state, token) => callCount++);
 
-            Assert.Equal(2, callCount);
+            Assert.Equal(1, callCount);
+            Assert.Same(versions2, seenVersions);
+
+            // Apply func not called as no change
+            await instance.OnProjectChangedAsync(
+                registration,
+                activeConfiguredProject,
+                update3,
+                hasChange: _ => false, // no change
+                applyFunc: (_, _, state, token) => callCount++);
+
+            Assert.Equal(1, callCount);
             Assert.Same(versions3, seenVersions);
         }
 
@@ -260,14 +251,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var registration = IDataProgressTrackerServiceRegistrationFactory.Create();
             var update = IProjectVersionedValueFactory.CreateEmpty();
-            var lastContextState = new StrongBox<ContextState?>();
 
             ContextState? observedState = null;
 
             await instance.OnProjectChangedAsync(
                 registration,
                 activeConfiguredProject,
-                lastContextState,
                 update,
                 hasChange: _ => true,
                 applyFunc: (_, _, state, token) => observedState = state);


### PR DESCRIPTION
Fixes [AB#1468419](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1468419)
Fixes #7860

https://github.com/dotnet/project-system/pull/7855 introduced a bug that stopped dynamic files (such as `.razor` files) being passed to Roslyn. The change incorrectly passed the evaluation project update to the source item handlers, rather than the source items update. There was no unit test for this scenario.

This fixes the bug by passing the right data to the right handler, and adding a unit test to ensure coverage of this behaviour.

This PR also re-instates #7862 which we previously reverted.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7889)