### PR TITLE
Include launch profile command name in error message

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             // Now find the DebugTargets provider for this profile
             IDebugProfileLaunchTargetsProvider launchProvider = GetLaunchTargetsProvider(activeProfile) ??
-                throw new Exception(string.Format(VSResources.DontKnowHowToRunProfile, activeProfile.Name));
+                throw new Exception(string.Format(VSResources.DontKnowHowToRunProfile_2, activeProfile.Name, activeProfile.CommandName));
 
             IReadOnlyList<IDebugLaunchSettings> launchSettings;
             if (fromDebugLaunch && launchProvider is IDebugProfileLaunchTargetsProvider2 launchProvider2)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -106,11 +106,11 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The project doesn&apos;t know how to run the profile {0}..
+        ///   Looks up a localized string similar to The project doesn&apos;t know how to run the profile with name &apos;{0}&apos; and command &apos;{1}&apos;..
         /// </summary>
-        internal static string DontKnowHowToRunProfile {
+        internal static string DontKnowHowToRunProfile_2 {
             get {
-                return ResourceManager.GetString("DontKnowHowToRunProfile", resourceCulture);
+                return ResourceManager.GetString("DontKnowHowToRunProfile_2", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -126,8 +126,12 @@
   <data name="ActiveLaunchProfileNotFound" xml:space="preserve">
     <value>There aren't any active launch profiles configured for this project.</value>
   </data>
-  <data name="DontKnowHowToRunProfile" xml:space="preserve">
-    <value>The project doesn't know how to run the profile {0}.</value>
+  <data name="DontKnowHowToRunProfile_2" xml:space="preserve">
+    <value>The project doesn't know how to run the profile with name '{0}' and command '{1}'.</value>
+    <comment>
+      {0} is the profile name, which comes from the user.
+      {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
+    </comment>
   </data>
   <data name="ErrorInProfilesFile" xml:space="preserve">
     <value>An error in the launch settings file needs to be corrected before you can run the '{0}' project . Please see the error list for details.</value>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -7,6 +7,14 @@
         <target state="translated">Profil {0}</target>
         <note>Default name for new launch profiles. The {0} is a decimal number chosen to guarantee the name is unique.</note>
       </trans-unit>
+      <trans-unit id="DontKnowHowToRunProfile_2">
+        <source>The project doesn't know how to run the profile with name '{0}' and command '{1}'.</source>
+        <target state="new">The project doesn't know how to run the profile with name '{0}' and command '{1}'.</target>
+        <note>
+      {0} is the profile name, which comes from the user.
+      {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
+    </note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Název sestavení architektury</target>
@@ -163,11 +171,6 @@
       <trans-unit id="ActiveLaunchProfileNotFound">
         <source>There aren't any active launch profiles configured for this project.</source>
         <target state="translated">Projekt nemá nakonfigurované aktivní profily spouštění.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DontKnowHowToRunProfile">
-        <source>The project doesn't know how to run the profile {0}.</source>
-        <target state="translated">Projekt neumí spustit profil {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorInProfilesFile">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -7,6 +7,14 @@
         <target state="translated">Profil "{0}"</target>
         <note>Default name for new launch profiles. The {0} is a decimal number chosen to guarantee the name is unique.</note>
       </trans-unit>
+      <trans-unit id="DontKnowHowToRunProfile_2">
+        <source>The project doesn't know how to run the profile with name '{0}' and command '{1}'.</source>
+        <target state="new">The project doesn't know how to run the profile with name '{0}' and command '{1}'.</target>
+        <note>
+      {0} is the profile name, which comes from the user.
+      {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
+    </note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Der Name der Frameworkassembly.</target>
@@ -163,11 +171,6 @@
       <trans-unit id="ActiveLaunchProfileNotFound">
         <source>There aren't any active launch profiles configured for this project.</source>
         <target state="translated">Für dieses Projekt sind keine aktiven Startprofile konfiguriert.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DontKnowHowToRunProfile">
-        <source>The project doesn't know how to run the profile {0}.</source>
-        <target state="translated">Das Profil "{0}" kann vom Projekt nicht ausgeführt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorInProfilesFile">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -7,6 +7,14 @@
         <target state="translated">Perfil {0}</target>
         <note>Default name for new launch profiles. The {0} is a decimal number chosen to guarantee the name is unique.</note>
       </trans-unit>
+      <trans-unit id="DontKnowHowToRunProfile_2">
+        <source>The project doesn't know how to run the profile with name '{0}' and command '{1}'.</source>
+        <target state="new">The project doesn't know how to run the profile with name '{0}' and command '{1}'.</target>
+        <note>
+      {0} is the profile name, which comes from the user.
+      {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
+    </note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Nombre del ensamblado del marco.</target>
@@ -163,11 +171,6 @@
       <trans-unit id="ActiveLaunchProfileNotFound">
         <source>There aren't any active launch profiles configured for this project.</source>
         <target state="translated">No se han configurado perfiles de inicio activos para este proyecto.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DontKnowHowToRunProfile">
-        <source>The project doesn't know how to run the profile {0}.</source>
-        <target state="translated">El proyecto no sabe cómo ejecutar el perfil {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorInProfilesFile">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -7,6 +7,14 @@
         <target state="translated">Profil {0}</target>
         <note>Default name for new launch profiles. The {0} is a decimal number chosen to guarantee the name is unique.</note>
       </trans-unit>
+      <trans-unit id="DontKnowHowToRunProfile_2">
+        <source>The project doesn't know how to run the profile with name '{0}' and command '{1}'.</source>
+        <target state="new">The project doesn't know how to run the profile with name '{0}' and command '{1}'.</target>
+        <note>
+      {0} is the profile name, which comes from the user.
+      {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
+    </note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Nom de l'assembly de framework.</target>
@@ -163,11 +171,6 @@
       <trans-unit id="ActiveLaunchProfileNotFound">
         <source>There aren't any active launch profiles configured for this project.</source>
         <target state="translated">Aucun profil de lancement actif n'est configuré pour ce projet.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DontKnowHowToRunProfile">
-        <source>The project doesn't know how to run the profile {0}.</source>
-        <target state="translated">Le projet ne sait pas comment exécuter le profil {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorInProfilesFile">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -7,6 +7,14 @@
         <target state="translated">Profilo {0}</target>
         <note>Default name for new launch profiles. The {0} is a decimal number chosen to guarantee the name is unique.</note>
       </trans-unit>
+      <trans-unit id="DontKnowHowToRunProfile_2">
+        <source>The project doesn't know how to run the profile with name '{0}' and command '{1}'.</source>
+        <target state="new">The project doesn't know how to run the profile with name '{0}' and command '{1}'.</target>
+        <note>
+      {0} is the profile name, which comes from the user.
+      {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
+    </note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Nome dell'assembly del framework.</target>
@@ -163,11 +171,6 @@
       <trans-unit id="ActiveLaunchProfileNotFound">
         <source>There aren't any active launch profiles configured for this project.</source>
         <target state="translated">Non ci sono profili di avvio attivi configurati per questo progetto.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DontKnowHowToRunProfile">
-        <source>The project doesn't know how to run the profile {0}.</source>
-        <target state="translated">Il progetto non dispone di informazioni sufficienti per eseguire il profilo {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorInProfilesFile">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -7,6 +7,14 @@
         <target state="translated">プロファイル {0}</target>
         <note>Default name for new launch profiles. The {0} is a decimal number chosen to guarantee the name is unique.</note>
       </trans-unit>
+      <trans-unit id="DontKnowHowToRunProfile_2">
+        <source>The project doesn't know how to run the profile with name '{0}' and command '{1}'.</source>
+        <target state="new">The project doesn't know how to run the profile with name '{0}' and command '{1}'.</target>
+        <note>
+      {0} is the profile name, which comes from the user.
+      {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
+    </note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">フレームワーク アセンブリの名前です。</target>
@@ -163,11 +171,6 @@
       <trans-unit id="ActiveLaunchProfileNotFound">
         <source>There aren't any active launch profiles configured for this project.</source>
         <target state="translated">このプロジェクト用に構成されたアクティブな起動プロファイルはありません。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DontKnowHowToRunProfile">
-        <source>The project doesn't know how to run the profile {0}.</source>
-        <target state="translated">プロジェクトには、プロファイル {0} を実行する方法が分かりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorInProfilesFile">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -7,6 +7,14 @@
         <target state="translated">프로필 {0}</target>
         <note>Default name for new launch profiles. The {0} is a decimal number chosen to guarantee the name is unique.</note>
       </trans-unit>
+      <trans-unit id="DontKnowHowToRunProfile_2">
+        <source>The project doesn't know how to run the profile with name '{0}' and command '{1}'.</source>
+        <target state="new">The project doesn't know how to run the profile with name '{0}' and command '{1}'.</target>
+        <note>
+      {0} is the profile name, which comes from the user.
+      {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
+    </note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">프레임워크 어셈블리의 이름입니다.</target>
@@ -163,11 +171,6 @@
       <trans-unit id="ActiveLaunchProfileNotFound">
         <source>There aren't any active launch profiles configured for this project.</source>
         <target state="translated">이 프로젝트에 대해 구성된 활성 시작 프로필이 없습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DontKnowHowToRunProfile">
-        <source>The project doesn't know how to run the profile {0}.</source>
-        <target state="translated">프로젝트에서 {0} 프로필을 실행하는 방법을 모릅니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorInProfilesFile">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -7,6 +7,14 @@
         <target state="translated">Profil {0}</target>
         <note>Default name for new launch profiles. The {0} is a decimal number chosen to guarantee the name is unique.</note>
       </trans-unit>
+      <trans-unit id="DontKnowHowToRunProfile_2">
+        <source>The project doesn't know how to run the profile with name '{0}' and command '{1}'.</source>
+        <target state="new">The project doesn't know how to run the profile with name '{0}' and command '{1}'.</target>
+        <note>
+      {0} is the profile name, which comes from the user.
+      {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
+    </note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Nazwa zestawu struktury.</target>
@@ -163,11 +171,6 @@
       <trans-unit id="ActiveLaunchProfileNotFound">
         <source>There aren't any active launch profiles configured for this project.</source>
         <target state="translated">Brak skonfigurowanych aktywnych profilów uruchamiania dla tego projektu.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DontKnowHowToRunProfile">
-        <source>The project doesn't know how to run the profile {0}.</source>
-        <target state="translated">Projekt nie ma informacji dotyczących uruchamiania profilu {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorInProfilesFile">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -7,6 +7,14 @@
         <target state="translated">Perfil {0}</target>
         <note>Default name for new launch profiles. The {0} is a decimal number chosen to guarantee the name is unique.</note>
       </trans-unit>
+      <trans-unit id="DontKnowHowToRunProfile_2">
+        <source>The project doesn't know how to run the profile with name '{0}' and command '{1}'.</source>
+        <target state="new">The project doesn't know how to run the profile with name '{0}' and command '{1}'.</target>
+        <note>
+      {0} is the profile name, which comes from the user.
+      {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
+    </note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">O nome do assembly de estrutura.</target>
@@ -163,11 +171,6 @@
       <trans-unit id="ActiveLaunchProfileNotFound">
         <source>There aren't any active launch profiles configured for this project.</source>
         <target state="translated">Não há nenhum perfil de inicialização configurado para esse projeto.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DontKnowHowToRunProfile">
-        <source>The project doesn't know how to run the profile {0}.</source>
-        <target state="translated">O projeto não sabe como executar o perfil {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorInProfilesFile">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -7,6 +7,14 @@
         <target state="translated">Профиль {0}</target>
         <note>Default name for new launch profiles. The {0} is a decimal number chosen to guarantee the name is unique.</note>
       </trans-unit>
+      <trans-unit id="DontKnowHowToRunProfile_2">
+        <source>The project doesn't know how to run the profile with name '{0}' and command '{1}'.</source>
+        <target state="new">The project doesn't know how to run the profile with name '{0}' and command '{1}'.</target>
+        <note>
+      {0} is the profile name, which comes from the user.
+      {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
+    </note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Имя сборки платформы.</target>
@@ -163,11 +171,6 @@
       <trans-unit id="ActiveLaunchProfileNotFound">
         <source>There aren't any active launch profiles configured for this project.</source>
         <target state="translated">Для этого проекта не настроены действующие профили запуска.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DontKnowHowToRunProfile">
-        <source>The project doesn't know how to run the profile {0}.</source>
-        <target state="translated">Проекту не известно, как запустить профиль {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorInProfilesFile">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -7,6 +7,14 @@
         <target state="translated">{0} Profili</target>
         <note>Default name for new launch profiles. The {0} is a decimal number chosen to guarantee the name is unique.</note>
       </trans-unit>
+      <trans-unit id="DontKnowHowToRunProfile_2">
+        <source>The project doesn't know how to run the profile with name '{0}' and command '{1}'.</source>
+        <target state="new">The project doesn't know how to run the profile with name '{0}' and command '{1}'.</target>
+        <note>
+      {0} is the profile name, which comes from the user.
+      {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
+    </note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Çerçeve bütünleştirilmiş kodunun adı.</target>
@@ -163,11 +171,6 @@
       <trans-unit id="ActiveLaunchProfileNotFound">
         <source>There aren't any active launch profiles configured for this project.</source>
         <target state="translated">Bu proje için yapılandırılmış etkin bir başlatma profili yok.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DontKnowHowToRunProfile">
-        <source>The project doesn't know how to run the profile {0}.</source>
-        <target state="translated">Proje, {0} profilinin nasıl çalıştırılacağını bilmiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorInProfilesFile">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -7,6 +7,14 @@
         <target state="translated">配置文件 {0}</target>
         <note>Default name for new launch profiles. The {0} is a decimal number chosen to guarantee the name is unique.</note>
       </trans-unit>
+      <trans-unit id="DontKnowHowToRunProfile_2">
+        <source>The project doesn't know how to run the profile with name '{0}' and command '{1}'.</source>
+        <target state="new">The project doesn't know how to run the profile with name '{0}' and command '{1}'.</target>
+        <note>
+      {0} is the profile name, which comes from the user.
+      {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
+    </note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">框架程序集的名称。</target>
@@ -163,11 +171,6 @@
       <trans-unit id="ActiveLaunchProfileNotFound">
         <source>There aren't any active launch profiles configured for this project.</source>
         <target state="translated">没有为此项目配置任何活动的启动配置文件。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DontKnowHowToRunProfile">
-        <source>The project doesn't know how to run the profile {0}.</source>
-        <target state="translated">该项目不知道如何运行配置文件 {0}。</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorInProfilesFile">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -7,6 +7,14 @@
         <target state="translated">設定檔 {0}</target>
         <note>Default name for new launch profiles. The {0} is a decimal number chosen to guarantee the name is unique.</note>
       </trans-unit>
+      <trans-unit id="DontKnowHowToRunProfile_2">
+        <source>The project doesn't know how to run the profile with name '{0}' and command '{1}'.</source>
+        <target state="new">The project doesn't know how to run the profile with name '{0}' and command '{1}'.</target>
+        <note>
+      {0} is the profile name, which comes from the user.
+      {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
+    </note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">架構組件的名稱。</target>
@@ -163,11 +171,6 @@
       <trans-unit id="ActiveLaunchProfileNotFound">
         <source>There aren't any active launch profiles configured for this project.</source>
         <target state="translated">此專案未設有任何使用中的啟動設定檔。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DontKnowHowToRunProfile">
-        <source>The project doesn't know how to run the profile {0}.</source>
-        <target state="translated">專案不知道如何執行設定檔 {0}。</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorInProfilesFile">


### PR DESCRIPTION
While investigating a customer feedback ticket, it was unclear why a launch profile handler was not claiming support for the given profile. It would be useful to see the profile name in the error message sent by the customer. This change includes that detail.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8053)