### PR TITLE
Remove intermediate Dataflow block

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -87,13 +87,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
                 "CrossTarget Joint Input: {1}",
                 SyncLink);
 
-            IDisposable SyncLink((ISourceBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>> Intermediate, ITargetBlock<IProjectVersionedValue<EventData>> Action) blocks)
+            IDisposable SyncLink((ISourceBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>> Source, ITargetBlock<IProjectVersionedValue<EventData>> Action, string[] RuleNames) state)
             {
                 return ProjectDataSources.SyncLinkTo(
-                    blocks.Intermediate.SyncLinkOptions(),
+                    state.Source.SyncLinkOptions(DataflowOption.WithRuleNames(state.RuleNames)),
                     subscriptionService.ProjectCatalogSource.SourceBlock.SyncLinkOptions(),
                     configuredProject.Capabilities.SourceBlock.SyncLinkOptions(),
-                    blocks.Action,
+                    state.Action,
                     linkOptions: DataflowOption.PropagateCompletion);
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencyRulesSubscriberBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencyRulesSubscriberBase.cs
@@ -2,7 +2,6 @@
 
 using System.Threading.Tasks.Dataflow;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 
@@ -16,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
         private readonly IUnconfiguredProjectTasksService _tasksService;
 
         private DependenciesSnapshotProvider? _provider;
-        private DisposableBag? _subscriptions;
+        private IDisposable? _subscriptions;
 
         public event EventHandler<DependencySubscriptionChangedEventArgs>? DependenciesChanged;
 
@@ -73,9 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
                     configuredProject.UnconfiguredProject,
                     nameFormat: nameFormat);
 
-            _subscriptions ??= new DisposableBag();
-
-            _subscriptions.Add(syncLink((dataSource.SourceBlock, actionBlock, ruleNames)));
+            _subscriptions = syncLink((dataSource.SourceBlock, actionBlock, ruleNames));
         }
 
         private Task OnProjectChangedAsync(ConfiguredProject configuredProject, T e)


### PR DESCRIPTION
Previously, an intermediate Dataflow block was created for the sole purpose of specifying rule names. It's more to configure this directly during the `SyncLink` operation.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8023)