### PR TITLE
Fix pipeline warning about Build VS Bootstrapper version

### DIFF
--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -169,6 +169,7 @@ steps:
 - task: MicroBuildBuildVSBootstrapper@2
   displayName: Build VS Bootstrapper
   inputs:
+    bootstrapperCoreVersion: 'latest'
     vsMajorVersion: 17
     channelName: 'int.main'
     manifests: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\VSSetup\Insertion\Microsoft.VisualStudio.ProjectSystem.Managed.vsman'


### PR DESCRIPTION
In our `official.yml` pipeline, we see this warning:

![image](https://user-images.githubusercontent.com/17788297/155609015-2af4ad87-0ca2-4cb1-9686-a4c8f0c9e0a1.png)

I started an email conversation with the team that makes this plugin. Apparently, the plugin is supposed to default to `latest` when it has no version specified. I have informed that team this clearly is not happening, as every pipeline I've looked at shows this warning. To remove this warning for the time being, we are explicitly setting the `bootstrapperCoreVersion` to `latest`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7942)