### PR TITLE
Re-enable OptProf

### DIFF
--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -51,6 +51,9 @@ steps:
 - task: MicroBuildSwixPlugin@1
   displayName: Install Swix Plugin
 
+- task: MicroBuildSwixPlugin@4
+  displayName: Install Swix Plugin
+
 # This requires the OptimizationInputs via the 'Publish OptimizationInputs drop' step in the release pipeline.
 # To generate ProfilingInputs for the first time, set this input: ShouldSkipOptimize: true
 # See documentation here: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/2602/Build-With-Expired-(or-Without-Prior)-Optimization-Profiling-Data
@@ -66,7 +69,6 @@ steps:
     feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
     ShouldSkipOptimize: ${{ parameters.SkipOptimize }}
     NumberCommitsToSearch: '100'
-  enabled: false
 
 ###################################################################################################################################################################
 # BUILD SOLUTION
@@ -186,7 +188,6 @@ steps:
     usePat: true
     AccessToken: '$(System.AccessToken)'
   condition: succeeded()
-  enabled: false
 
 # MicroBuildBuildVSBootstrapper requires MicroBuildSigningPlugin for signjson.exe to run.
 - task: MicroBuildBuildVSBootstrapper@2
@@ -198,7 +199,6 @@ steps:
     manifests: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\VSSetup\Insertion\Microsoft.VisualStudio.ProjectSystem.Managed.vsman'
     outputFolder: $(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\VSSetup\Insertion
   condition: succeeded()
-  enabled: false
 
 - task: PowerShell@2
   displayName: Update RunSettings via Bootstrapper data
@@ -206,7 +206,6 @@ steps:
     filePath: build\optprof\UpdateRunSettings.ps1
     arguments: '-profilingInputsPath "ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)" -bootstrapperInfoPath "$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json"'
     failOnStderr: true
-  enabled: false
 
 - task: artifactDropTask@0
   displayName: 'Publish to Artifact Services: RunSettings'
@@ -219,7 +218,6 @@ steps:
     AccessToken: '$(System.AccessToken)'
     dropMetadataContainerName: RunSettings
   condition: succeeded()
-  enabled: false
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: MicroBuildOutputs'

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -46,14 +46,6 @@ steps:
     signType: ${{ parameters.SignType }}
     esrpSigning: true
 
-# This is used as a PackageReference with ExcludeAssets="all", which means it is not executed.
-# RepoToolset has custom logic to run the contents of this plugin, so it is not executed normally.
-# - task: MicroBuildSwixPlugin@1
-#   displayName: Install Swix Plugin
-
-- task: MicroBuildSwixPlugin@4
-  displayName: Install Swix Plugin
-
 # This requires the OptimizationInputs via the 'Publish OptimizationInputs drop' step in the release pipeline.
 # To generate ProfilingInputs for the first time, set this input: ShouldSkipOptimize: true
 # See documentation here: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/2602/Build-With-Expired-(or-Without-Prior)-Optimization-Profiling-Data
@@ -176,6 +168,12 @@ steps:
 ###################################################################################################################################################################
 # The published OptProf metadata is consumed by the release pipeline that profiles the assemblies to create the optimization data.
 # Release Pipeline URL: https://devdiv.visualstudio.com/DevDiv/_release?definitionId=3197
+
+# This is currently only used by the MicroBuildBuildVSBootstrapper task.
+# RepoToolset has custom logic to download the NuGet package of this plugin for an old version (1.1.37).
+# This plugin is not directly used by RepoToolset.
+- task: MicroBuildSwixPlugin@4
+  displayName: Install Swix Plugin
 
 # This is required to deploy the tests to devdiv.artifacts.visualstudio.com for the 'Deploy tests' step in the release pipeline.
 - task: artifactDropTask@0

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -48,8 +48,8 @@ steps:
 
 # This is used as a PackageReference with ExcludeAssets="all", which means it is not executed.
 # RepoToolset has custom logic to run the contents of this plugin, so it is not executed normally.
-- task: MicroBuildSwixPlugin@1
-  displayName: Install Swix Plugin
+# - task: MicroBuildSwixPlugin@1
+#   displayName: Install Swix Plugin
 
 - task: MicroBuildSwixPlugin@4
   displayName: Install Swix Plugin

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -46,6 +46,13 @@ steps:
     signType: ${{ parameters.SignType }}
     esrpSigning: true
 
+# This is currently only used by the MicroBuildBuildVSBootstrapper task.
+# RepoToolset has custom logic to download the NuGet package of this plugin for an old version (1.1.37).
+# This plugin is not directly used by RepoToolset.
+# Moving this task down to the OptProf section will cause test verification in the OptProf release pipeline to fail stating that the Microsoft.VisualStudio.ProjectSystem.Managed(.VS).dll(s) do not exist.
+- task: MicroBuildSwixPlugin@4
+  displayName: Install Swix Plugin
+
 # This requires the OptimizationInputs via the 'Publish OptimizationInputs drop' step in the release pipeline.
 # To generate ProfilingInputs for the first time, set this input: ShouldSkipOptimize: true
 # See documentation here: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/2602/Build-With-Expired-(or-Without-Prior)-Optimization-Profiling-Data
@@ -168,12 +175,6 @@ steps:
 ###################################################################################################################################################################
 # The published OptProf metadata is consumed by the release pipeline that profiles the assemblies to create the optimization data.
 # Release Pipeline URL: https://devdiv.visualstudio.com/DevDiv/_release?definitionId=3197
-
-# This is currently only used by the MicroBuildBuildVSBootstrapper task.
-# RepoToolset has custom logic to download the NuGet package of this plugin for an old version (1.1.37).
-# This plugin is not directly used by RepoToolset.
-- task: MicroBuildSwixPlugin@4
-  displayName: Install Swix Plugin
 
 # This is required to deploy the tests to devdiv.artifacts.visualstudio.com for the 'Deploy tests' step in the release pipeline.
 - task: artifactDropTask@0


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1497655

OptProf was disabled because it required the VS Bootstrapper task. This task was silently updated during SBOM changes and caused our build to start failing. To allow us to continue checking in code, I disabled OptProf which uses the VS Bootstrapper task. The VS Bootstrapper task required an updated MicroBuild Swix plugin, which at the time, I believed could not be updated because an old version is required by RepoToolset.

I did some investigation and found that the version of the Swix plugin we were installing via the DevOps task was `1.1.87`. However, if you look at the build logs, the version used by RepoToolset is `1.1.37`. This means the task we have in our pipeline was **only** being used by VS Bootstrapper, and RepoToolset acquires its own package to do VSIX creation. Thus, I could update the plugin to the latest version (which installs 1.1.2XX) and I put this task in the OptProf section since it is not needed prior to doing the build itself.

For this PR to work (meaning, the build succeeds), we need an updated set of optimization data. Currently, I hooked up our OptProf release pipeline to the branch for this PR. This **should** give us optimization data to use when the normal build runs. If this doesn't work, after this PR, I'd need to run a build manually and have (the use of) optimization disabled so that it can produce new optimization data for the following build. Either way, I'll have to update our release pipeline here to trigger against `main` at the time of merging this PR: https://devdiv.visualstudio.com/DevDiv/_release?view=all&_a=releases&definitionId=3197

To the issue side of things, I've been talking to Jackson and it is likely that OptProf reduces the NGEN'ed binary size. The issue created by the perf tests seems to suggest that disabling OptProf increased the size of the NGEN'ed binaries. We don't produce these binaries but they are created as part of the setup authoring process (a process that is, to me, a black box at the moment). So, the failure is on a set of information I've never seen before, and we don't directly produce during a build. If we see the size of the `.ni.dll` binaries in the perf tests go back down after this PR, that proves this assumption.

Additionally, this PR will add a warning to our build. I couldn't figure out how to resolve it in a timely manner so it will remain for the time being.

![image](https://user-images.githubusercontent.com/17788297/160218519-9295002f-7256-4f89-8334-47080875484d.png)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8013)