### PR TITLE
Fix up-to-date tracking for App.config files

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -440,7 +440,7 @@
            https://github.com/dotnet/msbuild/blob/d2f9dbccd913c5612fd3a3cb78b2524fbcb023da/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1152-L1165
            We skip this check if AppConfig is empty, which occurs for .NET Framework console apps. See https://github.com/dotnet/project-system/issues/6758.
       -->
-      <UpToDateCheckBuilt Condition=" '@(AppConfigWithTargetPath)' != '' and '@(AppConfig)' != '' " Include="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Original="$(AppConfig)"/>
+      <UpToDateCheckBuilt Condition=" '@(AppConfigWithTargetPath)' != '' and '$(AppConfig)' != '' " Include="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Original="$(AppConfig)"/>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Fixes #8015

There was an attempt two years ago to fix this, in #5994. I don't see how that fix could have ever worked.

The MSBuild item that modelled the `App.config` source/destination paths had an invalid condition. It was verifying that the an `AppConfig` _item_ existed, while it should have been verifying an `AppConfig` _property_ existed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8051)