### PR TITLE
Cancel dependencies tree processing on project unload

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -268,14 +268,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
             }
         }
 
-        public async Task<AggregateCrossTargetProjectContext?> GetCurrentAggregateProjectContextAsync()
+        public async Task<AggregateCrossTargetProjectContext?> GetCurrentAggregateProjectContextAsync(CancellationToken cancellationToken)
         {
             if (IsDisposing || IsDisposed)
             {
                 return null;
             }
 
-            await InitializeAsync();
+            await InitializeAsync(cancellationToken);
 
             return _context.Current;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -131,7 +131,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
             string projectFullPath,
             AggregateCrossTargetProjectContext currentAggregateContext,
             TargetFramework targetFrameworkToUpdate,
-            EventData e)
+            EventData e,
+            CancellationToken cancellationToken)
         {
             Assumes.NotNull(_state);
 
@@ -159,6 +160,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
             }
 
             IDependenciesChanges? changes = changesBuilder.TryBuildChanges();
+
+            cancellationToken.ThrowIfCancellationRequested();
 
             // Notify subscribers of a change in dependency data.
             // NOTE even if changes is null, it's possible the catalog has changed. If we don't take the newer

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
@@ -57,7 +57,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
             string projectFullPath,
             AggregateCrossTargetProjectContext currentAggregateContext,
             TargetFramework targetFrameworkToUpdate,
-            EventData e)
+            EventData e,
+            CancellationToken cancellationToken)
         {
             IProjectSharedFoldersSnapshot sharedProjectsUpdate = e.Item2;
             IProjectCatalogSnapshot catalogs = e.Item3;


### PR DESCRIPTION
Previously the code went to lengths to prevent unload during processing.

With this change, we allow the project to unload, and wire through a cancellation token that is cancelled as the project unloads.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8024)