### PR TITLE
Include up-to-date check log level in telemetry

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
@@ -157,7 +157,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     (TelemetryPropertyName.UpToDateCheckFailReason, (object)reason),
                     (TelemetryPropertyName.UpToDateCheckDurationMillis, _stopwatch.Elapsed.TotalMilliseconds),
                     (TelemetryPropertyName.UpToDateCheckFileCount, _timestampCache.Count),
-                    (TelemetryPropertyName.UpToDateCheckConfigurationCount, _upToDateCheckConfiguredInput.ImplicitInputs.Length)
+                    (TelemetryPropertyName.UpToDateCheckConfigurationCount, _upToDateCheckConfiguredInput.ImplicitInputs.Length),
+                    (TelemetryPropertyName.UpToDateCheckLogLevel, Level)
                 });
 
                 // Remember the failure reason for use in IncrementalBuildFailureDetector.
@@ -177,7 +178,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     (TelemetryPropertyName.UpToDateCheckDurationMillis, (object)_stopwatch.Elapsed.TotalMilliseconds),
                     (TelemetryPropertyName.UpToDateCheckFileCount, _timestampCache.Count),
-                    (TelemetryPropertyName.UpToDateCheckConfigurationCount, _upToDateCheckConfiguredInput.ImplicitInputs.Length)
+                    (TelemetryPropertyName.UpToDateCheckConfigurationCount, _upToDateCheckConfiguredInput.ImplicitInputs.Length),
+                    (TelemetryPropertyName.UpToDateCheckLogLevel, Level)
                 });
 
                 Info(nameof(Resources.FUTD_UpToDate));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
@@ -1,5 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Microsoft.VisualStudio.ProjectSystem;
+
 namespace Microsoft.VisualStudio.Telemetry
 {
     /// <summary>
@@ -36,6 +38,11 @@ namespace Microsoft.VisualStudio.Telemetry
         ///     and for multi-targeting projects this will equal the number of target frameworks being targeted.
         /// </remarks>
         public const string UpToDateCheckConfigurationCount = Prefix + ".uptodatecheck.configurationcount";
+
+        /// <summary>
+        ///     Indicates the user's chosen logging level. Values from the <see cref="LogLevel"/> enum.
+        /// </summary>
+        public const string UpToDateCheckLogLevel = Prefix + ".uptodatecheck.loglevel";
 
         /// <summary>
         ///     Indicates the project when the dependency tree is updated with all resolved dependencies.

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private const string _msBuildProjectDirectory = "NewProjectDirectory";
         private const string _msBuildAllProjects = "Project1;Project2";
         private const string _outputPath = "NewOutputPath";
+        private const LogLevel _logLevel = LogLevel.Info;
 
         private readonly DateTime _projectFileTimeUtc = new(1999, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
@@ -58,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             // Enable "Info" log level, as we assert logged messages in tests
             var projectSystemOptions = new Mock<IProjectSystemOptions>(MockBehavior.Strict);
             projectSystemOptions.Setup(o => o.GetFastUpToDateLoggingLevelAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(LogLevel.Info);
+                .ReturnsAsync(_logLevel);
             projectSystemOptions.Setup(o => o.GetIsFastUpToDateCheckEnabledAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => _isFastUpToDateCheckEnabled);
 
@@ -1579,7 +1580,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             Assert.Equal(TelemetryEventName.UpToDateCheckFail, telemetryEvent.EventName);
             Assert.NotNull(telemetryEvent.Properties);
-            Assert.Equal(4, telemetryEvent.Properties.Count);
+            Assert.Equal(5, telemetryEvent.Properties.Count);
 
             var reasonProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckFailReason));
             Assert.Equal(reason, reasonProp.propertyValue);
@@ -1596,6 +1597,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var configurationCount = Assert.IsType<int>(configurationCountProp.propertyValue);
             Assert.True(configurationCount == 1);
 
+            var logLevelProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckLogLevel));
+            var logLevel = Assert.IsType<LogLevel>(logLevelProp.propertyValue);
+            Assert.True(logLevel == _logLevel);
+
             _telemetryEvents.Clear();
         }
 
@@ -1606,7 +1611,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             Assert.Equal(TelemetryEventName.UpToDateCheckSuccess, telemetryEvent.EventName);
 
             Assert.NotNull(telemetryEvent.Properties);
-            Assert.Equal(3, telemetryEvent.Properties.Count);
+            Assert.Equal(4, telemetryEvent.Properties.Count);
 
             var durationProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckDurationMillis));
             var duration = Assert.IsType<double>(durationProp.propertyValue);
@@ -1619,6 +1624,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var configurationCountProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckConfigurationCount));
             var configurationCount = Assert.IsType<int>(configurationCountProp.propertyValue);
             Assert.True(configurationCount == 1);
+
+            var logLevelProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckLogLevel));
+            var logLevel = Assert.IsType<LogLevel>(logLevelProp.propertyValue);
+            Assert.True(logLevel == _logLevel);
 
             _telemetryEvents.Clear();
         }


### PR DESCRIPTION
It would be useful to know how widespread use of this logging is for a few reasons:

- We enable incremental build failure logging when set to a level higher than 'None'.
- When analysing the check's duration, we would expect the duration to be higher when verbose logging is enabled. Once we know the log level, we can filter or group accordingly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7970)