### PR TITLE
Make TargetPlatformIdentifier available to visibility conditions for MAUI

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ConfigurationGeneralPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ConfigurationGeneralPage.xaml
@@ -26,7 +26,14 @@
 
   <!-- eg: ".NETCoreApp,Version=v5.0" -->
   <StringProperty Name="TargetFrameworkMoniker" Visible="False" ReadOnly="True" />
-  
+
+  <!-- eg: "net6.0-windows" -> "Windows"
+           "net6.0-ios"     -> "ios"
+           "net6.0-android" -> "android"
+           "net6.0"         -> ""
+  -->
+  <StringProperty Name="TargetPlatformIdentifier" Visible="False" ReadOnly="True" />
+
   <!-- eg: "C#" -->
   <StringProperty Name="Language" Visible="False" ReadOnly="True" />
   


### PR DESCRIPTION
We use the `ConfigurationGeneralPage` to expose project properties to visibility conditions.

For MAUI we need the ability to condition properties on the target platform.

Adding this property here makes it available. The function can then be added in CPS.

cc @japarson 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7937)