### PR TITLE
Prevent memory leak

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.cs
@@ -89,16 +89,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
             Assumes.NotNull(_solutionBuildManager);
             Assumes.NotNull(_rdt);
 
-            if (_sbmCookie != 0)
-            {
-                HResult.Verify(_rdt.UnadviseRunningDocTableEvents(_sbmCookie), $"Error unadvising RDT events in {typeof(IncrementalBuildFailureDetector)}.");
-                _sbmCookie = 0;
-            }
-
             if (_rdtCookie != 0)
             {
-                HResult.Verify(_solutionBuildManager.UnadviseUpdateSolutionEvents(_rdtCookie), $"Error unadvising solution events in {typeof(IncrementalBuildFailureDetector)}.");
+                HResult.Verify(_rdt.UnadviseRunningDocTableEvents(_rdtCookie), $"Error unadvising RDT events in {typeof(IncrementalBuildFailureDetector)}.");
                 _rdtCookie = 0;
+            }
+
+            if (_sbmCookie != 0)
+            {
+                HResult.Verify(_solutionBuildManager.UnadviseUpdateSolutionEvents(_sbmCookie), $"Error unadvising solution events in {typeof(IncrementalBuildFailureDetector)}.");
+                _sbmCookie = 0;
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
The use of these cookies was inverted, meaning these components could remain active in memory.

In practice this is not a major issue, as this is a global service which is only disposed when VS shuts down.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7891)