### PR TITLE
Passing VersionOverride metadata as part of nomination

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedPackageReference.xaml
@@ -56,6 +56,11 @@
                   ReadOnly="True"
                   Visible="false" />
 
+  <!-- Specifies a version to use for this package reference and overrides any version specified in a central package management file. -->
+  <StringProperty Name="VersionOverride"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <BoolProperty Name="Visible"
                 ReadOnly="True"
                 Visible="False" />


### PR DESCRIPTION
In https://github.com/NuGet/NuGet.Client/pull/4426 I added a new attribute to `<PackageReference />` to allow the ability to override a centrally defined package version.  This change adds the property to nomination in project system

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7985)