### PR TITLE
Update pipelines to use VS 2022 images

### DIFF
--- a/build/ci/compliance.yml
+++ b/build/ci/compliance.yml
@@ -11,7 +11,7 @@ resources:
 - repo: self
   clean: true
 queue:
-  name: VSEngSS-MicroBuild2019-1ES
+  name: VSEngSS-MicroBuild2022-1ES
   demands: Cmd
   timeoutInMinutes: 90
 variables:
@@ -21,8 +21,13 @@ variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
 steps:
-- script: $(Build.SourcesDirectory)\build.cmd /build /no-test /ci /sign /diagnostic /no-deploy /no-integration /no-ibc /no-clearnugetcache /configuration $(BuildConfiguration)
+- task: MSBuild@1
   displayName: Build ProjectSystem.sln
+  inputs:
+    solution: $(Build.SourcesDirectory)\build\proj\Build.proj
+    msbuildArchitecture: x86
+    configuration: $(BuildConfiguration)
+    msbuildArguments: '/m /warnaserror /nologo /clp:Summary /p:Build=true /p:CIBuild=true /v:normal /bl:$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\log\Build.binlog'
 
 - task: PoliCheck@2
   # Scan for problematic terminology.

--- a/build/ci/integration-tests.yml
+++ b/build/ci/integration-tests.yml
@@ -25,8 +25,8 @@ jobs:
       inputs:
         solution: $(Build.SourcesDirectory)\build\proj\Build.proj
         msbuildArchitecture: x86
-        configuration: $(BuildConfiguration)
-        msbuildArguments: '/m /warnaserror /nologo /clp:Summary /p:Build=true /p:IntegrationTest=true /p:Deploy=true /p:CIBuild=true /v:normal /bl:$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\log\Build.binlog'
+        configuration: $(_configuration)
+        msbuildArguments: '/m /warnaserror /nologo /clp:Summary /p:Build=true /p:IntegrationTest=true /p:Deploy=true /p:CIBuild=true /v:normal /bl:$(Build.SourcesDirectory)\artifacts\$(_configuration)\log\Build.binlog'
 
     - task: PublishBuildArtifacts@1
       inputs:

--- a/build/ci/integration-tests.yml
+++ b/build/ci/integration-tests.yml
@@ -12,7 +12,7 @@ jobs:
   pool:
     name: NetCore1ESPool-Public
     # Image list: https://helix.dot.net/#1esPools
-    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2022.Pre.Open
+    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
   strategy:
     maxParallel: 2
     matrix:

--- a/build/ci/integration-tests.yml
+++ b/build/ci/integration-tests.yml
@@ -11,7 +11,8 @@ jobs:
 - job: Visual_Studio
   pool:
     name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.windows.10.amd64.vs2019.pre.open
+    # Image list: https://helix.dot.net/#1esPools
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2022.Pre.Open
   strategy:
     maxParallel: 2
     matrix:
@@ -19,8 +20,13 @@ jobs:
         _configuration: Debug
   timeoutInMinutes: 60
   steps:
-    - script: $(Build.SourcesDirectory)\build.cmd /build /no-test /integration /diagnostic /ci /no-sign /deploy /no-clearnugetcache /configuration $(_configuration)
+    - task: MSBuild@1
       displayName: Build ProjectSystem.sln
+      inputs:
+        solution: $(Build.SourcesDirectory)\build\proj\Build.proj
+        msbuildArchitecture: x86
+        configuration: $(BuildConfiguration)
+        msbuildArguments: '/m /warnaserror /nologo /clp:Summary /p:Build=true /p:IntegrationTest=true /p:Deploy=true /p:CIBuild=true /v:normal /bl:$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\log\Build.binlog'
 
     - task: PublishBuildArtifacts@1
       inputs:

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -13,7 +13,7 @@ resources:
 - repo: self
   clean: true
 queue:
-  name: VSEngSS-MicroBuild2019-1ES
+  name: VSEngSS-MicroBuild2022-1ES
   demands: Cmd
   timeoutInMinutes: 90
 variables:
@@ -76,7 +76,7 @@ steps:
   displayName: Build Src for SBOM
   inputs:
     solution: $(Build.SourcesDirectory)\build\proj\Build.proj
-    msbuildArchitecture: 'x86'
+    msbuildArchitecture: x86
     configuration: $(BuildConfiguration)
     msbuildArguments: '/m /warnaserror /nologo /clp:Summary /p:Build=true /p:CIBuild=true /p:QuickSrcBuild=true /v:normal /bl:$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\log\QuickSrcBuild.binlog'
 
@@ -90,7 +90,7 @@ steps:
   displayName: Build ProjectSystem.sln
   inputs:
     solution: $(Build.SourcesDirectory)\build\proj\Build.proj
-    msbuildArchitecture: 'x86'
+    msbuildArchitecture: x86
     configuration: $(BuildConfiguration)
     msbuildArguments: '/m /warnaserror /nologo /clp:Summary /p:Build=true /p:Test=true /p:CIBuild=true /v:normal /bl:$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\log\Build.binlog'
 

--- a/build/ci/one-loc-build.yml
+++ b/build/ci/one-loc-build.yml
@@ -10,7 +10,7 @@ resources:
 pool:
   name: NetCore1ESPool-Public
   # Image list: https://helix.dot.net/#1esPools
-  demands: ImageOverride -equals Build.Windows.10.Amd64.VS2022.Pre.Open
+  demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
   timeoutInMinutes: 15
 variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/build/ci/one-loc-build.yml
+++ b/build/ci/one-loc-build.yml
@@ -9,7 +9,8 @@ resources:
   clean: true
 pool:
   name: NetCore1ESPool-Public
-  demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
+  # Image list: https://helix.dot.net/#1esPools
+  demands: ImageOverride -equals Build.Windows.10.Amd64.VS2022.Pre.Open
   timeoutInMinutes: 15
 variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/build/ci/richnav.yml
+++ b/build/ci/richnav.yml
@@ -27,7 +27,7 @@ resources:
 pool:
   name: NetCore1ESPool-Public
   # Image list: https://helix.dot.net/#1esPools
-  demands: ImageOverride -equals Build.Windows.10.Amd64.VS2022.Pre.Open
+  demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
   timeoutInMinutes: 15
 variables:
   BuildConfiguration: Debug

--- a/build/ci/richnav.yml
+++ b/build/ci/richnav.yml
@@ -26,7 +26,8 @@ resources:
   clean: true
 pool:
   name: NetCore1ESPool-Public
-  demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
+  # Image list: https://helix.dot.net/#1esPools
+  demands: ImageOverride -equals Build.Windows.10.Amd64.VS2022.Pre.Open
   timeoutInMinutes: 15
 variables:
   BuildConfiguration: Debug
@@ -35,8 +36,13 @@ variables:
   EnableRichCodeNavigation: true
 
 steps:
-- script: $(Build.SourcesDirectory)\build.cmd /build /ci /no-deploy /no-integration /ibc /no-clearnugetcache /configuration $(BuildConfiguration)
+- task: MSBuild@1
   displayName: Build ProjectSystem.sln
+  inputs:
+    solution: $(Build.SourcesDirectory)\build\proj\Build.proj
+    msbuildArchitecture: x86
+    configuration: $(BuildConfiguration)
+    msbuildArguments: '/m /warnaserror /nologo /clp:Summary /p:Build=true /p:CIBuild=true /v:normal /bl:$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\log\Build.binlog'
 
 - task: RichCodeNavIndexer@0
   displayName: RichCodeNav Upload

--- a/build/ci/unit-tests-template.yml
+++ b/build/ci/unit-tests-template.yml
@@ -4,8 +4,13 @@ jobs:
   pool: ${{ parameters.pool }}
   timeoutInMinutes: 20
   steps:
-    - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /clearnugetcache /no-deploy /no-integration /no-ibc /configuration ${{ parameters.configuration }}
+    - task: MSBuild@1
       displayName: Build ProjectSystem.sln
+      inputs:
+        solution: $(Build.SourcesDirectory)\build\proj\Build.proj
+        msbuildArchitecture: x86
+        configuration: $(BuildConfiguration)
+        msbuildArguments: '/m /warnaserror /nologo /clp:Summary /p:Build=true /p:Test=true /p:CIBuild=true /v:normal /bl:$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\log\Build.binlog'
 
     - task: PublishBuildArtifacts@1
       inputs:

--- a/build/ci/unit-tests-template.yml
+++ b/build/ci/unit-tests-template.yml
@@ -9,8 +9,8 @@ jobs:
       inputs:
         solution: $(Build.SourcesDirectory)\build\proj\Build.proj
         msbuildArchitecture: x86
-        configuration: $(BuildConfiguration)
-        msbuildArguments: '/m /warnaserror /nologo /clp:Summary /p:Build=true /p:Test=true /p:CIBuild=true /v:normal /bl:$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\log\Build.binlog'
+        configuration: ${{ parameters.configuration }}
+        msbuildArguments: '/m /warnaserror /nologo /clp:Summary /p:Build=true /p:Test=true /p:CIBuild=true /v:normal /bl:$(Build.SourcesDirectory)\artifacts\${{ parameters.configuration }}\log\Build.binlog'
 
     - task: PublishBuildArtifacts@1
       inputs:

--- a/build/ci/unit-tests.yml
+++ b/build/ci/unit-tests.yml
@@ -32,7 +32,7 @@ jobs:
     pool:
       name: NetCore1ESPool-Public
       # Image list: https://helix.dot.net/#1esPools
-      demands: ImageOverride -equals Build.Windows.10.Amd64.VS2022.Pre.Open
+      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
 
 - template: unit-tests-template.yml
   parameters:
@@ -41,7 +41,7 @@ jobs:
     pool:
       name: NetCore1ESPool-Public
       # Image list: https://helix.dot.net/#1esPools
-      demands: ImageOverride -equals Build.Windows.10.Amd64.VS2022.Pre.Open
+      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
 
 - template: unit-tests-template.yml
   parameters:

--- a/build/ci/unit-tests.yml
+++ b/build/ci/unit-tests.yml
@@ -50,4 +50,6 @@ jobs:
     pool: 
       name: NetCore1ESPool-Public
       # Image list: https://helix.dot.net/#1esPools
-      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.ES.Open
+      # NOTE: There currently is no Spanish VS 2022 image. Previous image was: Build.Windows.Amd64.VS2019.Pre.ES.Open
+      # 'Scout' is the data-center image as to simply provide a different environment to test.
+      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Scout.Open

--- a/build/ci/unit-tests.yml
+++ b/build/ci/unit-tests.yml
@@ -31,7 +31,8 @@ jobs:
     configuration: Debug
     pool:
       name: NetCore1ESPool-Public
-      demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
+      # Image list: https://helix.dot.net/#1esPools
+      demands: ImageOverride -equals Build.Windows.10.Amd64.VS2022.Pre.Open
 
 - template: unit-tests-template.yml
   parameters:
@@ -39,7 +40,8 @@ jobs:
     configuration: Release
     pool:
       name: NetCore1ESPool-Public
-      demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
+      # Image list: https://helix.dot.net/#1esPools
+      demands: ImageOverride -equals Build.Windows.10.Amd64.VS2022.Pre.Open
 
 - template: unit-tests-template.yml
   parameters:
@@ -47,4 +49,5 @@ jobs:
     configuration: Debug
     pool: 
       name: NetCore1ESPool-Public
-      demands: ImageOverride -equals Build.Windows.Amd64.VS2019.Pre.ES.Open
+      # Image list: https://helix.dot.net/#1esPools
+      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.ES.Open

--- a/build/loc/Directory.Build.props
+++ b/build/loc/Directory.Build.props
@@ -1,0 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
+<Project>
+  <!-- Empty to avoid importing Directory.Build.props in the root -->
+</Project>

--- a/build/loc/OneLocBuildSetup.csproj
+++ b/build/loc/OneLocBuildSetup.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IncludeVSSDKPackages>false</IncludeVSSDKPackages>
   </PropertyGroup>
 

--- a/build/loc/OneLocBuildSetup.csproj
+++ b/build/loc/OneLocBuildSetup.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IncludeVSSDKPackages>false</IncludeVSSDKPackages>
   </PropertyGroup>
 


### PR DESCRIPTION
### Description
- Updated all pipelines to use VS2022 images
  - VS 2022 images needed for C# 10
- Updated all builds to no longer use `build.cmd`, which allows for explicit use of x86 MSBuild
  - Running MSBuild as x86 unblocks allowing C# 10 to be used, such as from here: https://github.com/dotnet/project-system/pull/7786
  - The primary issue is described here on why the C# 10 changes were causing build failures, which works around that issue that is not fixed on our internal images (`VSEngSS-MicroBuild2022-1ES`): https://github.com/dotnet/msbuild/issues/7108
- Updated `OneLocBuildSetup.csproj` to .Net 6 and made it ignore the root `Directory.Build.props`

### Pipeline Runs with these changes
- RichNav: https://dev.azure.com/dnceng/public/_build/results?buildId=1659895
- OneLocBuild: https://dev.azure.com/dnceng/public/_build/results?buildId=1659975
- Compliance: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5873680
- Official: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5873681

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7974)