### PR TITLE
Disable OptProf to fix build

### DIFF
--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -184,7 +184,7 @@ steps:
   inputs:
     filePath: build\optprof\UpdateRunSettings.ps1
     arguments: '-profilingInputsPath "ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)" -bootstrapperInfoPath "$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json"'
-    failOnStderr: true'
+    failOnStderr: true
   enabled: false
 
 - task: artifactDropTask@0

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -32,7 +32,7 @@ parameters:
 - name: SkipOptimize
   displayName: Skip OptProf Optimization
   type: boolean
-  default: true
+  default: false
 
 ###################################################################################################################################################################
 # INSTALLATION
@@ -64,6 +64,7 @@ steps:
     feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
     ShouldSkipOptimize: ${{ parameters.SkipOptimize }}
     NumberCommitsToSearch: '100'
+  enabled: false
 
 ###################################################################################################################################################################
 # BUILD SOLUTION

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -32,7 +32,7 @@ parameters:
 - name: SkipOptimize
   displayName: Skip OptProf Optimization
   type: boolean
-  default: false
+  default: true
 
 ###################################################################################################################################################################
 # INSTALLATION
@@ -164,6 +164,7 @@ steps:
     usePat: true
     AccessToken: '$(System.AccessToken)'
   condition: succeeded()
+  enabled: false
 
 # MicroBuildBuildVSBootstrapper requires MicroBuildSigningPlugin for signjson.exe to run.
 - task: MicroBuildBuildVSBootstrapper@2
@@ -175,13 +176,15 @@ steps:
     manifests: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\VSSetup\Insertion\Microsoft.VisualStudio.ProjectSystem.Managed.vsman'
     outputFolder: $(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\VSSetup\Insertion
   condition: succeeded()
+  enabled: false
 
 - task: PowerShell@2
   displayName: Update RunSettings via Bootstrapper data
   inputs:
     filePath: build\optprof\UpdateRunSettings.ps1
     arguments: '-profilingInputsPath "ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)" -bootstrapperInfoPath "$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json"'
-    failOnStderr: true
+    failOnStderr: true'
+  enabled: false
 
 - task: artifactDropTask@0
   displayName: 'Publish to Artifact Services: RunSettings'
@@ -194,6 +197,7 @@ steps:
     AccessToken: '$(System.AccessToken)'
     dropMetadataContainerName: RunSettings
   condition: succeeded()
+  enabled: false
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: MicroBuildOutputs'


### PR DESCRIPTION
Working build from these changes: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5861305

There was a change in the dependencies for the VS Bootstrapper task. This change was made to help those doing SBOM. Because of our reliance on RepoInsertionTool, we can't update the MicroBuild SwixBuild plugin, which is now necessary to use VS Bootstrapper task at the moment. Since we need this task to produce OptProf data, we have to disable OptProf until we can remove our reliance on RepoInsertionTool and use the latest MicroBuild SwixBuild plugin.

Along with disabling these tasks, the trigger for the [OptProf release pipeline](https://devdiv.visualstudio.com/DevDiv/_release?definitionId=3197) will also be disabled:

![image](https://user-images.githubusercontent.com/17788297/157565677-7309b77c-5614-4808-9600-dcd9df49c43b.png)

OptProf release trigger disabled:

![image](https://user-images.githubusercontent.com/17788297/157569702-cbd1b7c6-a693-4410-a992-82413afc9803.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7968)