### PR TITLE
Add windows platform to TargetFramework value for .NET 7 when needed.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
@@ -208,7 +208,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         private static bool IsNetCore5OrHigher(string targetFrameworkAlias)
         {
-            return targetFrameworkAlias.Contains("5.0") || targetFrameworkAlias.Contains("6.0");
+            return targetFrameworkAlias.Contains("5.0") || targetFrameworkAlias.Contains("6.0") || targetFrameworkAlias.Contains("7.0");
         }
 
         private async Task<bool> IsWindowsPlatformNeededAsync()


### PR DESCRIPTION
Fixes [AB#1473348](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1473348).

The platform value is needed to be added to the `TargetFramework` value for WPF and Windows Forms projects to be able to build properly. We have been adding this value for .NET 5 and 6; this change extends this behavior for .NET 7.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7950)