### PR TITLE
Remove redundant casts (solution-wide codefix)

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
@@ -200,8 +200,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
         {
             if (_deltaApplier is null)
             {
-                _deltaApplier = (IDeltaApplier)(_callback.GetDeltaApplier()
-                    ?? _deltaApplierCreator.Value.CreateManagedDeltaApplier(_runtimeVersion));
+                _deltaApplier = _callback.GetDeltaApplier()
+                    ?? _deltaApplierCreator.Value.CreateManagedDeltaApplier(_runtimeVersion);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/MetadataExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/MetadataExtensions.cs
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// <returns>The boolean value if found and successfully parsed as a boolean, otherwise <see langword="null"/>.</returns>
         public static bool? GetBoolProperty(this IImmutableDictionary<string, string> properties, string key)
         {
-            return properties.TryGetBoolProperty(key, out bool value) ? value : (bool?)null;
+            return properties.TryGetBoolProperty(key, out bool value) ? value : null;
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// <typeparam name="T">The enum type.</typeparam>
         public static T? GetEnumProperty<T>(this IImmutableDictionary<string, string> properties, string key) where T : struct, Enum
         {
-            return properties.TryGetEnumProperty(key, out T value) ? value : (T?)null;
+            return properties.TryGetEnumProperty(key, out T value) ? value : null;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesChangesBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesChangesBuilder.cs
@@ -36,8 +36,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
             }
 
             return new DependenciesChanges(
-                _added == null ? (IImmutableList<IDependencyModel>)ImmutableList<IDependencyModel>.Empty : ImmutableArray.CreateRange(_added),
-                _removed == null ? (IImmutableList<IDependencyModel>)ImmutableList<IDependencyModel>.Empty : ImmutableArray.CreateRange(_removed));
+                _added == null ? ImmutableList<IDependencyModel>.Empty : ImmutableArray.CreateRange(_added),
+                _removed == null ? ImmutableList<IDependencyModel>.Empty : ImmutableArray.CreateRange(_removed));
         }
 
         public override string ToString() => ToString(_added, _removed);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
             // We only have resolved data if the update came via the JointRule data source.
             if (buildProjectChange != null)
             {
-                Func<string, bool>? isEvaluatedItemSpec = ResolvedItemRequiresEvaluatedItem ? evaluationProjectChange.After.Items.ContainsKey : (Func<string, bool>?)null;
+                Func<string, bool>? isEvaluatedItemSpec = ResolvedItemRequiresEvaluatedItem ? evaluationProjectChange.After.Items.ContainsKey : null;
 
                 HandleChangesForRule(
                     resolved: true,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             await Assert.ThrowsAsync<ArgumentNullException>("path", () =>
             {
-                return storage.AddFileAsync((string?)null!);
+                return storage.AddFileAsync(null!);
             });
         }
 
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             await Assert.ThrowsAsync<ArgumentNullException>("path", () =>
             {
-                return storage.CreateEmptyFileAsync((string?)null!);
+                return storage.CreateEmptyFileAsync(null!);
             });
         }
 
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             await Assert.ThrowsAsync<ArgumentNullException>("path", async () =>
             {
-                await storage.CreateFolderAsync((string?)null!);
+                await storage.CreateFolderAsync(null!);
             });
         }
 
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             await Assert.ThrowsAsync<ArgumentNullException>("path", async () =>
             {
-                await storage.AddFolderAsync((string?)null!);
+                await storage.AddFolderAsync(null!);
             });
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/References/AlwaysAllowValidProjectReferenceCheckerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/References/AlwaysAllowValidProjectReferenceCheckerTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.References
 
             Assert.ThrowsAsync<ArgumentNullException>("referencedProject", () =>
             {
-                return checker.CanAddProjectReferenceAsync((object)null!);
+                return checker.CanAddProjectReferenceAsync(null!);
             });
         }
 
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.References
 
             Assert.ThrowsAsync<ArgumentNullException>("referencedProjects", () =>
             {
-                return checker.CanAddProjectReferencesAsync((IImmutableSet<object>)null!);
+                return checker.CanAddProjectReferencesAsync(null!);
             });
         }
 
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.References
 
             Assert.ThrowsAsync<ArgumentNullException>("referencingProject", () =>
             {
-                return checker.CanBeReferencedAsync((object)null!);
+                return checker.CanBeReferencedAsync(null!);
             });
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProviderTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProviderTestBase.cs
@@ -225,7 +225,7 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
             object[] arguments = new object[3 + additionalArguments.Length];
             arguments[0] = specialFilesManager;
             arguments[1] = projectTree;
-            arguments[2] = (ICreateFileFromTemplateService)null!;
+            arguments[2] = null!;
             additionalArguments.CopyTo(arguments, 3);
 
             // We override CreateFileAsync to call the CreateEmptyFileAsync which makes writting tests in the base easier

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/AppDesignerFolderProjectTreePropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/AppDesignerFolderProjectTreePropertiesProviderTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree
 
             Assert.Throws<ArgumentNullException>("ruleSnapshots", () =>
             {
-                propertiesProvider.UpdateProjectTreeSettings((IImmutableDictionary<string, IProjectRuleSnapshot>)null!, ref projectTreeSettings);
+                propertiesProvider.UpdateProjectTreeSettings(null!, ref projectTreeSettings);
             });
         }
 
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree
 
             Assert.Throws<ArgumentNullException>("propertyContext", () =>
             {
-                propertiesProvider.CalculatePropertyValues((IProjectTreeCustomizablePropertyContext)null!, propertyValues);
+                propertiesProvider.CalculatePropertyValues(null!, propertyValues);
             });
         }
 
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree
 
             Assert.Throws<ArgumentNullException>("propertyValues", () =>
             {
-                propertiesProvider.CalculatePropertyValues(propertyContext, (IProjectTreeCustomizablePropertyValues)null!);
+                propertiesProvider.CalculatePropertyValues(propertyContext, null!);
             });
         }
 
@@ -630,12 +630,12 @@ Root (flags: {ProjectRoot})
 
         private static AppDesignerFolderProjectTreePropertiesProvider CreateInstance()
         {
-            return CreateInstance((IProjectImageProvider?)null, (IProjectDesignerService?)null);
+            return CreateInstance(null, null);
         }
 
         private static AppDesignerFolderProjectTreePropertiesProvider CreateInstance(IProjectDesignerService designerService)
         {
-            return CreateInstance((IProjectImageProvider?)null, designerService);
+            return CreateInstance(null, designerService);
         }
 
         private static AppDesignerFolderProjectTreePropertiesProvider CreateInstance(IProjectImageProvider? imageProvider, IProjectDesignerService? designerService)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/ProjectRootImageProjectTreeModifierTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/ProjectRootImageProjectTreeModifierTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree
 
             Assert.Throws<ArgumentNullException>("propertyContext", () =>
             {
-                propertiesProvider.CalculatePropertyValues((IProjectTreeCustomizablePropertyContext)null!, propertyValues);
+                propertiesProvider.CalculatePropertyValues(null!, propertyValues);
             });
         }
 
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree
 
             Assert.Throws<ArgumentNullException>("propertyValues", () =>
             {
-                propertiesProvider.CalculatePropertyValues(propertyContext, (IProjectTreeCustomizablePropertyValues)null!);
+                propertiesProvider.CalculatePropertyValues(propertyContext, null!);
             });
         }
 
@@ -193,12 +193,12 @@ Root (flags: {ProjectRoot})
 
         private static ProjectRootImageProjectTreePropertiesProvider CreateInstance()
         {
-            return CreateInstance((IProjectImageProvider)null!);
+            return CreateInstance(null!);
         }
 
         private static ProjectRootImageProjectTreePropertiesProvider CreateInstance(IProjectImageProvider imageProvider)
         {
-            return CreateInstance((IProjectCapabilitiesService)null!, imageProvider);
+            return CreateInstance(null!, imageProvider);
         }
 
         private static ProjectRootImageProjectTreePropertiesProvider CreateInstance(IProjectCapabilitiesService? capabilities, IProjectImageProvider? imageProvider)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/PackageRestoreConfiguredInputFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/PackageRestoreConfiguredInputFactory.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         public static IReadOnlyCollection<PackageRestoreConfiguredInput>? Create(ProjectRestoreInfo restoreInfo)
         {
             ProjectConfiguration projectConfiguration = ProjectConfigurationFactory.Create("Debug|x64");
-            IComparable projectVersion = (IComparable)0;
+            IComparable projectVersion = 0;
 
             return new PackageRestoreConfiguredInput[1]{new PackageRestoreConfiguredInput(projectConfiguration, restoreInfo, projectVersion)};
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractAddItemCommandHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractAddItemCommandHandlerTests.cs
@@ -82,7 +82,7 @@ Root (flags: {ProjectRoot})
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 
-            var result = await command.GetCommandStatusAsync(nodes, TestAddItemCommand.CommandId, true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, TestAddItemCommand.CommandId, true, "commandText", 0);
 
             Assert.True(result.Handled);
             Assert.Equal("commandText", result.CommandText);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommandTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommandTests.cs
@@ -97,13 +97,13 @@ Root (flags: {ProjectRoot})
 
             // Command is enabled if there is no build in progress.
             var command = CreateInstance(isBuilding: false);
-            var results = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var results = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
             Assert.True(results.Handled);
             Assert.Equal(CommandStatus.Enabled | CommandStatus.Supported, results.Status);
 
             // Command is disabled if there is build in progress.
             command = CreateInstance(isBuilding: true);
-            results = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            results = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
             Assert.True(results.Handled);
             Assert.Equal(CommandStatus.Supported, results.Status);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractOpenProjectDesignerCommandTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractOpenProjectDesignerCommandTests.cs
@@ -65,7 +65,7 @@ Root (flags: {ProjectRoot})
 
             var nodes = ImmutableHashSet.Create(tree, tree.Children[0]);
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.False(result.Handled);
         }
@@ -99,7 +99,7 @@ Root (flags: {ProjectRoot})
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.False(result.Handled);
         }
@@ -133,7 +133,7 @@ Root (flags: {ProjectRoot})
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Handled);
             Assert.Equal("commandText", result.CommandText);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageProjectContextMenuCommandTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageProjectContextMenuCommandTests.cs
@@ -33,7 +33,7 @@ Root (flags: {ProjectRoot})
 
             var nodes = ImmutableHashSet.Create(tree.Root);
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Handled);
         }
@@ -50,7 +50,7 @@ Root (flags: {ProjectRoot})
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.False(result.Handled);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageTopLevelBuildMenuCommandTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageTopLevelBuildMenuCommandTests.cs
@@ -33,7 +33,7 @@ Root (flags: {ProjectRoot})
 
             var nodes = ImmutableHashSet.Create(tree.Root);
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Handled);
         }
@@ -50,7 +50,7 @@ Root (flags: {ProjectRoot})
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Handled);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommandTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommandTests.cs
@@ -21,7 +21,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]); // test1.fs
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Status.HasFlag(CommandStatus.Enabled));
             Assert.False(result.Status.HasFlag(CommandStatus.Ninched));
@@ -40,7 +40,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var nodes = ImmutableHashSet.Create(tree.Children[1]); // test2.fs
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Status.HasFlag(CommandStatus.Ninched));
             Assert.False(result.Status.HasFlag(CommandStatus.Enabled));
@@ -62,7 +62,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var nodes = ImmutableHashSet.Create(tree.Children[2].Children[0]); // test3.fs
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Status.HasFlag(CommandStatus.Enabled));
             Assert.False(result.Status.HasFlag(CommandStatus.Ninched));
@@ -84,7 +84,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var nodes = ImmutableHashSet.Create(tree.Children[2].Children[1]); // test4.fs
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Status.HasFlag(CommandStatus.Ninched));
             Assert.False(result.Status.HasFlag(CommandStatus.Enabled));
@@ -109,7 +109,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var nodes = ImmutableHashSet.Create(tree.Children[2]); // first folder
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Status.HasFlag(CommandStatus.Enabled));
             Assert.False(result.Status.HasFlag(CommandStatus.Ninched));
@@ -134,7 +134,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]); // first folder
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Status.HasFlag(CommandStatus.Enabled));
             Assert.False(result.Status.HasFlag(CommandStatus.Ninched));
@@ -157,7 +157,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var nodes = ImmutableHashSet.Create(tree.Children[1]); // second folder
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Status.HasFlag(CommandStatus.Ninched));
             Assert.False(result.Status.HasFlag(CommandStatus.Enabled));

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommandTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommandTests.cs
@@ -21,7 +21,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var nodes = ImmutableHashSet.Create(tree.Children[1]); // test2.fs
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Status.HasFlag(CommandStatus.Enabled));
             Assert.False(result.Status.HasFlag(CommandStatus.Ninched));
@@ -40,7 +40,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]); // test1.fs
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Status.HasFlag(CommandStatus.Ninched));
             Assert.False(result.Status.HasFlag(CommandStatus.Enabled));
@@ -62,7 +62,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var nodes = ImmutableHashSet.Create(tree.Children[2].Children[1]); // test4.fs
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Status.HasFlag(CommandStatus.Enabled));
             Assert.False(result.Status.HasFlag(CommandStatus.Ninched));
@@ -84,7 +84,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var nodes = ImmutableHashSet.Create(tree.Children[2].Children[0]); // test3.fs
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Status.HasFlag(CommandStatus.Ninched));
             Assert.False(result.Status.HasFlag(CommandStatus.Enabled));
@@ -109,7 +109,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var nodes = ImmutableHashSet.Create(tree.Children[3]); // second folder
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Status.HasFlag(CommandStatus.Enabled));
             Assert.False(result.Status.HasFlag(CommandStatus.Ninched));
@@ -134,7 +134,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var nodes = ImmutableHashSet.Create(tree.Children[2]); // first folder
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Status.HasFlag(CommandStatus.Enabled));
             Assert.False(result.Status.HasFlag(CommandStatus.Ninched));
@@ -157,7 +157,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]); // first folder
 
-            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", 0);
 
             Assert.True(result.Status.HasFlag(CommandStatus.Ninched));
             Assert.False(result.Status.HasFlag(CommandStatus.Enabled));

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/ActiveEditorContextTrackerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/ActiveEditorContextTrackerTests.cs
@@ -232,7 +232,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
         private static ActiveEditorContextTracker CreateInstance()
         {
-            return new ActiveEditorContextTracker((UnconfiguredProject?)null);
+            return new ActiveEditorContextTracker(null);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/ProjectDesignerServiceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/ProjectDesignerServiceTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             hierarchy.ImplementGetGuid(VsHierarchyPropID.ProjectDesignerEditor, result: editorGuid);
 
             var project = (IVsProject4)hierarchy;
-            project.ImplementOpenItemWithSpecific(editorGuid, VSConstants.LOGVIEWID_Primary, (IVsWindowFrame?)null);
+            project.ImplementOpenItemWithSpecific(editorGuid, VSConstants.LOGVIEWID_Primary, null);
 
             var projectVsServices = IUnconfiguredProjectVsServicesFactory.Implement(() => hierarchy, () => project);
 
@@ -167,7 +167,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
         private static ProjectDesignerService CreateInstance(IVsProjectDesignerPageService vsProjectDesignerPageService)
         {
-            return CreateInstance((IUnconfiguredProjectVsServices?)null, vsProjectDesignerPageService);
+            return CreateInstance(null, vsProjectDesignerPageService);
         }
 
         private static ProjectDesignerService CreateInstance(IUnconfiguredProjectVsServices? projectVsServices, IVsProjectDesignerPageService? vsProjectDesignerPageService)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/DesignTimeAssemblyResolutionTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/DesignTimeAssemblyResolutionTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         {
             var resolution = CreateInstance();
 
-            var result = resolution.ResolveAssemblyPathInTargetFx((string[]?)null, 1, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
+            var result = resolution.ResolveAssemblyPathInTargetFx(null, 1, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
 
             Assert.Equal(VSConstants.E_INVALIDARG, result);
             Assert.Equal(0u, resolvedAssemblyPaths);
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         {
             var resolution = CreateInstance();
 
-            var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib" }, 1, (VsResolvedAssemblyPath[]?)null, out uint resolvedAssemblyPaths);
+            var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib" }, 1, null, out uint resolvedAssemblyPaths);
 
             Assert.Equal(VSConstants.E_INVALIDARG, result);
             Assert.Equal(0u, resolvedAssemblyPaths);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/FlagsStringMatcherTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/FlagsStringMatcherTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         {
             var detector = new FlagsStringMatcher(ProjectTreeFlags.Empty);
 
-            Assert.Throws<ArgumentNullException>(() => detector.Matches((string)null!));
+            Assert.Throws<ArgumentNullException>(() => detector.Matches(null!));
         }
 
         [Theory]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProviderTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
 
             await Assert.ThrowsAsync<ArgumentNullException>("documentMoniker", () =>
             {
-                return provider.GetSpecificEditorAsync((string)null!);
+                return provider.GetSpecificEditorAsync(null!);
             });
         }
 
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
 
             await Assert.ThrowsAsync<ArgumentNullException>("documentMoniker", () =>
             {
-                return provider.SetUseGlobalEditorAsync((string)null!, false);
+                return provider.SetUseGlobalEditorAsync(null!, false);
             });
         }
 


### PR DESCRIPTION
Roslyn flagged these as redundant, and they were removed via a codefix.

Three categories of casts were removed:

1. C# 10 does a better job of inferring the type for ternary conditional expressions, based on the target type
2. Casts that were previously required for nullable reference types
3. Casts of zero to enum types are not required



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7989)