### PR TITLE
Feature update namespace

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -13,7 +13,6 @@
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json;
-      D:\microsoft\dotnet\cps\bin\Debug\packages\nuget;
     </RestoreSources>
   </PropertyGroup>
 
@@ -74,10 +73,10 @@
     <PackageReference Include="StreamJsonRpc"                                                         Version="2.10.42" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.2.229-pre-g395742c8dc" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.2.229-pre-g395742c8dc" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.2.229-pre-g395742c8dc" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.2.229-pre-g395742c8dc" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.2.237-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.2.237-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.2.237-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.2.237-pre" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.1.0-2.21558.8" />

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -74,10 +74,10 @@
     <PackageReference Include="StreamJsonRpc"                                                         Version="2.10.42" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.2.232-pre-g881dca9a09" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.2.232-pre-g881dca9a09" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.2.232-pre-g881dca9a09" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.2.232-pre-g881dca9a09" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.2.229-pre-g395742c8dc" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.2.229-pre-g395742c8dc" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.2.229-pre-g395742c8dc" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.2.229-pre-g395742c8dc" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.1.0-2.21558.8" />

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -13,6 +13,7 @@
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json;
+      D:\microsoft\dotnet\cps\bin\Debug\packages\nuget;
     </RestoreSources>
   </PropertyGroup>
 
@@ -22,8 +23,8 @@
     <PackageReference Update="Microsoft.VisualStudioEng.MicroBuild.Core"                              Version="1.0.0" />
 
     <!-- Toolset -->
-    <PackageReference Update="Nerdbank.Streams"                                                       Version="2.6.81" />
-    <PackageReference Update="System.IO.Pipelines"                                                    Version="5.0.1" />
+    <PackageReference Update="Nerdbank.Streams"                                                       Version="2.8.57" />
+    <PackageReference Update="System.IO.Pipelines"                                                    Version="6.0.1" />
     <PackageReference Update="RoslynTools.RepoToolset"                                                Version="$(RoslynToolsRepoToolsetVersion)" />
     <PackageReference Update="RoslynTools.ModifyVsixManifest"                                         Version="$(RoslynToolsModifyVsixManifestVersion)" />
     <PackageReference Update="RoslynTools.SignTool"                                                   Version="$(RoslynToolsSignToolVersion)" />
@@ -40,7 +41,7 @@
     <PackageReference Update="Microsoft.Internal.VisualStudio.Interop"                                Version="17.1.0-preview-2-32002-062"/>
     <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="17.1.1035-preview2" />
     <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.1.224-preview"/>
-    <PackageReference Update="Microsoft.VisualStudio.Composition"                                     Version="16.9.20"/>
+    <PackageReference Update="Microsoft.VisualStudio.Composition"                                     Version="17.0.46"/>
     <PackageReference Update="Microsoft.VisualStudio.Data.Core"                                       Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.0.0-preview-2-31223-026"/>
     <PackageReference Update="Microsoft.VisualStudio.Data.Services"                                   Version="17.0.0-preview-2-31223-026" />
@@ -51,7 +52,7 @@
     <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.1.0-preview-2-32002-062" />
     <PackageReference Update="Microsoft.VisualStudio.Interop"                                         Version="17.1.0-preview-2-32002-062"/>
     <PackageReference Update="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50728" />
-    <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="17.1.11-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="17.2.16-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Settings.15.0"                                   Version="16.8.30406.155-pre" />
     <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="2.3.2262-g94fae01e" />
     <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes"                           Version="15.0.36" />
@@ -60,23 +61,23 @@
     <PackageReference Update="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.1.0-preview-2-32002-062" />
     <PackageReference Update="Microsoft.VisualStudio.Telemetry"                                       Version="16.4.13" />
     <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.1.0-preview-2-32002-062" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="17.1.42-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.1.42-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="17.2.10-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.2.10-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="17.1.0-preview-2-32002-062" />
-    <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="17.0.42" />
+    <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="17.0.46" />
     <PackageReference Update="Microsoft.VisualStudio.XmlEditor"                                       Version="17.1.0-preview-2-32002-062" />
     <PackageReference Update="System.Threading.Tasks.Dataflow"                                        Version="6.0.0" />
     <PackageReference Update="Microsoft.VSDesigner"                                                   Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="VsWebSite.Interop"                                                      Version="16.8.30523.219"/>
 
     <!-- https://github.com/dotnet/roslyn/issues/53877 -->
-    <PackageReference Include="StreamJsonRpc"                                                         Version="2.8.28" />
+    <PackageReference Include="StreamJsonRpc"                                                         Version="2.10.42" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.1.221-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.1.221-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.1.221-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.1.221-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.2.232-pre-g881dca9a09" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.2.232-pre-g881dca9a09" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.2.232-pre-g881dca9a09" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.2.232-pre-g881dca9a09" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.1.0-2.21558.8" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
@@ -134,7 +134,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                             return;
                         }
 
-                        _roslynServices.ApplyChangesToSolution(currentSolution.Workspace, result.Result);
+                        bool applied = _roslynServices.ApplyChangesToSolution(currentSolution.Workspace, result.Result);
+
+                        System.Diagnostics.Debug.Assert(applied, "ApplyChangesToSolution returned false");
                     }
                     finally
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
@@ -52,7 +52,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             IWaitIndicator waitService,
             IRoslynServices roslynServices,
             IVsService<SVsSettingsPersistenceManager, ISettingsManager> settingsManagerService)
-
         {
             _unconfiguredProject = unconfiguredProject;
             _userNotificationServices = userNotificationServices;
@@ -221,7 +220,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             return actions;
         }
 
-        private Project? GetCurrentProject() =>
-            _workspace.CurrentSolution.Projects.FirstOrDefault(proj => StringComparers.Paths.Equals(proj.FilePath, _projectVsServices.Project.FullPath));
+        private Project? GetCurrentProject()
+        {
+            return _workspace.CurrentSolution.Projects.FirstOrDefault(
+                proj => StringComparers.Paths.Equals(proj.FilePath, _projectVsServices.Project.FullPath));
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
@@ -189,7 +190,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
         {
             string destinationFileRelative = _unconfiguredProject.MakeRelative(destinationFilePath);
             string destinationFolder = Path.GetDirectoryName(destinationFileRelative);
-            var documentFolders = destinationFolder.Split(new char[]{Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar}, System.StringSplitOptions.RemoveEmptyEntries);
+
+            string[] documentFolders = destinationFolder.Split(Delimiter.Path, StringSplitOptions.RemoveEmptyEntries);
 
             HashSet<Renamer.RenameDocumentActionSet> actions = new();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
@@ -66,15 +66,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
 
         public async Task OnBeforeFilesMovedAsync(IReadOnlyCollection<IFileMoveItem> items)
         {
-            _actions = new();
             Project? project = GetCurrentProject();
-            if (project is null)
-            {
-                return;
-            }
 
-            if (!TryGetFilesToMove(items, out List<string>? filesToMove, out string destination))
+            if (project is null || !TryGetFilesToMove(items, out List<string>? filesToMove, out string destination))
             {
+                _actions = null;
                 return;
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -77,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                 return;
             }
 
-            _actions = await GetNamespaceUpdateActionsAsync(project, filesToMove!, destination);
+            _actions = await GetNamespaceUpdateActionsAsync(project, filesToMove, destination);
         }
 
         public async Task OnAfterFileMoveAsync()
@@ -90,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             ApplyNamespaceUpdateActions(_actions!);
         }
 
-        private bool TryGetFilesToMove(IReadOnlyCollection<IFileMoveItem> items, out List<string>? filesToMove, out string destination)
+        private static bool TryGetFilesToMove(IReadOnlyCollection<IFileMoveItem> items, [NotNullWhen(returnValue: true)] out List<string>? filesToMove, out string destination)
         {
             destination = string.Empty;
             filesToMove = null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
@@ -23,7 +23,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicLanguageService)]
     internal class FileMoveNotificationListener : IFileMoveNotificationListener
     {
-        private const string _compileItemType = "Compile";
         private const string PromptNamespaceUpdate = "SolutionNavigator.PromptNamespaceUpdate";
         private const string EnableNamespaceUpdate = "SolutionNavigator.EnableNamespaceUpdate";
 
@@ -99,7 +98,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             // TODO : Parse children in Folders
             foreach (var item in items)
             {
-                bool isCompileItem = item.ItemType is not null && item.ItemType.Equals(_compileItemType, System.StringComparison.OrdinalIgnoreCase);
+                bool isCompileItem = StringComparers.ItemTypes.Equals(item.ItemType, Compile.SchemaName);
+
                 if (item.WithinProject && isCompileItem && !item.IsLinked && !item.IsFolder)
                 {
                     filesToMove ??= new();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
@@ -26,7 +26,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
         private const string PromptNamespaceUpdate = "SolutionNavigator.PromptNamespaceUpdate";
         private const string EnableNamespaceUpdate = "SolutionNavigator.EnableNamespaceUpdate";
 
-        private HashSet<Renamer.RenameDocumentActionSet>? _actions;
         private readonly SemaphoreSlim _semaphore = new(1,1);
 
         private readonly UnconfiguredProject _unconfiguredProject;
@@ -38,6 +37,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
         private readonly IWaitIndicator _waitService;
         private readonly IRoslynServices _roslynServices;
         private readonly IVsService<SVsSettingsPersistenceManager, ISettingsManager> _settingsManagerService;
+
+        private HashSet<Renamer.RenameDocumentActionSet>? _actions;
 
         [ImportingConstructor]
         public FileMoveNotificationListener(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
@@ -84,12 +84,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
 
         public async Task OnAfterFileMoveAsync()
         {
-            if (_actions?.Count == 0 || !await CheckUserConfirmationAsync())
+            if (_actions is { Count: not 0 } && await CheckUserConfirmationAsync())
             {
-                return;
+                ApplyNamespaceUpdateActions(_actions);
             }
-
-            ApplyNamespaceUpdateActions(_actions!);
         }
 
         private static bool TryGetFilesToMove(IReadOnlyCollection<IFileMoveItem> items, [NotNullWhen(returnValue: true)] out List<string>? filesToMove, out string destination)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
@@ -1,0 +1,218 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Rename;
+using Microsoft.VisualStudio.LanguageServices;
+using Microsoft.VisualStudio.OperationProgress;
+using Microsoft.VisualStudio.ProjectSystem.Waiting;
+using Microsoft.VisualStudio.Settings;
+using Microsoft.VisualStudio.Threading;
+using Path = System.IO.Path;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
+{
+    [Order(Order.Default)]
+    [Export(typeof(IFileMoveNotificationListener))]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicLanguageService)]
+    internal class FileMoveNotificationListener : IFileMoveNotificationListener
+    {
+        private const string _compileItemType = "Compile";
+        private const string PromptNamespaceUpdate = "SolutionNavigator.PromptNamespaceUpdate";
+        private const string EnableNamespaceUpdate = "SolutionNavigator.EnableNamespaceUpdate";
+
+        private HashSet<Renamer.RenameDocumentActionSet>? _actions;
+        private readonly SemaphoreSlim _semaphore = new(1,1);
+
+        private readonly UnconfiguredProject _unconfiguredProject;
+        private readonly IUserNotificationServices _userNotificationServices;
+        private readonly IUnconfiguredProjectVsServices _projectVsServices;
+        private readonly Workspace _workspace;
+        private readonly IProjectThreadingService _threadingService;
+        private readonly IVsService<SVsOperationProgress, IVsOperationProgressStatusService> _operationProgressService;
+        private readonly IWaitIndicator _waitService;
+        private readonly IRoslynServices _roslynServices;
+        private readonly IVsService<SVsSettingsPersistenceManager, ISettingsManager> _settingsManagerService;
+
+        [ImportingConstructor]
+        public FileMoveNotificationListener(
+            UnconfiguredProject unconfiguredProject,
+            IUserNotificationServices userNotificationServices,
+            IUnconfiguredProjectVsServices projectVsServices,
+            [Import(typeof(VisualStudioWorkspace))] Workspace workspace,
+            IProjectThreadingService threadingService,
+            IVsService<SVsOperationProgress, IVsOperationProgressStatusService> operationProgressService,
+            IWaitIndicator waitService,
+            IRoslynServices roslynServices,
+            IVsService<SVsSettingsPersistenceManager, ISettingsManager> settingsManagerService)
+
+        {
+            _unconfiguredProject = unconfiguredProject;
+            _userNotificationServices = userNotificationServices;
+            _projectVsServices = projectVsServices;
+            _workspace = workspace;
+            _threadingService = threadingService;
+            _operationProgressService = operationProgressService;
+            _waitService = waitService;
+            _roslynServices = roslynServices;
+            _settingsManagerService = settingsManagerService;
+        }
+
+        public async Task OnBeforeFilesMovedAsync(IReadOnlyCollection<IFileMoveInfo> items)
+        {
+            _actions = new();
+            Project? project = GetCurrentProject();
+            if (project is null)
+            {
+                return;
+            }
+
+            if (!TryGetFilesToMove(items, out List<string>? filesToMove, out string destination))
+            {
+                return;
+            }
+
+            _actions = await GetNamespaceUpdateActionsAsync(project, filesToMove!, destination);
+        }
+
+        public async Task OnAfterFileMoveAsync()
+        {
+            if (_actions?.Count == 0 || !await CheckUserConfirmationAsync())
+            {
+                return;
+            }
+
+            ApplyNamespaceUpdateActions(_actions!);
+        }
+
+        private bool TryGetFilesToMove(IReadOnlyCollection<IFileMoveInfo> items, out List<string>? filesToMove, out string destination)
+        {
+            destination = string.Empty;
+            filesToMove = null;
+
+            // TODO : Parse children in Folders
+            foreach (var item in items)
+            {
+                bool isCompileItem = item.ItemType is not null && item.ItemType.Equals(_compileItemType, System.StringComparison.OrdinalIgnoreCase);
+                if (item.WithinProject && isCompileItem && !item.IsLinked && !item.IsFolder)
+                {
+                    filesToMove ??= new();
+                    filesToMove.Add(item.Source);
+                    destination = item.Destination;
+                }
+            }
+
+            return filesToMove is not null;
+        }
+
+        private void ApplyNamespaceUpdateActions(HashSet<Renamer.RenameDocumentActionSet> actions)
+        {
+            foreach (var documentAction in actions)
+            {
+                _ = _threadingService.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    await _semaphore.WaitAsync();
+
+                    Solution currentSolution = await PublishLatestSolutionAsync(CancellationToken.None);
+
+                    string actionMessage = documentAction.ApplicableActions.First().GetDescription(CultureInfo.CurrentCulture);
+
+                    await _projectVsServices.ThreadingService.SwitchToUIThread();
+                    WaitIndicatorResult<Solution> result = _waitService.Run(
+                        title: VSResources.Renaming_Type,
+                        message: actionMessage,
+                        allowCancel: true,
+                        token => documentAction.UpdateSolutionAsync(currentSolution, token));
+
+                    // Do not warn the user if the rename was cancelled by the user
+                    if (result.IsCancelled)
+                    {
+                        return;
+                    }
+
+                    _roslynServices.ApplyChangesToSolution(currentSolution.Workspace, result.Result);
+
+                    _semaphore.Release();
+
+                });
+            }
+        }
+
+        private async Task<Solution> PublishLatestSolutionAsync(CancellationToken cancellationToken)
+        {
+            // WORKAROUND: We don't yet have a way to wait for the changes to propagate 
+            // to Roslyn (tracked by https://github.com/dotnet/project-system/issues/3425), so 
+            // instead we wait for the IntelliSense stage to finish for the entire solution
+
+            var operationProgressStatusService = await _operationProgressService.GetValueAsync(cancellationToken);
+            var stageStatus = operationProgressStatusService.GetStageStatus(CommonOperationProgressStageIds.Intellisense);
+
+            await stageStatus.WaitForCompletionAsync().WithCancellation(cancellationToken);
+
+            // The result of that wait, is basically a "new" published Solution, so grab it
+            return _workspace.CurrentSolution;
+        }
+
+        private async Task<bool> CheckUserConfirmationAsync()
+        {
+            ISettingsManager settings = await _settingsManagerService.GetValueAsync();
+            bool promptNamespaceUpdate = settings.GetValueOrDefault(PromptNamespaceUpdate, true);
+            bool enabledNamespaceUpdate = settings.GetValueOrDefault(EnableNamespaceUpdate, true);
+
+            if (!enabledNamespaceUpdate || !promptNamespaceUpdate)
+            {
+                return enabledNamespaceUpdate;
+            }
+
+            await _projectVsServices.ThreadingService.SwitchToUIThread();
+
+            bool confirmation = _userNotificationServices.Confirm(VSResources.UpdateNamespacePromptMessage, out promptNamespaceUpdate);
+
+            await settings.SetValueAsync(PromptNamespaceUpdate, !promptNamespaceUpdate, true);
+
+            return confirmation;
+        }
+
+        private async Task<HashSet<Renamer.RenameDocumentActionSet>> GetNamespaceUpdateActionsAsync(Project project, List<string> filesToMove, string destinationFilePath)
+        {
+            string destinationFileRelative = _unconfiguredProject.MakeRelative(destinationFilePath);
+            string destinationFolder = Path.GetDirectoryName(destinationFileRelative);
+            var documentFolders = destinationFolder.Split(new char[]{Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar}, System.StringSplitOptions.RemoveEmptyEntries);
+
+            HashSet<Renamer.RenameDocumentActionSet> actions = new();
+
+            foreach (var filenameWithPath in filesToMove)
+            {
+                string filename = Path.GetFileName(filenameWithPath);
+
+                var oldDocument = project.Documents.FirstOrDefault(d => StringComparers.Paths.Equals(d.FilePath, filenameWithPath));
+                if (oldDocument is null)
+                {
+                    continue;
+                }
+
+                // This is a file item to another directory, it should only detect this a Update Namespace action.
+                // TODO: Upgrade this api to get rid of the exclamation sign
+                Renamer.RenameDocumentActionSet documentAction = await Renamer.RenameDocumentAsync(oldDocument, null!, documentFolders);
+
+                if (documentAction.ApplicableActions.IsEmpty ||
+                    documentAction.ApplicableActions.Any(a => !a.GetErrors().IsEmpty))
+                {
+                    continue;
+                }
+
+                actions.Add(documentAction);
+            }
+
+            return actions;
+        }
+
+        private Project? GetCurrentProject() =>
+            _workspace.CurrentSolution.Projects.FirstOrDefault(proj => StringComparers.Paths.Equals(proj.FilePath, _projectVsServices.Project.FullPath));
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             _settingsManagerService = settingsManagerService;
         }
 
-        public async Task OnBeforeFilesMovedAsync(IReadOnlyCollection<IFileMoveInfo> items)
+        public async Task OnBeforeFilesMovedAsync(IReadOnlyCollection<IFileMoveItem> items)
         {
             _actions = new();
             Project? project = GetCurrentProject();
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             ApplyNamespaceUpdateActions(_actions!);
         }
 
-        private bool TryGetFilesToMove(IReadOnlyCollection<IFileMoveInfo> items, out List<string>? filesToMove, out string destination)
+        private bool TryGetFilesToMove(IReadOnlyCollection<IFileMoveItem> items, out List<string>? filesToMove, out string destination)
         {
             destination = string.Empty;
             filesToMove = null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                                 title: VSResources.Renaming_Type,
                                 message: renameOperationName,
                                 allowCancel: true,
-                                token => documentRenameResult.UpdateSolutionAsync(currentSolution, token));
+                                context => documentRenameResult.UpdateSolutionAsync(currentSolution, context.CancellationToken));
 
                 // Do not warn the user if the rename was cancelled by the user	
                 if (indicatorResult.IsCancelled)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitIndicator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitIndicator.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
             _waitDialogFactoryService = waitDialogFactoryService;
         }
 
-        public WaitIndicatorResult<T> Run<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncMethod) where T : class?
+        public WaitIndicatorResult<T> Run<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncMethod)
         {
             _joinableTaskContext.VerifyIsOnMainThread();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitIndicator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitIndicator.cs
@@ -3,7 +3,6 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Waiting;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -25,16 +24,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
             _waitDialogFactoryService = waitDialogFactoryService;
         }
 
-        public WaitIndicatorResult<T> Run<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncMethod)
+        public WaitIndicatorResult Run(string title, string message, bool allowCancel, Func<IWaitContext, Task> asyncMethod, int totalSteps = 0)
         {
             _joinableTaskContext.VerifyIsOnMainThread();
 
-            using IWaitContext waitContext = StartWait(title, message, allowCancel);
+            using IWaitContext waitContext = new VisualStudioWaitContext(_waitDialogFactoryService.Value, title, message, allowCancel, totalSteps);
 
             try
             {
 #pragma warning disable VSTHRD102 // Deliberate usage  
-                T result = _joinableTaskContext.Factory.Run(() => asyncMethod(waitContext.CancellationToken));
+                _joinableTaskContext.Factory.Run(() => asyncMethod(waitContext));
+#pragma warning restore VSTHRD102
+
+                return WaitIndicatorResult.Completed;
+            }
+            catch (OperationCanceledException)
+            {
+                return WaitIndicatorResult.Cancelled;
+            }
+            catch (AggregateException aggregate) when (aggregate.InnerExceptions.All(e => e is OperationCanceledException))
+            {
+                return WaitIndicatorResult.Cancelled;
+            }
+        }
+
+        public WaitIndicatorResult<T> Run<T>(string title, string message, bool allowCancel, Func<IWaitContext, Task<T>> asyncMethod, int totalSteps = 0)
+        {
+            _joinableTaskContext.VerifyIsOnMainThread();
+
+            using IWaitContext waitContext = new VisualStudioWaitContext(_waitDialogFactoryService.Value, title, message, allowCancel, totalSteps);
+
+            try
+            {
+#pragma warning disable VSTHRD102 // Deliberate usage  
+                T result = _joinableTaskContext.Factory.Run(() => asyncMethod(waitContext));
 #pragma warning restore VSTHRD102
 
                 return WaitIndicatorResult<T>.FromResult(result);
@@ -47,11 +70,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
             {
                 return WaitIndicatorResult<T>.Cancelled;
             }
-        }
-
-        private IWaitContext StartWait(string title, string message, bool allowCancel)
-        {
-            return new VisualStudioWaitContext(_waitDialogFactoryService.Value, title, message, allowCancel);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -508,7 +508,7 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Adjust namespaces for moved files ?.
+        ///   Looks up a localized string similar to Adjust namespaces for moved files?.
         /// </summary>
         internal static string UpdateNamespacePromptMessage {
             get {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -508,6 +508,15 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Adjust namespaces for moved files ?.
+        /// </summary>
+        internal static string UpdateNamespacePromptMessage {
+            get {
+                return ResourceManager.GetString("UpdateNamespacePromptMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to User Control (Windows Forms) Designer.
         /// </summary>
         internal static string UserControlEditor_DisplayName {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -293,4 +293,7 @@ In order to debug this project, add an executable project to this solution which
     <value>WARNING: Potential incremental build failure in '{0}'. See: https://aka.ms/incremental-build-failure</value>
     <comment>{0} is the file name of the project.</comment>
   </data>
+  <data name="UpdateNamespacePromptMessage" xml:space="preserve">
+    <value>Adjust namespaces for moved files ?</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -294,6 +294,6 @@ In order to debug this project, add an executable project to this solution which
     <comment>{0} is the file name of the project.</comment>
   </data>
   <data name="UpdateNamespacePromptMessage" xml:space="preserve">
-    <value>Adjust namespaces for moved files ?</value>
+    <value>Adjust namespaces for moved files?</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -205,8 +205,8 @@ Pokud chcete projekt ladit, přidejte do řešení spustitelný projekt, který 
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
       <trans-unit id="UpdateNamespacePromptMessage">
-        <source>Adjust namespaces for moved files ?</source>
-        <target state="new">Adjust namespaces for moved files ?</target>
+        <source>Adjust namespaces for moved files?</source>
+        <target state="new">Adjust namespaces for moved files?</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -204,6 +204,11 @@ Pokud chcete projekt ladit, přidejte do řešení spustitelný projekt, který 
         <target state="translated">(Nenastaveno)</target>
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
+      <trans-unit id="UpdateNamespacePromptMessage">
+        <source>Adjust namespaces for moved files ?</source>
+        <target state="new">Adjust namespaces for moved files ?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">Pracovní adresář {0} zadaný v ladicím profilu {1} neexistuje.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -204,6 +204,11 @@ Um das Projekt zu debuggen, fügen Sie dieser Projektmappe ein ausführbares Pro
         <target state="translated">(Nicht festgelegt)</target>
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
+      <trans-unit id="UpdateNamespacePromptMessage">
+        <source>Adjust namespaces for moved files ?</source>
+        <target state="new">Adjust namespaces for moved files ?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">Das im Debugprofil "{1}" angegebene Arbeitsverzeichnis "{0}" ist nicht vorhanden.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -205,8 +205,8 @@ Um das Projekt zu debuggen, fügen Sie dieser Projektmappe ein ausführbares Pro
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
       <trans-unit id="UpdateNamespacePromptMessage">
-        <source>Adjust namespaces for moved files ?</source>
-        <target state="new">Adjust namespaces for moved files ?</target>
+        <source>Adjust namespaces for moved files?</source>
+        <target state="new">Adjust namespaces for moved files?</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -204,6 +204,11 @@ Para depurar este proyecto, agregue un proyecto ejecutable a esta solución con 
         <target state="translated">(No establecido)</target>
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
+      <trans-unit id="UpdateNamespacePromptMessage">
+        <source>Adjust namespaces for moved files ?</source>
+        <target state="new">Adjust namespaces for moved files ?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">El directorio de trabajo '{0}' especificado en el perfil de depuración '{1}' no existe.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -205,8 +205,8 @@ Para depurar este proyecto, agregue un proyecto ejecutable a esta solución con 
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
       <trans-unit id="UpdateNamespacePromptMessage">
-        <source>Adjust namespaces for moved files ?</source>
-        <target state="new">Adjust namespaces for moved files ?</target>
+        <source>Adjust namespaces for moved files?</source>
+        <target state="new">Adjust namespaces for moved files?</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -205,8 +205,8 @@ Pour déboguer ce projet, ajoutez à cette solution un projet exécutable qui fa
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
       <trans-unit id="UpdateNamespacePromptMessage">
-        <source>Adjust namespaces for moved files ?</source>
-        <target state="new">Adjust namespaces for moved files ?</target>
+        <source>Adjust namespaces for moved files?</source>
+        <target state="new">Adjust namespaces for moved files?</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -204,6 +204,11 @@ Pour déboguer ce projet, ajoutez à cette solution un projet exécutable qui fa
         <target state="translated">(Non défini)</target>
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
+      <trans-unit id="UpdateNamespacePromptMessage">
+        <source>Adjust namespaces for moved files ?</source>
+        <target state="new">Adjust namespaces for moved files ?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">Le répertoire de travail '{0}' spécifié dans le profil de débogage '{1}' n'existe pas.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -205,8 +205,8 @@ Per eseguire il debug del progetto, aggiungere a questa soluzione un progetto es
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
       <trans-unit id="UpdateNamespacePromptMessage">
-        <source>Adjust namespaces for moved files ?</source>
-        <target state="new">Adjust namespaces for moved files ?</target>
+        <source>Adjust namespaces for moved files?</source>
+        <target state="new">Adjust namespaces for moved files?</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -204,6 +204,11 @@ Per eseguire il debug del progetto, aggiungere a questa soluzione un progetto es
         <target state="translated">(Non impostato)</target>
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
+      <trans-unit id="UpdateNamespacePromptMessage">
+        <source>Adjust namespaces for moved files ?</source>
+        <target state="new">Adjust namespaces for moved files ?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">La directory di lavoro '{0}' specificata nel profilo di debug '{1}' non esiste.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -205,8 +205,8 @@ In order to debug this project, add an executable project to this solution which
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
       <trans-unit id="UpdateNamespacePromptMessage">
-        <source>Adjust namespaces for moved files ?</source>
-        <target state="new">Adjust namespaces for moved files ?</target>
+        <source>Adjust namespaces for moved files?</source>
+        <target state="new">Adjust namespaces for moved files?</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -204,6 +204,11 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">(未設定)</target>
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
+      <trans-unit id="UpdateNamespacePromptMessage">
+        <source>Adjust namespaces for moved files ?</source>
+        <target state="new">Adjust namespaces for moved files ?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">'{1}' デバッグ プロファイルに指定した作業ディレクトリ '{0}' が存在しません。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -205,8 +205,8 @@ In order to debug this project, add an executable project to this solution which
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
       <trans-unit id="UpdateNamespacePromptMessage">
-        <source>Adjust namespaces for moved files ?</source>
-        <target state="new">Adjust namespaces for moved files ?</target>
+        <source>Adjust namespaces for moved files?</source>
+        <target state="new">Adjust namespaces for moved files?</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -204,6 +204,11 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">(설정되지 않음)</target>
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
+      <trans-unit id="UpdateNamespacePromptMessage">
+        <source>Adjust namespaces for moved files ?</source>
+        <target state="new">Adjust namespaces for moved files ?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">'{1}' 디버그 프로필에 지정된 작업 디렉터리 '{0}'이(가) 없습니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -204,6 +204,11 @@ Aby debugować ten projekt, dodaj projekt wykonywalny do tego rozwiązania, któ
         <target state="translated">(Nie ustawiono)</target>
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
+      <trans-unit id="UpdateNamespacePromptMessage">
+        <source>Adjust namespaces for moved files ?</source>
+        <target state="new">Adjust namespaces for moved files ?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">Katalog roboczy „{0}” określony w profilu debugowania „{1}” nie istnieje.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -205,8 +205,8 @@ Aby debugować ten projekt, dodaj projekt wykonywalny do tego rozwiązania, któ
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
       <trans-unit id="UpdateNamespacePromptMessage">
-        <source>Adjust namespaces for moved files ?</source>
-        <target state="new">Adjust namespaces for moved files ?</target>
+        <source>Adjust namespaces for moved files?</source>
+        <target state="new">Adjust namespaces for moved files?</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -204,6 +204,11 @@ Para depurar esse projeto, adicione um projeto executável a essa solução que 
         <target state="translated">(Não definido)</target>
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
+      <trans-unit id="UpdateNamespacePromptMessage">
+        <source>Adjust namespaces for moved files ?</source>
+        <target state="new">Adjust namespaces for moved files ?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">O diretório de trabalho '{0}' especificado no perfil de depuração '{1}' não existe.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -205,8 +205,8 @@ Para depurar esse projeto, adicione um projeto executável a essa solução que 
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
       <trans-unit id="UpdateNamespacePromptMessage">
-        <source>Adjust namespaces for moved files ?</source>
-        <target state="new">Adjust namespaces for moved files ?</target>
+        <source>Adjust namespaces for moved files?</source>
+        <target state="new">Adjust namespaces for moved files?</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -204,6 +204,11 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">(Не задано)</target>
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
+      <trans-unit id="UpdateNamespacePromptMessage">
+        <source>Adjust namespaces for moved files ?</source>
+        <target state="new">Adjust namespaces for moved files ?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">Рабочий каталог "{0}", указанный в профиле отладки "{1}", не существует.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -205,8 +205,8 @@ In order to debug this project, add an executable project to this solution which
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
       <trans-unit id="UpdateNamespacePromptMessage">
-        <source>Adjust namespaces for moved files ?</source>
-        <target state="new">Adjust namespaces for moved files ?</target>
+        <source>Adjust namespaces for moved files?</source>
+        <target state="new">Adjust namespaces for moved files?</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -204,6 +204,11 @@ Bu projede hata ayıklamak için bu çözüme, kitaplık projesine başvuran bir
         <target state="translated">(Ayarlanmadı)</target>
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
+      <trans-unit id="UpdateNamespacePromptMessage">
+        <source>Adjust namespaces for moved files ?</source>
+        <target state="new">Adjust namespaces for moved files ?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">'{1}' hata ayıklama profilinde belirtilen '{0}' çalışma dizini yok.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -205,8 +205,8 @@ Bu projede hata ayıklamak için bu çözüme, kitaplık projesine başvuran bir
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
       <trans-unit id="UpdateNamespacePromptMessage">
-        <source>Adjust namespaces for moved files ?</source>
-        <target state="new">Adjust namespaces for moved files ?</target>
+        <source>Adjust namespaces for moved files?</source>
+        <target state="new">Adjust namespaces for moved files?</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -205,8 +205,8 @@ In order to debug this project, add an executable project to this solution which
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
       <trans-unit id="UpdateNamespacePromptMessage">
-        <source>Adjust namespaces for moved files ?</source>
-        <target state="new">Adjust namespaces for moved files ?</target>
+        <source>Adjust namespaces for moved files?</source>
+        <target state="new">Adjust namespaces for moved files?</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -204,6 +204,11 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">(未设置)</target>
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
+      <trans-unit id="UpdateNamespacePromptMessage">
+        <source>Adjust namespaces for moved files ?</source>
+        <target state="new">Adjust namespaces for moved files ?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">“{1}”调试配置文件中指定的工作目录“{0}”不存在。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -204,6 +204,11 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">(未設定)</target>
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
+      <trans-unit id="UpdateNamespacePromptMessage">
+        <source>Adjust namespaces for moved files ?</source>
+        <target state="new">Adjust namespaces for moved files ?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">'{1}' 偵錯設定檔中指定的工作目錄 '{0}' 不存在。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -205,8 +205,8 @@ In order to debug this project, add an executable project to this solution which
         <note>Text to display to the user in the property page UI when the "startup object" property is not set.</note>
       </trans-unit>
       <trans-unit id="UpdateNamespacePromptMessage">
-        <source>Adjust namespaces for moved files ?</source>
-        <target state="new">Adjust namespaces for moved files ?</target>
+        <source>Adjust namespaces for moved files?</source>
+        <target state="new">Adjust namespaces for moved files?</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/IWaitContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/IWaitContext.cs
@@ -7,7 +7,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.Waiting
 {
     internal interface IWaitContext : IDisposable
     {
+        /// <summary>
+        ///     Gets a cancellation token that represents the user's request for cancellation.
+        /// </summary>
+        /// <remarks>
+        ///     If the wait operation does not support cancellation, this will be <see cref="CancellationToken.None"/>.
+        /// </remarks>
         CancellationToken CancellationToken { get; }
-        string Message { get; set; }
+
+        /// <summary>
+        ///     Allows the operation being waited on to update the ongoing operation's status for the user.
+        /// </summary>
+        /// <param name="message">The message to display, or <see langword="null"/> if no change is required.</param>
+        /// <param name="currentStep">The current step's (one-based) index, or <see langword="null"/> if no change is required.</param>
+        /// <param name="totalSteps">The total number of steps, or <see langword="null"/> if no change is required.</param>
+        /// <param name="progressText">A progress messate display, or <see langword="null"/> if no change is required.</param>
+        void Update(
+            string? message = null,
+            int? currentStep = null,
+            int? totalSteps = null,
+            string? progressText = null);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/IWaitIndicator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/IWaitIndicator.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Composition;
 
@@ -10,6 +9,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Waiting
     [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IWaitIndicator
     {
-        WaitIndicatorResult<T> Run<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncMethod);
+        WaitIndicatorResult Run(string title, string message, bool allowCancel, Func<IWaitContext, Task> asyncMethod, int totalSteps = 0);
+
+        WaitIndicatorResult<T> Run<T>(string title, string message, bool allowCancel, Func<IWaitContext, Task<T>> asyncMethod, int totalSteps = 0);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/IWaitIndicator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/IWaitIndicator.cs
@@ -10,6 +10,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Waiting
     [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IWaitIndicator
     {
-        WaitIndicatorResult<T> Run<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncMethod) where T : class?;
+        WaitIndicatorResult<T> Run<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncMethod);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/WaitIndicatorResult.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/WaitIndicatorResult.cs
@@ -5,7 +5,29 @@ using System;
 namespace Microsoft.VisualStudio.ProjectSystem.Waiting
 {
     /// <summary>
-    ///     Represents the result of <see cref="IWaitIndicator.Run{T}(string, string, bool, Func{System.Threading.CancellationToken, System.Threading.Tasks.Task{T}})"/>.
+    ///     Represents the result of <see cref="IWaitIndicator.Run(string, string, bool, Func{IWaitContext, System.Threading.Tasks.Task}, int)"/>.
+    /// </summary>
+    internal readonly struct WaitIndicatorResult
+    {
+        public static readonly WaitIndicatorResult Cancelled = new(isCancelled: true);
+        public static readonly WaitIndicatorResult Completed = new(isCancelled: false);
+
+        private readonly bool _isCancelled;
+
+        private WaitIndicatorResult(bool isCancelled)
+        {
+            _isCancelled = isCancelled;
+        }
+
+        /// <summary>
+        ///     Gets a value indicating whether the operation was cancelled, either 
+        ///     by the user or the operation itself.
+        /// </summary>
+        public bool IsCancelled => _isCancelled;
+    }
+
+    /// <summary>
+    ///     Represents the result of <see cref="IWaitIndicator.Run{T}(string, string, bool, Func{IWaitContext, System.Threading.Tasks.Task{T}}, int)"/>.
     /// </summary>
     internal readonly struct WaitIndicatorResult<T>
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/WaitIndicatorResult.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/WaitIndicatorResult.cs
@@ -8,11 +8,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Waiting
     ///     Represents the result of <see cref="IWaitIndicator.Run{T}(string, string, bool, Func{System.Threading.CancellationToken, System.Threading.Tasks.Task{T}})"/>.
     /// </summary>
     internal readonly struct WaitIndicatorResult<T>
-        where T : class?
     {
-#pragma warning disable RS0038 // Prefer null literal
         public static readonly WaitIndicatorResult<T> Cancelled = new(isCancelled: true, result: default!);
-#pragma warning restore RS0038 
 
         private readonly bool _isCancelled;
         private readonly T _result;
@@ -41,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Waiting
             {
                 Verify.Operation(!_isCancelled, "Cannot get the result of a cancelled operation.");
 
-                return _result!;
+                return _result;
             }
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitContextTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitContextTests.cs
@@ -22,19 +22,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
         }
 
         [Fact]
-        public static void SetPropertyMessage_Test()
-        {
-            string title = "Test001";
-            string message = "Testing001";
-            bool isCancelable = true;
-            var context = Create(title, message, isCancelable);
-            Assert.Equal(message, context.Message);
-            var message2 = "Testing002";
-            context.Message = message2;
-            Assert.Equal(message2, context.Message);
-        }
-
-        [Fact]
         public static void CreateWrongType_Test()
         {
             Assert.ThrowsAny<Exception>(() => _ = CreateWrongType(string.Empty, string.Empty, false));

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitIndicatorTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitIndicatorTests.cs
@@ -69,16 +69,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
             var (instance, userCancel) = CreateInstance(isCancelable: true);
 
             CancellationToken? result = default;
-            instance.Run("", "", true, token =>
+            instance.Run("", "", true, context =>
             {
                 userCancel();
 
-                result = token;
+                result = context.CancellationToken;
 
                 return TaskResult.EmptyString;
             });
 
-            Assert.True(result!.Value.IsCancellationRequested);
+            Assert.NotNull(result);
+            Assert.True(result.Value.IsCancellationRequested);
         }
 
         [Fact]
@@ -86,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
         {
             var (instance, _) = CreateInstance();
 
-            var result = instance.Run("", "", false, token =>
+            var result = instance.Run("", "", false, _ =>
             {
                 return Task.FromResult("Hello");
             });


### PR DESCRIPTION
This PR adds a feature where after moving compile items between folders (by drag drop on Solution Explorer), the user is prompted to update the namespaces.

Requires VS PR: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/CPS/pullrequest/378467
Requires CPS PR: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/CPS/pullrequest/378467

Two new options are added to control this behaviour:

![image](https://user-images.githubusercontent.com/350947/156290071-01acc67c-52b6-4628-b6c0-713dda4f18a6.png)

![image](https://user-images.githubusercontent.com/350947/156356436-c52a237b-f970-457c-bdbf-e660b362992d.png)

![image](https://user-images.githubusercontent.com/350947/156356680-6e0fce5a-45b5-4ffa-a427-d831aa1e3c49.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7925)