### PR TITLE
Add the Title property to the Package page

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
@@ -40,6 +40,11 @@
     </StringProperty.Metadata>
   </StringProperty>
 
+  <StringProperty Name="Title"
+                  DisplayName="Title"
+                  Description="A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio."
+                  Category="General" />
+
   <StringProperty Name="Version"
                   DisplayName="Package Version"
                   Description="The version of the package, following the major.minor.patch pattern. Version numbers may include a pre-release suffix."

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.cs.xlf
@@ -292,6 +292,16 @@
         <target state="translated">Adresa URL úložiště</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Title|Description">
+        <source>A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</source>
+        <target state="new">A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Title|DisplayName">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ToolCommandName|Description">
         <source>The command name via which the .NET tool will be invoked on the command line.</source>
         <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.de.xlf
@@ -292,6 +292,16 @@
         <target state="translated">Repository-URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Title|Description">
+        <source>A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</source>
+        <target state="new">A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Title|DisplayName">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ToolCommandName|Description">
         <source>The command name via which the .NET tool will be invoked on the command line.</source>
         <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.es.xlf
@@ -292,6 +292,16 @@
         <target state="translated">Dirección URL del repositorio</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Title|Description">
+        <source>A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</source>
+        <target state="new">A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Title|DisplayName">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ToolCommandName|Description">
         <source>The command name via which the .NET tool will be invoked on the command line.</source>
         <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.fr.xlf
@@ -292,6 +292,16 @@
         <target state="translated">URL du dépôt</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Title|Description">
+        <source>A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</source>
+        <target state="new">A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Title|DisplayName">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ToolCommandName|Description">
         <source>The command name via which the .NET tool will be invoked on the command line.</source>
         <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.it.xlf
@@ -292,6 +292,16 @@
         <target state="translated">URL del repository</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Title|Description">
+        <source>A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</source>
+        <target state="new">A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Title|DisplayName">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ToolCommandName|Description">
         <source>The command name via which the .NET tool will be invoked on the command line.</source>
         <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ja.xlf
@@ -292,6 +292,16 @@
         <target state="translated">リポジトリ URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Title|Description">
+        <source>A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</source>
+        <target state="new">A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Title|DisplayName">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ToolCommandName|Description">
         <source>The command name via which the .NET tool will be invoked on the command line.</source>
         <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ko.xlf
@@ -292,6 +292,16 @@
         <target state="translated">리포지토리 URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Title|Description">
+        <source>A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</source>
+        <target state="new">A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Title|DisplayName">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ToolCommandName|Description">
         <source>The command name via which the .NET tool will be invoked on the command line.</source>
         <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pl.xlf
@@ -292,6 +292,16 @@
         <target state="translated">Adres URL repozytorium</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Title|Description">
+        <source>A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</source>
+        <target state="new">A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Title|DisplayName">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ToolCommandName|Description">
         <source>The command name via which the .NET tool will be invoked on the command line.</source>
         <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pt-BR.xlf
@@ -292,6 +292,16 @@
         <target state="translated">URL do repositório</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Title|Description">
+        <source>A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</source>
+        <target state="new">A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Title|DisplayName">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ToolCommandName|Description">
         <source>The command name via which the .NET tool will be invoked on the command line.</source>
         <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ru.xlf
@@ -292,6 +292,16 @@
         <target state="translated">URL-адрес репозитория</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Title|Description">
+        <source>A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</source>
+        <target state="new">A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Title|DisplayName">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ToolCommandName|Description">
         <source>The command name via which the .NET tool will be invoked on the command line.</source>
         <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.tr.xlf
@@ -292,6 +292,16 @@
         <target state="translated">Depo URL'si</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Title|Description">
+        <source>A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</source>
+        <target state="new">A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Title|DisplayName">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ToolCommandName|Description">
         <source>The command name via which the .NET tool will be invoked on the command line.</source>
         <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hans.xlf
@@ -292,6 +292,16 @@
         <target state="translated">存储库 URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Title|Description">
+        <source>A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</source>
+        <target state="new">A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Title|DisplayName">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ToolCommandName|Description">
         <source>The command name via which the .NET tool will be invoked on the command line.</source>
         <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hant.xlf
@@ -292,6 +292,16 @@
         <target state="translated">存放庫 URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Title|Description">
+        <source>A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</source>
+        <target state="new">A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Title|DisplayName">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|ToolCommandName|Description">
         <source>The command name via which the .NET tool will be invoked on the command line.</source>
         <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>


### PR DESCRIPTION
Fixes #2937

This property allows specifying an optional display name for a package, to be used on nuget.org and in the Visual Studio Package Manager.

![image](https://user-images.githubusercontent.com/350947/162964814-9a9f1b27-8539-4615-ae9c-44eb6592033d.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8065)