### PR TITLE
Fix redundant build (overbuild) loop issue in the fast up-to-date check

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -304,7 +304,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     before = beforeItems;
 
                 var after = projectChange.After.Items
-                    .Select(item => new UpToDateCheckInputItem(path: item.Key, metadata: item.Value))
+                    .Select(item => new UpToDateCheckInputItem(path: item.Key, itemType, metadata: item.Value))
                     .ToHashSet(UpToDateCheckInputItem.PathComparer);
 
                 var diff = new SetDiff<UpToDateCheckInputItem>(before, after, UpToDateCheckInputItem.PathComparer);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckInputItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckInputItem.cs
@@ -13,6 +13,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         public static readonly IEqualityComparer<UpToDateCheckInputItem> PathComparer = new UpToDateCheckInputItemPathComparer();
 
         /// <summary>
+        /// The set of item types which are eligible to be copied to the project's output directory
+        /// when <c>CopyToOutputDirectory</c> metadata is present.
+        /// </summary>
+        /// <remarks>
+        /// Mirrors the items specified in MSBuild's <c>_GetCopyToOutputDirectoryItemsFromThisProject</c>
+        /// target.
+        /// </remarks>
+        private static readonly ImmutableHashSet<string> s_copyToOutputDirectoryItemTypes
+            = ImmutableHashSet<string>.Empty.WithComparer(StringComparers.ItemTypes)
+                .Add(None.SchemaName)
+                .Add(Content.SchemaName)
+                .Add(Compile.SchemaName)
+                .Add("EmbeddedResource");
+
+        /// <summary>
         /// Gets the relative path to the item.
         /// </summary>
         public string Path { get; }
@@ -30,18 +45,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// </summary>
         public BuildUpToDateCheck.CopyType CopyType { get; }
 
-        public UpToDateCheckInputItem(string path, string? targetPath, BuildUpToDateCheck.CopyType copyType)
+        public UpToDateCheckInputItem(string path, string itemType, IImmutableDictionary<string, string> metadata)
         {
             Path = path;
-            TargetPath = targetPath;
-            CopyType = copyType;
-        }
 
-        public UpToDateCheckInputItem(string path, IImmutableDictionary<string, string> metadata)
-        {
-            Path = path;
-            TargetPath = GetTargetPath();
-            CopyType = GetCopyType();
+            // We only track copies to a target path for certain item types.
+            // For other item types, set a null target path, and a copy type of "never".
+            bool isCopyToOutputDirectoryType = s_copyToOutputDirectoryItemTypes.Contains(itemType);
+
+            TargetPath = isCopyToOutputDirectoryType ? GetTargetPath() : null;
+            CopyType = isCopyToOutputDirectoryType ? GetCopyType() : BuildUpToDateCheck.CopyType.CopyNever;
 
             string? GetTargetPath()
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectCatalogSnapshotFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectCatalogSnapshotFactory.cs
@@ -26,7 +26,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             }
 
             var propertyPageCatalog = new Mock<IPropertyPagesCatalog>();
-            propertyPageCatalog.Setup(o => o.GetSchema(It.IsAny<string>())).Returns<string>(n => ruleNameToRule[n]);
+            propertyPageCatalog.Setup(o => o.GetSchema(It.IsAny<string>()))
+                .Returns<string>(ruleName => ruleNameToRule.TryGetValue(ruleName, out var rule) ? rule : new Rule { DataSource = new DataSource { ItemType = ruleName } });
 
             var namedCatalogs = ImmutableDictionary<string, IPropertyPagesCatalog>.Empty.Add("File", propertyPageCatalog.Object);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTestBase.cs
@@ -14,7 +14,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             .Add(new ItemType("None", true))
             .Add(new ItemType("Content", true))
             .Add(new ItemType("Compile", true))
-            .Add(new ItemType("Resource", true));
+            .Add(new ItemType("Resource", true))
+            .Add(new ItemType("EmbeddedResource", true));
 
         private protected static IProjectRuleSnapshotModel SimpleItems(params string[] items)
         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -33,6 +33,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private readonly DateTime _projectFileTimeUtc = new(1999, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         private readonly List<ITelemetryServiceFactory.TelemetryParameters> _telemetryEvents = new();
+        private readonly Dictionary<ProjectConfiguration, DateTime> _lastCheckTimeAtUtc = new();
+
         private readonly BuildUpToDateCheck _buildUpToDateCheck;
         private readonly ITestOutputHelper _output;
         private readonly IFileSystemMock _fileSystem;
@@ -42,7 +44,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private bool _isFastUpToDateCheckEnabled = true;
 
         private UpToDateCheckConfiguredInput? _state;
-        private Dictionary<ProjectConfiguration, DateTime> _lastCheckTimeAtUtc = new();
 
         public BuildUpToDateCheckTests(ITestOutputHelper output)
         {
@@ -1425,11 +1426,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 HashItems(("Compile", new[] { "Path1" })),
                 HashItems(("Compile", new[] { "Path1", "Path2" })));
 
-            static int HashItems(params (string itemType, string[] paths)[] items)
+            static int HashItems(params (string ItemType, string[] Paths)[] items)
             {
                 var itemsByItemType = items.ToImmutableDictionary(
-                    i => i.itemType,
-                    i => i.paths.Select(p => new UpToDateCheckInputItem(p, null, BuildUpToDateCheck.CopyType.CopyNever)).ToImmutableArray());
+                    i => i.ItemType,
+                    i => i.Paths.Select(p => new UpToDateCheckInputItem(p, i.ItemType, ImmutableDictionary<string, string>.Empty)).ToImmutableArray());
 
                 return BuildUpToDateCheck.ComputeItemHash(itemsByItemType);
             }


### PR DESCRIPTION
Fixes #6508

The fast up-to-date check tracks project items. When these items have `CopyToOutputDirectory` metadata, the check ensures the destination file exists. If it does not, a build is scheduled.

MSBuild only considers four item types when copying files to the output directory: `None`, `Content`, `Compile` and `EmbeddedResource`.

This change restricts the fast up-to-date check to only consider these four item types when assessing which items to copy to the output directory.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7959)