### PR TITLE
Don't send up-to-date check telemetry during validation

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             private readonly Stopwatch _stopwatch;
             private readonly TimestampCache _timestampCache;
             private readonly string _fileName;
-            private readonly ITelemetryService _telemetryService;
+            private readonly ITelemetryService? _telemetryService;
             private readonly UpToDateCheckConfiguredInput _upToDateCheckConfiguredInput;
 
             public LogLevel Level { get; }
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             public string? FailureReason { get; private set; }
 
-            public Log(TextWriter writer, LogLevel requestedLogLevel, Stopwatch stopwatch, TimestampCache timestampCache, string projectPath, ITelemetryService telemetryService, UpToDateCheckConfiguredInput upToDateCheckConfiguredInput)
+            public Log(TextWriter writer, LogLevel requestedLogLevel, Stopwatch stopwatch, TimestampCache timestampCache, string projectPath, ITelemetryService? telemetryService, UpToDateCheckConfiguredInput upToDateCheckConfiguredInput)
             {
                 _writer = writer;
                 Level = requestedLogLevel;
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Minimal(resourceName, values);
 
                 // Send telemetry.
-                _telemetryService.PostProperties(TelemetryEventName.UpToDateCheckFail, new[]
+                _telemetryService?.PostProperties(TelemetryEventName.UpToDateCheckFail, new[]
                 {
                     (TelemetryPropertyName.UpToDateCheckFailReason, (object)reason),
                     (TelemetryPropertyName.UpToDateCheckDurationMillis, _stopwatch.Elapsed.TotalMilliseconds),
@@ -173,7 +173,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 _stopwatch.Stop();
 
                 // Send telemetry.
-                _telemetryService.PostProperties(TelemetryEventName.UpToDateCheckSuccess, new[]
+                _telemetryService?.PostProperties(TelemetryEventName.UpToDateCheckSuccess, new[]
                 {
                     (TelemetryPropertyName.UpToDateCheckDurationMillis, (object)_stopwatch.Elapsed.TotalMilliseconds),
                     (TelemetryPropertyName.UpToDateCheckFileCount, _timestampCache.Count),

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -789,7 +789,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 var timestampCache = new TimestampCache(_fileSystem);
 
                 LogLevel requestedLogLevel = await _projectSystemOptions.GetFastUpToDateLoggingLevelAsync(token);
-                var logger = new Log(logWriter, requestedLogLevel, sw, timestampCache, _configuredProject.UnconfiguredProject.FullPath ?? "", _telemetryService, state);
+                var logger = new Log(logWriter, requestedLogLevel, sw, timestampCache, _configuredProject.UnconfiguredProject.FullPath ?? "", isValidationRun ? null : _telemetryService, state);
 
                 try
                 {


### PR DESCRIPTION
When a project is configured to validate for incremental build failures, we run the fast up-to-date check a second time after the build. If the project is not up-to-date, then there is an incremental build failure.

For that second run, we should not send the regular check's telemetry. We have different telemetry to track the failure.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7971)