### PR TITLE
Add ActiveDebugProfile to properties accessible to CPS

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -391,6 +391,9 @@
 
   <StringProperty Name="TargetFSharpCoreVersion"
                   Visible="False" />
+  
+  <StringProperty Name="ActiveDebugProfile"
+                  Visible="False" />
 
   <StringProperty Name="URL"
                   ReadOnly="True"


### PR DESCRIPTION
This PR makes the MSBuild ActiveDebugProfile (currently active launch profile) accessible to CPS so that CPS can select the active launch profile when the debug property page opens. Related to #7595

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7896)