### PR TITLE
Run operation directly off the UI thread

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.ProjectChecker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.ProjectChecker.cs
@@ -11,7 +11,6 @@ using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.ProjectSystem.Build;
 using Microsoft.VisualStudio.ProjectSystem.UpToDate;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
 {
@@ -49,13 +48,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
             public void OnProjectBuildCompleted()
             {
                 _project.Services.ThreadingPolicy.RunAndForget(
-                    async () =>
-                    {
-                        await TaskScheduler.Default;
-
-                        await CheckAsync(_projectAsynchronousTasksService.UnloadCancellationToken);
-                    },
-                    unconfiguredProject: _project);
+                    () => CheckAsync(_projectAsynchronousTasksService.UnloadCancellationToken),
+                    unconfiguredProject: _project,
+                    options: ForkOptions.StartOnThreadPool | ForkOptions.CancelOnUnload | ForkOptions.NoAssistanceMask);
 
                 return;
 


### PR DESCRIPTION
Previously we would use `RunAndForget` on the UI thread, then have that continuation switch to the thread pool.

By using `ForkOptions.StartOnThreadPool` we can invoke directly on the thread pool.

This also allows removing a state machine.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7908)