### PR TITLE
Revert "Avoid race condition in JointRuleSource"

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -73,10 +73,10 @@
     <PackageReference Include="StreamJsonRpc"                                                         Version="2.10.42" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.2.362-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.2.362-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.2.362-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.2.362-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.2.340-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.2.340-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.2.340-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.2.340-pre" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.1.0-2.21558.8" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreConfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreConfiguredInputDataSource.cs
@@ -17,17 +17,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
     [AppliesTo(ProjectCapability.PackageReferences)]
     internal class PackageRestoreConfiguredInputDataSource : ChainedProjectValueDataSourceBase<PackageRestoreConfiguredInput>, IPackageRestoreConfiguredInputDataSource
     {
-        private static readonly ImmutableHashSet<string> s_evaluationRuleNames = Empty.OrdinalIgnoreCaseStringSet
-            .Add(NuGetRestore.SchemaName)
-            .Add(ProjectReference.SchemaName)
-            .Add(DotNetCliToolReference.SchemaName);
-
-        private static readonly ImmutableHashSet<string> s_buildRuleNames = Empty.OrdinalIgnoreCaseStringSet
-            .Add(CollectedFrameworkReference.SchemaName)
-            .Add(CollectedPackageDownload.SchemaName)
-            .Add(CollectedPackageVersion.SchemaName)
-            .Add(CollectedPackageReference.SchemaName);
-
+        private static readonly ImmutableHashSet<string> s_rules = Empty.OrdinalIgnoreCaseStringSet
+                                                                        .Add(NuGetRestore.SchemaName)                       // Evaluation
+                                                                        .Add(ProjectReference.SchemaName)                   // Evaluation
+                                                                        .Add(DotNetCliToolReference.SchemaName)             // Evaluation
+                                                                        .Add(CollectedFrameworkReference.SchemaName)        // Project Build
+                                                                        .Add(CollectedPackageDownload.SchemaName)           // Project Build                                                                        
+                                                                        .Add(CollectedPackageVersion.SchemaName)            // Project Build
+                                                                        .Add(CollectedPackageReference.SchemaName);         // Project Build
         private readonly UnconfiguredProject _containingProject;
         private readonly IProjectSubscriptionService _projectSubscriptionService;
 
@@ -49,10 +46,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             IProjectValueDataSource<IProjectSubscriptionUpdate> source = _projectSubscriptionService.JointRuleSource;
 
             // Transform the changes from evaluation/design-time build -> restore data
-            DisposableValue<ISourceBlock<RestoreUpdate>> transformBlock = source.SourceBlock.TransformWithNoDelta(
-                update => update.Derive(u => CreateRestoreInput(update, u.ProjectConfiguration, u.CurrentState)),
-                suppressVersionOnlyUpdates: false,    // We need to coordinate these at the unconfigured-level
-                options: new JointRuleDataflowLinkOptions { EvaluationRuleNames = s_evaluationRuleNames, BuildRuleNames = s_buildRuleNames });
+            DisposableValue<ISourceBlock<RestoreUpdate>> transformBlock = source.SourceBlock.TransformWithNoDelta(update => update.Derive(u => CreateRestoreInput(update, u.ProjectConfiguration, u.CurrentState)),
+                                                                                                suppressVersionOnlyUpdates: false,    // We need to coordinate these at the unconfigured-level
+                                                                                                ruleNames: s_rules);
 
             // Set the link up so that we publish changes to target block
             transformBlock.Value.LinkTo(targetBlock, DataflowOption.PropagateCompletion);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/ImmutableStringHashSet.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/ImmutableStringHashSet.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace System.Collections.Immutable
+{
+    internal static class ImmutableStringHashSet
+    {
+        public static readonly ImmutableHashSet<string> EmptyOrdinal
+            = ImmutableHashSet<string>.Empty;
+
+        public static readonly ImmutableHashSet<string> EmptyOrdinalIgnoreCase
+            = ImmutableHashSet<string>.Empty.WithComparer(StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataflowUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataflowUtilities.cs
@@ -471,9 +471,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <param name="ruleNames">
         ///     The names of the rules that describe the project data the caller is interested in.
         /// </param>
-        /// <param name="options">
-        ///     Optional link options. If null, completion will be propagated.
-        /// </param>
         /// <returns>
         ///     The transformed source block and a disposable value that terminates the link.
         /// </returns>
@@ -488,8 +485,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             this ISourceBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>> source,
             Func<IProjectVersionedValue<IProjectSubscriptionUpdate>, TOut> transform,
             bool suppressVersionOnlyUpdates,
-            IEnumerable<string>? ruleNames = null,
-            DataflowLinkOptions? options = null)
+            IEnumerable<string>? ruleNames = null)
         {
             Requires.NotNull(source, nameof(source));
             Requires.NotNull(transform, nameof(transform));
@@ -497,7 +493,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             IPropagatorBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>, TOut> transformBlock = DataflowBlockSlim.CreateTransformBlock(transform, skipIntermediateInputData: true, skipIntermediateOutputData: true);
 
             IDisposable link = source.LinkTo(transformBlock,
-                                             options ?? DataflowOption.PropagateCompletion,
+                                             DataflowOption.PropagateCompletion,
                                              initialDataAsNew: true,
                                              suppressVersionOnlyUpdates: suppressVersionOnlyUpdates,
                                              ruleNames: ruleNames);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectChangeDiff.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectChangeDiff.cs
@@ -15,9 +15,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             IImmutableSet<string>? changedItems = null,
             IImmutableDictionary<string, string>? renamedItems = null)
         {
-            AddedItems = addedItems ?? Empty.OrdinalStringSet;
-            RemovedItems = removedItems ?? Empty.OrdinalStringSet;
-            ChangedItems = changedItems ?? Empty.OrdinalStringSet;
+            AddedItems = addedItems ?? ImmutableStringHashSet.EmptyOrdinal;
+            RemovedItems = removedItems ?? ImmutableStringHashSet.EmptyOrdinal;
+            ChangedItems = changedItems ?? ImmutableStringHashSet.EmptyOrdinal;
             RenamedItems = renamedItems ?? ImmutableStringDictionary<string>.EmptyOrdinal;
         }
 
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public IImmutableSet<string> ChangedProperties
         {
-            get { return Empty.OrdinalStringSet; }
+            get { return ImmutableStringHashSet.EmptyOrdinal; }
         }
 
         public bool AnyChanges

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/CrossTarget/RuleSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/CrossTarget/RuleSource.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.CrossTarget
+{
+    internal enum RuleSource
+    {
+        /// <summary>
+        ///     Rule data sourced by evaluation.
+        /// </summary>
+        Evaluation,
+
+        /// <summary>
+        ///     Rule data sourced by both evaluation and design-time build,
+        ///     joined by project version to ensure consistency.
+        /// </summary>
+        Joint
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencyRulesSubscriberBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencyRulesSubscriberBase.cs
@@ -63,10 +63,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
         protected void Subscribe(
             ConfiguredProject configuredProject,
             IProjectValueDataSource<IProjectSubscriptionUpdate> dataSource,
+            string[] ruleNames,
             string nameFormat,
-            Func<(ISourceBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>> Intermediate, ITargetBlock<IProjectVersionedValue<T>> Action), IDisposable> syncLink,
-            string[]? ruleNames = null,
-            DataflowLinkOptions? options = null)
+            Func<(ISourceBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>> Intermediate, ITargetBlock<IProjectVersionedValue<T>> Action), IDisposable> syncLink)
         {
             // Use an intermediate buffer block for project rule data to allow subsequent blocks
             // to only observe specific rule name(s).
@@ -85,9 +84,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
             _subscriptions.Add(
                 dataSource.SourceBlock.LinkTo(
                     intermediateBlock,
-                    ruleNames: ruleNames ?? Array.Empty<string>(),
+                    ruleNames: ruleNames,
                     suppressVersionOnlyUpdates: false,
-                    linkOptions: options ?? DataflowOption.PropagateCompletion));
+                    linkOptions: DataflowOption.PropagateCompletion));
 
             _subscriptions.Add(syncLink((intermediateBlock, actionBlock)));
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
@@ -39,6 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
             Subscribe(
                 configuredProject,
                 subscriptionService.ProjectRuleSource,
+                ruleNames: new[] { ConfigurationGeneral.SchemaName },
                 "Dependencies Shared Projects Input: {1}",
                 blocks => ProjectDataSources.SyncLinkTo(
                     blocks.Intermediate.SyncLinkOptions(),
@@ -46,8 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
                     subscriptionService.ProjectCatalogSource.SourceBlock.SyncLinkOptions(),
                     configuredProject.Capabilities.SourceBlock.SyncLinkOptions(),
                     blocks.Action,
-                    linkOptions: DataflowOption.PropagateCompletion),
-                ruleNames: new[] { ConfigurationGeneral.SchemaName });
+                    linkOptions: DataflowOption.PropagateCompletion));
         }
 
         protected override IProjectCapabilitiesSnapshot GetCapabilitiesSnapshot(EventData e) => e.Item4;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
@@ -24,13 +24,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private readonly IUpToDateCheckStatePersistence? _persistentState;
         private readonly IProjectAsynchronousTasksService _projectAsynchronousTasksService;
 
-        private static readonly ImmutableHashSet<string> s_evaluationRuleNames = Empty.OrdinalIgnoreCaseStringSet
+        private static ImmutableHashSet<string> ProjectPropertiesSchemas => ImmutableStringHashSet.EmptyOrdinal
             .Add(ConfigurationGeneral.SchemaName)
-            .Add(CopyUpToDateMarker.SchemaName);
-
-        private static readonly ImmutableHashSet<string> s_buildRuleNames = Empty.OrdinalIgnoreCaseStringSet
             .Add(ResolvedAnalyzerReference.SchemaName)
             .Add(ResolvedCompilationReference.SchemaName)
+            .Add(CopyUpToDateMarker.SchemaName)
             .Add(UpToDateCheckInput.SchemaName)
             .Add(UpToDateCheckOutput.SchemaName)
             .Add(UpToDateCheckBuilt.SchemaName);
@@ -71,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 // Sync-link various sources to our transform block
                 ProjectDataSources.SyncLinkTo(
-                    source1.SourceBlock.SyncLinkOptions(new JointRuleDataflowLinkOptions() { BuildRuleNames = s_buildRuleNames, EvaluationRuleNames = s_evaluationRuleNames }),
+                    source1.SourceBlock.SyncLinkOptions(DataflowOption.WithRuleNames(ProjectPropertiesSchemas)),
                     source2.SourceBlock.SyncLinkOptions(),
                     source3.SourceBlock.SyncLinkOptions(),
                     source4.SourceBlock.SyncLinkOptions(),


### PR DESCRIPTION
Reverts dotnet/project-system#7993

Moving to `JointRuleDataflowLinkOptions` came with a change in behaviour that breaks some core components. We need to back this out pending further investigation.