### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 981: Build ID 1673665

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
@@ -49,12 +49,12 @@
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">Položka {0} se přidala do {1} (CopyToOutputDirectory={2}, TargetPath={3})</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">Položka {0} se odebrala z {1} (CopyToOutputDirectory={2}, TargetPath={3})</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingConfiguration_1">
@@ -84,22 +84,22 @@
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItemDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Cíl {0} neexistuje. Není aktuální.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItem_3">
         <source>Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</source>
-        <target state="new">Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</target>
+        <target state="translated">Kontroluje se položka {0} s CopyToOutputDirectory={1} {2}:</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNewerThanDestination_4">
         <source>{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</target>
+        <target state="translated">Položka {0} s CopyToOutputDirectory={1} zdroje {2} je novější než cíl {3}, není aktuální.</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} and {3} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Zdroj {0} neexistuje. Není aktuální.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
@@ -114,12 +114,12 @@
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_2">
         <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="new">{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</target>
+        <target state="translated">Položka {0} z {1} má CopyToOutputDirectory nastaveno na hodnotu Always a projekt má DisableFastUpToDateCopyAlwaysOptimization nastaveno na hodnotu true, není aktuální.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</target>
+        <target state="translated">Položka {0} se zdrojem CopyToOutputDirectory=Always ({1} {2}, počet bajtů: {3}) se liší od cíle ({4} {5}, počet bajtů: {6}), není aktuální.</target>
         <note>Do not translate CopyToOutputDirectory="Always". {0} is an MSBuild item type. {1} and {4} are file paths. {2} and {5} are date times. {3} and {6} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
@@ -224,7 +224,7 @@
       </trans-unit>
       <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
         <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="new">Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</target>
+        <target state="translated">Optimalizuje se položka CopyToOutputDirectory=Always. Tuto možnost zakažte nastavením možnosti DisableFastUpToDateCopyAlwaysOptimization na hodnotu true.</target>
         <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
@@ -49,12 +49,12 @@
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0}-Element hinzugefügt „{1}“ (CopyToOutputDirectory={2}, TargetPath=„{3}“)</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0}-Element entfernt „{1}“ (CopyToOutputDirectory={2}, TargetPath=„{3}“)</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingConfiguration_1">
@@ -84,22 +84,22 @@
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItemDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Das Ziel '{0}' ist nicht vorhanden, nicht aktuell.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItem_3">
         <source>Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</source>
-        <target state="new">Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</target>
+        <target state="translated">{0}-Element mit CopyToOutputDirectory=„{1}“ „{2}“ wird überprüft:</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNewerThanDestination_4">
         <source>{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</target>
+        <target state="translated">{0}-Element mit CopyToOutputDirectory=„{1}“ Quelle „{2}“ ist neuer als das Ziel „{3}“, nicht aktuell.</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} and {3} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Die Quelle '{0}' ist nicht vorhanden, nicht aktuell.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
@@ -114,12 +114,12 @@
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_2">
         <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="new">{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</target>
+        <target state="translated">Für {0}-Element „{1}“ ist „CopyToOutputDirectory“ auf „Always“ festgelegt, und für das Projekt ist „DisableFastUpToDateCopyAlwaysOptimization“ auf „true“ festgelegt, nicht aktuell.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</target>
+        <target state="translated">{0}-Element mit der Quelle CopyToOutputDirectory=„Always“ („{1}“ {2}, {3} Byte) unterscheidet sich vom Ziel („{4}“ {5}, {6} Byte), nicht aktuell.</target>
         <note>Do not translate CopyToOutputDirectory="Always". {0} is an MSBuild item type. {1} and {4} are file paths. {2} and {5} are date times. {3} and {6} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
@@ -224,7 +224,7 @@
       </trans-unit>
       <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
         <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="new">Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</target>
+        <target state="translated">Das Element CopyToOutputDirectory=„Always“ wird optimiert. Deaktivieren Sie dies, indem Sie „DisableFastUpToDateCopyAlwaysOptimization“ auf „true“ festlegen.</target>
         <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
@@ -49,12 +49,12 @@
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} elemento añadido “{1}” (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} elemento quitado “{1}” (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingConfiguration_1">
@@ -84,22 +84,22 @@
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItemDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">El destino '{0}' no existe, no está actualizado.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItem_3">
         <source>Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</source>
-        <target state="new">Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</target>
+        <target state="translated">Comprobando {0} elemento con CopyToOutputDirectory="{1}" '{2}':</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNewerThanDestination_4">
         <source>{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</target>
+        <target state="translated">{0} elemento con CopyToOutputDirectory="{1}" source “{2}” es más reciente que el destino “{3}”, no actualizado.</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} and {3} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">La fuente '{0}' no existe, no está actualizada.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
@@ -114,12 +114,12 @@
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_2">
         <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="new">{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</target>
+        <target state="translated">{0} elemento “{1}” tiene CopyToOutputDirectory establecido en “Always” y el proyecto tiene DisableFastUpToDateCopyAlwaysOptimization establecido en “true”, no actualizado.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</target>
+        <target state="translated">{0} elemento con el origen CopyToOutputDirectory="Always" ('{1}' {2}, {3} bytes) difiere del destino ('{4}' {5}, {6} bytes), no actualizado.</target>
         <note>Do not translate CopyToOutputDirectory="Always". {0} is an MSBuild item type. {1} and {4} are file paths. {2} and {5} are date times. {3} and {6} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
@@ -224,7 +224,7 @@
       </trans-unit>
       <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
         <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="new">Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</target>
+        <target state="translated">Optimizando el elemento CopyToOutputDirectory="Always". Para deshabilitarlo, establezca DisableFastUpToDateCopyAlwaysOptimization en "true".</target>
         <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
@@ -49,12 +49,12 @@
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} élément ajouté '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} élément supprimé '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingConfiguration_1">
@@ -84,22 +84,22 @@
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItemDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">La destination '{0}' n’existe pas, elle n’est pas à jour.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItem_3">
         <source>Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</source>
-        <target state="new">Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</target>
+        <target state="translated">Vérification de {0} élément avec CopyToOutputDirectory="{1}" '{2}':</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNewerThanDestination_4">
         <source>{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</target>
+        <target state="translated">{0} élément avec CopyToOutputDirectory= "{1}"source '{2}' est plus récent que la destination '{3}', pas à jour.</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} and {3} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">La '{0}' source n’existe pas, elle n’est pas à jour.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
@@ -114,12 +114,12 @@
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_2">
         <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="new">{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</target>
+        <target state="translated">{0} 'élément '{1}' a CopyToOutputDirectory défini sur 'Always', et le projet a DisableFastUpToDateCopyAlwaysOptimization défini sur 'true', et non à jour.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</target>
+        <target state="translated">{0} élément avec CopyToOutputDirectory="Always" source ('{1}' {2}, {3} octets) diffère de la destination ('{4}' {5}, {6} octets), pas à jour.</target>
         <note>Do not translate CopyToOutputDirectory="Always". {0} is an MSBuild item type. {1} and {4} are file paths. {2} and {5} are date times. {3} and {6} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
@@ -224,7 +224,7 @@
       </trans-unit>
       <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
         <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="new">Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</target>
+        <target state="translated">Optimisation de l’élément CopyToOutputDirectory=="Always". Désactivez cette option en définissant DisableFastUpToDateCopyAlwaysOptimization sur « true ».</target>
         <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
@@ -49,12 +49,12 @@
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">Elemento {0} aggiunto '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">Elemento {0} rimosso '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingConfiguration_1">
@@ -84,22 +84,22 @@
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItemDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">La destinazione '{0}' non esiste, non è aggiornata.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItem_3">
         <source>Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</source>
-        <target state="new">Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</target>
+        <target state="translated">Controllo di elemento {0} con CopyToOutputDirectory="{1}" '{2}':</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNewerThanDestination_4">
         <source>{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</target>
+        <target state="translated">Elemento {0} con CopyToOutputDirectory="{1}" origine '{2}' è più recente della destinazione '{3}', non aggiornato.</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} and {3} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">L'origine '{0}' non esiste, non è aggiornata.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
@@ -114,12 +114,12 @@
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_2">
         <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="new">{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</target>
+        <target state="translated">Elemento {0} '{1}' ha CopyToOutputDirectory impostato su 'Always' e il progetto ha DisableFastUpToDateCopyAlwaysOptimization impostato su 'true', non aggiornato.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</target>
+        <target state="translated">Elemento {0} con origine CopyToOutputDirectory="Always" ('{1}' {2}, {3} byte) differisce dalla destinazione ('{4}' {5}, {6} byte), non aggiornato.</target>
         <note>Do not translate CopyToOutputDirectory="Always". {0} is an MSBuild item type. {1} and {4} are file paths. {2} and {5} are date times. {3} and {6} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
@@ -224,7 +224,7 @@
       </trans-unit>
       <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
         <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="new">Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</target>
+        <target state="translated">Ottimizzazione dell'elemento CopyToOutputDirectory="Always". Disabilitare questa impostazione impostando DisableFastUpToDateCopyAlwaysOptimization su "true".</target>
         <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
@@ -49,12 +49,12 @@
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} 項目が追加されました '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} 項目が削除されました '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingConfiguration_1">
@@ -84,22 +84,22 @@
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItemDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">宛先 '{0}' が存在せず、最新ではありません。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItem_3">
         <source>Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</source>
-        <target state="new">Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</target>
+        <target state="translated">CopyToOutputDirectory="{1}" '{2}' を保持する項目 {0}をチェックする:</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNewerThanDestination_4">
         <source>{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</target>
+        <target state="translated">CopyToOutputDirectory="{1}" ソース '{2}' の項目{0}が、宛先 '{3}' より新しく、最新ではありません。</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} and {3} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">ソース '{0}' が存在せず、最新ではありません。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
@@ -114,12 +114,12 @@
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_2">
         <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="new">{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</target>
+        <target state="translated">{0} 項目 '{1}' は CopyToOutputDirectory が 'Always' に設定され、プロジェクトの DisableFastUpToDateCopyAlwaysOptimization が 'true' に設定され、それは最新の状態ではありません。</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</target>
+        <target state="translated">CopyToOutputDirectory="Always" ソース ('{1}' {2}, {3} バイト) を持つ{0}項目は、宛先 ('{4}' {5}, {6} バイト) と異なり、最新ではありません。</target>
         <note>Do not translate CopyToOutputDirectory="Always". {0} is an MSBuild item type. {1} and {4} are file paths. {2} and {5} are date times. {3} and {6} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
@@ -224,7 +224,7 @@
       </trans-unit>
       <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
         <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="new">Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</target>
+        <target state="translated">CopyToOutputDirectory="Always" である項目を最適化しています。DisableFastUpToDateCopyAlwaysOptimization を "true" に設定します。</target>
         <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
@@ -49,12 +49,12 @@
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} 항목 '{1}' 추가됨(CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} 항목이 '{1}' 제거됨(CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingConfiguration_1">
@@ -84,22 +84,22 @@
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItemDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">대상 '{0}'이(가) 존재하지 않으며 최신 상태가 아닙니다.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItem_3">
         <source>Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</source>
-        <target state="new">Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</target>
+        <target state="translated">CopyToOutputDirectory="{1}" '{2}'로 {0} 항목 확인:</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNewerThanDestination_4">
         <source>{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</target>
+        <target state="translated">CopyToOutputDirectory="{1}" 소스가 '{2}'인 {0} 항목이 대상 '{3}'보다 최신이고 최신 상태가 아닙니다.</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} and {3} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">원본 '{0}'이(가) 존재하지 않으며 최신 상태가 아닙니다.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
@@ -114,12 +114,12 @@
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_2">
         <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="new">{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</target>
+        <target state="translated">{0} 항목 '{1}'에는 CopyToOutputDirectory가 'Always'로 설정되어 있고 프로젝트에는 DisableFastUpToDateCopyAlwaysOptimization이 최신 상태가 아닌 'true'로 설정되어 있습니다.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</target>
+        <target state="translated">CopyToOutputDirectory="Always" 소스('{1}' {2}, {3}바이트)가 있는 {0} 항목이 대상('{4}' {5}, {6}바이트)과 다릅니다. 최신 상태가 아닙니다.</target>
         <note>Do not translate CopyToOutputDirectory="Always". {0} is an MSBuild item type. {1} and {4} are file paths. {2} and {5} are date times. {3} and {6} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
@@ -224,7 +224,7 @@
       </trans-unit>
       <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
         <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="new">Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</target>
+        <target state="translated">CopyToOutputDirectory="항상" 항목 최적화. DisableFastUpToDateCopyAlwaysOptimization을 "true"로 설정하여 이 기능을 비활성화합니다.</target>
         <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
@@ -49,12 +49,12 @@
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} dodano element „{1}” (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} usunięto element „{1}” (CopyToOutputDirectory={2} TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingConfiguration_1">
@@ -84,22 +84,22 @@
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItemDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Miejsce docelowe „{0}” nie istnieje, nie jest aktualne.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItem_3">
         <source>Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</source>
-        <target state="new">Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</target>
+        <target state="translated">Sprawdzanie {0} elementem CopyToOutputDirectory=„{1}” '{2}':</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNewerThanDestination_4">
         <source>{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</target>
+        <target state="translated">{0} element z copyToOutputDirectory=„{1}” źródło „{2}” jest nowsze niż miejsce docelowe „{3}”, nieaktualne.</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} and {3} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Źródło „{0}” nie istnieje, nie jest aktualne.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
@@ -114,12 +114,12 @@
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_2">
         <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="new">{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</target>
+        <target state="translated">{0} element „{1}” ma właściwość CopyToOutputDirectory ustawioną na wartość „Always”, a projekt ma wartość DisableFastUpToDateCopyAlwaysOptimization ustawioną na wartość „true”, a nie aktualną.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</target>
+        <target state="translated">{0} element z poleceniem CopyToOutputDirectory=„ Zawsze” źródło ('{1}' {2} {3} B) różni się od lokalizacji docelowej („{4}” {5} {6} bajty), nieaktualne.</target>
         <note>Do not translate CopyToOutputDirectory="Always". {0} is an MSBuild item type. {1} and {4} are file paths. {2} and {5} are date times. {3} and {6} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
@@ -224,7 +224,7 @@
       </trans-unit>
       <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
         <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="new">Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</target>
+        <target state="translated">Optymalizowanie elementu CopyToOutputDirectory= element „Zawsze”. Wyłącz tę opcję, ustawiając wartość DisableFastUpToDateCopyAlwaysOptimization na wartość „true”.</target>
         <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
@@ -49,12 +49,12 @@
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} item adicionado '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} item removido '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingConfiguration_1">
@@ -84,22 +84,22 @@
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItemDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">O destino '{0}' não existe, não atualizado.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItem_3">
         <source>Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</source>
-        <target state="new">Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</target>
+        <target state="translated">Verificando {0} item com CopyToOutputDirectory="{1}" '{2}':</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNewerThanDestination_4">
         <source>{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</target>
+        <target state="translated">O item {0} com a origem CopyToOutputDirectory="{1}", '{2}' é mais recente que o destino '{3}', não atualizado.</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} and {3} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">A origem '{0}' não existe, não atualizada.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
@@ -114,12 +114,12 @@
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_2">
         <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="new">{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</target>
+        <target state="translated">{0} item '{1}' tem o CopyToOutputDirectory definido como 'Always', e o projeto tem DisableFastUpToDateCopyAlwaysOptimization definido como 'true', não atualizado.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</target>
+        <target state="translated">{0} item com a origem CopyToOutputDirectory="Always" ('{1}' {2}, {3} bytes) difere do destino ('{4}' {5}, {6} bytes), não atualizado.</target>
         <note>Do not translate CopyToOutputDirectory="Always". {0} is an MSBuild item type. {1} and {4} are file paths. {2} and {5} are date times. {3} and {6} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
@@ -224,7 +224,7 @@
       </trans-unit>
       <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
         <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="new">Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</target>
+        <target state="translated">Otimizando o item CopyToOutputDirectory="Always". Desabilite isso definindo DisableFastUpToDateCopyAlwaysOptimization como “true”.</target>
         <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
@@ -49,12 +49,12 @@
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">Элемент {0} добавлен \"{1}\" (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">Элемент {0} удален \"{1}\" (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingConfiguration_1">
@@ -84,22 +84,22 @@
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItemDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Назначение “{0}” не существует. Обновление не выполнено.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItem_3">
         <source>Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</source>
-        <target state="new">Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</target>
+        <target state="translated">Проверка элемента {0} с параметром CopyToOutputDirectory="{1}" '{2}':</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNewerThanDestination_4">
         <source>{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</target>
+        <target state="translated">Элемент {0} с источником CopyToOutputDirectory="{1}" '{2}' является более новым по сравнению с местом назначения '{3}', обновление не выполнено.</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} and {3} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">Источник “{0}” не существует. Обновление не выполнено.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
@@ -114,12 +114,12 @@
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_2">
         <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="new">{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</target>
+        <target state="translated">Параметр CopyToOutputDirectory для элемента {0} '{1}' имеет значение \"Always\", а параметр DisableFastUpToDateCopyAlwaysOptimization для проекта имеет значение \"true\", обновление не выполнено.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</target>
+        <target state="translated">Элемент {0} с источником CopyToOutputDirectory="Always" ('{1}' {2}, {3} байт) отличается от места назначения ('{4}' {5}, {6} байт), обновление не выполнено.</target>
         <note>Do not translate CopyToOutputDirectory="Always". {0} is an MSBuild item type. {1} and {4} are file paths. {2} and {5} are date times. {3} and {6} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
@@ -224,7 +224,7 @@
       </trans-unit>
       <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
         <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="new">Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</target>
+        <target state="translated">Оптимизация элемента CopyToOutputDirectory="Always". Отключите этот параметр, установив значение "true" для параметра DisableFastUpToDateCopyAlwaysOptimization.</target>
         <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
@@ -49,12 +49,12 @@
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} öğesi eklendi '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} öğesi kaldırıldı '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingConfiguration_1">
@@ -84,22 +84,22 @@
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItemDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">'{0}' hedefi yok ve güncel değil.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItem_3">
         <source>Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</source>
-        <target state="new">Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</target>
+        <target state="translated">CopyToOutputDirectory="{1}" '{2}' içeren {0} öğesi denetleniyor:</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNewerThanDestination_4">
         <source>{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</target>
+        <target state="translated">CopyToOutputDirectory="{1}" '{2}' kaynağına sahip {0} öğesi, '{3}' hedefinden daha yeni, güncel değil.</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} and {3} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">'{0}' kaynağı yok ve güncel değil.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
@@ -114,12 +114,12 @@
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_2">
         <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="new">{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</target>
+        <target state="translated">{0} '{1}' öğesinde copyToOutputDirectory seçeneği 'Always' olarak ayarlandı ve projede DisableFastUpToDateCopyAlwaysOptimization seçeneği 'true' olarak ayarlandı, güncel değil.</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</target>
+        <target state="translated">CopyToOutputDirectory="Always" kaynağına ('{1}' {2}, {3} bayt) sahip {0} öğesi hedeften ('{4}' {5}, {6} bayt) farklı, güncel değil.</target>
         <note>Do not translate CopyToOutputDirectory="Always". {0} is an MSBuild item type. {1} and {4} are file paths. {2} and {5} are date times. {3} and {6} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
@@ -224,7 +224,7 @@
       </trans-unit>
       <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
         <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="new">Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</target>
+        <target state="translated">CopyToOutputDirectory="Always" öğesi iyileştiriliyor. DisableFastUpToDateCopyAlwaysOptimization seçeneğini "true" olarak ayarlayarak bunu devre dışı bırakın.</target>
         <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
@@ -49,12 +49,12 @@
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} 项已添加'{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} 项已删除'{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingConfiguration_1">
@@ -84,22 +84,22 @@
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItemDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">目标 '{0}' 不存在，不是最新的。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItem_3">
         <source>Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</source>
-        <target state="new">Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</target>
+        <target state="translated">正在检查具有 CopyToOutputDirectory="{1}" '{2}' 的 {0} 项:</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNewerThanDestination_4">
         <source>{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</target>
+        <target state="translated">具有 CopyToOutputDirectory="{1}"源 '{2}' 的 {0} 项比目标 '{3}' 更新，不是最新版本。</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} and {3} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">源 '{0}' 不存在，不是最新的。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
@@ -114,12 +114,12 @@
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_2">
         <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="new">{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</target>
+        <target state="translated">{0} 项'{1}'将 CopyToOutputDirectory 设置为“Always”，并且项目已将 DisableFastUpToDateCopyAlwaysOptimization 设置为“true”，不是最新版本。</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</target>
+        <target state="translated">具有 CopyToOutputDirectory="Always" 源的 {0} 项('{1}' {2}，{3} 字节)不同于目标('{4}' {5}，{6} 字节)，不是最新版本。</target>
         <note>Do not translate CopyToOutputDirectory="Always". {0} is an MSBuild item type. {1} and {4} are file paths. {2} and {5} are date times. {3} and {6} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
@@ -224,7 +224,7 @@
       </trans-unit>
       <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
         <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="new">Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</target>
+        <target state="translated">正在优化 CopyToOutputDirectory="Always"项。通过将 DisableFastUpToDateCopyAlwaysOptimization 设置为"true"来禁用此功能。</target>
         <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
@@ -49,12 +49,12 @@
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsAddition_4">
         <source>{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item added '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} 項目已新增 '{1}' (CopyToOutputDirectory={2}，TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_ChangedItemsRemoval_4">
         <source>{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</source>
-        <target state="new">{0} item removed '{1}' (CopyToOutputDirectory={2}, TargetPath='{3}')</target>
+        <target state="translated">{0} 項目已移除 '{1}' (CopyToOutputDirectory={2}，TargetPath='{3}')</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'TargetPath'. {0} is an MSBuild item type. {1} is a file path. {2} and {3} are metadata values.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingConfiguration_1">
@@ -84,22 +84,22 @@
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItemDestinationNotFound_1">
         <source>Destination '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Destination '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">目的地 '{0}' 不存在，不是最新狀態。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectoryItem_3">
         <source>Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</source>
-        <target state="new">Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</target>
+        <target state="translated">正在使用 CopyToOutputDirectory="{1}" '{2}' 檢查 {0} 項目:</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNewerThanDestination_4">
         <source>{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="{1}" source '{2}' is newer than destination '{3}', not up-to-date.</target>
+        <target state="translated">{0} 項目與 CopyToOutputDirectory="{1}" 來源 '{2}' 比目的地 '{3}' 更新，不是最新的。</target>
         <note>Do not translate CopyToOutputDirectory. {0} is an MSBuild item type. {1} is from an enum of valid values. {2} and {3} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_CheckingCopyToOutputDirectorySourceNotFound_1">
         <source>Source '{0}' does not exist, not up-to-date.</source>
-        <target state="new">Source '{0}' does not exist, not up-to-date.</target>
+        <target state="translated">來源 '{0}' 不存在，不是最新狀態。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_ComparingInputOutputTimestamps_1">
@@ -114,12 +114,12 @@
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemExists_2">
         <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="new">{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</target>
+        <target state="translated">{0} 項目 '{1}' CopyToOutputDirectory 已設定為 'Always'，且專案已將 DisableFastUpToDateCopyAlwaysOptimization 設定為 'true'，而非最新。</target>
         <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
-        <target state="new">{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</target>
+        <target state="translated">{0} 項目與 CopyToOutputDirectory="Always" 來源 ('{1}' {2}, {3} bytes) 不同於目的地 ('{4}' {5}, {6} bytes)，不是最新的。</target>
         <note>Do not translate CopyToOutputDirectory="Always". {0} is an MSBuild item type. {1} and {4} are file paths. {2} and {5} are date times. {3} and {6} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">
@@ -224,7 +224,7 @@
       </trans-unit>
       <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
         <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="new">Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</target>
+        <target state="translated">正在最佳化 CopyToOutputDirectory="Always" 項目。將 DisableFastUpToDateCopyAlwaysOptimization 設定為 "true" 以停用此設定。</target>
         <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/ceLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/7994)