### PR TITLE
Use C# 10 compiler and lang version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -65,7 +65,7 @@
 
   <PropertyGroup Condition="'$(Language)' == 'C#'">
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <Features>strict</Features>
   </PropertyGroup>

--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -29,7 +29,7 @@
     <PackageReference Update="RoslynTools.SignTool"                                                   Version="$(RoslynToolsSignToolVersion)" />
     <PackageReference Update="XliffTasks"                                                             Version="1.0.0-beta.20574.1" />
     <PackageReference Update="Microsoft.DiaSymReader.Pdb2Pdb"                                         Version="$(MicrosoftDiaSymReaderPdb2PdbVersion)" />
-    <PackageReference Update="Microsoft.Net.Compilers.Toolset"                                        Version="3.11.0" />
+    <PackageReference Update="Microsoft.Net.Compilers.Toolset"                                        Version="4.2.0-1.final" />
     <PackageReference Update="OpenCover"                                                              Version="4.7.1138-rc" />
     <PackageReference Update="Codecov"                                                                Version="$(CodecovVersion)" />
     <PackageReference Update="MicroBuild.Plugins.SwixBuild"                                           Version="$(MicroBuildPluginsSwixBuildVersion)" />

--- a/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
+++ b/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <!-- TODO: Function doesn't return a value on all code paths (https://github.com/dotnet/project-system/issues/2592) -->
-    <NoWarn>$(NoWarn);42353;NU5125</NoWarn>
+    <NoWarn>$(NoWarn);42353;NU5125;IDE1006</NoWarn>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <TargetFramework>net472</TargetFramework>
     <IsManagedProjectSystemProject>false</IsManagedProjectSystemProject>

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -11,7 +11,7 @@
     <CreateVsixContainer>false</CreateVsixContainer>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <!-- TODO: Function/Property doesn't return a value on all code paths (https://github.com/dotnet/project-system/issues/2592) -->
-    <NoWarn>$(NoWarn);42353;42355;42105;NU5125</NoWarn>
+    <NoWarn>$(NoWarn);42353;42355;42105;NU5125;IDE1006</NoWarn>
     <IsManagedProjectSystemProject>false</IsManagedProjectSystemProject>
     <!-- Nuget -->
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
A previous attempt at this engaged the implicit usings feature, which requires SDK support. Our build machines are still on VS2019, which don't have the relevant SDK. Updating to VS2022 currently hits a bug on internal build pools.

This change just turns on the C# 10 language, without using any features that require SDK support.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7967)