### PR TITLE
Rework WarningLevel property

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/WarningLevelOverriddenValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/WarningLevelOverriddenValueProvider.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties;
+
+/// <summary>
+/// Provides a synthetic property indicating if the <c>WarningLevel</c> set by the
+/// user (if any) will be overridden by the SDK.
+/// </summary>
+/// <remarks>
+/// Based on the logic in https://github.com/dotnet/sdk/blob/a35fecf11708d1de6eb86f3dc3294f1644d3212e/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets.
+/// To summarize: in the .NET 5.0 SDK and up, the <c>EffectiveAnalysisLevel</c>
+/// property is computed from the <c>AnalysisLevel</c> property. If
+/// <c>EffectiveAnalysisLevel</c> is >= 5.0, the SDK will override any previously-set
+/// value of <c>WarningLevel</c> with its own.
+/// </remarks>
+[ExportInterceptingPropertyValueProvider(WarningLevelOverriddenPropertyName, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+internal class WarningLevelOverriddenValueProvider : InterceptingPropertyValueProviderBase
+{
+    internal const string WarningLevelOverriddenPropertyName = "WarningLevelOverridden";
+    internal const string EffectiveAnalysisLevelPropertyName = "EffectiveAnalysisLevel";
+
+    public override Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
+    {
+        return OnGetPropertyValueAsync(defaultProperties);
+    }
+
+    public override Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+    {
+        return OnGetPropertyValueAsync(defaultProperties);
+    }
+
+    private static async Task<string> OnGetPropertyValueAsync(IProjectProperties defaultProperties)
+    {
+        string effectiveAnalysisLevelString = await defaultProperties.GetEvaluatedPropertyValueAsync(EffectiveAnalysisLevelPropertyName);
+
+        return
+            (float.TryParse(effectiveAnalysisLevelString, out float effectiveAnalysisLevel)
+             && effectiveAnalysisLevel >= 5.0f)
+            ? bool.TrueString
+            : bool.FalseString;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/WarningLevelOverriddenValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/WarningLevelOverriddenValueProvider.cs
@@ -34,8 +34,8 @@ internal class WarningLevelOverriddenValueProvider : InterceptingPropertyValuePr
         string effectiveAnalysisLevelString = await defaultProperties.GetEvaluatedPropertyValueAsync(EffectiveAnalysisLevelPropertyName);
 
         return
-            (float.TryParse(effectiveAnalysisLevelString, out float effectiveAnalysisLevel)
-             && effectiveAnalysisLevel >= 5.0f)
+            (decimal.TryParse(effectiveAnalysisLevelString, out decimal effectiveAnalysisLevel)
+             && effectiveAnalysisLevel >= 5.0m)
             ? bool.TrueString
             : bool.FalseString;
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -26,7 +26,7 @@
     <Category Name="StrongNaming"
               Description="Configures strong name signing of build outputs."
               DisplayName="Strong naming" />
-    
+
     <Category Name="Advanced"
               DisplayName="Advanced"
               Description="Advanced settings for the application." />
@@ -173,11 +173,31 @@
                DisplayName="Embedded in DLL/EXE, portable across platforms" />
   </EnumProperty>
 
+  <BoolProperty Name="WarningLevelOverridden"
+                DisplayName="WarningLevelOverridden"
+                Category="ErrorsAndWarnings"
+                ReadOnly="True">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="True"
+                  Persistence="ProjectFileWithInterception" />
+    </BoolProperty.DataSource>
+    <BoolProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition" Value="false" />
+    </BoolProperty.Metadata>
+  </BoolProperty>
+  
   <EnumProperty Name="WarningLevel"
                 DisplayName="Warning level"
                 Description="Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2146798"
                 Category="ErrorsAndWarnings">
+    <EnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>
+          (has-evaluated-value "Build" "WarningLevelOverridden" false)
+        </NameValuePair.Value>
+      </NameValuePair>
+    </EnumProperty.Metadata>
     <EnumValue Name="0"
                DisplayName="0 - Disable all warnings" />
     <EnumValue Name="1"
@@ -198,6 +218,43 @@
                DisplayName="9999 - All warnings" />
   </EnumProperty>
 
+   <EnumProperty Name="WarningLevel_Readonly"
+                DisplayName="Warning level"
+                Description="Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page."
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2146798"
+                Category="ErrorsAndWarnings"
+                ReadOnly="True">
+    <EnumProperty.DataSource>
+      <DataSource HasConfigurationCondition="True"
+                  PersistedName="WarningLevel" />
+    </EnumProperty.DataSource>
+    <EnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>
+          (not (has-evaluated-value "Build" "WarningLevelOverridden" false))
+        </NameValuePair.Value>
+      </NameValuePair>
+    </EnumProperty.Metadata>
+    <EnumValue Name="0"
+               DisplayName="0 - Disable all warnings" />
+    <EnumValue Name="1"
+               DisplayName="1 - Severe warning messages" />
+    <EnumValue Name="2"
+               DisplayName="2 - Less severe warnings, such as warnings about hiding class members" />
+    <EnumValue Name="3"
+               DisplayName="3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false" />
+    <EnumValue Name="4"
+               DisplayName="4 - Informational warnings" />
+    <EnumValue Name="5"
+               DisplayName="5 - Warnings from C# 9" />
+    <EnumValue Name="6"
+               DisplayName="6 - Warnings from C# 10" />
+    <EnumValue Name="7"
+               DisplayName="7 - Warnings from C# 11" />
+    <EnumValue Name="9999"
+               DisplayName="9999 - All warnings" />
+  </EnumProperty>
+  
   <StringProperty Name="NoWarn"
                   DisplayName="Suppress specific warnings"
                   Description="Blocks the compiler from generating the specified warnings. Separate multiple warning numbers with a comma (',') or semicolon (';')."

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.cs.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Zpracovávat upozornění jako chyby</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|WarningLevelOverridden|DisplayName">
+        <source>WarningLevelOverridden</source>
+        <target state="new">WarningLevelOverridden</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|Advanced|Description">
         <source>Advanced settings for the application.</source>
         <target state="translated">Upřesňující nastavení aplikace.</target>
@@ -250,6 +255,16 @@
       <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
         <source>When to run the post-build event</source>
         <target state="translated">Kdy má být spuštěna událost po sestavení</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|Description">
+        <source>Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -403,6 +418,51 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.9999|DisplayName">
+        <source>9999 - All warnings</source>
+        <target state="new">9999 - All warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.0|DisplayName">
+        <source>0 - Disable all warnings</source>
+        <target state="new">0 - Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.1|DisplayName">
+        <source>1 - Severe warning messages</source>
+        <target state="new">1 - Severe warning messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.2|DisplayName">
+        <source>2 - Less severe warnings, such as warnings about hiding class members</source>
+        <target state="new">2 - Less severe warnings, such as warnings about hiding class members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.3|DisplayName">
+        <source>3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</source>
+        <target state="new">3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.4|DisplayName">
+        <source>4 - Informational warnings</source>
+        <target state="new">4 - Informational warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.5|DisplayName">
+        <source>5 - Warnings from C# 9</source>
+        <target state="new">5 - Warnings from C# 9</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.6|DisplayName">
+        <source>6 - Warnings from C# 10</source>
+        <target state="new">6 - Warnings from C# 10</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.7|DisplayName">
+        <source>7 - Warnings from C# 11</source>
+        <target state="new">7 - Warnings from C# 11</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.9999|DisplayName">
         <source>9999 - All warnings</source>
         <target state="new">9999 - All warnings</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.de.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Warnungen als Fehler behandeln</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|WarningLevelOverridden|DisplayName">
+        <source>WarningLevelOverridden</source>
+        <target state="new">WarningLevelOverridden</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|Advanced|Description">
         <source>Advanced settings for the application.</source>
         <target state="translated">Erweiterte Einstellungen für die Anwendung.</target>
@@ -250,6 +255,16 @@
       <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
         <source>When to run the post-build event</source>
         <target state="translated">Wann das Postbuildereignis ausgeführt werden soll</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|Description">
+        <source>Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -403,6 +418,51 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.9999|DisplayName">
+        <source>9999 - All warnings</source>
+        <target state="new">9999 - All warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.0|DisplayName">
+        <source>0 - Disable all warnings</source>
+        <target state="new">0 - Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.1|DisplayName">
+        <source>1 - Severe warning messages</source>
+        <target state="new">1 - Severe warning messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.2|DisplayName">
+        <source>2 - Less severe warnings, such as warnings about hiding class members</source>
+        <target state="new">2 - Less severe warnings, such as warnings about hiding class members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.3|DisplayName">
+        <source>3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</source>
+        <target state="new">3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.4|DisplayName">
+        <source>4 - Informational warnings</source>
+        <target state="new">4 - Informational warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.5|DisplayName">
+        <source>5 - Warnings from C# 9</source>
+        <target state="new">5 - Warnings from C# 9</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.6|DisplayName">
+        <source>6 - Warnings from C# 10</source>
+        <target state="new">6 - Warnings from C# 10</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.7|DisplayName">
+        <source>7 - Warnings from C# 11</source>
+        <target state="new">7 - Warnings from C# 11</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.9999|DisplayName">
         <source>9999 - All warnings</source>
         <target state="new">9999 - All warnings</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.es.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Tratar advertencias como errores</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|WarningLevelOverridden|DisplayName">
+        <source>WarningLevelOverridden</source>
+        <target state="new">WarningLevelOverridden</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|Advanced|Description">
         <source>Advanced settings for the application.</source>
         <target state="translated">Configuración avanzada de la aplicación.</target>
@@ -250,6 +255,16 @@
       <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
         <source>When to run the post-build event</source>
         <target state="translated">Cuándo ejecutar el evento posterior a la compilación</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|Description">
+        <source>Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -403,6 +418,51 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.9999|DisplayName">
+        <source>9999 - All warnings</source>
+        <target state="new">9999 - All warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.0|DisplayName">
+        <source>0 - Disable all warnings</source>
+        <target state="new">0 - Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.1|DisplayName">
+        <source>1 - Severe warning messages</source>
+        <target state="new">1 - Severe warning messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.2|DisplayName">
+        <source>2 - Less severe warnings, such as warnings about hiding class members</source>
+        <target state="new">2 - Less severe warnings, such as warnings about hiding class members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.3|DisplayName">
+        <source>3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</source>
+        <target state="new">3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.4|DisplayName">
+        <source>4 - Informational warnings</source>
+        <target state="new">4 - Informational warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.5|DisplayName">
+        <source>5 - Warnings from C# 9</source>
+        <target state="new">5 - Warnings from C# 9</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.6|DisplayName">
+        <source>6 - Warnings from C# 10</source>
+        <target state="new">6 - Warnings from C# 10</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.7|DisplayName">
+        <source>7 - Warnings from C# 11</source>
+        <target state="new">7 - Warnings from C# 11</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.9999|DisplayName">
         <source>9999 - All warnings</source>
         <target state="new">9999 - All warnings</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.fr.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Considérer les avertissements comme des erreurs</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|WarningLevelOverridden|DisplayName">
+        <source>WarningLevelOverridden</source>
+        <target state="new">WarningLevelOverridden</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|Advanced|Description">
         <source>Advanced settings for the application.</source>
         <target state="translated">Paramètres de ressources avancés de l'application</target>
@@ -250,6 +255,16 @@
       <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
         <source>When to run the post-build event</source>
         <target state="translated">Quand exécuter l’événement post-build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|Description">
+        <source>Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -403,6 +418,51 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.9999|DisplayName">
+        <source>9999 - All warnings</source>
+        <target state="new">9999 - All warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.0|DisplayName">
+        <source>0 - Disable all warnings</source>
+        <target state="new">0 - Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.1|DisplayName">
+        <source>1 - Severe warning messages</source>
+        <target state="new">1 - Severe warning messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.2|DisplayName">
+        <source>2 - Less severe warnings, such as warnings about hiding class members</source>
+        <target state="new">2 - Less severe warnings, such as warnings about hiding class members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.3|DisplayName">
+        <source>3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</source>
+        <target state="new">3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.4|DisplayName">
+        <source>4 - Informational warnings</source>
+        <target state="new">4 - Informational warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.5|DisplayName">
+        <source>5 - Warnings from C# 9</source>
+        <target state="new">5 - Warnings from C# 9</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.6|DisplayName">
+        <source>6 - Warnings from C# 10</source>
+        <target state="new">6 - Warnings from C# 10</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.7|DisplayName">
+        <source>7 - Warnings from C# 11</source>
+        <target state="new">7 - Warnings from C# 11</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.9999|DisplayName">
         <source>9999 - All warnings</source>
         <target state="new">9999 - All warnings</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.it.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Considera gli avvisi come errori</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|WarningLevelOverridden|DisplayName">
+        <source>WarningLevelOverridden</source>
+        <target state="new">WarningLevelOverridden</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|Advanced|Description">
         <source>Advanced settings for the application.</source>
         <target state="translated">Impostazioni avanzate per l'applicazione.</target>
@@ -250,6 +255,16 @@
       <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
         <source>When to run the post-build event</source>
         <target state="translated">Quando eseguire l’evento post-compilazione</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|Description">
+        <source>Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -403,6 +418,51 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.9999|DisplayName">
+        <source>9999 - All warnings</source>
+        <target state="new">9999 - All warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.0|DisplayName">
+        <source>0 - Disable all warnings</source>
+        <target state="new">0 - Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.1|DisplayName">
+        <source>1 - Severe warning messages</source>
+        <target state="new">1 - Severe warning messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.2|DisplayName">
+        <source>2 - Less severe warnings, such as warnings about hiding class members</source>
+        <target state="new">2 - Less severe warnings, such as warnings about hiding class members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.3|DisplayName">
+        <source>3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</source>
+        <target state="new">3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.4|DisplayName">
+        <source>4 - Informational warnings</source>
+        <target state="new">4 - Informational warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.5|DisplayName">
+        <source>5 - Warnings from C# 9</source>
+        <target state="new">5 - Warnings from C# 9</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.6|DisplayName">
+        <source>6 - Warnings from C# 10</source>
+        <target state="new">6 - Warnings from C# 10</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.7|DisplayName">
+        <source>7 - Warnings from C# 11</source>
+        <target state="new">7 - Warnings from C# 11</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.9999|DisplayName">
         <source>9999 - All warnings</source>
         <target state="new">9999 - All warnings</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ja.xlf
@@ -132,6 +132,11 @@
         <target state="translated">警告をエラーとして扱う</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|WarningLevelOverridden|DisplayName">
+        <source>WarningLevelOverridden</source>
+        <target state="new">WarningLevelOverridden</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|Advanced|Description">
         <source>Advanced settings for the application.</source>
         <target state="translated">アプリケーションの詳細設定。</target>
@@ -250,6 +255,16 @@
       <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
         <source>When to run the post-build event</source>
         <target state="translated">ビルド後のイベントをいつ実行するか</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|Description">
+        <source>Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -403,6 +418,51 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.9999|DisplayName">
+        <source>9999 - All warnings</source>
+        <target state="new">9999 - All warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.0|DisplayName">
+        <source>0 - Disable all warnings</source>
+        <target state="new">0 - Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.1|DisplayName">
+        <source>1 - Severe warning messages</source>
+        <target state="new">1 - Severe warning messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.2|DisplayName">
+        <source>2 - Less severe warnings, such as warnings about hiding class members</source>
+        <target state="new">2 - Less severe warnings, such as warnings about hiding class members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.3|DisplayName">
+        <source>3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</source>
+        <target state="new">3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.4|DisplayName">
+        <source>4 - Informational warnings</source>
+        <target state="new">4 - Informational warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.5|DisplayName">
+        <source>5 - Warnings from C# 9</source>
+        <target state="new">5 - Warnings from C# 9</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.6|DisplayName">
+        <source>6 - Warnings from C# 10</source>
+        <target state="new">6 - Warnings from C# 10</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.7|DisplayName">
+        <source>7 - Warnings from C# 11</source>
+        <target state="new">7 - Warnings from C# 11</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.9999|DisplayName">
         <source>9999 - All warnings</source>
         <target state="new">9999 - All warnings</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ko.xlf
@@ -132,6 +132,11 @@
         <target state="translated">경고를 오류로 처리</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|WarningLevelOverridden|DisplayName">
+        <source>WarningLevelOverridden</source>
+        <target state="new">WarningLevelOverridden</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|Advanced|Description">
         <source>Advanced settings for the application.</source>
         <target state="translated">응용 프로그램에 대한 고급 설정입니다.</target>
@@ -250,6 +255,16 @@
       <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
         <source>When to run the post-build event</source>
         <target state="translated">빌드 후 이벤트를 실행하는 경우</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|Description">
+        <source>Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -403,6 +418,51 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.9999|DisplayName">
+        <source>9999 - All warnings</source>
+        <target state="new">9999 - All warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.0|DisplayName">
+        <source>0 - Disable all warnings</source>
+        <target state="new">0 - Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.1|DisplayName">
+        <source>1 - Severe warning messages</source>
+        <target state="new">1 - Severe warning messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.2|DisplayName">
+        <source>2 - Less severe warnings, such as warnings about hiding class members</source>
+        <target state="new">2 - Less severe warnings, such as warnings about hiding class members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.3|DisplayName">
+        <source>3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</source>
+        <target state="new">3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.4|DisplayName">
+        <source>4 - Informational warnings</source>
+        <target state="new">4 - Informational warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.5|DisplayName">
+        <source>5 - Warnings from C# 9</source>
+        <target state="new">5 - Warnings from C# 9</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.6|DisplayName">
+        <source>6 - Warnings from C# 10</source>
+        <target state="new">6 - Warnings from C# 10</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.7|DisplayName">
+        <source>7 - Warnings from C# 11</source>
+        <target state="new">7 - Warnings from C# 11</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.9999|DisplayName">
         <source>9999 - All warnings</source>
         <target state="new">9999 - All warnings</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pl.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Traktuj ostrzeżenia jako błędy</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|WarningLevelOverridden|DisplayName">
+        <source>WarningLevelOverridden</source>
+        <target state="new">WarningLevelOverridden</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|Advanced|Description">
         <source>Advanced settings for the application.</source>
         <target state="translated">Ustawienia zaawansowane aplikacji.</target>
@@ -250,6 +255,16 @@
       <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
         <source>When to run the post-build event</source>
         <target state="translated">Kiedy uruchomić zdarzenie po kompilacji.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|Description">
+        <source>Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -403,6 +418,51 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.9999|DisplayName">
+        <source>9999 - All warnings</source>
+        <target state="new">9999 - All warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.0|DisplayName">
+        <source>0 - Disable all warnings</source>
+        <target state="new">0 - Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.1|DisplayName">
+        <source>1 - Severe warning messages</source>
+        <target state="new">1 - Severe warning messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.2|DisplayName">
+        <source>2 - Less severe warnings, such as warnings about hiding class members</source>
+        <target state="new">2 - Less severe warnings, such as warnings about hiding class members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.3|DisplayName">
+        <source>3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</source>
+        <target state="new">3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.4|DisplayName">
+        <source>4 - Informational warnings</source>
+        <target state="new">4 - Informational warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.5|DisplayName">
+        <source>5 - Warnings from C# 9</source>
+        <target state="new">5 - Warnings from C# 9</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.6|DisplayName">
+        <source>6 - Warnings from C# 10</source>
+        <target state="new">6 - Warnings from C# 10</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.7|DisplayName">
+        <source>7 - Warnings from C# 11</source>
+        <target state="new">7 - Warnings from C# 11</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.9999|DisplayName">
         <source>9999 - All warnings</source>
         <target state="new">9999 - All warnings</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pt-BR.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Tratar avisos como erros</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|WarningLevelOverridden|DisplayName">
+        <source>WarningLevelOverridden</source>
+        <target state="new">WarningLevelOverridden</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|Advanced|Description">
         <source>Advanced settings for the application.</source>
         <target state="translated">Configurações avançadas do aplicativo.</target>
@@ -250,6 +255,16 @@
       <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
         <source>When to run the post-build event</source>
         <target state="translated">Quando executar o evento pós-build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|Description">
+        <source>Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -403,6 +418,51 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.9999|DisplayName">
+        <source>9999 - All warnings</source>
+        <target state="new">9999 - All warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.0|DisplayName">
+        <source>0 - Disable all warnings</source>
+        <target state="new">0 - Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.1|DisplayName">
+        <source>1 - Severe warning messages</source>
+        <target state="new">1 - Severe warning messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.2|DisplayName">
+        <source>2 - Less severe warnings, such as warnings about hiding class members</source>
+        <target state="new">2 - Less severe warnings, such as warnings about hiding class members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.3|DisplayName">
+        <source>3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</source>
+        <target state="new">3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.4|DisplayName">
+        <source>4 - Informational warnings</source>
+        <target state="new">4 - Informational warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.5|DisplayName">
+        <source>5 - Warnings from C# 9</source>
+        <target state="new">5 - Warnings from C# 9</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.6|DisplayName">
+        <source>6 - Warnings from C# 10</source>
+        <target state="new">6 - Warnings from C# 10</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.7|DisplayName">
+        <source>7 - Warnings from C# 11</source>
+        <target state="new">7 - Warnings from C# 11</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.9999|DisplayName">
         <source>9999 - All warnings</source>
         <target state="new">9999 - All warnings</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ru.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Обрабатывать предупреждения как ошибки</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|WarningLevelOverridden|DisplayName">
+        <source>WarningLevelOverridden</source>
+        <target state="new">WarningLevelOverridden</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|Advanced|Description">
         <source>Advanced settings for the application.</source>
         <target state="translated">Расширенные параметры приложения.</target>
@@ -250,6 +255,16 @@
       <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
         <source>When to run the post-build event</source>
         <target state="translated">Когда выполнять событие после сборки</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|Description">
+        <source>Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -403,6 +418,51 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.9999|DisplayName">
+        <source>9999 - All warnings</source>
+        <target state="new">9999 - All warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.0|DisplayName">
+        <source>0 - Disable all warnings</source>
+        <target state="new">0 - Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.1|DisplayName">
+        <source>1 - Severe warning messages</source>
+        <target state="new">1 - Severe warning messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.2|DisplayName">
+        <source>2 - Less severe warnings, such as warnings about hiding class members</source>
+        <target state="new">2 - Less severe warnings, such as warnings about hiding class members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.3|DisplayName">
+        <source>3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</source>
+        <target state="new">3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.4|DisplayName">
+        <source>4 - Informational warnings</source>
+        <target state="new">4 - Informational warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.5|DisplayName">
+        <source>5 - Warnings from C# 9</source>
+        <target state="new">5 - Warnings from C# 9</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.6|DisplayName">
+        <source>6 - Warnings from C# 10</source>
+        <target state="new">6 - Warnings from C# 10</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.7|DisplayName">
+        <source>7 - Warnings from C# 11</source>
+        <target state="new">7 - Warnings from C# 11</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.9999|DisplayName">
         <source>9999 - All warnings</source>
         <target state="new">9999 - All warnings</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.tr.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Uyarıları hata olarak değerlendir</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|WarningLevelOverridden|DisplayName">
+        <source>WarningLevelOverridden</source>
+        <target state="new">WarningLevelOverridden</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|Advanced|Description">
         <source>Advanced settings for the application.</source>
         <target state="translated">Uygulamanın gelişmiş ayarları.</target>
@@ -250,6 +255,16 @@
       <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
         <source>When to run the post-build event</source>
         <target state="translated">Derleme sonrası olayının çalıştırılacağı zaman</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|Description">
+        <source>Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -403,6 +418,51 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.9999|DisplayName">
+        <source>9999 - All warnings</source>
+        <target state="new">9999 - All warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.0|DisplayName">
+        <source>0 - Disable all warnings</source>
+        <target state="new">0 - Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.1|DisplayName">
+        <source>1 - Severe warning messages</source>
+        <target state="new">1 - Severe warning messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.2|DisplayName">
+        <source>2 - Less severe warnings, such as warnings about hiding class members</source>
+        <target state="new">2 - Less severe warnings, such as warnings about hiding class members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.3|DisplayName">
+        <source>3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</source>
+        <target state="new">3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.4|DisplayName">
+        <source>4 - Informational warnings</source>
+        <target state="new">4 - Informational warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.5|DisplayName">
+        <source>5 - Warnings from C# 9</source>
+        <target state="new">5 - Warnings from C# 9</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.6|DisplayName">
+        <source>6 - Warnings from C# 10</source>
+        <target state="new">6 - Warnings from C# 10</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.7|DisplayName">
+        <source>7 - Warnings from C# 11</source>
+        <target state="new">7 - Warnings from C# 11</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.9999|DisplayName">
         <source>9999 - All warnings</source>
         <target state="new">9999 - All warnings</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hans.xlf
@@ -132,6 +132,11 @@
         <target state="translated">将警告视为错误</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|WarningLevelOverridden|DisplayName">
+        <source>WarningLevelOverridden</source>
+        <target state="new">WarningLevelOverridden</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|Advanced|Description">
         <source>Advanced settings for the application.</source>
         <target state="translated">应用程序的高级设置。</target>
@@ -250,6 +255,16 @@
       <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
         <source>When to run the post-build event</source>
         <target state="translated">何时运行生成后事件</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|Description">
+        <source>Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -403,6 +418,51 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.9999|DisplayName">
+        <source>9999 - All warnings</source>
+        <target state="new">9999 - All warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.0|DisplayName">
+        <source>0 - Disable all warnings</source>
+        <target state="new">0 - Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.1|DisplayName">
+        <source>1 - Severe warning messages</source>
+        <target state="new">1 - Severe warning messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.2|DisplayName">
+        <source>2 - Less severe warnings, such as warnings about hiding class members</source>
+        <target state="new">2 - Less severe warnings, such as warnings about hiding class members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.3|DisplayName">
+        <source>3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</source>
+        <target state="new">3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.4|DisplayName">
+        <source>4 - Informational warnings</source>
+        <target state="new">4 - Informational warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.5|DisplayName">
+        <source>5 - Warnings from C# 9</source>
+        <target state="new">5 - Warnings from C# 9</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.6|DisplayName">
+        <source>6 - Warnings from C# 10</source>
+        <target state="new">6 - Warnings from C# 10</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.7|DisplayName">
+        <source>7 - Warnings from C# 11</source>
+        <target state="new">7 - Warnings from C# 11</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.9999|DisplayName">
         <source>9999 - All warnings</source>
         <target state="new">9999 - All warnings</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hant.xlf
@@ -132,6 +132,11 @@
         <target state="translated">將警告視為錯誤</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|WarningLevelOverridden|DisplayName">
+        <source>WarningLevelOverridden</source>
+        <target state="new">WarningLevelOverridden</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|Advanced|Description">
         <source>Advanced settings for the application.</source>
         <target state="translated">應用程式的進階設定。</target>
@@ -250,6 +255,16 @@
       <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
         <source>When to run the post-build event</source>
         <target state="translated">何時執行建置後事件</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|Description">
+        <source>Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Inferred from the 'Analysis level' property of the 'Code Analysis' page.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel_Readonly|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|Description">
@@ -403,6 +418,51 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|WarningLevel.9999|DisplayName">
+        <source>9999 - All warnings</source>
+        <target state="new">9999 - All warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.0|DisplayName">
+        <source>0 - Disable all warnings</source>
+        <target state="new">0 - Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.1|DisplayName">
+        <source>1 - Severe warning messages</source>
+        <target state="new">1 - Severe warning messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.2|DisplayName">
+        <source>2 - Less severe warnings, such as warnings about hiding class members</source>
+        <target state="new">2 - Less severe warnings, such as warnings about hiding class members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.3|DisplayName">
+        <source>3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</source>
+        <target state="new">3 - Less severe warnings, such as warnings about expressions that always evaluate to true or false</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.4|DisplayName">
+        <source>4 - Informational warnings</source>
+        <target state="new">4 - Informational warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.5|DisplayName">
+        <source>5 - Warnings from C# 9</source>
+        <target state="new">5 - Warnings from C# 9</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.6|DisplayName">
+        <source>6 - Warnings from C# 10</source>
+        <target state="new">6 - Warnings from C# 10</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.7|DisplayName">
+        <source>7 - Warnings from C# 11</source>
+        <target state="new">7 - Warnings from C# 11</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel_Readonly.9999|DisplayName">
         <source>9999 - All warnings</source>
         <target state="new">9999 - All warnings</target>
         <note />

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/WarningLevelOverriddenValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/WarningLevelOverriddenValueProviderTests.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties;
+
+public class WarningLevelOverriddenValueProviderTests
+{
+    [Theory]
+    [InlineData("", "False")]
+    [InlineData("3.0", "False")]
+    [InlineData("4.0", "False")]
+    [InlineData("4.9", "False")]
+    [InlineData("5.0", "True")]
+    [InlineData("5.1", "True")]
+    [InlineData("6.0", "True")]
+    public async Task CheckValueAsync(string effectiveAnalysisLevel, string expectedWarningLevelOverriddenValue)
+    {
+        var provider = new WarningLevelOverriddenValueProvider();
+        var defaultProperties = IProjectPropertiesFactory.CreateWithPropertyAndValue(
+            WarningLevelOverriddenValueProvider.EffectiveAnalysisLevelPropertyName,
+            effectiveAnalysisLevel);
+
+        var unevaluatedResult = await provider.OnGetUnevaluatedPropertyValueAsync(
+            WarningLevelOverriddenValueProvider.WarningLevelOverriddenPropertyName,
+            string.Empty,
+            defaultProperties);
+
+        Assert.Equal(expectedWarningLevelOverriddenValue, actual: unevaluatedResult);
+
+        var evaluatedResult = await provider.OnGetEvaluatedPropertyValueAsync(
+            WarningLevelOverriddenValueProvider.WarningLevelOverriddenPropertyName,
+            string.Empty,
+            defaultProperties);
+
+        Assert.Equal(expectedWarningLevelOverriddenValue, actual: evaluatedResult);
+    }
+}


### PR DESCRIPTION
Fixes #7977.
Related to [AB#1459442](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1459442).

Historically, the `WarningLevel` property (corresponding to the `-warn:<n>` switch) controlled what set of warnings would be produced by the C# compiler. "0" meant produce no warnings (only errors). "1" meant produce only the most severe warnings. "2" meant produce all the warnings in 1, plus a set of less severe warnings. "3" meant all the warnings in 2 (and 1) plus additional, even less severe warnings. And so on. The default for a long time was "4" which effectively turned on all warnings the compiler could produce. The general idea was that, if need be, the user could pick a low `WarningLevel` to identify and subsequently fix the most impactful warnings in their code, and gradually ratchet the level up over time.

The scope and effective behavior of `WarningLevel` changed with .NET 5 and C# 9.0. This added a new warning level, 5, which controlled not only additional warnings added with C# 9.0 support, but _also_ certain analyzers included with the .NET 5.0 SDK. The SDK also sets the `WarningLevel` to 5 by default. Similarly, the .NET 6.0 SDK adds level 6, sets that as the default, and adds new analyzers/warnings tied to that level. The idea now is that as you adopt newer versions of the SDK you get new warnings, but have the option of turning them off by reducing the `WarningLevel`.

Along the way the logic of how `WarningLevel` is set to a default value in the SDK has become complicated. If you are targeting .NET 5.0 or later, the `WarningLevel` is computed based on the `EffectiveAnalysisLevel` property, which is itself computed from `AnalysisLevel`. If the `EffectiveAnalysisLevel` is 5.0 or greater, the SDK targets will override any `WarningLevel` set in the project in favor of specific values that correspond to the `EffectiveAnalysisLevel`. In these cases it doesn't make sense to provide controls to the user to change `WarningLevel`; the new value will be written to the project file but won't be honored, and the control will go back to the value provided by the SDK.

Here we address this by adding a hidden, synthetic property named `WarningLevelOverridden`. When it is true, we replace the `WarningLevel` controls with an equivalent read-only version and point the user to the `AnalysisLevel` property. A property interceptor computes the value of `WarningLevelOverridden` based on `EffectiveAnalysisLevel`.

This change also expands the set of admissible/supported `WarningLevel` values by adding those currently set by the .NET 6.0 SDK. This partially addresses the problem that we won't show the current value in the control if it isn't one of the admissible values, and may subsequently try to set the value to `null` when manipulating the value.

![WarningLevelBehavior](https://user-images.githubusercontent.com/10506730/159805135-74ca4119-b732-4a23-92f4-631e125aceb8.gif)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8004)