### PR TITLE
Improve solution close performance

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.ProjectSystem.VS;
 using Microsoft.VisualStudio.ProjectSystem.VS.Xproj;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.Packaging
@@ -28,8 +29,24 @@ namespace Microsoft.VisualStudio.Packaging
         public const string ActivationContextGuid = "E7DF1626-44DD-4E8C-A8A0-92EAB6DDC16E";
         public const string PackageGuid = "860A27C0-B665-47F3-BC12-637E16A1050A";
 
+        /// <summary>
+        /// A static instance of the package's JTF. Will be null if the package has not
+        /// yet been initialized. Note that package initialization occurs after many
+        /// MEF components are instantiated.
+        /// </summary>
+        /// <remarks>
+        /// Async work queued with this instance of the JTF will be awaited before
+        /// the package is unloaded. This allows shutdown work to be safely scheduled
+        /// to run in the background without blocking the main thread, without having to
+        /// worry that the work might not complete before the process exits.
+        /// </remarks>
+        public static JoinableTaskFactory? PackageJoinableTaskFactory { get; private set; }
+
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
+            // Assign the package's JTF instance to a public static property for use elsewhere
+            PackageJoinableTaskFactory = JoinableTaskFactory;
+
             IComponentModel componentModel = await this.GetServiceAsync<SComponentModel, IComponentModel>();
 
             IEnumerable<IPackageService> packageServices = componentModel.GetExtensions<IPackageService>();


### PR DESCRIPTION
Previously we would block the main thread while waiting for serialization of the fast up-to-date check's persistent state to occur.

This change has two parts:

1. Return immediately from the `OnAfterSolutionClose` callback.
2. Schedule the actual serialization on the thread pool.

To guarantee that the async serialization completes before the VS process exits, we register the task with the package's JTF. Tasks registered with that factory must all complete before the package can be unloaded and VS can shut down.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7929)