### PR TITLE
Fix analyzer references appearing as unresolved

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -45,6 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
         protected override void HandleAddedItem(
             string projectFullPath,
             string addedItem,
+            bool isResolvedItem,
             IProjectChangeDescription projectChange,
             IProjectRuleSnapshot evaluationRuleSnapshot,
             DependenciesChangesBuilder changesBuilder,
@@ -54,6 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
             if (TryCreatePackageDependencyModel(
                 projectFullPath,
                 addedItem,
+                isResolvedItem,
                 properties: projectChange.After.GetProjectItemProperties(addedItem)!,
                 evaluationRuleSnapshot,
                 isEvaluatedItemSpec,
@@ -68,14 +70,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
         protected override void HandleRemovedItem(
             string projectFullPath,
             string removedItem,
+            bool isResolvedItem,
             IProjectChangeDescription projectChange,
             IProjectRuleSnapshot evaluationRuleSnapshot,
             DependenciesChangesBuilder changesBuilder,
             TargetFramework targetFramework,
             Func<string, bool>? isEvaluatedItemSpec)
         {
-            bool isResolvedItem = isEvaluatedItemSpec is not null;
-
             string originalItemSpec = isResolvedItem
                 ? projectChange.Before.GetProjectItemProperties(removedItem)?.GetStringProperty(ProjectItemMetadata.Name) ?? removedItem
                 : removedItem;
@@ -90,6 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
         private bool TryCreatePackageDependencyModel(
             string projectFullPath,
             string itemSpec,
+            bool isResolvedItem,
             IImmutableDictionary<string, string> properties,
             IProjectRuleSnapshot evaluationRuleSnapshot,
             Func<string, bool>? isEvaluatedItemSpec,
@@ -100,8 +102,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
             Requires.NotNullOrEmpty(itemSpec, nameof(itemSpec));
             Requires.NotNull(properties, nameof(properties));
             Requires.NotNull(targetFramework, nameof(targetFramework));
-
-            bool isResolvedItem = isEvaluatedItemSpec is not null;
 
             string originalItemSpec;
 


### PR DESCRIPTION
Fixes [AB#1506157](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1506157)

Refactoring in #7988 made an incorrect assumption, which is fixed here.

The assumption was that a non-null `Func<string, bool>? isEvaluatedItemSpec` value indicates a resolved dependency. However that is not true, as for analyzer references, `AnalyzerRuleHandler` overrides `ResolvedItemRequiresEvaluatedItem` to return `false`. This means that for analyzer references that are resolved, `isEvaluatedItemSpec` is null.

The fix is to thread the `isResolvedItem` through the code explicitly, rather than inferring it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8032)