### PR TITLE
Pass CentralPackageTransitivePinningEnabled and CentralPackageVersionOverrideEnabled to NuGet restore

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -13,6 +13,14 @@
                   ReadOnly="True"
                   Visible="False" />
 
+  <StringProperty Name="CentralPackageTransitivePinningEnabled"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="CentralPackageVersionOverrideEnabled"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <StringProperty Name="CLRSupport"
                   ReadOnly="True"
                   Visible="False" />


### PR DESCRIPTION
This was missed as part of https://github.com/dotnet/project-system/pull/7985 but I added some properties that need to also be passed to NuGet restore:

https://github.com/NuGet/NuGet.Client/pull/4426 added a property to enable/disable the use of `VersionOverride`: `CentralPackageVersionOverrideEnabled`

https://github.com/NuGet/NuGet.Client/pull/4025 added a property to enable/disable the feature to "pin" transitive versions: `CentralPackageTransitivePinningEnabled`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8028)