### PR TITLE
Don't indent case contents when block

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -170,7 +170,7 @@ csharp_new_line_between_query_expression_clauses = true
 
 # Identation options
 csharp_indent_case_contents = true
-csharp_indent_case_contents_when_block = true
+csharp_indent_case_contents_when_block = false
 csharp_indent_switch_labels = true
 csharp_indent_labels = no_change
 csharp_indent_block_contents = true


### PR DESCRIPTION
This makes VS format case blocks the way we seem to do them in this repo.

## Before

```c#
switch (foo)
{
    case Bar:
        {
            // block content
            break;
        }
}
```

## After

```c#
switch (foo)
{
    case Bar:
    {
        // block content
        break;
    }
}
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7907)