### PR TITLE
Update fault event level, when DisplayMissingCompnents failed.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Acquisition/MissingSetupComponentRegistrationService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Acquisition/MissingSetupComponentRegistrationService.cs
@@ -144,7 +144,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             {
                 var displayMissingComponentsTask = DisplayMissingComponentsPromptAsync();
 
-                _projectFaultHandlerService.Forget(displayMissingComponentsTask, project: null, ProjectFaultSeverity.LimitedFunctionality);
+                _projectFaultHandlerService.Forget(displayMissingComponentsTask, project: project.UnconfiguredProject, ProjectFaultSeverity.Recoverable);
             }
         }
 


### PR DESCRIPTION
The reason behind it is that the task failed in our future VS prototype branch, as VS setup component is not yet working.  Reporting the project has limited service will put the project into a state where several import features are disabled (like operation progress).  This should not have any impact on normal function of this code.

Basically, a failure to display a missing component doesn't need leave the project system to the partial failure state, so we can limit the impact of this missing feature until setup component is fixed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8050)