### PR TITLE
Changing embedded rules trigger project build

### DIFF
--- a/build/import/VisualStudio.XamlRules.targets
+++ b/build/import/VisualStudio.XamlRules.targets
@@ -66,4 +66,9 @@
     </Copy>
   </Target>
 
+  <ItemGroup>
+    <!-- XamlPropertyRuleNoCodeBehind are embedded during build. Changes to them must trigger builds. -->
+    <UpToDateCheckInput Include="@(XamlPropertyRuleNoCodeBehind)" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
PR #7959 fixed an overbuild issue seen in our repo. That fix highlighted a bug in our build where embedded rule files were inivisible to the fast up-to-date check.

This change ensures `XamlPropertyRuleNoCodeBehind` items are added to the `UpToDateCheckInput` item group, so that we build correctly when one of these files is changed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7983)