### PR TITLE
[17.2] Fix broken analyzer child nodes in Solution Explorer

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/AnalyzerDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/AnalyzerDependencyModel.cs
@@ -8,9 +8,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
     internal class AnalyzerDependencyModel : DependencyModel
     {
+        // NOTE we include ProjectTreeFlags.FileSystemEntity here so that Roslyn can
+        // correctly identify the analyzer's path in order to attach child nodes to
+        // these dependency items in Solution Explorer. Without this flag, CPS will
+        // remove whatever file path we pass during tree construction (for performance
+        // reasons).
+
         private static readonly DependencyFlagCache s_flagCache = new(
-            resolved: DependencyTreeFlags.AnalyzerDependency + DependencyTreeFlags.SupportsBrowse,
-            unresolved: DependencyTreeFlags.AnalyzerDependency + DependencyTreeFlags.SupportsBrowse);
+            resolved: DependencyTreeFlags.AnalyzerDependency + DependencyTreeFlags.SupportsBrowse + ProjectTreeFlags.FileSystemEntity,
+            unresolved: DependencyTreeFlags.AnalyzerDependency + DependencyTreeFlags.SupportsBrowse + ProjectTreeFlags.FileSystemEntity);
 
         private static readonly DependencyIconSet s_iconSet = new(
             icon: KnownMonikers.CodeInformation,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/AnalyzerDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/AnalyzerDependencyModelTests.cs
@@ -37,7 +37,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.AnalyzerDependency +
                 DependencyTreeFlags.SupportsBrowse +
-                DependencyTreeFlags.ResolvedDependencyFlags,
+                DependencyTreeFlags.ResolvedDependencyFlags +
+                ProjectTreeFlags.FileSystemEntity,
                 model.Flags);
         }
 
@@ -69,7 +70,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             Assert.Equal(
                 DependencyTreeFlags.AnalyzerDependency +
                 DependencyTreeFlags.SupportsBrowse +
-                DependencyTreeFlags.UnresolvedDependencyFlags,
+                DependencyTreeFlags.UnresolvedDependencyFlags +
+                ProjectTreeFlags.FileSystemEntity,
                 model.Flags);
         }
 
@@ -102,7 +104,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
                 DependencyTreeFlags.AnalyzerDependency +
                 DependencyTreeFlags.SupportsBrowse + 
                 DependencyTreeFlags.ResolvedDependencyFlags -
-                DependencyTreeFlags.SupportsRemove,
+                DependencyTreeFlags.SupportsRemove +
+                ProjectTreeFlags.FileSystemEntity,
                 model.Flags);
         }
     }


### PR DESCRIPTION
In 17.2, CPS made a change to how paths are used for non-file items in the tree. These changes improve the performance of searching the dependency tree by path, as the pseudo-id used for items not having paths allows a fast lookup.

That change broke the ability for Roslyn to determine the correct file path for analyzer nodes (via `CanonicalName`), which then broke the ability to attach child nodes to the analyzer in Solution Explorer (for example, to show source generators and the files they create).

In this commit, we add the `FileSystemEntity` flag to analyzer nodes. This causes CPS to preserve the full path provided on the `IProjectTree`, which restores the `CanonicalName` for Roslyn.

## Before

![image](https://user-images.githubusercontent.com/350947/162104571-39a8b1c0-d71d-43e2-8f70-472f13bfbe93.png)

## After

![image](https://user-images.githubusercontent.com/350947/162104238-71a4c626-614d-46b7-b691-7cf650e40ec1.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8045)