### PR TITLE
Fix overbuild loop when the set of inputs changes, but outputs aren't updated by build

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckBuildEventNotifier.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckBuildEventNotifier.cs
@@ -92,12 +92,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
 
             var operation = (VSSOLNBUILDUPDATEFLAGS)options;
 
-            if ((operation & flags) == flags)
-            {
-                return true;
-            }
-
-            return false;
+            return (operation & flags) == flags;
         }
 
         private static IEnumerable<IBuildUpToDateCheckProviderInternal> FindActiveConfiguredProviders(IVsHierarchy vsHierarchy)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -50,6 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         private IImmutableDictionary<string, string> _lastGlobalProperties = ImmutableStringDictionary<string>.EmptyOrdinal;
         private string _lastFailureReason = "";
+        private DateTime _lastBuildStartTimeUtc = DateTime.MinValue;
 
         private ISubscription _subscription;
         private int _isDisposed;
@@ -105,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             subscription.Dispose();
         }
 
-        private bool CheckGlobalConditions(Log log, DateTime lastCheckedAtUtc, bool validateFirstRun, UpToDateCheckImplicitConfiguredInput state)
+        private bool CheckGlobalConditions(Log log, DateTime lastSuccessfulBuildStartTimeUtc, bool validateFirstRun, UpToDateCheckImplicitConfiguredInput state)
         {
             if (!_tasksService.IsTaskQueueEmpty(ProjectCriticalOperation.Build))
             {
@@ -117,7 +118,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return log.Fail("Disabled", nameof(Resources.FUTD_DisableFastUpToDateCheckTrue));
             }
 
-            if (validateFirstRun && !state.WasStateRestored && lastCheckedAtUtc == DateTime.MinValue)
+            if (validateFirstRun && !state.WasStateRestored && lastSuccessfulBuildStartTimeUtc == DateTime.MinValue)
             {
                 // We had no persisted state, and this is the first run. We cannot know if the project is up-to-date
                 // or not, so schedule a build.
@@ -144,7 +145,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             return true;
         }
 
-        private bool CheckInputsAndOutputs(Log log, DateTime lastCheckedAtUtc, in TimestampCache timestampCache, UpToDateCheckImplicitConfiguredInput state, HashSet<string>? ignoreKinds, CancellationToken token)
+        private bool CheckInputsAndOutputs(Log log, DateTime lastSuccessfulBuildStartTimeUtc, in TimestampCache timestampCache, UpToDateCheckImplicitConfiguredInput state, HashSet<string>? ignoreKinds, CancellationToken token)
         {
             // UpToDateCheckInput/Output/Built items have optional 'Set' metadata that determine whether they
             // are treated separately or not. If omitted, such inputs/outputs are included in the default set,
@@ -216,9 +217,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 Assumes.NotNull(earliestOutputPath);
 
-                if (earliestOutputTime < state.LastItemsChangedAtUtc)
+                ISubscription subscription = Volatile.Read(ref _subscription);
+
+                if (lastSuccessfulBuildStartTimeUtc < state.LastItemsChangedAtUtc)
                 {
-                    log.Fail("ProjectItemsChangedSinceEarliestOutput", nameof(Resources.FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3), state.LastItemsChangedAtUtc, earliestOutputPath, earliestOutputTime);
+                    log.Fail("ProjectItemsChangedSinceLastSuccessfulBuildStart", nameof(Resources.FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2), state.LastItemsChangedAtUtc, lastSuccessfulBuildStartTimeUtc);
 
                     if (log.Level >= LogLevel.Info)
                     {
@@ -267,10 +270,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         return log.Fail("InputNewerThanEarliestOutput", itemType is null ? nameof(Resources.FUTD_InputNewerThanOutput_4) : nameof(Resources.FUTD_TypedInputNewerThanOutput_5), input, inputTime.Value, earliestOutputPath, earliestOutputTime, itemType ?? "");
                     }
 
-                    if (inputTime > lastCheckedAtUtc && lastCheckedAtUtc != DateTime.MinValue)
+                    if (inputTime > lastSuccessfulBuildStartTimeUtc && lastSuccessfulBuildStartTimeUtc != DateTime.MinValue)
                     {
                         // Bypass this test if no check has yet been performed. We handle that in CheckGlobalConditions.
-                        return log.Fail("InputModifiedSinceLastCheck", itemType is null ? nameof(Resources.FUTD_InputModifiedSinceLastCheck_3) : nameof(Resources.FUTD_TypedInputModifiedSinceLastCheck_4), input, inputTime.Value, lastCheckedAtUtc, itemType ?? "");
+                        return log.Fail("InputModifiedSinceLastSuccessfulBuildStart", itemType is null ? nameof(Resources.FUTD_InputModifiedSinceLastSuccessfulBuildStart_3) : nameof(Resources.FUTD_TypedInputModifiedSinceLastSuccessfulBuildStart_4), input, inputTime.Value, lastSuccessfulBuildStartTimeUtc, itemType ?? "");
                     }
 
                     if (latestInput is null || inputTime > latestInput.Value.Time)
@@ -740,11 +743,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             return true;
         }
 
-        void IBuildUpToDateCheckProviderInternal.NotifyRebuildStarting()
+        void IBuildUpToDateCheckProviderInternal.NotifyBuildStarting(DateTime buildStartTimeUtc)
         {
-            ISubscription subscription = Volatile.Read(ref _subscription);
+            _lastBuildStartTimeUtc = buildStartTimeUtc;
+        }
 
-            subscription.UpdateLastCheckedAtUtc();
+        void IBuildUpToDateCheckProviderInternal.NotifyBuildCompleted(bool wasSuccessful)
+        {
+            if (_lastBuildStartTimeUtc == default)
+            {
+                // This should not happen
+                System.Diagnostics.Debug.Fail("Notification of build completion should follow notification of build starting.");
+
+                return;
+            }
+
+            if (wasSuccessful)
+            {
+                ISubscription subscription = Volatile.Read(ref _subscription);
+
+                subscription.UpdateLastSuccessfulBuildStartTimeUtc(_lastBuildStartTimeUtc);
+            }
+
+            _lastBuildStartTimeUtc = default;
         }
 
         private static bool ConfiguredInputMatchesTargetFramework(UpToDateCheckImplicitConfiguredInput input, string buildTargetFramework)
@@ -804,9 +825,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             ISubscription subscription = Volatile.Read(ref _subscription);
 
-            return await subscription.RunAsync(CheckAsync, updateLastCheckedAt: !isValidationRun, cancellationToken);
+            return await subscription.RunAsync(CheckAsync, cancellationToken);
 
-            async Task<(bool, ImmutableArray<ProjectConfiguration>)> CheckAsync(UpToDateCheckConfiguredInput state, IReadOnlyDictionary<ProjectConfiguration, DateTime> lastCheckedAtUtc, CancellationToken token)
+            async Task<(bool, ImmutableArray<ProjectConfiguration>)> CheckAsync(UpToDateCheckConfiguredInput state, IReadOnlyDictionary<ProjectConfiguration, DateTime> lastSuccessfulBuildStartTimeUtcByConfiguration, CancellationToken token)
             {
                 token.ThrowIfCancellationRequested();
 
@@ -850,13 +871,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                             logger.Indent++;
                         }
 
-                        if (!lastCheckedAtUtc.TryGetValue(implicitState.ProjectConfiguration, out DateTime configurationLastCheckedAtUtc))
+                        if (!lastSuccessfulBuildStartTimeUtcByConfiguration.TryGetValue(implicitState.ProjectConfiguration, out DateTime lastSuccessfulBuildStartTimeUtc))
                         {
-                            configurationLastCheckedAtUtc = DateTime.MinValue;
+                            lastSuccessfulBuildStartTimeUtc = DateTime.MinValue;
                         }
 
-                        if (!CheckGlobalConditions(logger, configurationLastCheckedAtUtc, validateFirstRun: !isValidationRun, implicitState)
-                            || !CheckInputsAndOutputs(logger, configurationLastCheckedAtUtc, timestampCache, implicitState, ignoreKinds, token)
+                        if (!CheckGlobalConditions(logger, lastSuccessfulBuildStartTimeUtc, validateFirstRun: !isValidationRun, implicitState)
+                            || !CheckInputsAndOutputs(logger, lastSuccessfulBuildStartTimeUtc, timestampCache, implicitState, ignoreKinds, token)
                             || !CheckMarkers(logger, timestampCache, implicitState)
                             || !CheckCopyToOutputDirectoryFiles(logger, timestampCache, implicitState, token)
                             || !CheckCopiedOutputFiles(logger, timestampCache, implicitState, token))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -770,7 +770,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         private static bool ConfiguredInputMatchesTargetFramework(UpToDateCheckImplicitConfiguredInput input, string buildTargetFramework)
         {
-            return input.ProjectConfiguration.Dimensions.TryGetValue(TargetFrameworkGlobalPropertyName, out string? configurationTargetFramework)
+            return input.ProjectConfiguration.Dimensions.TryGetValue(ConfigurationGeneral.TargetFrameworkProperty, out string? configurationTargetFramework)
                 && buildTargetFramework.Equals(configurationTargetFramework);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/IBuildUpToDateCheckProviderInternal.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/IBuildUpToDateCheckProviderInternal.cs
@@ -5,25 +5,40 @@ using Microsoft.VisualStudio.ProjectSystem.Build;
 namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 {
     /// <summary>
-    /// Interface through which components internal to the .NET Project System may
-    /// interact with the fast up-to-date check.
+    /// Interface through which components internal to the .NET Project System may interact with the fast up-to-date check.
     /// </summary>
+    /// <remarks>
+    /// The fast up-to-date check needs to know about build events for two reasons:
+    /// <list type="number">
+    ///     <item>
+    ///         An <see cref="IBuildUpToDateCheckProvider"/> is only invoked for builds, not for rebuilds. We need
+    ///         to know when rebuilds occur.
+    ///     </item>
+    ///     <item>
+    ///         A call to <see cref="IBuildUpToDateCheckProvider"/> does not necessarily guarantee a build will occur.
+    ///         We need to know the time at which the last successful build occurred.
+    ///     </item>
+    /// </list>
+    /// Members of this interface are called by <c>UpToDateCheckBuildEventNotifier</c> in the VS layer.
+    /// </remarks>
+    [ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Private, Cardinality = Composition.ImportCardinality.ExactlyOne)]
     internal interface IBuildUpToDateCheckProviderInternal
     {
         /// <summary>
-        /// Notifies the fast up-to-date check that a rebuild is starting.
+        /// Notifies the fast up-to-date check that a build is starting.
         /// </summary>
         /// <remarks>
-        /// <para>
-        /// An <see cref="IBuildUpToDateCheckProvider"/> is only invoked for builds, not for rebuilds.
-        /// Our implementation of this check keeps track of the last build time. For our purposes, that
-        /// includes the last rebuild time too.
-        /// </para>
-        /// <para>
-        /// This method allows an external component (<c>BuildUpToDateCheckRebuildNotifier</c>, in the VS layer)
-        /// to provide this information.
-        /// </para>
+        /// Must also be called for rebuilds.
         /// </remarks>
-        void NotifyRebuildStarting();
+        void NotifyBuildStarting(DateTime buildStartTimeUtc);
+
+        /// <summary>
+        /// Notifies the fast up-to-date check that a build completed, and whether it completed
+        /// successfully or not.
+        /// </summary>
+        /// <remarks>
+        /// Must also be called for rebuilds.
+        /// </remarks>
+        void NotifyBuildCompleted(bool wasSuccessful);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
@@ -394,11 +394,11 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Input &apos;{0}&apos; ({1}) has been modified since the last up-to-date check ({2}), not up-to-date..
+        ///   Looks up a localized string similar to Input &apos;{0}&apos; ({1}) has been modified since the last successful build started ({2}), not up-to-date..
         /// </summary>
-        internal static string FUTD_InputModifiedSinceLastCheck_3 {
+        internal static string FUTD_InputModifiedSinceLastSuccessfulBuildStart_3 {
             get {
-                return ResourceManager.GetString("FUTD_InputModifiedSinceLastCheck_3", resourceCulture);
+                return ResourceManager.GetString("FUTD_InputModifiedSinceLastSuccessfulBuildStart_3", resourceCulture);
             }
         }
         
@@ -556,11 +556,11 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The set of project items was changed more recently ({0}) than the earliest output &apos;{1}&apos; ({2}), not up-to-date..
+        ///   Looks up a localized string similar to The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date..
         /// </summary>
-        internal static string FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3 {
+        internal static string FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2 {
             get {
-                return ResourceManager.GetString("FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3", resourceCulture);
+                return ResourceManager.GetString("FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2", resourceCulture);
             }
         }
         
@@ -583,11 +583,11 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Input {3} item &apos;{0}&apos; ({1}) has been modified since the last up-to-date check ({2}), not up-to-date..
+        ///   Looks up a localized string similar to Input {3} item &apos;{0}&apos; ({1}) has been modified since the last successful build started ({2}), not up-to-date..
         /// </summary>
-        internal static string FUTD_TypedInputModifiedSinceLastCheck_4 {
+        internal static string FUTD_TypedInputModifiedSinceLastSuccessfulBuildStart_4 {
             get {
-                return ResourceManager.GetString("FUTD_TypedInputModifiedSinceLastCheck_4", resourceCulture);
+                return ResourceManager.GetString("FUTD_TypedInputModifiedSinceLastSuccessfulBuildStart_4", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
@@ -226,9 +226,9 @@ This project was loaded using the wrong project type, likely as a result of rena
     <value>No build outputs defined in Set="{0}".</value>
     <comment>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</comment>
   </data>
-  <data name="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3" xml:space="preserve">
-    <value>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</value>
-    <comment>{0} and {2} are datetimes. {1} is a file path.</comment>
+  <data name="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2" xml:space="preserve">
+    <value>The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</value>
+    <comment>{0} and {1} are datetimes.</comment>
   </data>
   <data name="FUTD_SetOfChangedItemsIsEmpty" xml:space="preserve">
     <value>The set of changed items is empty.</value>
@@ -265,12 +265,12 @@ This project was loaded using the wrong project type, likely as a result of rena
     <value>Input {4} item '{0}' is newer ({1}) than earliest output '{2}' ({3}), not up-to-date.</value>
     <comment>{0} and {2} are file paths. {1} and {3} are datetimes. {4} is an MSBuild item type.</comment>
   </data>
-  <data name="FUTD_InputModifiedSinceLastCheck_3" xml:space="preserve">
-    <value>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</value>
+  <data name="FUTD_InputModifiedSinceLastSuccessfulBuildStart_3" xml:space="preserve">
+    <value>Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</value>
     <comment>{0} is a file path. {1} and {2} are datetimes.</comment>
   </data>
-  <data name="FUTD_TypedInputModifiedSinceLastCheck_4" xml:space="preserve">
-    <value>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</value>
+  <data name="FUTD_TypedInputModifiedSinceLastSuccessfulBuildStart_4" xml:space="preserve">
+    <value>Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</value>
     <comment>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</comment>
   </data>
   <data name="FUTD_NoInputsDefined" xml:space="preserve">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
@@ -157,9 +157,9 @@
         <target state="translated">Vstupní značka je novější než výstupní značka. Není aktuální.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
-        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">Vstup {0} ({1}) byla od poslední kontroly aktuálnosti ({2}) změněna. Není aktuální.</target>
+      <trans-unit id="FUTD_InputModifiedSinceLastSuccessfulBuildStart_3">
+        <source>Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
@@ -247,10 +247,10 @@
         <target state="translated">Sada změněných položek je prázdná.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
-        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="translated">Sada položek projektu byla změněna v nedávnější době ({0}), než odpovídá nejstaršímu výstupu {1} ({2}). Není aktuální.</target>
-        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2">
+        <source>The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</target>
+        <note>{0} and {1} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
@@ -262,9 +262,9 @@
         <target state="translated">Zdroj {0}: {1}</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
-      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
-        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">Vstupní položka {3} {0} ({1}) byla od poslední kontroly aktuálnosti ({2}) změněna. Není aktuální.</target>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastSuccessfulBuildStart_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
@@ -157,9 +157,9 @@
         <target state="translated">Der Eingabemarker ist neuer als der Ausgabemarker und nicht aktuell.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
-        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">Die Eingabe "{0}" ({1}) wurde seit der letzten Aktuellen Überprüfung ({2}) geändert und ist nicht auf dem neuesten Stand.</target>
+      <trans-unit id="FUTD_InputModifiedSinceLastSuccessfulBuildStart_3">
+        <source>Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
@@ -247,10 +247,10 @@
         <target state="translated">Der Satz geänderter Elemente ist leer.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
-        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="translated">Der Satz von Projektelementen wurde vor kurzem geändert ({0}) als die früheste Ausgabe "{1}" ({2}), nicht aktuell.</target>
-        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2">
+        <source>The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</target>
+        <note>{0} and {1} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
@@ -262,9 +262,9 @@
         <target state="translated">Quelle {0}: "{1}"</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
-      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
-        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">Die Eingabe {3}-Element "{0}" ({1}) wurde seit der letzten aktuellen Überprüfung ({2}) geändert und ist nicht auf dem neuesten Stand.</target>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastSuccessfulBuildStart_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
@@ -157,9 +157,9 @@
         <target state="translated">El marcador de entrada es más reciente que el de salida, no está actualizado.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
-        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">La entrada "{0}" ({1}) ha sido modificada desde la última comprobación de actualización ({2}), no está actualizada.</target>
+      <trans-unit id="FUTD_InputModifiedSinceLastSuccessfulBuildStart_3">
+        <source>Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
@@ -247,10 +247,10 @@
         <target state="translated">El conjunto de elementos modificados está vacío.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
-        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="translated">El conjunto de elementos del proyecto se modificó más recientemente ({0}) que la salida más antigua "{1}" ({2}), no actualizada</target>
-        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2">
+        <source>The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</target>
+        <note>{0} and {1} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
@@ -262,9 +262,9 @@
         <target state="translated">Origen {0}: "{1}"</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
-      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
-        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">El elemento {3} de entrada "{0}" ({1}) ha sido modificado desde la última comprobación de actualización ({2}), no está actualizado.</target>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastSuccessfulBuildStart_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
@@ -157,9 +157,9 @@
         <target state="translated">Le marqueur d’entrée est plus récent que le marqueur de sortie, pas à jour.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
-        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">L''{0}' d’entrée ({1}) a été modifiée depuis la dernière vérification à jour ({2}), et non à jour.</target>
+      <trans-unit id="FUTD_InputModifiedSinceLastSuccessfulBuildStart_3">
+        <source>Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
@@ -247,10 +247,10 @@
         <target state="translated">L’ensemble d’éléments modifiés est vide.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
-        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="translated">L’ensemble d’éléments de projet a été modifié plus récemment ({0}) que le '{1}' de sortie le plus ancien ({2}). Il n’est pas à jour.</target>
-        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2">
+        <source>The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</target>
+        <note>{0} and {1} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
@@ -262,9 +262,9 @@
         <target state="translated">Source {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
-      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
-        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">L''{0}' d’élément de {3} d’entrée ({1}) a été modifiée depuis la dernière vérification à jour ({2}), et non à jour.</target>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastSuccessfulBuildStart_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
@@ -157,9 +157,9 @@
         <target state="translated">Il marcatore di input è più recente del marcatore di output, non aggiornato.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
-        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">L'input '{0}' ({1}) è stato modificato dopo l'ultimo controllo aggiornato ({2}), non aggiornato.</target>
+      <trans-unit id="FUTD_InputModifiedSinceLastSuccessfulBuildStart_3">
+        <source>Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
@@ -247,10 +247,10 @@
         <target state="translated">Il set di elementi modificati è vuoto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
-        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="translated">Il set di elementi del progetto è stato modificato più di recente ({0}) rispetto al primo output '{1}' ({2}), non aggiornato.</target>
-        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2">
+        <source>The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</target>
+        <note>{0} and {1} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
@@ -262,9 +262,9 @@
         <target state="translated">{0} di origine: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
-      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
-        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">L'elemento di input {3} '{0}' ({1}) è stato modificato dopo l'ultimo controllo aggiornato ({2}), non aggiornato.</target>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastSuccessfulBuildStart_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
@@ -157,9 +157,9 @@
         <target state="translated">入力マーカーは出力マーカーよりも新しく、最新ではありません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
-        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">入力 '{0}' ({1}) は、前回の最新のチェック ({2}) 以降に変更されており、最新ではありません。</target>
+      <trans-unit id="FUTD_InputModifiedSinceLastSuccessfulBuildStart_3">
+        <source>Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
@@ -247,10 +247,10 @@
         <target state="translated">変更された項目のセットが空です。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
-        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="translated">プロジェクト項目のセットは、最も前の出力 '{1}' ({2}) よりも最近 ({0}) に変更され、最新ではありませんでした。</target>
-        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2">
+        <source>The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</target>
+        <note>{0} and {1} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
@@ -262,9 +262,9 @@
         <target state="translated">ソース {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
-      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
-        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">入力 {3} 項目 '{0}' ({1}) は、前回の最新のチェック ({2}) 以降に変更されており、最新ではありません。</target>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastSuccessfulBuildStart_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
@@ -157,9 +157,9 @@
         <target state="translated">입력 마커가 최신이 아니라 출력 마커보다 최신입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
-        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">입력 '{0}'({1})이(가) 최신이 아닌 마지막 최신 확인({2}) 이후 수정되었습니다.</target>
+      <trans-unit id="FUTD_InputModifiedSinceLastSuccessfulBuildStart_3">
+        <source>Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
@@ -247,10 +247,10 @@
         <target state="translated">변경된 항목 집합이 비어 있습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
-        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="translated">프로젝트 항목 집합이 최신이 아닌 가장 이른 출력 '{1}'({2})보다 최근에({0}) 변경되었습니다.</target>
-        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2">
+        <source>The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</target>
+        <note>{0} and {1} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
@@ -262,9 +262,9 @@
         <target state="translated">원본 {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
-      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
-        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">입력 {3} 항목 '{0}'({1})은(는) 최신이 아닌 마지막 최신 확인({2}) 이후에 수정되었습니다.</target>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastSuccessfulBuildStart_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
@@ -157,9 +157,9 @@
         <target state="translated">Znacznik wejściowy jest nowszy niż znacznik wyjściowy, nieaktualny.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
-        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">Dane wejściowe „{0}” ({1}) zostały zmodyfikowane od czasu ostatniego sprawdzenia aktualności ({2}), nieaktualne.</target>
+      <trans-unit id="FUTD_InputModifiedSinceLastSuccessfulBuildStart_3">
+        <source>Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
@@ -247,10 +247,10 @@
         <target state="translated">Zestaw zmienionych elementów jest pusty.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
-        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="translated">Zestaw elementów projektu został zmieniony wcześniej ({0}) niż najwcześniejsze dane wyjściowe „{1}” ({2}), nieaktualne.</target>
-        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2">
+        <source>The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</target>
+        <note>{0} and {1} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
@@ -262,9 +262,9 @@
         <target state="translated">Źródło {0}: „{1}”</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
-      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
-        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">Dane {3} wejściowe „{0}” ({1}) zostały zmodyfikowane od czasu ostatniego sprawdzenia aktualności ({2}), nieaktualne.</target>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastSuccessfulBuildStart_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
@@ -157,9 +157,9 @@
         <target state="translated">O marcador de entrada é mais recente do que o marcador de saída, não atualizado.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
-        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">A entrada '{0}' ({1}) foi modificada desde a última verificação de atualização ({2}), não atualizada.</target>
+      <trans-unit id="FUTD_InputModifiedSinceLastSuccessfulBuildStart_3">
+        <source>Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
@@ -247,10 +247,10 @@
         <target state="translated">O conjunto de itens alterados está vazio.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
-        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="translated">O conjunto de itens de projeto foi alterado mais recentemente ({0}) do que a saída mais antiga '{1}' ({2}), não atualizada.</target>
-        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2">
+        <source>The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</target>
+        <note>{0} and {1} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
@@ -262,9 +262,9 @@
         <target state="translated">Origem {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
-      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
-        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">O item '{0}' de entrada {3} ({1}) foi modificado desde a última verificação de atualização ({2}), não atualizado.</target>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastSuccessfulBuildStart_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
@@ -157,9 +157,9 @@
         <target state="translated">Входной маркер новее выходного маркера. Обновление не выполнено.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
-        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">Входные данные "{0}" ({1}) были изменены с момента последней проверки актуальности ({2}). Обновление не выполнено.</target>
+      <trans-unit id="FUTD_InputModifiedSinceLastSuccessfulBuildStart_3">
+        <source>Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
@@ -247,10 +247,10 @@
         <target state="translated">Набор измененных элементов пуст.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
-        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="translated">Набор элементов проекта изменен позднее ({0}) самых ранних выходных данных "{1}" ({2}). Обновление не выполнено.</target>
-        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2">
+        <source>The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</target>
+        <note>{0} and {1} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
@@ -262,9 +262,9 @@
         <target state="translated">Источник {0}: "{1}"</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
-      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
-        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">Элемент "{0}" ({1}) входных данных {3} был изменен с момента последней проверки актуальности ({2}). Обновление не выполнено.</target>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastSuccessfulBuildStart_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
@@ -157,9 +157,9 @@
         <target state="translated">Giriş işaretçisi, çıkış işaretçisinden daha yeni ancak güncel değil.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
-        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">'{0}' girişi ({1}) son güncelleştirme denetiminden ({2}) bu yana değiştirildi ancak güncel değil.</target>
+      <trans-unit id="FUTD_InputModifiedSinceLastSuccessfulBuildStart_3">
+        <source>Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
@@ -247,10 +247,10 @@
         <target state="translated">Değiştirilen öğeler kümesi boş.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
-        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="translated">Proje öğeleri grubu, en eski '{1}' ({2}) çıkışından daha yakın zamanda ({0}) değiştirildi ancak güncel değil.</target>
-        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2">
+        <source>The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</target>
+        <note>{0} and {1} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
@@ -262,9 +262,9 @@
         <target state="translated">{0} kaynağı: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
-      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
-        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">{3} girişinin '{0}' ({1}) öğesi son güncelleştirme denetiminden ({2}) bu yana değiştirildi ancak güncel değil.</target>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastSuccessfulBuildStart_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
@@ -157,9 +157,9 @@
         <target state="translated">输入标记比输出标记新，不是最新的。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
-        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">自上次最新检查 ({1})以来，已修改输入'{0}' ({2})，不是最新的。</target>
+      <trans-unit id="FUTD_InputModifiedSinceLastSuccessfulBuildStart_3">
+        <source>Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
@@ -247,10 +247,10 @@
         <target state="translated">已更改项的集合为空。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
-        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="translated">项目项集最近更改的 ({0})早于最早输出'{1}' ({2})，不是最新的。</target>
-        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2">
+        <source>The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</target>
+        <note>{0} and {1} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
@@ -262,9 +262,9 @@
         <target state="translated">源 {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
-      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
-        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">输入{3}项'{0}' ({1}) 自上次最新检查 ({2})以来已修改，不是最新的。</target>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastSuccessfulBuildStart_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
@@ -157,9 +157,9 @@
         <target state="translated">輸入標記比輸出標記新，不是最新狀態。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_InputModifiedSinceLastCheck_3">
-        <source>Input '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">自上次最新檢查 ({2}) 以來，輸入 '{0}' ({1}) 已被修改，不是最新狀態。</target>
+      <trans-unit id="FUTD_InputModifiedSinceLastSuccessfulBuildStart_3">
+        <source>Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_InputNewerThanOutput_4">
@@ -247,10 +247,10 @@
         <target state="translated">變更的專案集是空的。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_3">
-        <source>The set of project items was changed more recently ({0}) than the earliest output '{1}' ({2}), not up-to-date.</source>
-        <target state="translated">專案項目集的變更時間 ({0}) 比最早的輸出 '{1}' ({2}) 更近，不是最新狀態。</target>
-        <note>{0} and {2} are datetimes. {1} is a file path.</note>
+      <trans-unit id="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2">
+        <source>The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</source>
+        <target state="new">The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</target>
+        <note>{0} and {1} are datetimes.</note>
       </trans-unit>
       <trans-unit id="FUTD_SkippingIgnoredKindItem_2">
         <source>Skipping '{0}' with ignored Kind="{1}"</source>
@@ -262,9 +262,9 @@
         <target state="translated">來源 {0}: '{1}'</target>
         <note>{0} is a datetime. {1} is a file path.</note>
       </trans-unit>
-      <trans-unit id="FUTD_TypedInputModifiedSinceLastCheck_4">
-        <source>Input {3} item '{0}' ({1}) has been modified since the last up-to-date check ({2}), not up-to-date.</source>
-        <target state="translated">自上次最新檢查 ({2}) 以來，輸入 {3} 項目 '{0}' ({1}) 已被修改，不是最新狀態。</target>
+      <trans-unit id="FUTD_TypedInputModifiedSinceLastSuccessfulBuildStart_4">
+        <source>Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</source>
+        <target state="new">Input {3} item '{0}' ({1}) has been modified since the last successful build started ({2}), not up-to-date.</target>
         <note>{0} is a file path. {1} and {2} are datetimes. {3} is an MSBuild item type.</note>
       </trans-unit>
       <trans-unit id="FUTD_TypedInputNewerThanOutput_5">

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private readonly DateTime _projectFileTimeUtc = new(1999, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         private readonly List<ITelemetryServiceFactory.TelemetryParameters> _telemetryEvents = new();
-        private readonly Dictionary<ProjectConfiguration, DateTime> _lastCheckTimeAtUtc = new();
+        private readonly Dictionary<ProjectConfiguration, DateTime> _lastSuccessfulBuildStartTimeUtcByConfiguration = new();
 
         private readonly BuildUpToDateCheck _buildUpToDateCheck;
         private readonly ITestOutputHelper _output;
@@ -105,15 +105,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             bool disableFastUpToDateCheck = false,
             bool disableFastUpToDateCopyAlwaysOptimization = false,
             string outDir = _outputPath,
-            DateTime? lastCheckTimeAtUtc = null,
+            DateTime? lastSuccessfulBuildStartTimeUtc = null,
             DateTime? lastItemsChangedAtUtc = null,
-            DateTime? updateLastCheckedAtUtcValue = null,
             UpToDateCheckImplicitConfiguredInput? upToDateCheckImplicitConfiguredInput = null,
             bool itemRemovedFromSourceSnapshot = false)
         {
             upToDateCheckImplicitConfiguredInput ??= UpToDateCheckImplicitConfiguredInput.CreateEmpty(ProjectConfigurationFactory.Create("testConfiguration"));
 
-            _lastCheckTimeAtUtc[upToDateCheckImplicitConfiguredInput.ProjectConfiguration] = lastCheckTimeAtUtc ?? DateTime.MinValue;
+            _lastSuccessfulBuildStartTimeUtcByConfiguration[upToDateCheckImplicitConfiguredInput.ProjectConfiguration] = lastSuccessfulBuildStartTimeUtc ?? DateTime.MinValue;
             
             projectSnapshot ??= new Dictionary<string, IProjectRuleSnapshotModel>();
 
@@ -150,25 +149,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             subscription.Setup(s => s.EnsureInitialized());
 
             subscription
-                .Setup(s => s.UpdateLastCheckedAtUtc())
-                .Callback(() => _lastCheckTimeAtUtc[upToDateCheckImplicitConfiguredInput.ProjectConfiguration] = updateLastCheckedAtUtcValue ?? DateTime.UtcNow);
+                .Setup(s => s.UpdateLastSuccessfulBuildStartTimeUtc(It.IsAny<DateTime>()))
+                .Callback((DateTime timeUtc) => _lastSuccessfulBuildStartTimeUtcByConfiguration[upToDateCheckImplicitConfiguredInput.ProjectConfiguration] = timeUtc);
 
             subscription
-                .Setup(s => s.UpdateLastCheckedAtUtc(It.IsAny<IEnumerable<ProjectConfiguration>>()))
-                .Callback((IEnumerable<ProjectConfiguration> configs) =>
-                {
-                    foreach (var config in configs)
-                    {
-                        _lastCheckTimeAtUtc[config] = updateLastCheckedAtUtcValue ?? DateTime.UtcNow;
-                    }
-                });
-
-            subscription
-                .Setup(s => s.RunAsync(It.IsAny<Func<UpToDateCheckConfiguredInput, IReadOnlyDictionary<ProjectConfiguration, DateTime>, CancellationToken, Task<(bool, ImmutableArray<ProjectConfiguration>)>>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Returns(async (Func<UpToDateCheckConfiguredInput, IReadOnlyDictionary<ProjectConfiguration, DateTime>, CancellationToken, Task<(bool, ImmutableArray<ProjectConfiguration>)>>  func, bool updateLastCheckedAt, CancellationToken token) =>
+                .Setup(s => s.RunAsync(It.IsAny<Func<UpToDateCheckConfiguredInput, IReadOnlyDictionary<ProjectConfiguration, DateTime>, CancellationToken, Task<(bool, ImmutableArray<ProjectConfiguration>)>>>(), It.IsAny<CancellationToken>()))
+                .Returns(async (Func<UpToDateCheckConfiguredInput, IReadOnlyDictionary<ProjectConfiguration, DateTime>, CancellationToken, Task<(bool, ImmutableArray<ProjectConfiguration>)>>  func, CancellationToken token) =>
                 {
                     Assumes.NotNull(_state);
-                    var result = await func(_state, _lastCheckTimeAtUtc, token);
+                    var result = await func(_state, _lastSuccessfulBuildStartTimeUtcByConfiguration, token);
                     return result.Item1;
                 });
             
@@ -202,9 +191,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         [InlineData(BuildAction.Rebuild)]
         public async Task IsUpToDateAsync_False_NonBuildAction(BuildAction buildAction)
         {
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(-1);
+            var lastBuildTime = DateTime.UtcNow.AddMinutes(-1);
 
-            await SetupAsync(lastCheckTimeAtUtc: lastCheckTime);
+            await SetupAsync(lastSuccessfulBuildStartTimeUtc: lastBuildTime);
 
             await AssertUpToDateAsync("No build outputs defined.");
 
@@ -214,9 +203,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         [Fact]
         public async Task IsUpToDateAsync_False_BuildTasksActive()
         {
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(-1);
+            var lastBuildTime = DateTime.UtcNow.AddMinutes(-1);
 
-            await SetupAsync(lastCheckTimeAtUtc: lastCheckTime);
+            await SetupAsync(lastSuccessfulBuildStartTimeUtc: lastBuildTime);
 
             await AssertUpToDateAsync("No build outputs defined.");
 
@@ -241,13 +230,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             };
 
             var outputTime      = DateTime.UtcNow.AddMinutes(-3);
-            var lastCheckTime   = DateTime.UtcNow.AddMinutes(-2);
+            var lastBuildTime   = DateTime.UtcNow.AddMinutes(-2);
             var itemChangedTime = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 projectSnapshot,
                 sourceSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangedTime);
 
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\BuiltOutputPath1", outputTime);
@@ -255,11 +244,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertNotUpToDateAsync(
                 new[]
                 {
-                    $"The set of project items was changed more recently ({itemChangedTime.ToLocalTime()}) than the earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({outputTime.ToLocalTime()}), not up-to-date.",
+                    $"The set of project items was changed more recently ({itemChangedTime.ToLocalTime()}) than the last successful build start time ({lastBuildTime.ToLocalTime()}), not up-to-date.",
                     "    Content item added 'ItemPath1' (CopyToOutputDirectory=Never, TargetPath='')",
                     "    Content item added 'ItemPath2' (CopyToOutputDirectory=Never, TargetPath='')",
                 },
-                "ProjectItemsChangedSinceEarliestOutput");
+                "ProjectItemsChangedSinceLastSuccessfulBuildStart");
         }
 
         [Fact]
@@ -297,7 +286,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var targetTime = sourceTime;
             var inputTime = DateTime.UtcNow.AddMinutes(-3);
             var outputTime = DateTime.UtcNow.AddMinutes(-2);
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(-1);
+            var lastBuildTime = DateTime.UtcNow.AddMinutes(-1);
 
             var sourcePath = @"C:\Dev\Solution\Project\CopyMe";
             var targetPath = @"C:\Dev\Solution\Project\Output\CopyMe";
@@ -313,7 +302,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 projectSnapshot: projectSnapshot,
                 sourceSnapshot: sourceSnapshot,
                 disableFastUpToDateCopyAlwaysOptimization: !optimized,
-                lastCheckTimeAtUtc: lastCheckTime);
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime);
 
             if (expectUpToDate)
             {
@@ -379,9 +368,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 [UpToDateCheckBuilt.SchemaName] = SimpleItems("BuiltOutputPath1")
             };
 
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(-1);
+            var lastBuildTime = DateTime.UtcNow.AddMinutes(-1);
 
-            await SetupAsync(projectSnapshot: projectSnapshot, lastCheckTimeAtUtc: lastCheckTime);
+            await SetupAsync(projectSnapshot: projectSnapshot, lastSuccessfulBuildStartTimeUtc: lastBuildTime);
 
             await AssertNotUpToDateAsync(
                 "Output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' does not exist, not up-to-date.",
@@ -393,7 +382,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         {
             var projectSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
             {
-                [UpToDateCheckBuilt.SchemaName] = SimpleItems("BuildDefault"),
+                [UpToDateCheckBuilt.SchemaName] = SimpleItems("Built"),
             };
 
             var sourceSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
@@ -403,36 +392,36 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             var inputTime = DateTime.UtcNow.AddMinutes(-5);
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(-3);
-            var buildTime = DateTime.UtcNow.AddMinutes(-2);
+            var lastBuildTime = DateTime.UtcNow.AddMinutes(-3);
+            var outputTime = DateTime.UtcNow.AddMinutes(-2);
 
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\ItemPath1", inputTime);
-            _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\BuildDefault", buildTime);
+            _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\Built", outputTime);
 
             var priorState = await SetupAsync(
                 projectSnapshot,
                 sourceSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             await AssertUpToDateAsync(
-                $"No inputs are newer than earliest output 'C:\\Dev\\Solution\\Project\\BuildDefault' ({buildTime.ToLocalTime()}). Newest input is 'C:\\Dev\\Solution\\Project\\ItemPath1' ({inputTime.ToLocalTime()}).");
+                $"No inputs are newer than earliest output 'C:\\Dev\\Solution\\Project\\Built' ({outputTime.ToLocalTime()}). Newest input is 'C:\\Dev\\Solution\\Project\\ItemPath1' ({inputTime.ToLocalTime()}).");
 
-            lastCheckTime = DateTime.UtcNow.AddMinutes(-1);
+            lastBuildTime = DateTime.UtcNow.AddMinutes(-1);
             itemChangeTime = DateTime.UtcNow.AddMinutes(0);
 
             await SetupAsync(
                 projectSnapshot,
                 sourceSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime,
                 upToDateCheckImplicitConfiguredInput: priorState,
                 itemRemovedFromSourceSnapshot: true);
 
             await AssertNotUpToDateAsync(new[] {
-                $"The set of project items was changed more recently ({itemChangeTime.ToLocalTime()}) than the earliest output 'C:\\Dev\\Solution\\Project\\BuildDefault' ({buildTime.ToLocalTime()}), not up-to-date.",
+                $"The set of project items was changed more recently ({itemChangeTime.ToLocalTime()}) than the last successful build start time ({lastBuildTime.ToLocalTime()}), not up-to-date.",
                 "    Compile item removed \'ItemPath1\' (CopyToOutputDirectory=Never, TargetPath='')"},
-                "ProjectItemsChangedSinceEarliestOutput");
+                "ProjectItemsChangedSinceLastSuccessfulBuildStart");
         }
 
         [Fact]
@@ -440,7 +429,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         {
             var projectSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
             {
-                [UpToDateCheckBuilt.SchemaName] = SimpleItems("BuiltOutputPath1")
+                [UpToDateCheckBuilt.SchemaName] = SimpleItems("Built")
             };
 
             var sourceSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
@@ -450,15 +439,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             var itemChangedTime = DateTime.UtcNow.AddMinutes(-3);
             var outputTime      = DateTime.UtcNow.AddMinutes(-2);
-            var lastCheckTime   = DateTime.UtcNow.AddMinutes(-1);
+            var lastBuildTime   = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 projectSnapshot,
                 sourceSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangedTime);
 
-            _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\BuiltOutputPath1", outputTime);
+            _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\Built", outputTime);
 
             await AssertNotUpToDateAsync(
                 "Input Compile item 'C:\\Dev\\Solution\\Project\\ItemPath1' does not exist and is required, not up-to-date.",
@@ -481,12 +470,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var itemChangedTime = DateTime.UtcNow.AddMinutes(-4);
             var outputTime      = DateTime.UtcNow.AddMinutes(-3);
             var inputTime       = DateTime.UtcNow.AddMinutes(-2);
-            var lastCheckTime   = DateTime.UtcNow.AddMinutes(-1);
+            var lastBuildTime   = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 projectSnapshot,
                 sourceSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangedTime);
 
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\BuiltOutputPath1", outputTime);
@@ -498,7 +487,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         }
 
         [Fact]
-        public async Task IsUpToDateAsync_False_InputChangedBetweenLastCheckAndEarliestOutput()
+        public async Task IsUpToDateAsync_False_InputChangedBetweenLastBuildStartAndAndEarliestOutput()
         {
             // This test covers a race condition described in https://github.com/dotnet/project-system/issues/4014
 
@@ -512,14 +501,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 [Compile.SchemaName] = SimpleItems("ItemPath1")
             };
 
-            // The rule is that no input item should be modified since the last up-to-date check started.
+            // The rule is that no input item should be modified since the last successful build started.
 
             var t0 = DateTime.UtcNow.AddMinutes(-5); // t0 Output file timestamp
             var t1 = DateTime.UtcNow.AddMinutes(-4); // t1 Input file timestamp
-            var t2 = DateTime.UtcNow.AddMinutes(-3); // t2 Check up-to-date (false) so start a build (setting last checked at time)
+            var t2 = DateTime.UtcNow.AddMinutes(-3); // t2 Check up-to-date (false) and build
             var t3 = DateTime.UtcNow.AddMinutes(-2); // t3 Modify input file (during build)
             var t4 = DateTime.UtcNow.AddMinutes(-1); // t4 Produce first (earliest) output DLL (from t0 input)
-                                                     // t5 Check incorrectly claims everything up-to-date, as t3 > t2 (inputTime > lastCheckedTime)
+                                                     // t5 Check incorrectly claims everything up-to-date, as t3 > t2 (inputTime > lastBuildStartTime)
 
             var inputFile = "C:\\Dev\\Solution\\Project\\ItemPath1";
             var outputPath = "C:\\Dev\\Solution\\Project\\BuiltOutputPath1";
@@ -528,7 +517,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _fileSystem.AddFile(inputFile, t1);
 
             // Run test (t2)
-            await SetupAsync(projectSnapshot, sourceSnapshot, lastCheckTimeAtUtc: t2);
+            await SetupAsync(projectSnapshot, sourceSnapshot, lastSuccessfulBuildStartTimeUtc: t2);
 
             await AssertNotUpToDateAsync(
                 $"Input Compile item '{inputFile}' is newer ({t1.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({t0.ToLocalTime()}), not up-to-date.",
@@ -542,12 +531,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             // Run check again (t5)
             await AssertNotUpToDateAsync(
-                $"Input Compile item '{inputFile}' ({t3.ToLocalTime()}) has been modified since the last up-to-date check ({t2.ToLocalTime()}), not up-to-date.",
-                "InputModifiedSinceLastCheck");
+                $"Input Compile item '{inputFile}' ({t3.ToLocalTime()}) has been modified since the last successful build started ({t2.ToLocalTime()}), not up-to-date.",
+                "InputModifiedSinceLastSuccessfulBuildStart");
         }
 
         [Fact]
-        public async Task IsUpToDateAsync_True_RebuildUpdatesLastCheckedTime()
+        public async Task IsUpToDateAsync_True_BuildAfterRebuild()
         {
             var projectSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
             {
@@ -559,15 +548,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 [Compile.SchemaName] = SimpleItems("ItemPath1")
             };
 
-            // The rule is that no input item should be modified since the last up-to-date check started.
+            // If an input was modified since the last successful build started, not up-to-date.
 
-            var t0 = DateTime.UtcNow.AddMinutes(-6); // t0 Output file timestamp
-            var t1 = DateTime.UtcNow.AddMinutes(-5); // t1 Input file timestamp
-            var t2 = DateTime.UtcNow.AddMinutes(-4); // t2 Check up-to-date (false) so start a build (setting last checked at time)
-            var t3 = DateTime.UtcNow.AddMinutes(-3); // t3 Modify input file (during build)
-            var t4 = DateTime.UtcNow.AddMinutes(-2); // t4 start rebuild (setting lastCheckedTime)
-            var t5 = DateTime.UtcNow.AddMinutes(-1); // t5 Produce first (earliest) output DLL (from t0 input)
-                                                     // t6 Check incorrectly claims everything up-to-date, as t3 < t5
+            var t0 = DateTime.Now.Date;    // t0 Output file timestamp
+            var t1 = t0.AddMinutes(1);     // t1 Input file timestamp
+                                           //    Check up-to-date (false)
+            var t2 = t0.AddMinutes(2);     // t2 Start and complete a successful build)
+            var t3 = t0.AddMinutes(3);     // t3 Modify input file
+            var t4 = t0.AddMinutes(4);     // t4 Rebuild (firing build events but not checking up-to-date)
+            var t5 = t0.AddMinutes(5);     // t5 Produce first (earliest) output DLL (from t0 input)
+                                           // t6 Check correctly claims everything up-to-date, as t3 < t5
 
             var inputFile = "C:\\Dev\\Solution\\Project\\ItemPath1";
             var outputPath = "C:\\Dev\\Solution\\Project\\BuiltOutputPath1";
@@ -576,19 +566,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _fileSystem.AddFile(inputFile, t1);
 
             // Run test (t2)
-            await SetupAsync(projectSnapshot, sourceSnapshot, lastCheckTimeAtUtc: t2, updateLastCheckedAtUtcValue: t4);
+            await SetupAsync(projectSnapshot, sourceSnapshot, lastSuccessfulBuildStartTimeUtc: t0.AddMinutes(-1));
 
             await AssertNotUpToDateAsync(
                 $"Input Compile item '{inputFile}' is newer ({t1.ToLocalTime()}) than earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({t0.ToLocalTime()}), not up-to-date.",
                 "InputNewerThanEarliestOutput");
 
-            // Modify input while build in progress (t3)
+            // Build (t2)
+            ((IBuildUpToDateCheckProviderInternal)_buildUpToDateCheck).NotifyBuildStarting(buildStartTimeUtc: t2);
+            ((IBuildUpToDateCheckProviderInternal)_buildUpToDateCheck).NotifyBuildCompleted(wasSuccessful: true);
+
+            // Modify input (t3)
             _fileSystem.AddFile(inputFile, t3);
 
-            // Rebuild
-            ((IBuildUpToDateCheckProviderInternal)_buildUpToDateCheck).NotifyRebuildStarting();
+            // Rebuild (t4)
+            ((IBuildUpToDateCheckProviderInternal)_buildUpToDateCheck).NotifyBuildStarting(buildStartTimeUtc: t4);
+            ((IBuildUpToDateCheckProviderInternal)_buildUpToDateCheck).NotifyBuildCompleted(wasSuccessful: true);
 
-            // Update write time of output (t5)
+            // Update output (t5)
             _fileSystem.AddFile(outputPath, t5);
 
             // Run check again (t6)
@@ -609,7 +604,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 [Compile.SchemaName] = SimpleItems("ItemPath1")
             };
 
-            // The rule is that no input item should be modified since the last up-to-date check started.
+            // The rule is that no input item should be modified since the last successful build started.
 
             var t0 = DateTime.UtcNow.AddMinutes(-3); // t0 Input file timestamp
             var t1 = DateTime.UtcNow.AddMinutes(-2); // t1 Rebuild (sets output file timestamp)
@@ -622,10 +617,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             _fileSystem.AddFile(outputPath, t1);
 
-            await SetupAsync(projectSnapshot, sourceSnapshot, updateLastCheckedAtUtcValue: t1);
+            await SetupAsync(projectSnapshot, sourceSnapshot, lastSuccessfulBuildStartTimeUtc: t1);
 
             // Rebuild (t1)
-            ((IBuildUpToDateCheckProviderInternal)_buildUpToDateCheck).NotifyRebuildStarting();
+            ((IBuildUpToDateCheckProviderInternal)_buildUpToDateCheck).NotifyBuildStarting(buildStartTimeUtc: t1);
+            ((IBuildUpToDateCheckProviderInternal)_buildUpToDateCheck).NotifyBuildCompleted(wasSuccessful: true);
 
             // Run test (t2)
             await AssertUpToDateAsync(
@@ -648,12 +644,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var itemChangeTime  = DateTime.UtcNow.AddMinutes(-4);
             var outputTime      = DateTime.UtcNow.AddMinutes(-3);
             var compileItemTime = DateTime.UtcNow.AddMinutes(-2);
-            var lastCheckTime   = DateTime.UtcNow.AddMinutes(-1);
+            var lastBuildTime   = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 projectSnapshot,
                 sourceSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\CustomOutputPath1", outputTime);
@@ -680,9 +676,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 }
             };
 
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(-5);
+            var lastBuildTime = DateTime.UtcNow.AddMinutes(-5);
 
-            await SetupAsync(projectSnapshot: projectSnapshot, lastCheckTimeAtUtc: lastCheckTime);
+            await SetupAsync(projectSnapshot: projectSnapshot, lastSuccessfulBuildStartTimeUtc: lastBuildTime);
 
             var outputTime   = DateTime.UtcNow.AddMinutes(-4);
             var resolvedTime = DateTime.UtcNow.AddMinutes(-3);
@@ -717,11 +713,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
             var outputTime     = DateTime.UtcNow.AddMinutes(-3);
             var inputTime      = DateTime.UtcNow.AddMinutes(-2);
-            var lastCheckTime  = DateTime.UtcNow.AddMinutes(-1);
+            var lastBuildTime  = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 projectSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             var outputItem = "C:\\Dev\\Solution\\Project\\BuiltOutputPath1";
@@ -752,13 +748,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             };
 
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime  = DateTime.UtcNow.AddMinutes(-3);
+            var lastBuildTime  = DateTime.UtcNow.AddMinutes(-3);
             var outputTime     = DateTime.UtcNow.AddMinutes(-2);
             var inputTime      = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 projectSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\BuiltOutputPath1", outputTime);
@@ -779,13 +775,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             };
 
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime  = DateTime.UtcNow.AddMinutes(-3);
+            var lastBuildTime  = DateTime.UtcNow.AddMinutes(-3);
             var outputTime     = DateTime.UtcNow.AddMinutes(-2);
             var inputTime      = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 projectSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\BuiltOutputPath1", outputTime);
@@ -808,13 +804,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             };
 
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime  = DateTime.UtcNow.AddMinutes(-3);
+            var lastBuildTime  = DateTime.UtcNow.AddMinutes(-3);
             var outputTime     = DateTime.UtcNow.AddMinutes(-2);
             var inputTime      = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 projectSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\Input1", inputTime);
@@ -845,11 +841,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var outputTime1    = DateTime.UtcNow.AddMinutes(-4);
             var inputTime2     = DateTime.UtcNow.AddMinutes(-3);
             var outputTime2    = DateTime.UtcNow.AddMinutes(-2);
-            var lastCheckTime  = DateTime.UtcNow.AddMinutes(-1);
+            var lastBuildTime  = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 projectSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\Input1", inputTime1);
@@ -879,11 +875,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var outputTime1    = DateTime.UtcNow.AddMinutes(-4);
             var outputTime2    = DateTime.UtcNow.AddMinutes(-3);
             var inputTime2     = DateTime.UtcNow.AddMinutes(-2);
-            var lastCheckTime  = DateTime.UtcNow.AddMinutes(-1);
+            var lastBuildTime  = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 projectSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\Input1", inputTime1);
@@ -916,10 +912,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var outputTime2    = DateTime.UtcNow.AddMinutes(-4);
             var inputTime      = DateTime.UtcNow.AddMinutes(-3);
             var outputTime1    = DateTime.UtcNow.AddMinutes(-2);
-            var lastCheckTime  = DateTime.UtcNow.AddMinutes(-1);
+            var lastBuildTime  = DateTime.UtcNow.AddMinutes(-1);
             await SetupAsync(
                 projectSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\Input", inputTime);
@@ -947,13 +943,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             };
 
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime  = DateTime.UtcNow.AddMinutes(-3);
+            var lastBuildTime  = DateTime.UtcNow.AddMinutes(-3);
             var buildTime      = DateTime.UtcNow.AddMinutes(-2);
             var inputTime      = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 projectSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\Input1", inputTime);
@@ -974,12 +970,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             };
 
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-3);
-            var lastCheckTime  = DateTime.UtcNow.AddMinutes(-2);
+            var lastBuildTime  = DateTime.UtcNow.AddMinutes(-2);
             var outputTime     = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 projectSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\Output1", outputTime);
@@ -1001,13 +997,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             };
 
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime  = DateTime.UtcNow.AddMinutes(-3);
+            var lastBuildTime  = DateTime.UtcNow.AddMinutes(-3);
             var outputTime     = DateTime.UtcNow.AddMinutes(-2);
             var inputTime      = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 projectSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\Input", inputTime);
@@ -1036,14 +1032,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-6);
             var input2Time     = DateTime.UtcNow.AddMinutes(-5);
-            var lastCheckTime  = DateTime.UtcNow.AddMinutes(-4);
+            var lastBuildTime  = DateTime.UtcNow.AddMinutes(-4);
             var output1Time    = DateTime.UtcNow.AddMinutes(-3);
             var output2Time    = DateTime.UtcNow.AddMinutes(-2);
             var input1Time     = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 projectSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\Input",        input1Time);
@@ -1071,12 +1067,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
             var inputTime      = DateTime.UtcNow.AddMinutes(-3);
-            var lastCheckTime  = DateTime.UtcNow.AddMinutes(-2);
+            var lastBuildTime  = DateTime.UtcNow.AddMinutes(-2);
             var outputTime     = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 projectSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\Input", inputTime);
@@ -1104,7 +1100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-7);
             var inputTime      = DateTime.UtcNow.AddMinutes(-6);
-            var lastCheckTime  = DateTime.UtcNow.AddMinutes(-5);
+            var lastBuildTime  = DateTime.UtcNow.AddMinutes(-5);
             var output4Time    = DateTime.UtcNow.AddMinutes(-4);
             var output3Time    = DateTime.UtcNow.AddMinutes(-3);
             var output2Time    = DateTime.UtcNow.AddMinutes(-2);
@@ -1112,7 +1108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await SetupAsync(
                 projectSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile("C:\\Dev\\Solution\\Project\\Input",        inputTime);
@@ -1139,13 +1135,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var sourcePath = @"C:\Dev\Solution\Project\CopiedOutputSource";
 
             var itemChangeTime  = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime   = DateTime.UtcNow.AddMinutes(-3);
+            var lastBuildTime   = DateTime.UtcNow.AddMinutes(-3);
             var destinationTime = DateTime.UtcNow.AddMinutes(-2);
             var sourceTime      = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 projectSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile(destinationPath, destinationTime);
@@ -1184,14 +1180,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var sourcePath = @"C:\Dev\Solution\Project\Item1";
 
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(-3);
+            var lastBuildTime = DateTime.UtcNow.AddMinutes(-3);
             var destinationTime = DateTime.UtcNow.AddMinutes(-2);
             var sourceTime = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 sourceSnapshot: sourceSnapshot,
                 outDir: outDirSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile(destinationPath, destinationTime);
@@ -1224,9 +1220,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 [UpToDateCheckBuilt.SchemaName] = ItemWithMetadata("CopiedOutputDestination", UpToDateCheckBuilt.OriginalProperty, "CopiedOutputSource")
             };
 
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(-1);
+            var lastBuildTime = DateTime.UtcNow.AddMinutes(-1);
 
-            await SetupAsync(projectSnapshot, lastCheckTimeAtUtc: lastCheckTime);
+            await SetupAsync(projectSnapshot, lastSuccessfulBuildStartTimeUtc: lastBuildTime);
 
             var destinationPath = @"C:\Dev\Solution\Project\CopiedOutputDestination";
             var sourcePath = @"C:\Dev\Solution\Project\CopiedOutputSource";
@@ -1255,12 +1251,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var sourcePath = @"C:\Dev\Solution\Project\CopiedOutputSource";
 
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime  = DateTime.UtcNow.AddMinutes(-3);
+            var lastBuildTime  = DateTime.UtcNow.AddMinutes(-3);
             var sourceTime     = DateTime.UtcNow.AddMinutes(-2);
 
             await SetupAsync(
                 projectSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile(sourcePath, sourceTime);
@@ -1288,13 +1284,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var sourcePath = @"C:\Dev\Solution\Project\Item1";
 
             var itemChangeTime  = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime   = DateTime.UtcNow.AddMinutes(-3);
+            var lastBuildTime   = DateTime.UtcNow.AddMinutes(-3);
             var destinationTime = DateTime.UtcNow.AddMinutes(-2);
             var sourceTime      = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 sourceSnapshot: sourceSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile(destinationPath, destinationTime);
@@ -1324,13 +1320,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var sourcePath = @"C:\Dev\Solution\Project\Item1";
 
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(-3);
+            var lastBuildTime = DateTime.UtcNow.AddMinutes(-3);
             var destinationTime = DateTime.UtcNow.AddMinutes(-2);
             var sourceTime = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 sourceSnapshot: sourceSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile(destinationPath, destinationTime);
@@ -1360,13 +1356,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var sourcePath = @"C:\Dev\Solution\Project\Item1";
 
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(-3);
+            var lastBuildTime = DateTime.UtcNow.AddMinutes(-3);
             var destinationTime = DateTime.UtcNow.AddMinutes(-2);
             var sourceTime = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 sourceSnapshot: sourceSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile(destinationPath, destinationTime);
@@ -1398,13 +1394,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var sourcePath = @"C:\Dev\Solution\Project\Item1";
 
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(-3);
+            var lastBuildTime = DateTime.UtcNow.AddMinutes(-3);
             var destinationTime = DateTime.UtcNow.AddMinutes(-2);
             var sourceTime = DateTime.UtcNow.AddMinutes(-1);
 
             await SetupAsync(
                 sourceSnapshot: sourceSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile(destinationPath, destinationTime);
@@ -1434,12 +1430,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var sourcePath = @"C:\Dev\Solution\Project\Item1";
 
             var itemChangeTime  = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime   = DateTime.UtcNow.AddMinutes(-3);
+            var lastBuildTime   = DateTime.UtcNow.AddMinutes(-3);
             var destinationTime = DateTime.UtcNow.AddMinutes(-2);
 
             await SetupAsync(
                 sourceSnapshot: sourceSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile(destinationPath, destinationTime);
@@ -1466,12 +1462,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var sourcePath = @"C:\Dev\Solution\Project\Item1";
 
             var itemChangeTime = DateTime.UtcNow.AddMinutes(-4);
-            var lastCheckTime  = DateTime.UtcNow.AddMinutes(-3);
+            var lastBuildTime  = DateTime.UtcNow.AddMinutes(-3);
             var sourceTime     = DateTime.UtcNow.AddMinutes(-2);
 
             await SetupAsync(
                 sourceSnapshot: sourceSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
             _fileSystem.AddFile(sourcePath, sourceTime);
@@ -1535,7 +1531,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var itemChangedTime = DateTime.UtcNow.AddMinutes(-4);
             var outputTime = DateTime.UtcNow.AddMinutes(-3);
             var inputTime = DateTime.UtcNow.AddMinutes(-2);
-            var lastCheckTime = DateTime.UtcNow.AddMinutes(-1);
+            var lastBuildTime = DateTime.UtcNow.AddMinutes(-1);
 
             var configuredInput = UpToDateCheckImplicitConfiguredInput.CreateEmpty(
                 ProjectConfigurationFactory.Create("TargetFramework", "alphaFramework"));
@@ -1543,7 +1539,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await SetupAsync(
                 projectSnapshot,
                 sourceSnapshot,
-                lastCheckTimeAtUtc: lastCheckTime,
+                lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangedTime,
                 upToDateCheckImplicitConfiguredInput: configuredInput);
 


### PR DESCRIPTION
Fixes #7700
Fixes #7821
Improves #7803 by breaking loop

The fast up-to-date check cannot rely solely on file timestamps to identify when a build is required. We also need to know when a build has occurred following a change in the project's items.

Historically we tracked the time the project's set of inputs changed, then compared that to the latest build output's time. This allowed an overbuild performance bug to occur, where the change in the set of items would not correspond with a change in build outputs. In this state, the project would build on every invocation.

PR #7906 recently fixed issue [AB#1471474](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1471474), where we would schedule a build after a rebuild occurred. The fix required adding build event tracking, flagging when a rebuild occurred, then using that time in future up-to-date checks.

This PR extends the build event tracking so that we know when the last successful build started.

With that information, we no longer check the items changed time against the build output time. Instead, we compare against the last successful build's start time. In this way, we trust that MSBuild has brought the project up-to-date with respect the change of inputs, and break out of the overbuild loop we would previously have found ourselves in.

We also no longer look for inputs that are newer than the last check time. Instead, if an input is newer than the start of the last successful build, then we need to schedule another build.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8005)