### PR TITLE
Use batch to update language service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.cs
@@ -75,7 +75,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                                                                     data.AssemblyName,
                                                                                     CancellationToken.None);
 
-                context.LastDesignTimeBuildSucceeded = false;  // By default, turn off diagnostics until the first design time build succeeds for this project.
+                context.StartBatch();
+
+                try
+                {
+                    // Update LastDesignTimeBuildSucceeded within a batch to avoid thread pool starvation.
+                    // https://github.com/dotnet/project-system/issues/8027
+
+                    context.LastDesignTimeBuildSucceeded = false;  // By default, turn off diagnostics until the first design time build succeeds for this project.
+                }
+                finally
+                {
+                    await context.EndBatchAsync();
+                }
 
                 return context;
             }


### PR DESCRIPTION
Fixes #8027
Fixes [AB#1511966](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1511966)

Changes made to the workspace context are synchronised within Roslyn IDE's language service. We generally use batches to ensure we don't block threads during these updates.

This is one case we missed. @sharwell observed one-thread-per-project blocked within the called code. This change will allow the thread pool thread to yield, so other productive work can be performed and thread pool starvation is avoided.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8031)