### PR TITLE
Fast up-to-date check handles changed items sooner

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -250,8 +250,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
-                Adding UpToDateCheckBuilt outputs:
-                    {_builtPath}
                 The set of project items was changed more recently ({itemChangedTime.ToLocalTime()}) than the last successful build start time ({lastBuildTime.ToLocalTime()}), not up-to-date.
                     Content item added 'ItemPath1' (CopyToOutputDirectory=Never, TargetPath='')
                     Content item added 'ItemPath2' (CopyToOutputDirectory=Never, TargetPath='')
@@ -510,8 +508,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
-                Adding UpToDateCheckBuilt outputs:
-                    {_builtPath}
                 The set of project items was changed more recently ({itemChangeTime.ToLocalTime()}) than the last successful build start time ({lastBuildTime.ToLocalTime()}), not up-to-date.
                     Compile item removed 'Input.cs' (CopyToOutputDirectory=Never, TargetPath='')
                 """,


### PR DESCRIPTION
This opportunity was identified as a result of work in #8054.

In #8005 we changed how the fast up-to-date check handled changes in the set of project items. That change means we no longer check against build output times.

As a consequence of that, we can do this check sooner, before we scan outputs. In the case that this check fails, it will fail a little faster. It also has the benefit that we only run the check once in the case that we have multiple sets of inputs/outputs, as previously we performed the check for each set.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8055)