### PR TITLE
Simplify or refine existing switch statements

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/AbstractExtenderCATIDProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/AbstractExtenderCATIDProvider.cs
@@ -23,19 +23,37 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
 
             return extenderCATIDType switch
             {
-                ExtenderCATIDType.HierarchyExtensionObject or ExtenderCATIDType.AutomationProject => GetExtenderCATID(ExtendeeObject.Project),               // IVsHierarchy.GetProperty(VSITEMID.Root, VSHPROPID_ExtObjectCATID)
-                                                                                                                                                             // DTE.Project
-                ExtenderCATIDType.HierarchyBrowseObject or ExtenderCATIDType.ProjectBrowseObject => GetExtenderCATID(ExtendeeObject.ProjectBrowseObject),    // IVsHierarchy.GetProperty(VSHPROPID_BrowseObjectCATID)
-                                                                                                                                                             // EnvDTE.Project.Properties
-                ExtenderCATIDType.ConfigurationBrowseObject => GetExtenderCATID(ExtendeeObject.Configuration),                                               // IVsCfgProvider2.GetCfgProviderProperty(VSCFGPROPID_IntrinsicExtenderCATID)/DTE.Configuration
-                ExtenderCATIDType.HierarchyConfigurationBrowseObject or ExtenderCATIDType.ProjectConfigurationBrowseObject => GetExtenderCATID(ExtendeeObject.ConfigurationBrowseObject), // IVsHierarchy.GetProperty(VSHPROPID_CfgBrowseObjectCATID)
-                                                                                                                                                             // EnvDTE.Configuration.Properties
-                ExtenderCATIDType.AutomationProjectItem => GetExtenderCATID(ExtendeeObject.ProjectItem),                                                     // EnvDTE.ProjectItem
-                ExtenderCATIDType.AutomationReference or ExtenderCATIDType.ReferenceBrowseObject => GetExtenderCATID(ExtendeeObject.ReferenceBrowseObject),  // VSLangProject.Reference
-                                                                                                                                                             // EnvDTE.ProjectItem.Properties (when reference)
-                ExtenderCATIDType.FileBrowseObject => GetExtenderCATID(ExtendeeObject.FileBrowseObject),                                                     // EnvDTE.ProjectItem.Properties (when file)
-                ExtenderCATIDType.AutomationFolderProperties or ExtenderCATIDType.FolderBrowseObject => GetExtenderCATID(ExtendeeObject.FolderBrowseObject), // FolderProperties or EnvDTE.ProjectItem.Properties (when folder)
-                ExtenderCATIDType.Unknown or _ => UnknownOrDefault()                                                                                         // EnvDTE.ProjectItem.Properties (when not file, folder, reference)
+                ExtenderCATIDType.HierarchyExtensionObject or                       // IVsHierarchy.GetProperty(VSITEMID.Root, VSHPROPID_ExtObjectCATID)
+                ExtenderCATIDType.AutomationProject =>                              // DTE.Project
+                    GetExtenderCATID(ExtendeeObject.Project),
+
+                ExtenderCATIDType.HierarchyBrowseObject or                          // IVsHierarchy.GetProperty(VSHPROPID_BrowseObjectCATID)
+                ExtenderCATIDType.ProjectBrowseObject =>                            // EnvDTE.Project.Properties
+                    GetExtenderCATID(ExtendeeObject.ProjectBrowseObject),
+
+                ExtenderCATIDType.ConfigurationBrowseObject =>                      // IVsCfgProvider2.GetCfgProviderProperty(VSCFGPROPID_IntrinsicExtenderCATID)/DTE.Configuration
+                    GetExtenderCATID(ExtendeeObject.Configuration),
+
+                ExtenderCATIDType.HierarchyConfigurationBrowseObject or             // IVsHierarchy.GetProperty(VSHPROPID_CfgBrowseObjectCATID)
+                ExtenderCATIDType.ProjectConfigurationBrowseObject =>               // EnvDTE.Configuration.Properties
+                    GetExtenderCATID(ExtendeeObject.ConfigurationBrowseObject),
+
+                ExtenderCATIDType.AutomationProjectItem =>                          // EnvDTE.ProjectItem
+                    GetExtenderCATID(ExtendeeObject.ProjectItem),
+
+                ExtenderCATIDType.AutomationReference or                            // VSLangProject.Reference
+                ExtenderCATIDType.ReferenceBrowseObject =>                          // EnvDTE.ProjectItem.Properties (when reference)
+                    GetExtenderCATID(ExtendeeObject.ReferenceBrowseObject),
+
+                ExtenderCATIDType.FileBrowseObject =>                               // EnvDTE.ProjectItem.Properties (when file)
+                    GetExtenderCATID(ExtendeeObject.FileBrowseObject),
+
+                ExtenderCATIDType.AutomationFolderProperties or                     // FolderProperties
+                ExtenderCATIDType.FolderBrowseObject =>                             // EnvDTE.ProjectItem.Properties (when folder)
+                    GetExtenderCATID(ExtendeeObject.FolderBrowseObject),
+
+                ExtenderCATIDType.Unknown or _ =>                                   // EnvDTE.ProjectItem.Properties (when not file, folder, reference)
+                    UnknownOrDefault()
             };
 
             string? UnknownOrDefault()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/AbstractExtenderCATIDProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/AbstractExtenderCATIDProvider.cs
@@ -21,41 +21,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             // The latter issue we can do nothing about, however, to address the former, map these types to a truer form it makes 
             // it easier on implementors and maintainers of this to understand the objects we're talking about.
 
-            switch (extenderCATIDType)
+            return extenderCATIDType switch
             {
-                case ExtenderCATIDType.HierarchyExtensionObject:                                // IVsHierarchy.GetProperty(VSITEMID.Root, VSHPROPID_ExtObjectCATID)
-                case ExtenderCATIDType.AutomationProject:                                       // DTE.Project
-                    return GetExtenderCATID(ExtendeeObject.Project);
+                ExtenderCATIDType.HierarchyExtensionObject or ExtenderCATIDType.AutomationProject => GetExtenderCATID(ExtendeeObject.Project),               // IVsHierarchy.GetProperty(VSITEMID.Root, VSHPROPID_ExtObjectCATID)
+                                                                                                                                                             // DTE.Project
+                ExtenderCATIDType.HierarchyBrowseObject or ExtenderCATIDType.ProjectBrowseObject => GetExtenderCATID(ExtendeeObject.ProjectBrowseObject),    // IVsHierarchy.GetProperty(VSHPROPID_BrowseObjectCATID)
+                                                                                                                                                             // EnvDTE.Project.Properties
+                ExtenderCATIDType.ConfigurationBrowseObject => GetExtenderCATID(ExtendeeObject.Configuration),                                               // IVsCfgProvider2.GetCfgProviderProperty(VSCFGPROPID_IntrinsicExtenderCATID)/DTE.Configuration
+                ExtenderCATIDType.HierarchyConfigurationBrowseObject or ExtenderCATIDType.ProjectConfigurationBrowseObject => GetExtenderCATID(ExtendeeObject.ConfigurationBrowseObject), // IVsHierarchy.GetProperty(VSHPROPID_CfgBrowseObjectCATID)
+                                                                                                                                                             // EnvDTE.Configuration.Properties
+                ExtenderCATIDType.AutomationProjectItem => GetExtenderCATID(ExtendeeObject.ProjectItem),                                                     // EnvDTE.ProjectItem
+                ExtenderCATIDType.AutomationReference or ExtenderCATIDType.ReferenceBrowseObject => GetExtenderCATID(ExtendeeObject.ReferenceBrowseObject),  // VSLangProject.Reference
+                                                                                                                                                             // EnvDTE.ProjectItem.Properties (when reference)
+                ExtenderCATIDType.FileBrowseObject => GetExtenderCATID(ExtendeeObject.FileBrowseObject),                                                     // EnvDTE.ProjectItem.Properties (when file)
+                ExtenderCATIDType.AutomationFolderProperties or ExtenderCATIDType.FolderBrowseObject => GetExtenderCATID(ExtendeeObject.FolderBrowseObject), // FolderProperties or EnvDTE.ProjectItem.Properties (when folder)
+                ExtenderCATIDType.Unknown or _ => UnknownOrDefault()                                                                                         // EnvDTE.ProjectItem.Properties (when not file, folder, reference)
+            };
 
-                case ExtenderCATIDType.HierarchyBrowseObject:                                   // IVsHierarchy.GetProperty(VSHPROPID_BrowseObjectCATID)
-                case ExtenderCATIDType.ProjectBrowseObject:                                     // EnvDTE.Project.Properties
-                    return GetExtenderCATID(ExtendeeObject.ProjectBrowseObject);
-
-                case ExtenderCATIDType.ConfigurationBrowseObject:                               // IVsCfgProvider2.GetCfgProviderProperty(VSCFGPROPID_IntrinsicExtenderCATID)/DTE.Configuration
-                    return GetExtenderCATID(ExtendeeObject.Configuration);
-
-                case ExtenderCATIDType.HierarchyConfigurationBrowseObject:                      // IVsHierarchy.GetProperty(VSHPROPID_CfgBrowseObjectCATID)
-                case ExtenderCATIDType.ProjectConfigurationBrowseObject:                        // EnvDTE.Configuration.Properties
-                    return GetExtenderCATID(ExtendeeObject.ConfigurationBrowseObject);
-
-                case ExtenderCATIDType.AutomationProjectItem:                                   // EnvDTE.ProjectItem
-                    return GetExtenderCATID(ExtendeeObject.ProjectItem);
-
-                case ExtenderCATIDType.AutomationReference:                                     // VSLangProject.Reference
-                case ExtenderCATIDType.ReferenceBrowseObject:                                   // EnvDTE.ProjectItem.Properties (when reference)
-                    return GetExtenderCATID(ExtendeeObject.ReferenceBrowseObject);
-
-                case ExtenderCATIDType.FileBrowseObject:                                        // EnvDTE.ProjectItem.Properties (when file)
-                    return GetExtenderCATID(ExtendeeObject.FileBrowseObject);
-
-                case ExtenderCATIDType.AutomationFolderProperties:                              // FolderProperties
-                case ExtenderCATIDType.FolderBrowseObject:                                      // EnvDTE.ProjectItem.Properties (when folder)
-                    return GetExtenderCATID(ExtendeeObject.FolderBrowseObject);
-
-                default:
-                case ExtenderCATIDType.Unknown:                                                 // EnvDTE.ProjectItem.Properties (when not file, folder, reference)
-                    BCLDebug.Assert(extenderCATIDType == ExtenderCATIDType.Unknown, $"Unrecognized CATID type {extenderCATIDType}");
-                    return null;
+            string? UnknownOrDefault()
+            {
+                BCLDebug.Assert(extenderCATIDType == ExtenderCATIDType.Unknown, $"Unrecognized CATID type {extenderCATIDType}");
+                return null;
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/CSharp/CSharpExtenderCATIDProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/CSharp/CSharpExtenderCATIDProvider.cs
@@ -18,33 +18,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.CSharp
 
         protected override string GetExtenderCATID(ExtendeeObject extendee)
         {
-            switch (extendee)
+            return extendee switch
             {
-                case ExtendeeObject.Project:
-                    return PrjCATID.prjCATIDProject;
+                ExtendeeObject.Project =>                   PrjCATID.prjCATIDProject,
+                ExtendeeObject.ProjectBrowseObject =>       PrjBrowseObjectCATID.prjCATIDCSharpProjectBrowseObject,
+                ExtendeeObject.Configuration =>             PrjBrowseObjectCATID.prjCATIDCSharpConfig,
+                ExtendeeObject.ConfigurationBrowseObject => PrjBrowseObjectCATID.prjCATIDCSharpProjectConfigBrowseObject,
+                ExtendeeObject.ProjectItem =>               PrjCATID.prjCATIDProjectItem,
+                ExtendeeObject.FolderBrowseObject =>        PrjBrowseObjectCATID.prjCATIDCSharpFolderBrowseObject,
+                ExtendeeObject.ReferenceBrowseObject =>     PrjBrowseObjectCATID.prjCATIDCSharpReferenceBrowseObject,
+                ExtendeeObject.FileBrowseObject or _ =>     FileBrowseObjectOrDefault()
+            };
 
-                case ExtendeeObject.ProjectBrowseObject:
-                    return PrjBrowseObjectCATID.prjCATIDCSharpProjectBrowseObject;
-
-                case ExtendeeObject.Configuration:
-                    return PrjBrowseObjectCATID.prjCATIDCSharpConfig;
-
-                case ExtendeeObject.ConfigurationBrowseObject:
-                    return PrjBrowseObjectCATID.prjCATIDCSharpProjectConfigBrowseObject;
-
-                case ExtendeeObject.ProjectItem:
-                    return PrjCATID.prjCATIDProjectItem;
-
-                case ExtendeeObject.FolderBrowseObject:
-                    return PrjBrowseObjectCATID.prjCATIDCSharpFolderBrowseObject;
-
-                case ExtendeeObject.ReferenceBrowseObject:
-                    return PrjBrowseObjectCATID.prjCATIDCSharpReferenceBrowseObject;
-
-                default:
-                case ExtendeeObject.FileBrowseObject:
-                    BCLDebug.Assert(extendee == ExtendeeObject.FileBrowseObject);
-                    return PrjBrowseObjectCATID.prjCATIDCSharpFileBrowseObject;
+            string FileBrowseObjectOrDefault()
+            {
+                BCLDebug.Assert(extendee == ExtendeeObject.FileBrowseObject);
+                return PrjBrowseObjectCATID.prjCATIDCSharpFileBrowseObject;
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicExtenderCATIDProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicExtenderCATIDProvider.cs
@@ -18,33 +18,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
 
         protected override string GetExtenderCATID(ExtendeeObject extendee)
         {
-            switch (extendee)
+            return extendee switch
             {
-                case ExtendeeObject.Project:
-                    return PrjCATID.prjCATIDProject;
+                ExtendeeObject.Project =>                   PrjCATID.prjCATIDProject,
+                ExtendeeObject.ProjectBrowseObject =>       PrjBrowseObjectCATID.prjCATIDVBProjectBrowseObject,
+                ExtendeeObject.Configuration =>             PrjBrowseObjectCATID.prjCATIDVBConfig,
+                ExtendeeObject.ConfigurationBrowseObject => PrjBrowseObjectCATID.prjCATIDVBProjectConfigBrowseObject,
+                ExtendeeObject.ProjectItem =>               PrjCATID.prjCATIDProjectItem,
+                ExtendeeObject.FolderBrowseObject =>        PrjBrowseObjectCATID.prjCATIDVBFolderBrowseObject,
+                ExtendeeObject.ReferenceBrowseObject =>     PrjBrowseObjectCATID.prjCATIDVBReferenceBrowseObject,
+                ExtendeeObject.FileBrowseObject or _ =>     FileBrowseObjectOrDefault()
+            };
 
-                case ExtendeeObject.ProjectBrowseObject:
-                    return PrjBrowseObjectCATID.prjCATIDVBProjectBrowseObject;
-
-                case ExtendeeObject.Configuration:
-                    return PrjBrowseObjectCATID.prjCATIDVBConfig;
-
-                case ExtendeeObject.ConfigurationBrowseObject:
-                    return PrjBrowseObjectCATID.prjCATIDVBProjectConfigBrowseObject;
-
-                case ExtendeeObject.ProjectItem:
-                    return PrjCATID.prjCATIDProjectItem;
-
-                case ExtendeeObject.FolderBrowseObject:
-                    return PrjBrowseObjectCATID.prjCATIDVBFolderBrowseObject;
-
-                case ExtendeeObject.ReferenceBrowseObject:
-                    return PrjBrowseObjectCATID.prjCATIDVBReferenceBrowseObject;
-
-                default:
-                case ExtendeeObject.FileBrowseObject:
-                    BCLDebug.Assert(extendee == ExtendeeObject.FileBrowseObject);
-                    return PrjBrowseObjectCATID.prjCATIDVBFileBrowseObject;
+            string FileBrowseObjectOrDefault()
+            {
+                BCLDebug.Assert(extendee == ExtendeeObject.FileBrowseObject);
+                return PrjBrowseObjectCATID.prjCATIDVBFileBrowseObject;
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractAddItemCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractAddItemCommand.cs
@@ -63,19 +63,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 
         private IProjectTree? GetNodeToAddTo(IProjectTree node)
         {
-            IProjectTree? target;
-            switch (Action)
+            return Action switch
             {
-                case OrderingMoveAction.MoveAbove:
-                case OrderingMoveAction.MoveBelow:
-                    target = node.Parent;
-                    break;
-                default:
-                    target = node;
-                    break;
-            }
-
-            return target;
+                OrderingMoveAction.MoveAbove or OrderingMoveAction.MoveBelow => node.Parent,
+                _ => node,
+            };
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -33,20 +33,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
                 project.ReevaluateIfNecessary();
                 ImmutableArray<ProjectItemElement> addedElements = GetAddedItemElements(previousIncludes, project);
 
-                switch (action)
+                // TODO: Should the result (success or failure) be ignored?
+                bool _ = action switch
                 {
-                    case OrderingMoveAction.MoveToTop:
-                        TryMoveElementsToTop(project, addedElements, target);
-                        break;
-                    case OrderingMoveAction.MoveAbove:
-                        TryMoveElementsAbove(project, addedElements, target);
-                        break;
-                    case OrderingMoveAction.MoveBelow:
-                        TryMoveElementsBelow(project, addedElements, target);
-                        break;
-                    default:
-                        break;
-                }
+                    OrderingMoveAction.MoveToTop => TryMoveElementsToTop(project, addedElements, target),
+                    OrderingMoveAction.MoveAbove => TryMoveElementsAbove(project, addedElements, target),
+                    OrderingMoveAction.MoveBelow => TryMoveElementsBelow(project, addedElements, target),
+                    _ => false
+                };
             });
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/FlagsStringMatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/FlagsStringMatcher.cs
@@ -21,19 +21,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
             switch (flags.Count)
             {
                 case 0:
-                {
                     // We are testing against the empty set of flags, which always returns true
                     _regex = null;
                     break;
-                }
                 case 1:
-                {
                     // Find the single flag, using full-word search
                     _regex = new Regex($@"\b({flags.First()})\b", options);
                     break;
-                }
                 default:
-                {
                     // Find all flags, in any order, using full-word search
                     // https://regex101.com/r/LPVGgB/1
                     var pattern = new StringBuilder("^");
@@ -47,7 +42,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
                     _regex = new Regex(pattern.ToString(), options);
                     break;
-                }
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
@@ -34,7 +34,11 @@ namespace Microsoft.VisualStudio.Build
             // <TargetFrameworks>net461;net452</TargetFrameworks>
             // <TargetFrameworks Condition = "'$(BuildingInsideVisualStudio)' == 'true'">net461</TargetFrameworks>
 
-            return element.Condition is "" or "true" or "'$(OS)' == 'Windows_NT'" or "'$(BuildingInsideVisualStudio)' == 'true'";
+            return element.Condition is
+                "" or
+                "true" or
+                "'$(OS)' == 'Windows_NT'" or
+                "'$(BuildingInsideVisualStudio)' == 'true'";
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
@@ -34,16 +34,7 @@ namespace Microsoft.VisualStudio.Build
             // <TargetFrameworks>net461;net452</TargetFrameworks>
             // <TargetFrameworks Condition = "'$(BuildingInsideVisualStudio)' == 'true'">net461</TargetFrameworks>
 
-            switch (element.Condition)
-            {
-                case "":
-                case "true":
-                case "'$(OS)' == 'Windows_NT'":
-                case "'$(BuildingInsideVisualStudio)' == 'true'":
-                    return true;
-            }
-
-            return false;
+            return element.Condition is "" or "true" or "'$(OS)' == 'Windows_NT'" or "'$(BuildingInsideVisualStudio)' == 'true'";
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/CSharp/CSharpProjectImageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/CSharp/CSharpProjectImageProvider.cs
@@ -21,18 +21,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging.CSharp
         {
             Requires.NotNullOrEmpty(key, nameof(key));
 
-            switch (key)
+            return key switch
             {
-                case ProjectImageKey.ProjectRoot:
-                    return KnownMonikers.CSProjectNode.ToProjectSystemType();
-
-                case ProjectImageKey.SharedItemsImportFile:
-                case ProjectImageKey.SharedProjectRoot:
-                    return KnownMonikers.CSSharedProject.ToProjectSystemType();
-
-                default:
-                    return null;
-            }
+                ProjectImageKey.ProjectRoot => KnownMonikers.CSProjectNode.ToProjectSystemType(),
+                ProjectImageKey.SharedItemsImportFile or ProjectImageKey.SharedProjectRoot => KnownMonikers.CSSharedProject.ToProjectSystemType(),
+                _ => null
+            };
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/VisualBasic/VisualBasicProjectImageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/VisualBasic/VisualBasicProjectImageProvider.cs
@@ -21,18 +21,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging.VisualBasic
         {
             Requires.NotNullOrEmpty(key, nameof(key));
 
-            switch (key)
+            return key switch
             {
-                case ProjectImageKey.ProjectRoot:
-                    return KnownMonikers.VBProjectNode.ToProjectSystemType();
-
-                case ProjectImageKey.SharedItemsImportFile:
-                case ProjectImageKey.SharedProjectRoot:
-                    return KnownMonikers.VBSharedProject.ToProjectSystemType();
-
-                default:
-                    return null;
-            }
+                ProjectImageKey.ProjectRoot => KnownMonikers.VBProjectNode.ToProjectSystemType(),
+                ProjectImageKey.SharedItemsImportFile or ProjectImageKey.SharedProjectRoot => KnownMonikers.VBSharedProject.ToProjectSystemType(),
+                _ => null
+            };
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/FSharp/FSharpCommandLineParserService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/FSharp/FSharpCommandLineParserService.cs
@@ -58,7 +58,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.FSharp
                     {
                         // not an option, should be a regular file
                         string extension = Path.GetExtension(arg).ToLowerInvariant();
-                        if (extension is ".fs" or ".fsi" or ".fsx" or ".fsscript" or ".ml" or ".mli")
+                        if (extension is
+                            ".fs" or
+                            ".fsi" or
+                            ".fsx" or
+                            ".fsscript" or
+                            ".ml" or
+                            ".mli")
                         {
                             sourceFiles.Add(new CommandLineSourceFile(arg, isScript: (extension == ".fsx") || (extension == ".fsscript")));
                         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/FSharp/FSharpCommandLineParserService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/FSharp/FSharpCommandLineParserService.cs
@@ -58,18 +58,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.FSharp
                     {
                         // not an option, should be a regular file
                         string extension = Path.GetExtension(arg).ToLowerInvariant();
-                        switch (extension)
+                        if (extension is ".fs" or ".fsi" or ".fsx" or ".fsscript" or ".ml" or ".mli")
                         {
-                            case ".fs":
-                            case ".fsi":
-                            case ".fsx":
-                            case ".fsscript":
-                            case ".ml":
-                            case ".mli":
-                                sourceFiles.Add(new CommandLineSourceFile(arg, isScript: (extension == ".fsx") || (extension == ".fsscript")));
-                                break;
-                            default:
-                                break;
+                            sourceFiles.Add(new CommandLineSourceFile(arg, isScript: (extension == ".fsx") || (extension == ".fsscript")));
                         }
                     }
                     else

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileExtensionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileExtensionValueProvider.cs
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private static void UpdateActiveLaunchProfile(IWritableLaunchProfile activeProfile, string propertyName, string unevaluatedPropertyValue)
         {
             // TODO: Should the result (success or failure) be ignored?
-            bool _ = propertyName switch
+            _ = propertyName switch
             {
                 AuthenticationModePropertyName => TrySetOtherProperty(activeProfile, LaunchProfileExtensions.RemoteAuthenticationModeProperty, unevaluatedPropertyValue, string.Empty),
                 NativeDebuggingPropertyName =>    TrySetOtherProperty(activeProfile, LaunchProfileExtensions.NativeDebuggingProperty, bool.Parse(unevaluatedPropertyValue), false),

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileExtensionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/DebugPropertyPage/ActiveLaunchProfileExtensionValueProvider.cs
@@ -85,31 +85,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         private static void UpdateActiveLaunchProfile(IWritableLaunchProfile activeProfile, string propertyName, string unevaluatedPropertyValue)
         {
-            switch (propertyName)
+            // TODO: Should the result (success or failure) be ignored?
+            bool _ = propertyName switch
             {
-                case AuthenticationModePropertyName:
-                    TrySetOtherProperty(activeProfile, LaunchProfileExtensions.RemoteAuthenticationModeProperty, unevaluatedPropertyValue, string.Empty);
-                    break;
-
-                case NativeDebuggingPropertyName:
-                    TrySetOtherProperty(activeProfile, LaunchProfileExtensions.NativeDebuggingProperty, bool.Parse(unevaluatedPropertyValue), false);
-                    break;
-
-                case RemoteDebugEnabledPropertyName:
-                    TrySetOtherProperty(activeProfile, LaunchProfileExtensions.RemoteDebugEnabledProperty, bool.Parse(unevaluatedPropertyValue), false);
-                    break;
-
-                case RemoteDebugMachinePropertyName:
-                    TrySetOtherProperty(activeProfile, LaunchProfileExtensions.RemoteDebugMachineProperty, unevaluatedPropertyValue, string.Empty);
-                    break;
-
-                case SqlDebuggingPropertyName:
-                    TrySetOtherProperty(activeProfile, LaunchProfileExtensions.SqlDebuggingProperty, bool.Parse(unevaluatedPropertyValue), false);
-                    break;
-
-                default:
-                    throw new InvalidOperationException($"{nameof(ActiveLaunchProfileExtensionValueProvider)} does not handle property '{propertyName}'.");
-            }
+                AuthenticationModePropertyName => TrySetOtherProperty(activeProfile, LaunchProfileExtensions.RemoteAuthenticationModeProperty, unevaluatedPropertyValue, string.Empty),
+                NativeDebuggingPropertyName =>    TrySetOtherProperty(activeProfile, LaunchProfileExtensions.NativeDebuggingProperty, bool.Parse(unevaluatedPropertyValue), false),
+                RemoteDebugEnabledPropertyName => TrySetOtherProperty(activeProfile, LaunchProfileExtensions.RemoteDebugEnabledProperty, bool.Parse(unevaluatedPropertyValue), false),
+                RemoteDebugMachinePropertyName => TrySetOtherProperty(activeProfile, LaunchProfileExtensions.RemoteDebugMachineProperty, unevaluatedPropertyValue, string.Empty),
+                SqlDebuggingPropertyName =>       TrySetOtherProperty(activeProfile, LaunchProfileExtensions.SqlDebuggingProperty, bool.Parse(unevaluatedPropertyValue), false),
+                _ => throw new InvalidOperationException($"{nameof(ActiveLaunchProfileExtensionValueProvider)} does not handle property '{propertyName}'."),
+            };
         }
 
         private static T GetOtherProperty<T>(ILaunchProfile? launchProfile, string propertyName, T defaultValue)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/ProjectLaunchProfileExtensionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/ProjectLaunchProfileExtensionValueProvider.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public void OnSetPropertyValue(string propertyName, string propertyValue, IWritableLaunchProfile launchProfile, ImmutableDictionary<string, object> globalSettings, Rule? rule)
         {
             // TODO: Should the result (success or failure) be ignored?
-            bool _ = propertyName switch
+            _ = propertyName switch
             {
                 AuthenticationModePropertyName => TrySetOtherProperty(launchProfile, LaunchProfileExtensions.RemoteAuthenticationModeProperty, propertyValue, string.Empty),
                 HotReloadEnabledPropertyName =>   TrySetOtherProperty(launchProfile, LaunchProfileExtensions.HotReloadEnabledProperty, bool.Parse(propertyValue), true),

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/ProjectLaunchProfileExtensionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/ProjectLaunchProfileExtensionValueProvider.cs
@@ -71,39 +71,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public void OnSetPropertyValue(string propertyName, string propertyValue, IWritableLaunchProfile launchProfile, ImmutableDictionary<string, object> globalSettings, Rule? rule)
         {
-            switch (propertyName)
+            // TODO: Should the result (success or failure) be ignored?
+            bool _ = propertyName switch
             {
-                case AuthenticationModePropertyName:
-                    TrySetOtherProperty(launchProfile, LaunchProfileExtensions.RemoteAuthenticationModeProperty, propertyValue, string.Empty);
-                    break;
-
-                case HotReloadEnabledPropertyName:
-                    TrySetOtherProperty(launchProfile, LaunchProfileExtensions.HotReloadEnabledProperty, bool.Parse(propertyValue), true);
-                    break;
-
-                case NativeDebuggingPropertyName:
-                    TrySetOtherProperty(launchProfile, LaunchProfileExtensions.NativeDebuggingProperty, bool.Parse(propertyValue), false);
-                    break;
-
-                case RemoteDebugEnabledPropertyName:
-                    TrySetOtherProperty(launchProfile, LaunchProfileExtensions.RemoteDebugEnabledProperty, bool.Parse(propertyValue), false);
-                    break;
-
-                case RemoteDebugMachinePropertyName:
-                    TrySetOtherProperty(launchProfile, LaunchProfileExtensions.RemoteDebugMachineProperty, propertyValue, string.Empty);
-                    break;
-
-                case SqlDebuggingPropertyName:
-                    TrySetOtherProperty(launchProfile, LaunchProfileExtensions.SqlDebuggingProperty, bool.Parse(propertyValue), false);
-                    break;
-
-                case WebView2DebuggingPropertyName:
-                    TrySetOtherProperty(launchProfile, LaunchProfileExtensions.JSWebView2DebuggingProperty, bool.Parse(propertyValue), false);
-                    break;
-
-                default:
-                    throw new InvalidOperationException($"{nameof(ProjectLaunchProfileExtensionValueProvider)} does not handle property '{propertyName}'.");
-            }
+                AuthenticationModePropertyName => TrySetOtherProperty(launchProfile, LaunchProfileExtensions.RemoteAuthenticationModeProperty, propertyValue, string.Empty),
+                HotReloadEnabledPropertyName =>   TrySetOtherProperty(launchProfile, LaunchProfileExtensions.HotReloadEnabledProperty, bool.Parse(propertyValue), true),
+                NativeDebuggingPropertyName =>    TrySetOtherProperty(launchProfile, LaunchProfileExtensions.NativeDebuggingProperty, bool.Parse(propertyValue), false),
+                RemoteDebugEnabledPropertyName => TrySetOtherProperty(launchProfile, LaunchProfileExtensions.RemoteDebugEnabledProperty, bool.Parse(propertyValue), false),
+                RemoteDebugMachinePropertyName => TrySetOtherProperty(launchProfile, LaunchProfileExtensions.RemoteDebugMachineProperty, propertyValue, string.Empty),
+                SqlDebuggingPropertyName =>       TrySetOtherProperty(launchProfile, LaunchProfileExtensions.SqlDebuggingProperty, bool.Parse(propertyValue), false),
+                WebView2DebuggingPropertyName =>  TrySetOtherProperty(launchProfile, LaunchProfileExtensions.JSWebView2DebuggingProperty, bool.Parse(propertyValue), false),
+                _ => throw new InvalidOperationException($"{nameof(ProjectLaunchProfileExtensionValueProvider)} does not handle property '{propertyName}'."),
+            };
         }
 
         private static T GetOtherProperty<T>(ILaunchProfile launchProfile, string propertyName, T defaultValue)


### PR DESCRIPTION
Relates to: https://github.com/dotnet/project-system/pull/7907

I went through all the switch statements (not switch expressions) in the C# code in our repo.
- 18 switch statements were present prior to this PR; 7 remain after this PR
- 1 switch statement in `FlagsStringMatcher.cs` had redundant `{ }` blocks for the cases; removed them
- Many switch statements could be replaced with switch expressions
- Some switch statements could be replaced with pattern matching
- Added a comment for some switch statements in which the value was discarded after conversion to switch expression

Criteria used:
- If all cases returned a value and were a single statement within the case (the exception being the `default` case), then I converted them to switch expressions
- If there were more than 3 cases when converting to a switch expression, I justified (aligned) the RHS values (except if `_` case was a throw statement)
  - The exception was `AbstractExtenderCATIDProvider.cs` as it had custom commenting
- If the switch statement cases had ambiguous scoping (`{ }`), the scoping was removed
- If the switch statement could be simplified using pattern matching into a single if statement, it was converted to an if statement
  - If a pattern is using more than 1 `or`, the values are vertically aligned to match the visual style of the prior switch statement's cases
- If none of the above criteria applied, then I left the switch expression alone

### Note
It is suggested to use the *Split* view to review this PR:

![image](https://user-images.githubusercontent.com/17788297/153532864-bf8065cc-999d-4b74-a7f0-dc13e2138acb.png)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7910)