### PR TITLE
Don't block thread pool threads during file IO

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckStatePersistence.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckStatePersistence.cs
@@ -68,12 +68,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
             }
         }
 
-        public async Task<(int ItemHash, DateTime ItemsChangedAtUtc)?> RestoreStateAsync(string projectPath, IImmutableDictionary<string, string> configurationDimensions)
+        public async Task<(int ItemHash, DateTime ItemsChangedAtUtc)?> RestoreStateAsync(string projectPath, IImmutableDictionary<string, string> configurationDimensions, CancellationToken cancellationToken)
         {
-            await InitializeAsync();
-            await InitializeDataAsync();
+            await InitializeAsync(cancellationToken);
+            await InitializeDataAsync(cancellationToken);
 
-            using (await _lock.EnterAsync())
+            using (await _lock.EnterAsync(cancellationToken))
             {
                 Assumes.NotNull(_dataByConfiguredProject);
 
@@ -83,16 +83,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                 return null;
             }
 
-            async Task InitializeDataAsync()
+            async Task InitializeDataAsync(CancellationToken cancellationToken)
             {
                 if (_cacheFilePath is null || _dataByConfiguredProject is null)
                 {
-                    string filePath = await GetCacheFilePathAsync(CancellationToken.None);
+                    string filePath = await GetCacheFilePathAsync(cancellationToken);
 
                     // Switch to a background thread before doing file I/O
                     await TaskScheduler.Default;
 
-                    using (await _lock.EnterAsync())
+                    using (await _lock.EnterAsync(cancellationToken))
                     {
                         if (_cacheFilePath is null || _dataByConfiguredProject is null)
                         {
@@ -125,9 +125,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
             }
         }
 
-        public async Task StoreStateAsync(string projectPath, IImmutableDictionary<string, string> configurationDimensions, int itemHash, DateTime itemsChangedAtUtc)
+        public async Task StoreStateAsync(string projectPath, IImmutableDictionary<string, string> configurationDimensions, int itemHash, DateTime itemsChangedAtUtc, CancellationToken cancellationToken)
         {
-            using (await _lock.EnterAsync())
+            using (await _lock.EnterAsync(cancellationToken))
             {
                 Assumes.NotNull(_dataByConfiguredProject);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckStatePersistence.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckStatePersistence.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
     {
         private const string ProjectItemCacheFileName = ".futdcache.v1";
 
-        private readonly object _lock = new();
+        private readonly AsyncSemaphore _lock = new(initialCount: 1);
 
         private Dictionary<(string ProjectPath, IImmutableDictionary<string, string> ConfigurationDimensions), (int ItemHash, DateTime ItemsChangedAtUtc)>? _dataByConfiguredProject;
 
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
             await InitializeAsync();
             await InitializeDataAsync();
 
-            lock (_lock)
+            using (await _lock.EnterAsync())
             {
                 Assumes.NotNull(_dataByConfiguredProject);
 
@@ -92,7 +92,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                     // Switch to a background thread before doing file I/O
                     await TaskScheduler.Default;
 
-                    lock (_lock)
+                    using (await _lock.EnterAsync())
                     {
                         if (_cacheFilePath is null || _dataByConfiguredProject is null)
                         {
@@ -125,9 +125,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
             }
         }
 
-        public void StoreState(string projectPath, IImmutableDictionary<string, string> configurationDimensions, int itemHash, DateTime itemsChangedAtUtc)
+        public async Task StoreStateAsync(string projectPath, IImmutableDictionary<string, string> configurationDimensions, int itemHash, DateTime itemsChangedAtUtc)
         {
-            lock (_lock)
+            using (await _lock.EnterAsync())
             {
                 Assumes.NotNull(_dataByConfiguredProject);
 
@@ -223,16 +223,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
 
         public int OnAfterCloseSolution(object pUnkReserved)
         {
-            lock (_lock)
+            JoinableFactory.Run(async () =>
             {
-                if (_hasUnsavedChange && _cacheFilePath is not null && _dataByConfiguredProject is not null)
+                using (await _lock.EnterAsync())
                 {
-                    Serialize(_cacheFilePath, _dataByConfiguredProject);
-                }
+                    if (_hasUnsavedChange && _cacheFilePath is not null && _dataByConfiguredProject is not null)
+                    {
+                        Serialize(_cacheFilePath, _dataByConfiguredProject);
+                    }
 
-                _cacheFilePath = null;
-                _dataByConfiguredProject = null;
-            }
+                    _cacheFilePath = null;
+                    _dataByConfiguredProject = null;
+                }
+            });
 
             return HResult.OK;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/IUpToDateCheckStatePersistence.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/IUpToDateCheckStatePersistence.cs
@@ -28,6 +28,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// <param name="configurationDimensions">The map of dimension names and values that describes the project configuration.</param>
         /// <param name="itemHash">The hash of items to be stored.</param>
         /// <param name="itemsChangedAtUtc">The time at which items were last known to have changed (in UTC).</param>
-        void StoreState(string projectPath, IImmutableDictionary<string, string> configurationDimensions, int itemHash, DateTime itemsChangedAtUtc);
+        Task StoreStateAsync(string projectPath, IImmutableDictionary<string, string> configurationDimensions, int itemHash, DateTime itemsChangedAtUtc);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/IUpToDateCheckStatePersistence.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/IUpToDateCheckStatePersistence.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Composition;
 
@@ -18,8 +19,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// </summary>
         /// <param name="projectPath">The full path of the project.</param>
         /// <param name="configurationDimensions">The map of dimension names and values that describes the project configuration.</param>
+        /// <param name="cancellationToken">Allows cancelling this asynchronous operation.</param>
         /// <returns>The hash and time at which items were last known to have changed (in UTC).</returns>
-        Task<(int ItemHash, DateTime ItemsChangedAtUtc)?> RestoreStateAsync(string projectPath, IImmutableDictionary<string, string> configurationDimensions);
+        Task<(int ItemHash, DateTime ItemsChangedAtUtc)?> RestoreStateAsync(string projectPath, IImmutableDictionary<string, string> configurationDimensions, CancellationToken cancellationToken);
 
         /// <summary>
         /// Stores up-to-date check state for a given configured project.
@@ -28,6 +30,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// <param name="configurationDimensions">The map of dimension names and values that describes the project configuration.</param>
         /// <param name="itemHash">The hash of items to be stored.</param>
         /// <param name="itemsChangedAtUtc">The time at which items were last known to have changed (in UTC).</param>
-        Task StoreStateAsync(string projectPath, IImmutableDictionary<string, string> configurationDimensions, int itemHash, DateTime itemsChangedAtUtc);
+        /// <param name="cancellationToken">Allows cancelling this asynchronous operation.</param>
+        /// <returns>A task that completes when this operation has finished.</returns>
+        Task StoreStateAsync(string projectPath, IImmutableDictionary<string, string> configurationDimensions, int itemHash, DateTime itemsChangedAtUtc, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
@@ -25,6 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private readonly ConfiguredProject _configuredProject;
         private readonly IProjectItemSchemaService _projectItemSchemaService;
         private readonly IUpToDateCheckStatePersistence? _persistentState;
+        private readonly IProjectAsynchronousTasksService _projectAsynchronousTasksService;
 
         private static ImmutableHashSet<string> ProjectPropertiesSchemas => ImmutableStringHashSet.EmptyOrdinal
             .Add(ConfigurationGeneral.SchemaName)
@@ -39,11 +40,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         public UpToDateCheckImplicitConfiguredInputDataSource(
             ConfiguredProject containingProject,
             IProjectItemSchemaService projectItemSchemaService,
+            [Import(ExportContractNames.Scopes.UnconfiguredProject)] IProjectAsynchronousTasksService projectAsynchronousTasksService,
             [Import(AllowDefault = true)] IUpToDateCheckStatePersistence? persistentState)
             : base(containingProject, synchronousDisposal: false, registerDataSource: false)
         {
             _configuredProject = containingProject;
             _projectItemSchemaService = projectItemSchemaService;
+            _projectAsynchronousTasksService = projectAsynchronousTasksService;
             _persistentState = persistentState;
         }
 
@@ -94,7 +97,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         // Restoring state requires the UI thread. We must use JTF.RunAsync here to ensure the UI
                         // thread is shared between related work and prevent deadlocks.
                         (int ItemHash, DateTime InputsChangedAtUtc)? restoredState =
-                            await JoinableFactory.RunAsync(() => _persistentState.RestoreStateAsync(_configuredProject.UnconfiguredProject.FullPath, _configuredProject.ProjectConfiguration.Dimensions));
+                            await JoinableFactory.RunAsync(() => _persistentState.RestoreStateAsync(_configuredProject.UnconfiguredProject.FullPath, _configuredProject.ProjectConfiguration.Dimensions, _projectAsynchronousTasksService.UnloadCancellationToken));
 
                         if (restoredState is not null)
                         {
@@ -114,7 +117,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 if (state.ItemHash is not null && _persistentState is not null && (priorItemHash != state.ItemHash || priorLastItemsChangedAtUtc != state.LastItemsChangedAtUtc))
                 {
-                    await _persistentState.StoreStateAsync(_configuredProject.UnconfiguredProject.FullPath, _configuredProject.ProjectConfiguration.Dimensions, state.ItemHash.Value, state.LastItemsChangedAtUtc);
+                    await _persistentState.StoreStateAsync(_configuredProject.UnconfiguredProject.FullPath, _configuredProject.ProjectConfiguration.Dimensions, state.ItemHash.Value, state.LastItemsChangedAtUtc, _projectAsynchronousTasksService.UnloadCancellationToken);
                 }
 
                 return new ProjectVersionedValue<UpToDateCheckImplicitConfiguredInput>(state, e.DataSourceVersions);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
@@ -114,7 +114,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 if (state.ItemHash is not null && _persistentState is not null && (priorItemHash != state.ItemHash || priorLastItemsChangedAtUtc != state.LastItemsChangedAtUtc))
                 {
-                    _persistentState.StoreState(_configuredProject.UnconfiguredProject.FullPath, _configuredProject.ProjectConfiguration.Dimensions, state.ItemHash.Value, state.LastItemsChangedAtUtc);
+                    await _persistentState.StoreStateAsync(_configuredProject.UnconfiguredProject.FullPath, _configuredProject.ProjectConfiguration.Dimensions, state.ItemHash.Value, state.LastItemsChangedAtUtc);
                 }
 
                 return new ProjectVersionedValue<UpToDateCheckImplicitConfiguredInput>(state, e.DataSourceVersions);


### PR DESCRIPTION
Fixes [AB#1484422](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1484422)

The file operations can take a while to complete. The previous code protected these operations and data structures using a monitor lock, which blocks threads. This could lead to thread pool threads being blocked

This change uses an async semaphore, which allows threads that are not granted access to the critical section to yield and do other useful work until they are able to gain access.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7923)