### PR TITLE
Fix bad globbing

### DIFF
--- a/build/import/Workarounds.targets
+++ b/build/import/Workarounds.targets
@@ -5,8 +5,8 @@
        deploy it as CopyToOutputDirectory item. Remove them both, xunit.extensibility.core carries the 
        version we will use.  -->
   <ItemGroup>
-    <None Remove="$(Pkgxunit_runner_visualstudio)\**\xunit.abstractions.dll" />
-    <None Remove="$(Pkgxunit_runner_console)\**\xunit.abstractions.dll" />
+    <None Remove="$(Pkgxunit_runner_visualstudio)\**\xunit.abstractions.dll" Condition="'$(Pkgxunit_runner_visualstudio)' != ''" />
+    <None Remove="$(Pkgxunit_runner_console)\**\xunit.abstractions.dll" Condition="'$(Pkgxunit_runner_console)' != ''"/>
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Since commit 1f2f03e5 we've removed copies of xunit.abstractions.dll from the "None" group during evaluation (see that commit and the related issues for the background on why). We specify the files to remove using a globs of the form:

`$(Pkgxunit_runner_visualstudio)\**\xunit.abstractions.dll`

and

`$(Pkgxunit_runner_console)\**\xunit.abstractions.dll`

The `Pkgxunit_runner_visualstudio` and `Pkgxunit_runner_console` specify the locations of the restored xunit.runner.visualstudio and xunit.runner.console NuGet packages, respectively. The globs are meant to allow us to remove xunit.abstractions.dll without taking a dependency on the layout of the files within those packages.

This removal is in Workarounds.targets which is imported by every one of our projects. However, the `Pkgxunit_runner_visualstudio` and  `Pkgxunit_runner_console` properties will only be defined in those few projects that reference the respective packages. In every other project, the glob effectively becomes "\\**\xunit.abstractions.dll", _which expands into a recursive search for xunit.abstractions.dll starting at the root of the current drive_.

From a performance perspective this is clearly undesirable, and MSBuild recently added a warning about this kind of globbing pattern. In our build it manifests as:

```
MSBUILD : error MSB5029: The value "\**\xunit.abstractions.dll" of the "Exclude"
attribute in element <ItemGroup> is a wildcard that results in enumerating all
files on the drive, which was likely not intended. Check that referenced
properties are always defined.
```

This fails the build.

Here we fix the issue by conditioning the `<None Remove="..." />` on the respective properties being defined.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7986)