### PR TITLE
Add PackAsTool and ToolCommandName properties to the Package page

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
@@ -157,6 +157,23 @@
     </StringProperty.ValueEditors>
   </StringProperty>
 
+  <BoolProperty Name="PackAsTool"
+                DisplayName="Pack as a .NET tool"
+                Description="Packs this project as a special package that contains a console application that may be installed via the &quot;dotnet tool&quot; command."
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2193012"
+                Category="General" />
+
+  <StringProperty Name="ToolCommandName"
+                  DisplayName=".NET tool command name"
+                  Description="The command name via which the .NET tool will be invoked on the command line."
+                  Category="General">
+    <StringProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-evaluated-value "Package" "PackAsTool" true)</NameValuePair.Value>
+      </NameValuePair>
+    </StringProperty.Metadata>
+  </StringProperty>
+
   <DynamicEnumProperty Name="NeutralLanguage"
                        DisplayName="Assembly neutral language"
                        EnumProvider="NeutralLanguageEnumProvider"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.cs.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Při sestavení generovat balíček NuGet</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|Description">
+        <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
+        <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|DisplayName">
+        <source>Pack as a .NET tool</source>
+        <target state="new">Pack as a .NET tool</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|Description">
         <source>Prompt the user to accept the license when installing this package.</source>
         <target state="translated">Při instalaci tohoto balíčku požádat uživatele, aby přijal licenci</target>
@@ -230,6 +240,16 @@
       <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
         <source>Repository URL</source>
         <target state="translated">Adresa URL úložiště</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|Description">
+        <source>The command name via which the .NET tool will be invoked on the command line.</source>
+        <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|DisplayName">
+        <source>.NET tool command name</source>
+        <target state="new">.NET tool command name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.de.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Beim Erstellen NuGet-Paket generieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|Description">
+        <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
+        <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|DisplayName">
+        <source>Pack as a .NET tool</source>
+        <target state="new">Pack as a .NET tool</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|Description">
         <source>Prompt the user to accept the license when installing this package.</source>
         <target state="translated">Hiermit wird der Benutzer bei der Installation dieses Pakets zum Akzeptieren der Lizenz aufgefordert.</target>
@@ -230,6 +240,16 @@
       <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
         <source>Repository URL</source>
         <target state="translated">Repository-URL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|Description">
+        <source>The command name via which the .NET tool will be invoked on the command line.</source>
+        <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|DisplayName">
+        <source>.NET tool command name</source>
+        <target state="new">.NET tool command name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.es.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Generar paquete NuGet al compilar</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|Description">
+        <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
+        <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|DisplayName">
+        <source>Pack as a .NET tool</source>
+        <target state="new">Pack as a .NET tool</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|Description">
         <source>Prompt the user to accept the license when installing this package.</source>
         <target state="translated">Solicite al usuario que acepte la licencia cuando instale este paquete.</target>
@@ -230,6 +240,16 @@
       <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
         <source>Repository URL</source>
         <target state="translated">Dirección URL del repositorio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|Description">
+        <source>The command name via which the .NET tool will be invoked on the command line.</source>
+        <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|DisplayName">
+        <source>.NET tool command name</source>
+        <target state="new">.NET tool command name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.fr.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Générer le package NuGet en même temps que la build</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|Description">
+        <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
+        <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|DisplayName">
+        <source>Pack as a .NET tool</source>
+        <target state="new">Pack as a .NET tool</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|Description">
         <source>Prompt the user to accept the license when installing this package.</source>
         <target state="translated">Invite l'utilisateur à accepter la licence au moment de l'installation de ce package.</target>
@@ -230,6 +240,16 @@
       <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
         <source>Repository URL</source>
         <target state="translated">URL du dépôt</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|Description">
+        <source>The command name via which the .NET tool will be invoked on the command line.</source>
+        <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|DisplayName">
+        <source>.NET tool command name</source>
+        <target state="new">.NET tool command name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.it.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Genera pacchetto NuGet durante la compilazione</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|Description">
+        <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
+        <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|DisplayName">
+        <source>Pack as a .NET tool</source>
+        <target state="new">Pack as a .NET tool</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|Description">
         <source>Prompt the user to accept the license when installing this package.</source>
         <target state="translated">Chiede all'utente di accettare la licenza durante l'installazione di questo pacchetto.</target>
@@ -230,6 +240,16 @@
       <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
         <source>Repository URL</source>
         <target state="translated">URL del repository</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|Description">
+        <source>The command name via which the .NET tool will be invoked on the command line.</source>
+        <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|DisplayName">
+        <source>.NET tool command name</source>
+        <target state="new">.NET tool command name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ja.xlf
@@ -12,6 +12,16 @@
         <target state="translated">ビルド時に NuGet パッケージを生成</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|Description">
+        <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
+        <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|DisplayName">
+        <source>Pack as a .NET tool</source>
+        <target state="new">Pack as a .NET tool</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|Description">
         <source>Prompt the user to accept the license when installing this package.</source>
         <target state="translated">このパッケージをインストールするときに、ライセンスの受け入れをユーザーに求めます。</target>
@@ -230,6 +240,16 @@
       <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
         <source>Repository URL</source>
         <target state="translated">リポジトリ URL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|Description">
+        <source>The command name via which the .NET tool will be invoked on the command line.</source>
+        <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|DisplayName">
+        <source>.NET tool command name</source>
+        <target state="new">.NET tool command name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ko.xlf
@@ -12,6 +12,16 @@
         <target state="translated">빌드 시 NuGet 패키지 생성</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|Description">
+        <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
+        <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|DisplayName">
+        <source>Pack as a .NET tool</source>
+        <target state="new">Pack as a .NET tool</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|Description">
         <source>Prompt the user to accept the license when installing this package.</source>
         <target state="translated">이 패키지를 설치할 때 사용자에게 이 라이선스에 동의하라는 메시지를 표시합니다.</target>
@@ -230,6 +240,16 @@
       <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
         <source>Repository URL</source>
         <target state="translated">리포지토리 URL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|Description">
+        <source>The command name via which the .NET tool will be invoked on the command line.</source>
+        <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|DisplayName">
+        <source>.NET tool command name</source>
+        <target state="new">.NET tool command name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pl.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Generuj pakiet NuGet podczas kompilacji</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|Description">
+        <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
+        <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|DisplayName">
+        <source>Pack as a .NET tool</source>
+        <target state="new">Pack as a .NET tool</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|Description">
         <source>Prompt the user to accept the license when installing this package.</source>
         <target state="translated">Monituj użytkownika o zaakceptowanie licencji podczas instalowania tego pakietu.</target>
@@ -230,6 +240,16 @@
       <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
         <source>Repository URL</source>
         <target state="translated">Adres URL repozytorium</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|Description">
+        <source>The command name via which the .NET tool will be invoked on the command line.</source>
+        <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|DisplayName">
+        <source>.NET tool command name</source>
+        <target state="new">.NET tool command name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pt-BR.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Gerar o pacote NuGet no build</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|Description">
+        <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
+        <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|DisplayName">
+        <source>Pack as a .NET tool</source>
+        <target state="new">Pack as a .NET tool</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|Description">
         <source>Prompt the user to accept the license when installing this package.</source>
         <target state="translated">Solicitar que o usuário aceite a licença ao instalar este pacote.</target>
@@ -230,6 +240,16 @@
       <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
         <source>Repository URL</source>
         <target state="translated">URL do repositório</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|Description">
+        <source>The command name via which the .NET tool will be invoked on the command line.</source>
+        <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|DisplayName">
+        <source>.NET tool command name</source>
+        <target state="new">.NET tool command name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ru.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Формировать пакет NuGet при сборке</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|Description">
+        <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
+        <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|DisplayName">
+        <source>Pack as a .NET tool</source>
+        <target state="new">Pack as a .NET tool</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|Description">
         <source>Prompt the user to accept the license when installing this package.</source>
         <target state="translated">Предлагать пользователю принять лицензию при установке этого пакета.</target>
@@ -230,6 +240,16 @@
       <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
         <source>Repository URL</source>
         <target state="translated">URL-адрес репозитория</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|Description">
+        <source>The command name via which the .NET tool will be invoked on the command line.</source>
+        <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|DisplayName">
+        <source>.NET tool command name</source>
+        <target state="new">.NET tool command name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.tr.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Derlemede NuGet paketi oluştur</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|Description">
+        <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
+        <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|DisplayName">
+        <source>Pack as a .NET tool</source>
+        <target state="new">Pack as a .NET tool</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|Description">
         <source>Prompt the user to accept the license when installing this package.</source>
         <target state="translated">Bu paketi yüklerken kullanıcının lisansı kabul etmesini isteyin.</target>
@@ -230,6 +240,16 @@
       <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
         <source>Repository URL</source>
         <target state="translated">Depo URL'si</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|Description">
+        <source>The command name via which the .NET tool will be invoked on the command line.</source>
+        <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|DisplayName">
+        <source>.NET tool command name</source>
+        <target state="new">.NET tool command name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hans.xlf
@@ -12,6 +12,16 @@
         <target state="translated">在构建时生成 NuGet 包</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|Description">
+        <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
+        <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|DisplayName">
+        <source>Pack as a .NET tool</source>
+        <target state="new">Pack as a .NET tool</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|Description">
         <source>Prompt the user to accept the license when installing this package.</source>
         <target state="translated">安装此包时，提示用户接受许可证。</target>
@@ -230,6 +240,16 @@
       <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
         <source>Repository URL</source>
         <target state="translated">存储库 URL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|Description">
+        <source>The command name via which the .NET tool will be invoked on the command line.</source>
+        <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|DisplayName">
+        <source>.NET tool command name</source>
+        <target state="new">.NET tool command name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hant.xlf
@@ -12,6 +12,16 @@
         <target state="translated">在建置時產生 NuGet 套件</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|Description">
+        <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
+        <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackAsTool|DisplayName">
+        <source>Pack as a .NET tool</source>
+        <target state="new">Pack as a .NET tool</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|Description">
         <source>Prompt the user to accept the license when installing this package.</source>
         <target state="translated">安裝此套件時，提示使用者接受授權。</target>
@@ -230,6 +240,16 @@
       <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
         <source>Repository URL</source>
         <target state="translated">存放庫 URL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|Description">
+        <source>The command name via which the .NET tool will be invoked on the command line.</source>
+        <target state="new">The command name via which the .NET tool will be invoked on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|ToolCommandName|DisplayName">
+        <source>.NET tool command name</source>
+        <target state="new">.NET tool command name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">


### PR DESCRIPTION
These properties support the creation of .NET tools, which are special NuGet packages that may be installed on a machine and executed from the command line.

![image](https://user-images.githubusercontent.com/350947/162980983-53407057-19c7-4fcd-aa76-15abdb1ae8bd.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8068)