### PR TITLE
Fix PackageLicenseFile property's file inclusion

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/PackageLicenseFileValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/PackageLicenseFileValueProvider.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
+{
+    // Sets the PackageLicenseFile property to the path from the root of the package, and creates the
+    // None item associated with the file on disk. The Include metadata of the None item is a relative
+    // path to the file on disk from the project's directory. The None item includes 2 metadata elements
+    // as Pack (set to True to be included in the package) and PackagePath (directory structure in the package
+    // for the file to be placed). The PackageLicenseFile property will use the directory indicated in PackagePath,
+    // and the filename of the file in the Include filepath.
+    //
+    // Example:
+    // <PropertyGroup>
+    //   <PackageLicenseFile>docs\LICENSE.txt</PackageLicenseFile>
+    // </PropertyGroup>
+    //
+    // <ItemGroup>
+    //   <None Include="..\..\..\LICENSE.txt">
+    //     <Pack>True</Pack>
+    //     <PackagePath>docs</PackagePath>
+    //   </None>
+    // </ItemGroup>
+    [ExportInterceptingPropertyValueProvider(PackageLicenseFilePropertyName, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    internal sealed class PackageLicenseFileValueProvider : PackageFilePropertyValueProviderBase
+    {
+        private const string PackageLicenseFilePropertyName = "PackageLicenseFile";
+
+        [ImportingConstructor]
+        public PackageLicenseFileValueProvider(
+            [Import(ExportContractNames.ProjectItemProviders.SourceFiles)] IProjectItemProvider sourceItemsProvider,
+            UnconfiguredProject unconfiguredProject) :
+            base(PackageLicenseFilePropertyName, sourceItemsProvider, unconfiguredProject)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/7846

Added property interceptor for PackageLicenseFile to correctly add the file to the project and update the property accordingly. It reuses the base interceptor logic for doing this kind of property, which has been used for other Packaging properties.

### Before
![PackageLicenseFile-Before](https://user-images.githubusercontent.com/17788297/161880867-94b3b6ec-3db9-4f88-b052-e3a033780fad.gif)

### After
![PackageLicenseFile-After](https://user-images.githubusercontent.com/17788297/161880876-1078276f-9a86-41c2-9a65-a893624f7f01.gif)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8041)