### PR TITLE
Use the MultiLineString editor

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
@@ -151,7 +151,11 @@
                   DisplayName="Release notes"
                   Description="A description of the changes made in this release of the package, often used in UI like the Updates tab of the Visual Studio Package Manager in place of the package description."
                   HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147242"
-                  Category="General" />
+                  Category="General">
+    <StringProperty.ValueEditors>
+      <ValueEditor EditorType="MultiLineString" />
+    </StringProperty.ValueEditors>
+  </StringProperty>
 
   <DynamicEnumProperty Name="NeutralLanguage"
                        DisplayName="Assembly neutral language"


### PR DESCRIPTION
Fixes [AB#1494063](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1494063).

Use the `MultiLineString` editor for the `PackageReleaseNotes` property, just as we do for `Description`. Otherwise you can't type new lines into the editor and would have to fall back to editing the project by hand.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7953)