### PR TITLE
Fix an incorrect assumption in the Fast Up-to-Date Check

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -796,9 +796,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {
                         if (logConfigurations)
                         {
-                            // Only null when the FUTD check is disabled. If we get here, we are not disabled.
-                            Assumes.NotNull(implicitState.ProjectConfiguration);
-
                             logger.Info(nameof(Resources.FUTD_CheckingConfiguration_1), implicitState.ProjectConfiguration.GetDisplayString());
                             logger.Indent++;
                         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -22,27 +22,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             return new UpToDateCheckImplicitConfiguredInput(projectConfiguration);
         }
 
-        public static UpToDateCheckImplicitConfiguredInput Disabled { get; } = new UpToDateCheckImplicitConfiguredInput(
-            projectConfiguration:                         null,
-            msBuildProjectFullPath:                       null,
-            msBuildProjectDirectory:                      null,
-            copyUpToDateMarkerItem:                       null,
-            outputRelativeOrFullPath:                     null,
-            newestImportInput:                            null,
-            isDisabled:                                   true,
-            inputSourceItemTypes:                         ImmutableArray<string>.Empty,
-            inputSourceItemsByItemType:                   ImmutableDictionary<string, ImmutableArray<UpToDateCheckInputItem>>.Empty,
-            upToDateCheckInputItemsByKindBySetName:       ImmutableDictionary<string, ImmutableDictionary<string, ImmutableArray<string>>>.Empty,
-            upToDateCheckOutputItemsByKindBySetName:      ImmutableDictionary<string, ImmutableDictionary<string, ImmutableArray<string>>>.Empty,
-            upToDateCheckBuiltItemsByKindBySetName:       ImmutableDictionary<string, ImmutableDictionary<string, ImmutableArray<string>>>.Empty,
-            copiedOutputFiles:                            ImmutableArray<(string DestinationRelative, string SourceRelative)>.Empty,
-            resolvedAnalyzerReferencePaths:               ImmutableArray<string>.Empty,
-            resolvedCompilationReferencePaths:            ImmutableArray<string>.Empty,
-            copyReferenceInputs:                          ImmutableArray<string>.Empty,
-            lastItemsChangedAtUtc:                        DateTime.MinValue,
-            lastItemChanges:                              ImmutableArray<(bool IsAdd, string ItemType, UpToDateCheckInputItem)>.Empty,
-            itemHash:                                     null,
-            wasStateRestored:                             false);
+        public static UpToDateCheckImplicitConfiguredInput CreateDisabled(ProjectConfiguration projectConfiguration)
+        {
+            return new UpToDateCheckImplicitConfiguredInput(
+                projectConfiguration: projectConfiguration,
+                msBuildProjectFullPath: null,
+                msBuildProjectDirectory: null,
+                copyUpToDateMarkerItem: null,
+                outputRelativeOrFullPath: null,
+                newestImportInput: null,
+                isDisabled: true,
+                inputSourceItemTypes: ImmutableArray<string>.Empty,
+                inputSourceItemsByItemType: ImmutableDictionary<string, ImmutableArray<UpToDateCheckInputItem>>.Empty,
+                upToDateCheckInputItemsByKindBySetName: ImmutableDictionary<string, ImmutableDictionary<string, ImmutableArray<string>>>.Empty,
+                upToDateCheckOutputItemsByKindBySetName: ImmutableDictionary<string, ImmutableDictionary<string, ImmutableArray<string>>>.Empty,
+                upToDateCheckBuiltItemsByKindBySetName: ImmutableDictionary<string, ImmutableDictionary<string, ImmutableArray<string>>>.Empty,
+                copiedOutputFiles: ImmutableArray<(string DestinationRelative, string SourceRelative)>.Empty,
+                resolvedAnalyzerReferencePaths: ImmutableArray<string>.Empty,
+                resolvedCompilationReferencePaths: ImmutableArray<string>.Empty,
+                copyReferenceInputs: ImmutableArray<string>.Empty,
+                lastItemsChangedAtUtc: DateTime.MinValue,
+                lastItemChanges: ImmutableArray<(bool IsAdd, string ItemType, UpToDateCheckInputItem)>.Empty,
+                itemHash: null,
+                wasStateRestored: false);
+        }
 
         /// <summary>
         /// Gets the project configuration for this configured data snapshot.
@@ -51,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// Useful when a project multi-targets and we want to differentiate targets in log output.
         /// <see langword="null"/> when the up-to-date check is disabled.
         /// </remarks>
-        public ProjectConfiguration? ProjectConfiguration { get; }
+        public ProjectConfiguration ProjectConfiguration { get; }
 
         public string? MSBuildProjectFullPath { get; }
 
@@ -132,7 +135,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// </summary>
         public ImmutableArray<string> CopyReferenceInputs { get; }
 
-        private UpToDateCheckImplicitConfiguredInput(ProjectConfiguration? projectConfiguration)
+        private UpToDateCheckImplicitConfiguredInput(ProjectConfiguration projectConfiguration)
         {
             var emptyItemBySetName = ImmutableDictionary.Create<string, ImmutableDictionary<string, ImmutableArray<string>>>(BuildUpToDateCheck.SetNameComparer);
 
@@ -152,7 +155,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         }
 
         private UpToDateCheckImplicitConfiguredInput(
-            ProjectConfiguration? projectConfiguration,
+            ProjectConfiguration projectConfiguration,
             string? msBuildProjectFullPath,
             string? msBuildProjectDirectory,
             string? copyUpToDateMarkerItem,
@@ -220,7 +223,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             if (isDisabled)
             {
-                return Disabled;
+                return CreateDisabled(ProjectConfiguration);
             }
 
             string? msBuildProjectFullPath = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, MSBuildProjectFullPath);


### PR DESCRIPTION
When the Fast Up-to-Date Check needs to check multiple configurations (because we're targeting multiple frameworks and we have one configuration per framework) we output `UpToDateCheckImplicitConfiguredInput.ProjectConfiguration` to the log. We have an `Assume.NotNull` asserting that the `ProjectConfiguration` cannot be `null` at this point, and a comment stating that the property will only be `null` if the FUTD Check is disabled--and if it is we wouldn't have gotten that far.

The assertion and comment are fundamentally incorrect, though it is true that `ProjectConfiguration` will be `null` when the check is disabled. Checking whether or not the FUTD Check is disabled doesn't happen until a later call to `CheckGlobalConditions`. And indeed, if you create a multi-targeting project and set the `DisableFastUpToDateCheck` property to true, the `Assumes.NotNull` will fail and throw an exception.

The fix here is to ensure that the `ProjectConfiguration` is never null, even when the FUTD Check is disabled. We always have an `UpToDateCheckImplicitConfiguredInput` for each configuration anyway, so there's no reason not to do this. I'm also going to need the `ProjectConfiguration` for each configuration to properly support single-target builds, so this simplifies that feature work as well.

The only downside is that we will now create more `UpToDateCheckImplicitConfiguredInput` objects when the FUTD Check is disabled, rather than reusing a singleton representing the disabled state. Given how rare it is to disable the FUTD Check in this way I don't see this as being a concern.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7917)