### PR TITLE
Strip out spaces in VB settings class/member .settings properties

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
@@ -200,7 +200,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                         End If
 
                         If Settings.UseSpecialClassName Then
-                            Return SpecialClassName.Replace(" ", "_")
+                            Return SpecialClassName
                         End If
                     Catch ex As Exception When Common.ReportWithoutCrash(ex, String.Format("Failed to crack open {0} to determine if we were supposed to use the ""Special"" settings class name", FullPath), NameOf(SettingsDesigner))
                     End Try
@@ -224,7 +224,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Debug.Fail("Can't get a class name from an empty path!")
                 Return ""
             End If
-            Return IO.Path.GetFileNameWithoutExtension(PathName).Replace(" ", "_")
+            Return IO.Path.GetFileNameWithoutExtension(PathName)
         End Function
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
@@ -200,7 +200,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                         End If
 
                         If Settings.UseSpecialClassName Then
-                            Return SpecialClassName
+                            Return SpecialClassName.Replace(" ", "_")
                         End If
                     Catch ex As Exception When Common.ReportWithoutCrash(ex, String.Format("Failed to crack open {0} to determine if we were supposed to use the ""Special"" settings class name", FullPath), NameOf(SettingsDesigner))
                     End Try
@@ -224,7 +224,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Debug.Fail("Can't get a class name from an empty path!")
                 Return ""
             End If
-            Return IO.Path.GetFileNameWithoutExtension(PathName)
+            Return IO.Path.GetFileNameWithoutExtension(PathName).Replace(" ", "_")
         End Function
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
@@ -3,6 +3,7 @@
 Imports System.ComponentModel.Design
 Imports System.IO
 Imports Microsoft.VisualStudio.Editors.Interop
+Imports Microsoft.VisualStudio.Editors.ResourceEditor
 Imports Microsoft.VisualStudio.Shell.Interop
 
 Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
@@ -224,7 +225,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Debug.Fail("Can't get a class name from an empty path!")
                 Return ""
             End If
-            Return IO.Path.GetFileNameWithoutExtension(PathName)
+            Return ResourceEditorView.GetGeneratedClassNameFromFileName(IO.Path.GetFileNameWithoutExtension(PathName))
         End Function
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
@@ -8,6 +8,7 @@ Imports System.Reflection
 Imports System.Runtime.InteropServices
 
 Imports Microsoft.VisualStudio.Designer.Interfaces
+Imports Microsoft.VisualStudio.Editors.DesignerFramework
 Imports Microsoft.VisualStudio.Editors.Interop
 Imports Microsoft.VisualStudio.OLE.Interop
 Imports Microsoft.VisualStudio.Shell
@@ -170,7 +171,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     ' If this is the "default" settings file, we add the "My" module as well...
                     '
                     If shouldGenerateMyStuff Then
-                        AddMyModule(CompileUnit, projectRootNamespace, wszDefaultNamespace.Replace(" ", "_"))
+                        AddMyModule(CompileUnit, projectRootNamespace, DesignUtil.GenerateValidLanguageIndependentNamespace(wszDefaultNamespace))
                     End If
                 End If
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
@@ -587,8 +587,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             Debug.Assert(typeName <> "", "we shouldn't have an empty type-name when generating a Settings class")
             fullTypeName &= typeName
 
-            fullTypeName = fullTypeName.Replace(" ", "_")
-
             Return fullTypeName
 
         End Function

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
@@ -115,7 +115,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="pcbOutput"></param>
         ''' <param name="pGenerateProgress"></param>
         Private Function Generate(wszInputFilePath As String, bstrInputFileContents As String, wszDefaultNamespace As String, rgbOutputFileContents() As IntPtr, ByRef pcbOutput As UInteger, pGenerateProgress As IVsGeneratorProgress) As Integer Implements IVsSingleFileGenerator.Generate
-
             Dim BufPtr As IntPtr = IntPtr.Zero
             Try
                 ' get the DesignTimeSettings from the file content
@@ -171,7 +170,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     ' If this is the "default" settings file, we add the "My" module as well...
                     '
                     If shouldGenerateMyStuff Then
-                        AddMyModule(CompileUnit, projectRootNamespace, wszDefaultNamespace)
+                        AddMyModule(CompileUnit, projectRootNamespace, wszDefaultNamespace.Replace(" ", "_"))
                     End If
                 End If
 
@@ -587,6 +586,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
             Debug.Assert(typeName <> "", "we shouldn't have an empty type-name when generating a Settings class")
             fullTypeName &= typeName
+
+            fullTypeName = fullTypeName.Replace(" ", "_")
 
             Return fullTypeName
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1289213/ by replacing spaces in the namespace/class name of the VB settings file with underscores.

Test as follows:
- Create new WPF VB project
- Create new folder (My Project)
- Create new settings file (Settings.settings)
- Click show all files 
- Observe no errors in the generated Settings VB file

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7960)